### PR TITLE
Fix check connection during new pipeline creation

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/RulesService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/RulesService.java
@@ -109,7 +109,7 @@ public class RulesService {
         validateSecretConfigReferences(secretParams, group.getClass(), group.getGroup(), errorMessagePrefix);
     }
 
-    private void validateSecretConfigReferences(SecretParams secretParams, Class<? extends Validatable> entityClass, String entityName, String entityNameOrErrorMessagePrefix) {
+    protected void validateSecretConfigReferences(SecretParams secretParams, Class<? extends Validatable> entityClass, String entityName, String entityNameOrErrorMessagePrefix) {
         secretParams.forEach(secretParam -> {
             SecretConfig secretConfig = goConfigService.cruiseConfig().getSecretConfigs().find(secretParam.getSecretConfigId());
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/SecretParamResolver.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/SecretParamResolver.java
@@ -16,10 +16,7 @@
 
 package com.thoughtworks.go.server.service;
 
-import com.thoughtworks.go.config.EnvironmentConfig;
-import com.thoughtworks.go.config.SecretConfig;
-import com.thoughtworks.go.config.SecretParam;
-import com.thoughtworks.go.config.SecretParams;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.plugin.access.secrets.SecretsExtension;
 import com.thoughtworks.go.plugin.domain.secrets.Secret;
@@ -35,6 +32,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static java.lang.String.format;
 import static java.util.stream.Collectors.groupingBy;
 
 @Component
@@ -54,6 +52,12 @@ public class SecretParamResolver {
     public void resolve(ScmMaterial scmMaterial) {
         rulesService.validateSecretConfigReferences(scmMaterial);
 
+        resolve(scmMaterial.getSecretParams());
+    }
+
+    // Method used for check_connection in new pipeline flow
+    public void resolve(ScmMaterial scmMaterial, String pipelineGroupName) {
+        rulesService.validateSecretConfigReferences(scmMaterial.getSecretParams(), PipelineConfigs.class, pipelineGroupName, format("Material with url: '%s' in Pipeline Group:", scmMaterial.getUriForDisplay()));
         resolve(scmMaterial.getSecretParams());
     }
 

--- a/server/webapp/WEB-INF/rails/app/assets/javascripts/check_connection.js
+++ b/server/webapp/WEB-INF/rails/app/assets/javascripts/check_connection.js
@@ -19,7 +19,7 @@ var CheckConnection = function() {
         return jQuery(selector).val();
     }
 
-    function _hookupCheckConnection(id, pipelineName, materialType, materialUrl, username, password, encryptedPassword, isChanged, projectPath, domain, view, branch, port) {
+    function _hookupCheckConnection(id, pipelineName, materialType, materialUrl, username, password, encryptedPassword, isChanged, projectPath, domain, view, branch, port, pipelineGroupName) {
         jQuery(id).click(function() {
             var isEncrypted = false;
             var finalPass = '';
@@ -31,7 +31,7 @@ var CheckConnection = function() {
                     isEncrypted = true;
                 }
             }
-            WizardPage.checkConnection(pipelineName, valueOf(username), finalPass, valueOf(materialUrl), materialType, isEncrypted, valueOf(projectPath), valueOf(domain), valueOf(view), valueOf(branch), valueOf(port));
+            WizardPage.checkConnection(pipelineName, valueOf(username), finalPass, valueOf(materialUrl), materialType, isEncrypted, valueOf(projectPath), valueOf(domain), valueOf(view), valueOf(branch), valueOf(port), valueOf(pipelineGroupName));
         });
     }
 

--- a/server/webapp/WEB-INF/rails/app/assets/javascripts/simple-pipeline.js
+++ b/server/webapp/WEB-INF/rails/app/assets/javascripts/simple-pipeline.js
@@ -15,7 +15,7 @@
  */
 var WizardPage = new (Class.create({
 
-  checkConnection: function (pipelineName, username, password, url, scm, isEncrypted, projectPath, domain, view, branch, port) {
+  checkConnection: function (pipelineName, username, password, url, scm, isEncrypted, projectPath, domain, view, branch, port, pipelineGroupName) {
 
     // copied verbatim from string-plus.js
     var snakeCaser = function (key, value) {
@@ -33,12 +33,9 @@ var WizardPage = new (Class.create({
 
     var messageBox = jQuery('#vcsconnection-message_' + scm);
 
-    var urlParams = new URLSearchParams(window.location.search);
-    var pipelineGroup = urlParams.get('group');
-
     var requestBody = {
       type: scm,
-      pipeline_group: pipelineGroup,
+      pipeline_group: pipelineGroupName,
       pipeline_name: pipelineName,
       attributes: {
         username: username,

--- a/server/webapp/WEB-INF/rails/app/assets/javascripts/simple-pipeline.js
+++ b/server/webapp/WEB-INF/rails/app/assets/javascripts/simple-pipeline.js
@@ -33,8 +33,12 @@ var WizardPage = new (Class.create({
 
     var messageBox = jQuery('#vcsconnection-message_' + scm);
 
+    var urlParams = new URLSearchParams(window.location.search);
+    var pipelineGroup = urlParams.get('group');
+
     var requestBody = {
       type: scm,
+      pipeline_group: pipelineGroup,
       pipeline_name: pipelineName,
       attributes: {
         username: username,

--- a/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/internal/material_test_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/internal/material_test_controller.rb
@@ -26,7 +26,10 @@ module ApiV1
 
         def test
           material_config = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.get_material_type(params[:type]).new).from_hash(params)
-          group_name = go_config_service.findGroupNameByPipeline(CaseInsensitiveString.new(params[:pipeline_name]))
+          group_name = params[:pipeline_group]
+          if group_name == nil
+            group_name = go_config_service.findGroupNameByPipeline(CaseInsensitiveString.new(params[:pipeline_name]))
+          end
           material_config.validateConcreteScmMaterial(PipelineConfigSaveValidationContext.forChain(false, group_name, go_config_service.cruise_config(), material_config))
           if material_config.errors.any?
             json = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(material_config).to_hash(url_builder: self)

--- a/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/internal/material_test_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/internal/material_test_controller.rb
@@ -41,7 +41,7 @@ module ApiV1
 
           material = MaterialConfigConverter.new.toMaterial(material_config)
           if material.respond_to?(:checkConnection)
-            validation_bean = check_connection_for_material material
+            validation_bean = check_connection_for_material(material, group_name)
             if validation_bean.isValid
               render_message('Connection OK.', :ok)
             else
@@ -74,11 +74,11 @@ module ApiV1
           "There was an error with the material configuration.\n" + combined_error_message
         end
 
-        def check_connection_for_material material
+        def check_connection_for_material(material, group_name)
           begin
-            secret_param_resolver.resolve(material.getSecretParams()) if material.is_a?(ScmMaterial)
+            secret_param_resolver.resolve(material, group_name) if material.is_a?(ScmMaterial)
             material.checkConnection(subprocess_execution_context)
-          rescue com.thoughtworks.go.config.exceptions.UnresolvedSecretParamException, com.thoughtworks.go.plugin.access.exceptions.SecretResolutionFailureException => e
+          rescue com.thoughtworks.go.config.exceptions.UnresolvedSecretParamException, com.thoughtworks.go.plugin.access.exceptions.SecretResolutionFailureException, com.thoughtworks.go.server.exceptions.RulesViolationException => e
             com.thoughtworks.go.domain.materials.ValidationBean.notValid(e.message);
           end
         end

--- a/server/webapp/WEB-INF/rails/app/views/admin/materials/shared/_check_connection.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/materials/shared/_check_connection.html.erb
@@ -4,6 +4,6 @@
 <script type="text/javascript">
     Util.on_load(function() {
         new CheckConnection().hookupCheckConnection("#<%=check_connection_button_id-%>", "<%=params[:pipeline_name]-%>", "<%= scope[:type] %>", "<%=scope[:url]-%>", "<%=scope[:username]-%>",
-                "<%=scope[:password]-%>", "<%=scope[:encrypted_password]-%>", "<%=scope[:password_changed]-%>", "<%= scope[:project_path] -%>", "<%= scope[:domain] -%>", "<%= scope[:view] -%>", "<%= scope[:branch] -%>", "<%= scope[:port] -%>");
+                "<%=scope[:password]-%>", "<%=scope[:encrypted_password]-%>", "<%=scope[:password_changed]-%>", "<%= scope[:project_path] -%>", "<%= scope[:domain] -%>", "<%= scope[:view] -%>", "<%= scope[:branch] -%>", "<%= scope[:port] -%>", "#pipeline_group_name_text_field");
     });
 </script>

--- a/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/internal/material_test_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/internal/material_test_controller_spec.rb
@@ -168,13 +168,13 @@ describe ApiV1::Admin::Internal::MaterialTestController do
 
         @secret_params = com.thoughtworks.go.config.SecretParams.parse('')
 
-        @secret_param_resolver = double(SecretParamResolver)
-        allow(@secret_param_resolver).to receive(:resolve)
-        allow(controller).to receive(:secret_param_resolver).and_return(@secret_param_resolver)
-
         @svn_material = double(com.thoughtworks.go.config.materials.svn.SvnMaterial)
-        allow(@svn_material).to receive(:is_a?).with(ScmMaterial).and_return(true)
         allow(@svn_material).to receive(:getSecretParams).and_return(@secret_params)
+        allow(@svn_material).to receive(:is_a?).with(ScmMaterial).and_return(true)
+
+        @secret_param_resolver = double(SecretParamResolver)
+        allow(@secret_param_resolver).to receive(:resolve).with(@svn_material, "default")
+        allow(controller).to receive(:secret_param_resolver).and_return(@secret_param_resolver)
       end
 
       it 'should resolve secret param before performing check connection for material' do
@@ -188,6 +188,7 @@ describe ApiV1::Admin::Internal::MaterialTestController do
 
         post_with_api_header :test, params: {
           type: 'svn',
+          pipeline_group: "default",
           attributes: {
             url: 'https://example.com/git/FooBarWidgets.git',
             password: 'password'
@@ -195,7 +196,7 @@ describe ApiV1::Admin::Internal::MaterialTestController do
         }
 
         expect(response).to have_api_message_response(200, 'Connection OK.')
-        expect(@secret_param_resolver).to have_received(:resolve).with(@secret_params).once
+        expect(@secret_param_resolver).to have_received(:resolve).with(@svn_material, "default").once
       end
 
       it 'should handle unresolved secret params exception and return the error message' do
@@ -208,6 +209,7 @@ describe ApiV1::Admin::Internal::MaterialTestController do
 
         post_with_api_header :test, params: {
           type: 'svn',
+          pipeline_group: "default",
           attributes: {
             url: 'https://example.com/git/FooBarWidgets.git',
             password: 'password'
@@ -227,6 +229,7 @@ describe ApiV1::Admin::Internal::MaterialTestController do
 
         post_with_api_header :test, params: {
           type: 'svn',
+          pipeline_group: "default",
           attributes: {
             url: 'https://example.com/git/FooBarWidgets.git',
             password: 'password'
@@ -249,6 +252,7 @@ describe ApiV1::Admin::Internal::MaterialTestController do
 
         post_with_api_header :test, params: {
           type: 'svn',
+          pipeline_group: "default",
           attributes: {
             url: 'https://example.com/git/FooBarWidgets.git',
             password: 'password'

--- a/server/webapp/WEB-INF/rails/webpack/models/materials/types.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/materials/types.ts
@@ -131,11 +131,15 @@ export class Material extends ValidatableMixin {
     return raw;
   }
 
-  checkConnection() {
+  checkConnection(pipelineGroup?: string) {
+    const payload = this.toApiPayload();
+    if (pipelineGroup) {
+      payload.pipeline_group = pipelineGroup;
+    }
     return ApiRequestBuilder.POST(
       SparkRoutes.materialConnectionCheck(),
       Material.API_VERSION_HEADER,
-      {payload: this.toApiPayload()}
+      {payload}
     );
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/materials/test_connection.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/materials/test_connection.tsx
@@ -24,6 +24,7 @@ import * as styles from "./test_connection.scss";
 
 interface Attrs {
   material: Material;
+  group?: string;
 
   // extra handlers will be fired in addition to defaults
   success?: (...args: any[]) => any;
@@ -41,13 +42,13 @@ export class TestConnection extends MithrilViewComponent<Attrs> {
   private complete?: (...args: any[]) => any;
 
   view(vnode: m.Vnode<Attrs>): m.Children | void | null {
-    this.success = vnode.attrs.success;
-    this.failure = vnode.attrs.failure;
+    this.success  = vnode.attrs.success;
+    this.failure  = vnode.attrs.failure;
     this.complete = vnode.attrs.complete;
 
     return <div className={styles.testConnectionButtonWrapper}>
       <Buttons.Secondary data-test-id="test-connection-button"
-                         onclick={() => this.testConnection(vnode.attrs.material)}>
+                         onclick={() => this.testConnection(vnode.attrs.material, vnode.attrs.group)}>
         <span className={this.testConnectionButtonIcon} data-test-id="test-connection-icon"/>
         {this.testConnectionButtonText}
       </Buttons.Secondary>
@@ -55,10 +56,10 @@ export class TestConnection extends MithrilViewComponent<Attrs> {
     </div>;
   }
 
-  private testConnection(material: Material) {
+  private testConnection(material: Material, pipelineGroup?: string) {
     this.testConnectionInProgress();
 
-    material.checkConnection().then((result: ApiResult<any>) => {
+    material.checkConnection(pipelineGroup).then((result: ApiResult<any>) => {
       result.do(() => {
         this.testConnectionSuccessful();
         if (!!this.success) {
@@ -80,18 +81,18 @@ export class TestConnection extends MithrilViewComponent<Attrs> {
 
   private testConnectionFailed(err: ErrorResponse) {
     this.testConnectionButtonIcon = styles.testConnectionFailure;
-    this.testConnectionMessage = <FlashMessage type={MessageType.alert} message={<pre>{err.message}</pre>}/>;
+    this.testConnectionMessage    = <FlashMessage type={MessageType.alert} message={<pre>{err.message}</pre>}/>;
   }
 
   private testConnectionSuccessful() {
     this.testConnectionButtonIcon = styles.testConnectionSuccess;
-    this.testConnectionMessage = <FlashMessage type={MessageType.success} message="Connection OK"/>;
+    this.testConnectionMessage    = <FlashMessage type={MessageType.success} message="Connection OK"/>;
   }
 
   private testConnectionInProgress() {
     this.testConnectionButtonIcon = styles.testConnectionInProgress;
     this.testConnectionButtonText = "Testing Connection...";
-    this.testConnectionMessage = undefined;
+    this.testConnectionMessage    = undefined;
   }
 
   private testConnectionComplete() {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines.tsx
@@ -69,7 +69,7 @@ export class PipelineCreatePage extends Page {
     const components = [
       <FillableSection>
         <UserInputPane heading="Part 1: Material">
-          <MaterialEditor material={this.material}/>
+          <MaterialEditor material={this.material} group={this.model.group()}/>
         </UserInputPane>
         <ConceptDiagram image={materialImg}>
           A <strong>material</strong> triggers your pipeline to run. Typically this is a <strong>source repository</strong> or an <strong>upstream pipeline</strong>.

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
@@ -15,9 +15,16 @@
  */
 
 import {MithrilViewComponent} from "jsx/mithril-component";
-import * as _ from "lodash";
 import * as m from "mithril";
-import {DependencyMaterialAttributes, GitMaterialAttributes, HgMaterialAttributes, Material, P4MaterialAttributes, SvnMaterialAttributes, TfsMaterialAttributes} from "models/materials/types";
+import {
+  DependencyMaterialAttributes,
+  GitMaterialAttributes,
+  HgMaterialAttributes,
+  Material,
+  P4MaterialAttributes,
+  SvnMaterialAttributes,
+  TfsMaterialAttributes
+} from "models/materials/types";
 import {Form, FormBody} from "views/components/forms/form";
 import {Option, SelectField, SelectFieldOptions} from "views/components/forms/input_fields";
 import {DefaultCache, DependencyFields, SuggestionCache} from "./non_scm_material_fields";
@@ -25,6 +32,7 @@ import {GitFields, HgFields, P4Fields, SvnFields, TfsFields} from "./scm_materia
 
 interface Attrs {
   material: Material;
+  group: string;
   cache?: SuggestionCache;
 }
 
@@ -44,7 +52,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
       </SelectField>
 
       <Form last={true} compactForm={true}>
-        {this.fieldsForType(vnode.attrs.material, this.cache)}
+        {this.fieldsForType(vnode.attrs.material, this.cache, vnode.attrs.group)}
       </Form>
     </FormBody>;
   }
@@ -60,37 +68,37 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
     ];
   }
 
-  fieldsForType(material: Material, cacheable: SuggestionCache): m.Children {
+  fieldsForType(material: Material, cacheable: SuggestionCache, group: string): m.Children {
     switch (material.type()) {
       case "git":
         if (!(material.attributes() instanceof GitMaterialAttributes)) {
           material.attributes(new GitMaterialAttributes());
         }
-        return <GitFields material={material}/>;
+        return <GitFields material={material} group={group}/>;
         break;
       case "hg":
         if (!(material.attributes() instanceof HgMaterialAttributes)) {
           material.attributes(new HgMaterialAttributes());
         }
-        return <HgFields material={material}/>;
+        return <HgFields material={material} group={group}/>;
         break;
       case "svn":
         if (!(material.attributes() instanceof SvnMaterialAttributes)) {
           material.attributes(new SvnMaterialAttributes());
         }
-        return <SvnFields material={material}/>;
+        return <SvnFields material={material} group={group}/>;
         break;
       case "p4":
         if (!(material.attributes() instanceof P4MaterialAttributes)) {
           material.attributes(new P4MaterialAttributes());
         }
-        return <P4Fields material={material}/>;
+        return <P4Fields material={material} group={group}/>;
         break;
       case "tfs":
         if (!(material.attributes() instanceof TfsMaterialAttributes)) {
           material.attributes(new TfsMaterialAttributes());
         }
-        return <TfsFields material={material}/>;
+        return <TfsFields material={material} group={group}/>;
         break;
       case "dependency":
         if (!(material.attributes() instanceof DependencyMaterialAttributes)) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
@@ -35,6 +35,7 @@ import {DESTINATION_DIR_HELP_MESSAGE, IDENTIFIER_FORMAT_HELP_MESSAGE} from "./me
 
 interface Attrs {
   material: Material;
+  group: string;
 }
 
 abstract class ScmFields extends MithrilViewComponent<Attrs> {
@@ -46,7 +47,7 @@ abstract class ScmFields extends MithrilViewComponent<Attrs> {
     const mattrs = vnode.attrs.material.attributes() as ScmMaterialAttributes;
     return [
       this.requiredFields(mattrs),
-      <TestConnection material={vnode.attrs.material}/>,
+      <TestConnection material={vnode.attrs.material} group={vnode.attrs.group}/>,
       <AdvancedSettings forceOpen={mattrs.errors().hasErrors("name") || mattrs.errors().hasErrors("destination")}>
         {this.extraFields(mattrs)}
         <TextField label={[

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_editor_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_editor_spec.tsx
@@ -27,7 +27,7 @@ describe("AddPipeline: Material Editor", () => {
     material = new Material();
 
     helper.mount(() => {
-      return <MaterialEditor material={material}/>;
+      return <MaterialEditor material={material} group={"default"}/>;
     });
   });
 
@@ -37,7 +37,8 @@ describe("AddPipeline: Material Editor", () => {
     expect(helper.q("select")).toBeTruthy();
     expect(helper.q("label")).toBeTruthy();
     expect(helper.q("label").textContent).toBe("Material Type*");
-    expect(helper.textAll("option")).toEqual(["Git", "Mercurial", "Subversion", "Perforce", "Team Foundation Server", "Another Pipeline"]);
+    expect(helper.textAll("option"))
+      .toEqual(["Git", "Mercurial", "Subversion", "Perforce", "Team Foundation Server", "Another Pipeline"]);
   });
 
   it("Selecting a material updates the model type", () => {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
@@ -33,7 +33,7 @@ describe("AddPipeline: SCM Material Fields", () => {
 
   it("GitFields structure", () => {
     const material = new Material("git", new GitMaterialAttributes());
-    helper.mount(() => <GitFields material={material}/>);
+    helper.mount(() => <GitFields material={material} group={"default"}/>);
 
     assertLabelledInputsPresent({
       "repository-url":          "Repository URL*",
@@ -49,7 +49,7 @@ describe("AddPipeline: SCM Material Fields", () => {
 
   it("HgFields structure", () => {
     const material = new Material("hg", new HgMaterialAttributes());
-    helper.mount(() => <HgFields material={material}/>);
+    helper.mount(() => <HgFields material={material} group={"default"}/>);
 
     assertLabelledInputsPresent({
       "repository-url":          "Repository URL*",
@@ -64,7 +64,7 @@ describe("AddPipeline: SCM Material Fields", () => {
 
   it("SvnFields structure", () => {
     const material = new Material("svn", new SvnMaterialAttributes());
-    helper.mount(() => <SvnFields material={material}/>);
+    helper.mount(() => <SvnFields material={material} group={"default"}/>);
 
     assertLabelledInputsPresent({
       "repository-url":          "Repository URL*",
@@ -80,7 +80,7 @@ describe("AddPipeline: SCM Material Fields", () => {
 
   it("P4Fields structure", () => {
     const material = new Material("p4", new P4MaterialAttributes());
-    helper.mount(() => <P4Fields material={material}/>);
+    helper.mount(() => <P4Fields material={material} group={"default"}/>);
 
     assertLabelledInputsPresent({
       "p4-protocol-host-port":     "P4 [Protocol:][Host:]Port*",
@@ -97,7 +97,7 @@ describe("AddPipeline: SCM Material Fields", () => {
 
   it("TfsFields structure", () => {
     const material = new Material("tfs", new TfsMaterialAttributes());
-    helper.mount(() => <TfsFields material={material}/>);
+    helper.mount(() => <TfsFields material={material} group={"default"}/>);
 
     assertLabelledInputsPresent({
       "repository-url":          "Repository URL*",


### PR DESCRIPTION
Issue: #6369
The password for material can be configured using a secret config. Validation for the same requires a group name. Since the pipeline hasn't been created yet, the config won't have the reference to the same.

Modified the material test API to accept a `pipeline_group` field.
On the UI end, fetched the group name from query params.