### PR TITLE
5587 warning in logs in rerunning job

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/domain/Stage.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/Stage.java
@@ -443,9 +443,6 @@ public class Stage extends PersistentObject {
     }
 
     public void building() {
-        if (state != null && !isReRun()) {
-            LOG.warn("Expected stage [{}] to have no state, but was {}", identifier, state, new Exception().fillInStackTrace());
-        }
         state = StageState.Building;
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
@@ -275,6 +275,8 @@ public class BuildAssignmentService implements ConfigChangedListener {
                 try {
                     pipeline = scheduledPipelineLoader.pipelineWithPasswordAwareBuildCauseByBuildId(job.getJobId());
                 } catch (StaleMaterialsOnBuildCause e) {
+                    // Detailed error msg is part of the exception object and it would be logged. Hence not adding msg while logging.
+                    LOGGER.error("", e);
                     return NO_WORK;
                 }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/ScheduledPipelineLoader.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ScheduledPipelineLoader.java
@@ -33,15 +33,17 @@ import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.serverhealth.ServerHealthState;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.utils.Timeout;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 
 /**
  * @understands loads scheduled pipeline for creating work
  */
 @Component
 public class ScheduledPipelineLoader {
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(BuildAssignmentService.class.getName());
+
     final private PipelineSqlMapDao pipelineDao;
     final private GoConfigService goConfigService;
     final private JobInstanceService jobInstanceService;
@@ -78,16 +80,11 @@ public class ScheduledPipelineLoader {
                 scheduleService.failJob(jobInstance);
                 final String message = "Cannot load job '" + jobInstance.buildLocator() + "' because material " + usedMaterial.config() + " was not found in config.";
                 final String description = "Job for pipeline '" + jobInstance.buildLocator() + "' has been failed as one or more material configurations were either changed or removed.";
-                transactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
-                    @Override public void afterCommit() {
-                        final ServerHealthState error = ServerHealthState.error(message, description, HealthStateType.general(HealthStateScope.forJob(jobInstance.getPipelineName(), jobInstance.getStageName(), jobInstance.getName())));
-                        error.setTimeout(Timeout.FIVE_MINUTES);
-                        serverHealthService.update(error);
-                        appendToConsoleLog(jobInstance, message);
-                        appendToConsoleLog(jobInstance, description);
-                    }
-                });
-                throw new StaleMaterialsOnBuildCause(message);
+                final ServerHealthState error = ServerHealthState.error(message, description, HealthStateType.general(HealthStateScope.forJob(jobInstance.getPipelineName(), jobInstance.getStageName(), jobInstance.getName())));
+                error.setTimeout(Timeout.FIVE_MINUTES);
+                serverHealthService.update(error);
+                appendToConsoleLog(jobInstance, message, description);
+                throw new StaleMaterialsOnBuildCause(joinTwoStringsWithNewLine(message, description));
             }
 
             usedMaterial.updateFromConfig(materialConfig);
@@ -133,11 +130,15 @@ public class ScheduledPipelineLoader {
         return knownMaterials;
     }
 
-    private void appendToConsoleLog(JobInstance jobInstance, String message) {
+    private void appendToConsoleLog(JobInstance jobInstance, String message, String description) {
         try {
-            consoleService.appendToConsoleLog(jobInstance.getIdentifier(), "\n" + message + "\n");
+            consoleService.appendToConsoleLog(jobInstance.getIdentifier(), "\n" + message + "\n\n" + description + "\n");
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private String joinTwoStringsWithNewLine(String str1, String str2){
+        return String.format("%s.%n%s", str1, str2);
     }
 }


### PR DESCRIPTION
Fixed 2 related issues: #5587 & #6376 

Fixed #5587 - by removing the statement that logs the warning message. Please check the issue comments section for a detailed description of why this change was made. 

Fixed #6376 - by making sure that whenever job fails due to stale material config (meaning material config changed, either by modification or removal of existing material config, after it was run successfully before and then previous stages are run from history after this material config change)  then log an error message to console and also log exception with a proper message in the server logs.

![aa](https://user-images.githubusercontent.com/24566436/59842581-6d415b80-9374-11e9-9ca9-9b863eb48658.png)
![bb](https://user-images.githubusercontent.com/24566436/59842582-6dd9f200-9374-11e9-9f48-35e6151e0fc7.png)
 
