### PR TITLE
Fixed 6377 - Console log errors in job details and preferences page

### DIFF
--- a/server/webapp/WEB-INF/rails/app/views/layouts/single_page_app.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/single_page_app.html.erb
@@ -15,10 +15,10 @@
   <%= stylesheet_link_tag 'frameworks' %>
   <%= stylesheet_link_tag "single_page_apps/#{controller_name}" %>
 
-  <% webpack_assets_service.getAssetPathsFor("single_page_apps/polyfill", "single_page_apps/#{controller_name}", "single_page_apps/header_footer_shim").each do |js| %>
+  <% webpack_assets_service.getJSAssetPathsFor("single_page_apps/polyfill", "single_page_apps/#{controller_name}", "single_page_apps/header_footer_shim").each do |js| %>
     <script src=<%= "#{js}" %>></script>
   <% end %>
-  <%= stylesheet_link_tag *webpack_assets_service.getCSSAssetPathsFor("single_page_apps/header_footer_shim") %>s
+  <%= stylesheet_link_tag *webpack_assets_service.getCSSAssetPathsFor("single_page_apps/header_footer_shim") %>
 
   <%= csrf_meta_tags %>
 </head>

--- a/server/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
@@ -15,7 +15,7 @@
  *#
 ## layout level variable
 #set ($title = "$presenter.buildName Job Details - Go")
-#set($extra_css_list = ['build_common', 'build_detail_summary','build_detail', 'sub_tab',
+#set($extra_css_list = ['build_common', 'build_detail', 'sub_tab',
     'transparent_message'])
 #set($current_tab='build')
 ## page level variable


### PR DESCRIPTION
Issue: #6377 

- [x] The stylesheet file _build_detail.summary.scss_ file was removed as part of clean up of unused stylesheet work. But there was one reference to that stylesheet that was not removed. And hence the error on a load of the job details page.

- [x] In preferences page, there was dynamic looping of a set of files to insert <script> tag in the page header. The set could contain both CSS as well as JS files. Hence if CSS file is loaded using script tag, an error is thrown. Fix is to load CSS only using link tag and load js only using script tag.
