### PR TITLE
Revert secret config validation and turn off the SPA toggle

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
@@ -119,7 +119,7 @@ public class GitMaterialConfig extends ScmMaterialConfig implements PasswordAwar
     public void validateConcreteScmMaterial(ValidationContext validationContext) {
         validateMaterialUrl(this.url, validationContext);
         validateCredentials();
-        validateSecretParams(validationContext);
+        validateEncryptedPassword();
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfig.java
@@ -125,9 +125,9 @@ public class HgMaterialConfig extends ScmMaterialConfig implements ParamsAttribu
     @Override
     public void validateConcreteScmMaterial(ValidationContext validationContext) {
         validateMaterialUrl(this.url, validationContext);
-        validateSecretParams(validationContext);
         validateCredentials();
         validateBranch();
+        validateEncryptedPassword();
     }
 
     private void validateBranch() {

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/perforce/P4MaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/perforce/P4MaterialConfig.java
@@ -150,8 +150,7 @@ public class P4MaterialConfig extends ScmMaterialConfig implements ParamsAttribu
         if (StringUtils.isBlank(getServerAndPort())) {
             errors.add(SERVER_AND_PORT, "P4 port cannot be empty.");
         }
-
-        validateSecretParams(validationContext);
+        validateEncryptedPassword();
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfig.java
@@ -79,7 +79,7 @@ public class SvnMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
     @Override
     public void validateConcreteScmMaterial(ValidationContext validationContext) {
         validateMaterialUrl(this.url, validationContext);
-        validateSecretParams(validationContext);
+        validateEncryptedPassword();
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfig.java
@@ -84,7 +84,6 @@ public class TfsMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
     @Override
     public void validateConcreteScmMaterial(ValidationContext validationContext) {
         validateMaterialUrl(this.url, validationContext);
-        validateSecretParams(validationContext);
 
         if (StringUtils.isBlank(userName)) {
             errors().add(USERNAME, "Username cannot be blank");
@@ -92,7 +91,7 @@ public class TfsMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
         if (StringUtils.isBlank(projectPath)) {
             errors().add(PROJECT_PATH, "Project Path cannot be blank");
         }
-
+        validateEncryptedPassword();
     }
 
     @Override

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/EnvironmentVariableConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/EnvironmentVariableConfigTest.java
@@ -248,24 +248,6 @@ class EnvironmentVariableConfigTest {
         }
 
         @Test
-        void shouldBeInvalidIfSecretParamContainsANonExistentSecretConfigId() {
-            EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig(goCipher, "plain_key", "{{SECRET:[secret_config_id][token]}}", false);
-            CruiseConfig cruiseConfig = mock(CruiseConfig.class);
-            PipelineConfigs group = mock(BasicPipelineConfigs.class);
-
-            when(validationContext.getCruiseConfig()).thenReturn(cruiseConfig);
-            when(validationContext.isWithinPipelines()).thenReturn(true);
-            when(validationContext.getPipelineGroup()).thenReturn(group);
-            when(cruiseConfig.getSecretConfigs()).thenReturn(new SecretConfigs());
-
-            environmentVariableConfig.validate(validationContext);
-
-            assertThat(environmentVariableConfig.errors()).isNotEmpty();
-            assertThat(environmentVariableConfig.errors().getAllOn(EnvironmentVariableConfig.VALUE))
-                    .contains("Secret config with ids 'secret_config_id' does not exist.");
-        }
-
-        @Test
         void shouldBeValidIfSecretParamContainsAExistentSecretConfigId() {
             EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig(goCipher, "plain_key", "{{SECRET:[secret_config_id][token]}}", false);
             SecretConfig secretConfig = mock(SecretConfig.class);
@@ -283,91 +265,6 @@ class EnvironmentVariableConfigTest {
             environmentVariableConfig.validate(validationContext);
 
             assertThat(environmentVariableConfig.errors()).isEmpty();
-        }
-
-        @Test
-        void shouldCallCanReferForPipelineGroup() {
-            final SecretConfig secretConfig = mock(SecretConfig.class);
-            EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig(goCipher, "plain_key", "{{SECRET:[secret_config_id][token]}}", false);
-            validationContext.getCruiseConfig().getSecretConfigs().add(secretConfig);
-            PipelineConfigs group = mock(BasicPipelineConfigs.class);
-
-            when(validationContext.isWithinPipelines()).thenReturn(true);
-            when(validationContext.getPipelineGroup()).thenReturn(group);
-            when(secretConfig.getId()).thenReturn("secret_config_id");
-            when(group.getGroup()).thenReturn("example");
-
-            environmentVariableConfig.validateTree(validationContext);
-
-            verify(secretConfig).canRefer(group.getClass(), "example");
-        }
-
-        @Test
-        void shouldCallCanReferForMergePipelineGroup() {
-            final SecretConfig secretConfig = mock(SecretConfig.class);
-            EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig(goCipher, "plain_key", "{{SECRET:[secret_config_id][token]}}", false);
-            validationContext.getCruiseConfig().getSecretConfigs().add(secretConfig);
-            PipelineConfigs group = mock(MergePipelineConfigs.class);
-
-            when(validationContext.isWithinPipelines()).thenReturn(true);
-            when(validationContext.getPipelineGroup()).thenReturn(group);
-            when(secretConfig.getId()).thenReturn("secret_config_id");
-            when(group.getGroup()).thenReturn("example");
-
-            environmentVariableConfig.validateTree(validationContext);
-
-            verify(secretConfig).canRefer(group.getClass(), "example");
-        }
-
-        @Test
-        void shouldCallCanReferForEnvironmentConfig() {
-            final SecretConfig secretConfig = mock(SecretConfig.class);
-            EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig(goCipher, "plain_key", "{{SECRET:[secret_config_id][token]}}", false);
-            validationContext.getCruiseConfig().getSecretConfigs().add(secretConfig);
-            EnvironmentConfig environmentConfig = mock(BasicEnvironmentConfig.class);
-
-            when(validationContext.isWithinEnvironment()).thenReturn(true);
-            when(validationContext.getEnvironment()).thenReturn(environmentConfig);
-            when(secretConfig.getId()).thenReturn("secret_config_id");
-            when(environmentConfig.name()).thenReturn(new CaseInsensitiveString("example-env"));
-
-            environmentVariableConfig.validateTree(validationContext);
-
-            verify(secretConfig).canRefer(environmentConfig.getClass(), "example-env");
-        }
-
-        @Test
-        void shouldCallCanReferForMergeEnvironmentConfig() {
-            final SecretConfig secretConfig = mock(SecretConfig.class);
-            EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig(goCipher, "plain_key", "{{SECRET:[secret_config_id][token]}}", false);
-            validationContext.getCruiseConfig().getSecretConfigs().add(secretConfig);
-            EnvironmentConfig environmentConfig = mock(MergeEnvironmentConfig.class);
-
-            when(validationContext.isWithinEnvironment()).thenReturn(true);
-            when(validationContext.getEnvironment()).thenReturn(environmentConfig);
-            when(secretConfig.getId()).thenReturn("secret_config_id");
-            when(environmentConfig.name()).thenReturn(new CaseInsensitiveString("example-env"));
-
-            environmentVariableConfig.validateTree(validationContext);
-
-            verify(secretConfig).canRefer(environmentConfig.getClass(), "example-env");
-        }
-
-        @Test
-        void shouldNotCallCanReferForTemplate() {
-            final SecretConfig secretConfig = mock(SecretConfig.class);
-            EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig(goCipher, "plain_key", "{{SECRET:[secret_config_id][token]}}", false);
-            validationContext.getCruiseConfig().getSecretConfigs().add(secretConfig);
-            PipelineTemplateConfig pipelineTemplateConfig = mock(PipelineTemplateConfig.class);
-
-            when(validationContext.isWithinTemplates()).thenReturn(true);
-            when(validationContext.getTemplate()).thenReturn(pipelineTemplateConfig);
-            when(secretConfig.getId()).thenReturn("secret_config_id");
-            when(pipelineTemplateConfig.name()).thenReturn(new CaseInsensitiveString("example-env"));
-
-            environmentVariableConfig.validateTree(validationContext);
-
-            verify(secretConfig, never()).canRefer(pipelineTemplateConfig.getClass(), "example-env");
         }
     }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/perforce/P4MaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/perforce/P4MaterialConfigTest.java
@@ -21,8 +21,6 @@ import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.IgnoredFiles;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
-import com.thoughtworks.go.config.rules.Allow;
-import com.thoughtworks.go.config.rules.Rules;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.ReflectionUtil;
@@ -33,8 +31,6 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.thoughtworks.go.config.rules.SupportedEntity.PIPELINE_GROUP;
-import static com.thoughtworks.go.helper.PipelineConfigMother.createGroup;
 import static com.thoughtworks.go.helper.MaterialConfigsMother.p4;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -172,48 +168,6 @@ class P4MaterialConfigTest {
             p4MaterialConfig.setPassword("badger");
 
             assertThat(p4MaterialConfig.validateTree(null)).isTrue();
-            assertThat(p4MaterialConfig.errors().getAll()).isEmpty();
-        }
-
-        @Test
-        void shouldFailIfSecretConfigForPasswordSpecifiedAsSecretParamDoesNotExist() {
-            final ValidationContext validationContext = mockValidationContextForSecretParams();
-            p4MaterialConfig.setPassword("{{SECRET:[secret_config_id][password]}}");
-
-            assertThat(p4MaterialConfig.validateTree(validationContext)).isFalse();
-            assertThat(p4MaterialConfig.errors().on("encryptedPassword")).isEqualTo("Secret config with ids `secret_config_id` does not exist.");
-        }
-
-
-        @Test
-        void shouldFailIfSecretConfigCannotBeUsedInPipelineGroupWhereCurrentMaterialIsDefined() {
-            p4MaterialConfig.setUserName("bob");
-            p4MaterialConfig.setPassword("{{SECRET:[secret_config_id][pass]}}");
-            final Rules directives = new Rules(new Allow("refer", PIPELINE_GROUP.getType(), "group_2"));
-            final SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.secret.file", directives);
-            final ValidationContext validationContext = mockValidationContextForSecretParams(secretConfig);
-            when(validationContext.getPipelineGroup()).thenReturn(createGroup("group_1", "up42"));
-
-            assertThat(p4MaterialConfig.validateTree(validationContext)).isFalse();
-
-            assertThat(p4MaterialConfig.errors().get("encryptedPassword"))
-                    .contains("Secret config with ids `secret_config_id` is not allowed to use in `pipelines` with name `group_1`.");
-        }
-
-        @Test
-        void shouldPassIfSecretConfigCanBeReferredInPipelineGroupWhereCurrentMaterialIsDefined() {
-            p4MaterialConfig.setUserName("bob");
-            p4MaterialConfig.setPassword("{{SECRET:[secret_config_id][pass]}}");
-            final Rules directives = new Rules(
-                    new Allow("refer", PIPELINE_GROUP.getType(), "group_2"),
-                    new Allow("refer", PIPELINE_GROUP.getType(), "group_1")
-            );
-            final SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.secret.file", directives);
-            final ValidationContext validationContext = mockValidationContextForSecretParams(secretConfig);
-            when(validationContext.getPipelineGroup()).thenReturn(createGroup("group_1", "up42"));
-
-            assertThat(p4MaterialConfig.validateTree(validationContext)).isTrue();
-
             assertThat(p4MaterialConfig.errors().getAll()).isEmpty();
         }
     }

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -33,8 +33,8 @@
     },
     {
       "key": "show_secret_config_spa",
-      "description": "Show Secret Config SPA in menu for admin. Default: true",
-      "value": true
+      "description": "Show Secret Config SPA in menu for admin. Default: false",
+      "value": false
     },
     {
       "key": "plugin_settings_api_using_rails",

--- a/tw-go-plugins/build.gradle
+++ b/tw-go-plugins/build.gradle
@@ -58,13 +58,6 @@ def dependencies = [
     tagName: '0.3.9',
     asset: 'json-config-plugin-0.3.9.jar',
     checksum: 'c83541a9761b00634e3b77d1d4d7b6f77c2ad877378f1e42348002f048c5c793'
-  ),
-  new GithubArtifact(
-    user: 'gocd',
-    repo: 'gocd-file-based-secrets-plugin',
-    tagName: 'v0.0.1-21',
-    asset: 'gocd-file-based-secrets-plugin-0.0.1-21.jar',
-    checksum: '9448d4cc2f5925c85a550c4d8f82cb52c756623271c1818739e4122520189674'
   )
 ]
 


### PR DESCRIPTION
- Removed secret config validation from Material and Environment variables
- Turned off the secret config SPA
- Removed file based secret plugin from the bundled plugin list

### Summary

Validation for the secret params defined as environment variables and in material password will be done at runtime. Refer https://github.com/gocd/gocd/issues/6369#issuecomment-498348913 for more information.