### PR TITLE
Read the temp console log file when build is in progress

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/view/artifacts/LocalArtifactsView.java
+++ b/server/src/main/java/com/thoughtworks/go/server/view/artifacts/LocalArtifactsView.java
@@ -43,7 +43,7 @@ public class LocalArtifactsView implements ArtifactsView {
 
     public final ModelAndView createView(String filePath, String sha) throws Exception {
         //return the artifact itself if this is a single file
-        File file = isConsoleOutput(filePath) ? consoleService.consoleLogArtifact(translatedId)
+        File file = isConsoleOutput(filePath) ? consoleService.consoleLogFile(translatedId)
                 : artifactsService.findArtifact(translatedId, filePath);
 
         if (file.exists() && file.isFile()) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/controller/ArtifactsControllerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/controller/ArtifactsControllerTest.java
@@ -39,11 +39,9 @@ import java.io.InputStream;
 
 import static com.thoughtworks.go.util.GoConstants.*;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.*;
 
 public class ArtifactsControllerTest {


### PR DESCRIPTION
Issue #6350. The Raw Console logs will point to the temporary console log file when the build is in progress.
If the temp file hasn't been created yet (e.g. before the build is assigned to an agent), the user will still see a file not found message.