### PR TITLE
Show errors on clone/move of pipeline

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentVariableConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentVariableConfig.java
@@ -223,7 +223,7 @@ public class EnvironmentVariableConfig implements Serializable, Validatable, Par
             }
 
             if (!canNotReferSecretConfigs.isEmpty()) {
-                addError(VALUE, format("Secret config with ids '%s' is not allowed to use in %s '%s'.", join(", ", canNotReferSecretConfigs), parent.getTag(), parent.getIdentifier()));
+                addError(VALUE, format("Secret config with ids '%s' is not allowed to be used in %s '%s'.", join(", ", canNotReferSecretConfigs), parent.getTag(), parent.getIdentifier()));
             }
 
         } catch (Exception e) {

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
@@ -427,7 +427,7 @@ public abstract class ScmMaterialConfig extends AbstractMaterialConfig implement
         }
 
         if (!canNotReferSecretConfigs.isEmpty()) {
-            addError(key, format("Secret config with ids `%s` is not allowed to use in `%s` with name `%s`.", join(", ", canNotReferSecretConfigs), pipelineGroup.getClass().getAnnotation(ConfigTag.class).value(), pipelineGroup.getGroup()));
+            addError(key, format("Secret config with ids `%s` is not allowed to be used in `%s` with name `%s`.", join(", ", canNotReferSecretConfigs), pipelineGroup.getClass().getAnnotation(ConfigTag.class).value(), pipelineGroup.getGroup()));
         }
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialConfigTest.java
@@ -252,7 +252,7 @@ class GitMaterialConfigTest {
             assertThat(gitMaterialConfig.validateTree(validationContext)).isFalse();
 
             assertThat(gitMaterialConfig.errors().get("encryptedPassword"))
-                    .contains("Secret config with ids `secret_config_id` is not allowed to use in `pipelines` with name `group_1`.");
+                    .contains("Secret config with ids `secret_config_id` is not allowed to be used in `pipelines` with name `group_1`.");
         }
 
         @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfigTest.java
@@ -320,7 +320,7 @@ class HgMaterialConfigTest {
             assertThat(material.validateTree(validationContext)).isFalse();
 
             assertThat(material.errors().get("encryptedPassword"))
-                    .contains("Secret config with ids `secret_config_id` is not allowed to use in `pipelines` with name `group_1`.");
+                    .contains("Secret config with ids `secret_config_id` is not allowed to be used in `pipelines` with name `group_1`.");
         }
 
         @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/perforce/P4MaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/perforce/P4MaterialConfigTest.java
@@ -197,7 +197,7 @@ class P4MaterialConfigTest {
             assertThat(p4MaterialConfig.validateTree(validationContext)).isFalse();
 
             assertThat(p4MaterialConfig.errors().get("encryptedPassword"))
-                    .contains("Secret config with ids `secret_config_id` is not allowed to use in `pipelines` with name `group_1`.");
+                    .contains("Secret config with ids `secret_config_id` is not allowed to be used in `pipelines` with name `group_1`.");
         }
 
         @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfigTest.java
@@ -221,7 +221,7 @@ class SvnMaterialConfigTest {
             assertThat(svnMaterialConfig.validateTree(validationContext)).isFalse();
 
             assertThat(svnMaterialConfig.errors().get("encryptedPassword"))
-                    .contains("Secret config with ids `secret_config_id` is not allowed to use in `pipelines` with name `group_1`.");
+                    .contains("Secret config with ids `secret_config_id` is not allowed to be used in `pipelines` with name `group_1`.");
         }
 
         @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfigTest.java
@@ -306,7 +306,7 @@ class TfsMaterialConfigTest {
             assertThat(tfsMaterialConfig.validateTree(validationContext)).isFalse();
 
             assertThat(tfsMaterialConfig.errors().get("encryptedPassword"))
-                    .contains("Secret config with ids `secret_config_id` is not allowed to use in `pipelines` with name `group_1`.");
+                    .contains("Secret config with ids `secret_config_id` is not allowed to be used in `pipelines` with name `group_1`.");
         }
 
         @Test

--- a/server/webapp/WEB-INF/rails/app/controllers/admin/pipeline_groups_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/admin/pipeline_groups_controller.rb
@@ -176,7 +176,10 @@ class Admin::PipelineGroupsController < AdminController
     if !@errors
       @errors = []
     end
-    @errors.concat [errors]
+    if errors != nil && errors.length > 0
+      @errors.concat [errors]
+    end
+
   end
 
   def is_group_admin(group)

--- a/server/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
@@ -212,7 +212,9 @@ module Admin
       if !@errors
         @errors = []
       end
-      @errors.concat [errors]
+      if errors != nil && errors.length > 0
+        @errors.concat [errors]
+      end
     end
 
     def update_other_tab

--- a/server/webapp/WEB-INF/rails/app/views/admin/pipeline_groups/index.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/pipeline_groups/index.html.erb
@@ -1,6 +1,6 @@
 <%- @tab_name = 'pipeline-groups' -%>
 <%- @view_title = 'Administration' %>
-
+<%= render :partial => "admin/shared/global_errors.html", :locals => {:scope => {}} -%>
 <div class="group_pipelines">
   <h1>
     Pipelines


### PR DESCRIPTION
Issue: #6369
If the pipeline contains a secret config, which is accessible in one group but not in another,
errors need to be shown as to why:

 - [x] clone
 - [x] move