### PR TITLE
Apply rules at runtime

### DIFF
--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2Test.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2Test.groovy
@@ -302,7 +302,7 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
               "secure"         : true,
               "name"           : "JAVA_HOME",
               "value"          : "/bin/java",
-              "encrypted_value": "some_encrypted_text"
+              "encrypted_value": new GoCipher().encrypt("some_encrypted_text")
             ]
           ]
         ]
@@ -513,7 +513,7 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
                          "secure"         : true,
                          "name"           : "JAVA_HOME",
                          "value"          : "/bin/java",
-                         "encrypted_value": "some_encrypted_text"
+                         "encrypted_value": new GoCipher().encrypt("some_encrypted_text")
                        ]],
             "remove": [
               "URL"
@@ -612,7 +612,7 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
               "secure"         : true,
               "name"           : "JAVA_HOME",
               "value"          : "/bin/java",
-              "encrypted_value": "some_encrypted_text"
+              "encrypted_value": new GoCipher().encrypt("some_encrypted_text")
             ]
           ]
         ]

--- a/api/api-pipeline-config-v7/src/test/groovy/com/thoughtworks/go/apiv7/shared/representers/EnvironmentVariableRepresenterTest.groovy
+++ b/api/api-pipeline-config-v7/src/test/groovy/com/thoughtworks/go/apiv7/shared/representers/EnvironmentVariableRepresenterTest.groovy
@@ -64,7 +64,7 @@ class EnvironmentVariableRepresenterTest {
       name: 'PASSWORD',
       secure: true,
       value: 'plainText',
-      encrypted_value: 'c!ph3rt3xt'
+      encrypted_value: new GoCipher().encrypt('c!ph3rt3xt')
     ])
     def actualEnvironmentVariableConfig = EnvironmentVariableRepresenter.fromJSON(jsonReader)
 

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/PipelineScheduleOptionsRepresenterTest.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/PipelineScheduleOptionsRepresenterTest.groovy
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.apiv1.pipelineoperations.representers
 
 import com.thoughtworks.go.api.util.GsonTransformer
+import com.thoughtworks.go.security.GoCipher
 import org.junit.jupiter.api.Test
 
 import static org.assertj.core.api.Assertions.assertThat
@@ -23,12 +24,15 @@ import static org.assertj.core.api.Assertions.assertThat
 class PipelineScheduleOptionsRepresenterTest {
   @Test
   void 'should deserialize'() {
+    def encryptedValue = new GoCipher().encrypt("encrypted_secval2")
     def scheduleOptionsJson = [
       update_materials_before_scheduling: true,
       materials                         : [[fingerprint: "fingerprint1", revision: "revision1"], [fingerprint: "fingerprint2", revision: "revision2"]],
-      environment_variables             : [[name: "VAR1", value: "val1"], [name: "VAR2", value: "val2"], [name: "SEC_VAR1", value: "secval1", secure: true], [name: "SEC_VAR2", encrypted_value: "encrypted_secval2", secure: true]]
+      environment_variables             : [[name: "VAR1", value: "val1"],
+                                           [name: "VAR2", value: "val2"],
+                                           [name: "SEC_VAR1", value: "secval1", secure: true],
+                                           [name: "SEC_VAR2", encrypted_value: encryptedValue, secure: true]]
     ]
-
 
     def jsonReader = GsonTransformer.instance.jsonReaderFrom(scheduleOptionsJson)
     def pipelineScheduleOptions = PipelineScheduleOptionsRepresenter.fromJSON(jsonReader)
@@ -41,7 +45,7 @@ class PipelineScheduleOptionsRepresenterTest {
 
     assertThat(pipelineScheduleOptions.getSecureEnvironmentVariables()).hasSize(2)
     assertThat(pipelineScheduleOptions.getSecureEnvironmentVariables().getVariable("SEC_VAR1").getValue()).isEqualTo("secval1")
-    assertThat(pipelineScheduleOptions.getSecureEnvironmentVariables().getVariable("SEC_VAR2").getEncryptedValue()).isEqualTo("encrypted_secval2")
+    assertThat(pipelineScheduleOptions.getSecureEnvironmentVariables().getVariable("SEC_VAR2").getEncryptedValue()).isEqualTo(encryptedValue)
 
     assertThat(pipelineScheduleOptions.getMaterials()).hasSize(2)
     assertThat(pipelineScheduleOptions.getMaterials().find { material -> material.getFingerprint().equals("fingerprint1") }.getRevision()).isEqualTo("revision1")
@@ -50,14 +54,16 @@ class PipelineScheduleOptionsRepresenterTest {
 
   @Test
   void 'should handle invalid encrypted value in json during deserialization'() {
+    def encryptedValue = new GoCipher().encrypt("encrypted_secval")
     def scheduleOptionsJson = [
-      environment_variables: [[name: "SEC_VAR", encrypted_value: "encrypted_secval", secure: true]]
+      environment_variables: [[name: "SEC_VAR", encrypted_value: encryptedValue, secure: true]]
     ]
 
     def jsonReader = GsonTransformer.instance.jsonReaderFrom(scheduleOptionsJson)
     def pipelineScheduleOptions = PipelineScheduleOptionsRepresenter.fromJSON(jsonReader)
 
     assertThat(pipelineScheduleOptions.getSecureEnvironmentVariables().size(), is(1))
-    assertThat(pipelineScheduleOptions.getSecureEnvironmentVariables().find { var -> var.getName().equals("SEC_VAR") }.getEncryptedValue()).isEqualTo("encrypted_secval")
+    assertThat(pipelineScheduleOptions.getSecureEnvironmentVariables().find { var -> var.getName().equals("SEC_VAR") }.getEncryptedValue())
+      .isEqualTo(encryptedValue)
   }
 }

--- a/api/api-shared-v2/src/test/groovy/com/thoughtworks/go/apiv2/shared/representers/EnvironmentVariableRepresenterTest.groovy
+++ b/api/api-shared-v2/src/test/groovy/com/thoughtworks/go/apiv2/shared/representers/EnvironmentVariableRepresenterTest.groovy
@@ -86,14 +86,14 @@ class EnvironmentVariableRepresenterTest {
     assertThatJson(json).isEqualTo([
       "environment_variables": [
         [
-          "name": "JAVA_HOME",
+          "name"  : "JAVA_HOME",
           "secure": false,
-          "value": "/bin/java"
+          "value" : "/bin/java"
         ],
         [
-          "name": "GROOVY_HOME",
+          "name"  : "GROOVY_HOME",
           "secure": false,
-          "value": "/bin/groovy"
+          "value" : "/bin/groovy"
         ]
       ]
     ])
@@ -139,7 +139,7 @@ class EnvironmentVariableRepresenterTest {
       name           : 'PASSWORD',
       secure         : true,
       value          : 'plainText',
-      encrypted_value: 'c!ph3rt3xt'
+      encrypted_value: new GoCipher().encrypt('c!ph3rt3xt')
     ])
     def actualEnvironmentVariableConfig = EnvironmentVariableRepresenter.fromJSON(jsonReader)
 

--- a/api/api-shared-v4/src/test/groovy/com/thoughtworks/go/apiv4/shared/representers/EnvironmentVariableRepresenterTest.groovy
+++ b/api/api-shared-v4/src/test/groovy/com/thoughtworks/go/apiv4/shared/representers/EnvironmentVariableRepresenterTest.groovy
@@ -21,9 +21,9 @@ import com.thoughtworks.go.config.EnvironmentVariableConfig
 import com.thoughtworks.go.security.GoCipher
 import org.junit.jupiter.api.Test
 
-import static org.junit.jupiter.api.Assertions.assertEquals
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertTrue
 
 class EnvironmentVariableRepresenterTest {
@@ -63,7 +63,7 @@ class EnvironmentVariableRepresenterTest {
       name: 'PASSWORD',
       secure: true,
       value: 'plainText',
-      encrypted_value: 'c!ph3rt3xt'
+      encrypted_value: new GoCipher().encrypt('c!ph3rt3xt')
     ])
     def actualEnvironmentVariableConfig = EnvironmentVariableRepresenter.fromJSON(jsonReader)
 

--- a/api/api-shared-v6/src/test/groovy/com/thoughtworks/go/apiv6/shared/representers/EnvironmentVariableRepresenterTest.groovy
+++ b/api/api-shared-v6/src/test/groovy/com/thoughtworks/go/apiv6/shared/representers/EnvironmentVariableRepresenterTest.groovy
@@ -62,7 +62,7 @@ class EnvironmentVariableRepresenterTest {
       name: 'PASSWORD',
       secure: true,
       value: 'plainText',
-      encrypted_value: 'c!ph3rt3xt'
+      encrypted_value: new GoCipher().encrypt('c!ph3rt3xt')
     ])
     def actualEnvironmentVariableConfig = EnvironmentVariableRepresenter.fromJSON(jsonReader)
 

--- a/common/src/test/java/com/thoughtworks/go/domain/DefaultJobPlanTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/DefaultJobPlanTest.java
@@ -16,10 +16,9 @@
 package com.thoughtworks.go.domain;
 
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,26 +26,18 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import static com.thoughtworks.go.utils.SerializationTester.serializeAndDeserialize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class DefaultJobPlanTest {
-
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-    private File workingFolder;
-
-    @Before
-    public void setUp() throws IOException {
-        workingFolder = temporaryFolder.newFolder("workingFolder");
-        File file = new File(workingFolder, "cruise-output/log.xml");
+class DefaultJobPlanTest {
+    @BeforeEach
+    void setUp(@TempDir File testDir) throws IOException {
+        File file = new File(testDir, "cruise-output/log.xml");
         file.getParentFile().mkdirs();
         file.createNewFile();
     }
 
     @Test
-    public void shouldApplyEnvironmentVariablesWhenRunningTheJob() {
+    void shouldApplyEnvironmentVariablesWhenRunningTheJob() {
         EnvironmentVariables variables = new EnvironmentVariables();
         variables.add("VARIABLE_NAME", "variable value");
         DefaultJobPlan plan = new DefaultJobPlan(new Resources(), new ArrayList<>(), new ArrayList<>(), -1, null, null,
@@ -54,11 +45,11 @@ public class DefaultJobPlanTest {
 
         EnvironmentVariableContext variableContext = new EnvironmentVariableContext();
         plan.applyTo(variableContext);
-        assertThat(variableContext.getProperty("VARIABLE_NAME"), is("variable value"));
+        assertThat(variableContext.getProperty("VARIABLE_NAME")).isEqualTo("variable value");
     }
 
     @Test
-    public void shouldRespectTriggerVariablesOverConfigVariables() {
+    void shouldRespectTriggerVariablesOverConfigVariables() {
         final EnvironmentVariables environmentVariables = new EnvironmentVariables(Arrays.asList(
                 new EnvironmentVariable("blah", "value"), new EnvironmentVariable("foo", "bar")));
         final EnvironmentVariables triggerEnvironmentVariables = new EnvironmentVariables(Arrays.asList(
@@ -68,17 +59,17 @@ public class DefaultJobPlanTest {
                 new ArrayList<>(), 0, new JobIdentifier(), "uuid", environmentVariables, triggerEnvironmentVariables, null, null);
         EnvironmentVariableContext variableContext = new EnvironmentVariableContext();
         original.applyTo(variableContext);
-        assertThat(variableContext.getProperty("blah"), is("override"));
-        assertThat(variableContext.getProperty("foo"), is("bar"));
+        assertThat(variableContext.getProperty("blah")).isEqualTo("override");
+        assertThat(variableContext.getProperty("foo")).isEqualTo("bar");
         //becuase its a security issue to let operator set values for unconfigured variables
-        assertThat(variableContext.getProperty("another"), is(nullValue()));
+        assertThat(variableContext.getProperty("another")).isNull();
     }
 
     @Test
-    public void shouldBeAbleToSerializeAndDeserialize() throws ClassNotFoundException, IOException {
+    void shouldBeAbleToSerializeAndDeserialize() throws ClassNotFoundException, IOException {
         DefaultJobPlan original = new DefaultJobPlan(new Resources(), new ArrayList<>(),
                 new ArrayList<>(), 0, new JobIdentifier(), "uuid", new EnvironmentVariables(), new EnvironmentVariables(), null, null);
         DefaultJobPlan clone = (DefaultJobPlan) serializeAndDeserialize(original);
-        assertThat(clone, is(original));
+        assertThat(clone).isEqualTo(original);
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BasicEnvironmentConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BasicEnvironmentConfig.java
@@ -416,5 +416,4 @@ public class BasicEnvironmentConfig implements EnvironmentConfig {
 
         return true;
     }
-
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentConfig.java
@@ -28,7 +28,7 @@ import java.util.Set;
 /**
  * @understands the current persistent information related to a logical grouping of machines
  */
-public interface EnvironmentConfig extends ParamsAttributeAware, Validatable, EnvironmentVariableScope, ConfigOriginTraceable {
+public interface EnvironmentConfig extends ParamsAttributeAware, Validatable, EnvironmentVariableScope, ConfigOriginTraceable, SecretParamAware {
 
     static final String NAME_FIELD = "name";
     static final String PIPELINES_FIELD = "pipelines";
@@ -113,5 +113,16 @@ public interface EnvironmentConfig extends ParamsAttributeAware, Validatable, En
 
     default List<ConfigErrors> getAllErrors() {
         return ErrorCollector.getAllErrors(this);
+    }
+
+
+    @Override
+    default boolean hasSecretParams() {
+        return getVariables().hasSecretParams();
+    }
+
+    @Override
+    default SecretParams getSecretParams() {
+        return getVariables().getSecretParams();
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentVariablesConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentVariablesConfig.java
@@ -30,7 +30,7 @@ import java.util.Map;
  */
 @ConfigTag("environmentvariables")
 @ConfigCollection(EnvironmentVariableConfig.class)
-public class EnvironmentVariablesConfig extends BaseCollection<EnvironmentVariableConfig> implements Serializable, ParamsAttributeAware, Validatable {
+public class EnvironmentVariablesConfig extends BaseCollection<EnvironmentVariableConfig> implements Serializable, ParamsAttributeAware, Validatable, SecretParamAware {
     private final ConfigErrors configErrors = new ConfigErrors();
 
     public EnvironmentVariablesConfig() {
@@ -157,4 +157,14 @@ public class EnvironmentVariablesConfig extends BaseCollection<EnvironmentVariab
 
     }
 
+    @Override
+    public boolean hasSecretParams() {
+        return this.stream().anyMatch(EnvironmentVariableConfig::hasSecretParams);
+    }
+
+    @Override
+    public SecretParams getSecretParams() {
+        return this.stream().map(EnvironmentVariableConfig::getSecretParams)
+                .collect(SecretParams.toFlatSecretParams());
+    }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/BasicEnvironmentConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/BasicEnvironmentConfigTest.java
@@ -168,5 +168,4 @@ class BasicEnvironmentConfigTest extends EnvironmentConfigTestBase {
 
         assertThat(reference.errors().isEmpty()).isTrue();
     }
-
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/EnvironmentConfigTestBase.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/EnvironmentConfigTestBase.java
@@ -184,6 +184,55 @@ public abstract class EnvironmentConfigTestBase {
         }
     }
 
+
+    @Nested
+    class HasSecretParams {
+        @Test
+        void shouldReturnTrueIfEnvironmentConfigHasEnvironmentVariablesDefinedUsingSecretParams() {
+            environmentConfig.addEnvironmentVariable("var1", "var_value1");
+            environmentConfig.addEnvironmentVariable("var2", "{{SECRET:[secret_config_id][token]}}");
+
+            boolean result = environmentConfig.hasSecretParams();
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalseIfEnvironmentConfigHasNoneOfTheEnvironmentVariablesDefinedUsingSecretParams() {
+            environmentConfig.addEnvironmentVariable("var1", "var_value1");
+            environmentConfig.addEnvironmentVariable("var2", "var_value2");
+
+            boolean result = environmentConfig.hasSecretParams();
+
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    class getSecretParams {
+        @Test
+        void shouldReturnEmptyIfEnvironmentConfigHasNoneOfTheEnvironmentVariablesDefinedUsingSecretParams() {
+            environmentConfig.addEnvironmentVariable("var1", "var_value1");
+            environmentConfig.addEnvironmentVariable("var2", "var_value2");
+
+            SecretParams secretParams = environmentConfig.getSecretParams();
+
+            assertThat(secretParams).isEmpty();
+        }
+
+        @Test
+        void shouldReturnSecretParamsIfEnvironmentConfigHasOneOfTheEnvironmentVariablesDefinedUsingSecretParams() {
+            environmentConfig.addEnvironmentVariable("var1", "var_value1");
+            environmentConfig.addEnvironmentVariable("var2", "{{SECRET:[secret_config_id][token]}}");
+
+            SecretParams secretParams = environmentConfig.getSecretParams();
+
+            assertThat(secretParams)
+                    .hasSize(1)
+                    .contains(new SecretParam("secret_config_id", "token"));
+        }
+    }
+
     protected static Map<String, String> envVar(String name, String value) {
         Map<String, String> map = new HashMap<>();
         map.put(EnvironmentVariableConfig.NAME, name);

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/domain/EnvironmentVariablesConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/domain/EnvironmentVariablesConfigTest.java
@@ -19,33 +19,30 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.security.CryptoException;
 import com.thoughtworks.go.security.GoCipher;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static com.thoughtworks.go.util.TestUtils.contains;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class EnvironmentVariablesConfigTest {
+class EnvironmentVariablesConfigTest {
 
     private EnvironmentVariablesConfig environmentVariablesConfig;
     private ValidationContext context = mock(ValidationContext.class);
     private GoCipher goCipher = mock(GoCipher.class);
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         when(context.getParent()).thenReturn(PipelineConfigMother.createPipelineConfig("some-pipeline", "stage-name", "job-name"));
         when(context.getParentDisplayName()).thenReturn("pipeline");
     }
 
     @Test
-    public void shouldPopulateErrorWhenDuplicateEnvironmentVariableNameIsPresent() {
+    void shouldPopulateErrorWhenDuplicateEnvironmentVariableNameIsPresent() {
         environmentVariablesConfig = new EnvironmentVariablesConfig();
         EnvironmentVariableConfig one = new EnvironmentVariableConfig("FOO", "BAR");
         EnvironmentVariableConfig two = new EnvironmentVariableConfig("FOO", "bAZ");
@@ -54,14 +51,14 @@ public class EnvironmentVariablesConfigTest {
 
         environmentVariablesConfig.validate(context);
 
-        assertThat(one.errors().isEmpty(), is(false));
-        assertThat(one.errors().firstError(), contains("Environment Variable name 'FOO' is not unique for pipeline 'some-pipeline'"));
-        assertThat(two.errors().isEmpty(), is(false));
-        assertThat(two.errors().firstError(), contains("Environment Variable name 'FOO' is not unique for pipeline 'some-pipeline'"));
+        assertThat(one.errors().isEmpty()).isFalse();
+        assertThat(one.errors().firstError()).contains("Environment Variable name 'FOO' is not unique for pipeline 'some-pipeline'");
+        assertThat(two.errors().isEmpty()).isFalse();
+        assertThat(two.errors().firstError()).contains("Environment Variable name 'FOO' is not unique for pipeline 'some-pipeline'");
     }
 
     @Test
-    public void shouldValidateTree() {
+    void shouldValidateTree() {
         environmentVariablesConfig = new EnvironmentVariablesConfig();
         EnvironmentVariableConfig one = new EnvironmentVariableConfig("FOO", "BAR");
         EnvironmentVariableConfig two = new EnvironmentVariableConfig("FOO", "bAZ");
@@ -72,97 +69,96 @@ public class EnvironmentVariablesConfigTest {
 
         environmentVariablesConfig.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", new PipelineConfig(new CaseInsensitiveString("p1"), null)));
 
-        assertThat(one.errors().isEmpty(), is(false));
-        assertThat(one.errors().firstError(), contains("Environment Variable name 'FOO' is not unique for pipeline 'p1'"));
-        assertThat(two.errors().isEmpty(), is(false));
-        assertThat(two.errors().firstError(), contains("Environment Variable name 'FOO' is not unique for pipeline 'p1'"));
-        assertThat(three.errors().isEmpty(), is(false));
-        assertThat(three.errors().firstError(), contains("Environment Variable cannot have an empty name for pipeline 'p1'."));
+        assertThat(one.errors().isEmpty()).isFalse();
+        assertThat(one.errors().firstError()).contains("Environment Variable name 'FOO' is not unique for pipeline 'p1'");
+        assertThat(two.errors().isEmpty()).isFalse();
+        assertThat(two.errors().firstError()).contains("Environment Variable name 'FOO' is not unique for pipeline 'p1'");
+        assertThat(three.errors().isEmpty()).isFalse();
+        assertThat(three.errors().firstError()).contains("Environment Variable cannot have an empty name for pipeline 'p1'.");
     }
 
-
     @Test
-    public void shouldPopulateErrorWhenVariableNameIsEmpty() {
+    void shouldPopulateErrorWhenVariableNameIsEmpty() {
         environmentVariablesConfig = new EnvironmentVariablesConfig();
         EnvironmentVariableConfig one = new EnvironmentVariableConfig("", "BAR");
         environmentVariablesConfig.add(one);
 
         environmentVariablesConfig.validate(context);
 
-        assertThat(one.errors().isEmpty(), is(false));
-        assertThat(one.errors().on(EnvironmentVariableConfig.NAME), contains("Environment Variable cannot have an empty name for pipeline 'some-pipeline'."));
+        assertThat(one.errors().isEmpty()).isFalse();
+        assertThat(one.errors().on(EnvironmentVariableConfig.NAME)).contains("Environment Variable cannot have an empty name for pipeline 'some-pipeline'.");
     }
 
     @Test
-    public void shouldPopulateErrorWhenVariableNameStartsWithSpace() {
+    void shouldPopulateErrorWhenVariableNameStartsWithSpace() {
         environmentVariablesConfig = new EnvironmentVariablesConfig();
         EnvironmentVariableConfig one = new EnvironmentVariableConfig(" foo", "BAR");
         environmentVariablesConfig.add(one);
 
         environmentVariablesConfig.validate(context);
 
-        assertThat(one.errors().isEmpty(), is(false));
-        assertThat(one.errors().on(EnvironmentVariableConfig.NAME), contains("Environment Variable cannot start or end with spaces for pipeline 'some-pipeline'."));
+        assertThat(one.errors().isEmpty()).isFalse();
+        assertThat(one.errors().on(EnvironmentVariableConfig.NAME)).contains("Environment Variable cannot start or end with spaces for pipeline 'some-pipeline'.");
     }
 
     @Test
-    public void shouldPopulateErrorWhenVariableNameEndsWithSpace() {
+    void shouldPopulateErrorWhenVariableNameEndsWithSpace() {
         environmentVariablesConfig = new EnvironmentVariablesConfig();
         EnvironmentVariableConfig one = new EnvironmentVariableConfig("FOO ", "BAR");
         environmentVariablesConfig.add(one);
 
         environmentVariablesConfig.validate(context);
 
-        assertThat(one.errors().isEmpty(), is(false));
-        assertThat(one.errors().on(EnvironmentVariableConfig.NAME), contains("Environment Variable cannot start or end with spaces for pipeline 'some-pipeline'."));
+        assertThat(one.errors().isEmpty()).isFalse();
+        assertThat(one.errors().on(EnvironmentVariableConfig.NAME)).contains("Environment Variable cannot start or end with spaces for pipeline 'some-pipeline'.");
     }
 
     @Test
-    public void shouldPopulateErrorWhenVariableNameContainsLeadingAndTrailingSpaces() {
+    void shouldPopulateErrorWhenVariableNameContainsLeadingAndTrailingSpaces() {
         environmentVariablesConfig = new EnvironmentVariablesConfig();
         EnvironmentVariableConfig one = new EnvironmentVariableConfig("     FOO   ", "BAR");
         environmentVariablesConfig.add(one);
 
         environmentVariablesConfig.validate(context);
 
-        assertThat(one.errors().isEmpty(), is(false));
-        assertThat(one.errors().on(EnvironmentVariableConfig.NAME), contains("Environment Variable cannot start or end with spaces for pipeline 'some-pipeline'."));
+        assertThat(one.errors().isEmpty()).isFalse();
+        assertThat(one.errors().on(EnvironmentVariableConfig.NAME)).contains("Environment Variable cannot start or end with spaces for pipeline 'some-pipeline'.");
     }
 
     @Test
-    public void shouldClearEnvironmentVariablesWhenTheMapIsNull() {
+    void shouldClearEnvironmentVariablesWhenTheMapIsNull() {
         environmentVariablesConfig = new EnvironmentVariablesConfig();
         EnvironmentVariableConfig one = new EnvironmentVariableConfig("FOO", "BAR");
         environmentVariablesConfig.add(one);
 
         environmentVariablesConfig.setConfigAttributes(null);
 
-        assertThat(environmentVariablesConfig.size(), is(0));
+        assertThat(environmentVariablesConfig.size()).isEqualTo(0);
     }
 
     @Test
-    public void shouldSetConfigAttributesSecurely(){
+    void shouldSetConfigAttributesSecurely() {
         environmentVariablesConfig = new EnvironmentVariablesConfig();
-        ArrayList<Map<String,String>> attribs = new ArrayList<>();
-        Map<String,String> var1 = new HashMap<>();
+        ArrayList<Map<String, String>> attribs = new ArrayList<>();
+        Map<String, String> var1 = new HashMap<>();
         var1.put(EnvironmentVariableConfig.NAME, "name-var1");
         var1.put(EnvironmentVariableConfig.VALUE, "val-var1");
         attribs.add(var1);
-        Map<String,String> var2 = new HashMap<>();
+        Map<String, String> var2 = new HashMap<>();
         var2.put(EnvironmentVariableConfig.NAME, "name-var2");
         var2.put(EnvironmentVariableConfig.VALUE, "val-var2");
         var2.put(EnvironmentVariableConfig.SECURE, "true");
         var2.put(EnvironmentVariableConfig.ISCHANGED, "true");
         attribs.add(var2);
-        assertThat(environmentVariablesConfig.size(), is(0));
+        assertThat(environmentVariablesConfig.size()).isEqualTo(0);
         environmentVariablesConfig.setConfigAttributes(attribs);
-        assertThat(environmentVariablesConfig.size(), is(2));
-        assertThat(environmentVariablesConfig, hasItem(new EnvironmentVariableConfig(null, "name-var1", "val-var1", false)));
-        assertThat(environmentVariablesConfig, hasItem(new EnvironmentVariableConfig(new GoCipher(), "name-var2", "val-var2", true)));
+        assertThat(environmentVariablesConfig.size()).isEqualTo(2);
+        assertThat(environmentVariablesConfig).contains(new EnvironmentVariableConfig(null, "name-var1", "val-var1", false));
+        assertThat(environmentVariablesConfig).contains(new EnvironmentVariableConfig(new GoCipher(), "name-var2", "val-var2", true));
     }
 
     @Test
-    public void shouldGetSecureVariables() throws CryptoException {
+    void shouldGetSecureVariables() throws CryptoException {
         EnvironmentVariablesConfig environmentVariablesConfig = new EnvironmentVariablesConfig();
         GoCipher mockGoCipher = mock(GoCipher.class);
         EnvironmentVariableConfig plainVar1 = new EnvironmentVariableConfig("var1", "var1_value");
@@ -173,12 +169,12 @@ public class EnvironmentVariablesConfigTest {
 
         List<EnvironmentVariableConfig> variables = environmentVariablesConfig.getSecureVariables();
 
-        assertThat(variables.size(), is(3));
-        assertThat(variables, hasItems(var1, var2, var3));
+        assertThat(variables.size()).isEqualTo(3);
+        assertThat(variables).contains(var1, var2, var3);
     }
 
     @Test
-    public void shouldGetOnlyPlainTextVariables() throws CryptoException {
+    void shouldGetOnlyPlainTextVariables() throws CryptoException {
         EnvironmentVariablesConfig environmentVariablesConfig = new EnvironmentVariablesConfig();
         EnvironmentVariableConfig plainVar1 = new EnvironmentVariableConfig("var1", "var1_value");
         EnvironmentVariableConfig plainVar2 = new EnvironmentVariableConfig("var2", "var2_value");
@@ -188,10 +184,62 @@ public class EnvironmentVariablesConfigTest {
 
         List<EnvironmentVariableConfig> variables = environmentVariablesConfig.getPlainTextVariables();
 
-        assertThat(variables.size(), is(2));
-        assertThat(variables, hasItems(plainVar1, plainVar2));
+        assertThat(variables.size()).isEqualTo(2);
+        assertThat(variables).contains(plainVar1, plainVar2);
     }
 
+    @Nested
+    class HasSecretParams {
+
+        @Test
+        void shouldBeFalseWhenNoneOfTheEnvironmentVariablesIsDefinedAsSecretParam() {
+            EnvironmentVariablesConfig environmentVariablesConfig = new EnvironmentVariablesConfig();
+            environmentVariablesConfig.add(new EnvironmentVariableConfig("var1", "var_value1"));
+            environmentVariablesConfig.add(new EnvironmentVariableConfig("var2", "var_value2"));
+
+            boolean result = environmentVariablesConfig.hasSecretParams();
+
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        void shouldBeTrueWhenOneOfTheEnvironmentVariableIsDefinedAsSecretParam() {
+            EnvironmentVariablesConfig environmentVariablesConfig = new EnvironmentVariablesConfig();
+            environmentVariablesConfig.add(new EnvironmentVariableConfig("var1", "var_value1"));
+            environmentVariablesConfig.add(new EnvironmentVariableConfig("Token", "{{SECRET:[secret_config_id][token]}}"));
+
+            boolean result = environmentVariablesConfig.hasSecretParams();
+
+            assertThat(result).isTrue();
+        }
+    }
+
+    @Nested
+    class getSecretParams {
+        @Test
+        void shouldReturnEmptyIfNoneOfTheEnvironmentVariablesIsDefinedAsSecretParam() {
+            EnvironmentVariablesConfig environmentVariablesConfig = new EnvironmentVariablesConfig();
+            environmentVariablesConfig.add(new EnvironmentVariableConfig("var1", "var_value1"));
+            environmentVariablesConfig.add(new EnvironmentVariableConfig("var2", "var_value2"));
+
+            SecretParams secretParams = environmentVariablesConfig.getSecretParams();
+
+            assertThat(secretParams).isEmpty();
+        }
+
+        @Test
+        void shouldReturnSecretParamsIfTheEnvironmentVariablesIsDefinedAsSecretParam() {
+            EnvironmentVariablesConfig environmentVariablesConfig = new EnvironmentVariablesConfig();
+            environmentVariablesConfig.add(new EnvironmentVariableConfig("var1", "var_value1"));
+            environmentVariablesConfig.add(new EnvironmentVariableConfig("var2", "{{SECRET:[secret_config_id][token]}}"));
+
+            SecretParams secretParams = environmentVariablesConfig.getSecretParams();
+
+            assertThat(secretParams)
+                    .hasSize(1)
+                    .contains(new SecretParam("secret_config_id", "token"));
+        }
+    }
 
     private EnvironmentVariableConfig secureVariable(final GoCipher goCipher, String key, String plainText, String cipherText) throws CryptoException {
         when(goCipher.encrypt(plainText)).thenReturn(cipherText);

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/ScmMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/ScmMaterial.java
@@ -57,7 +57,7 @@ public abstract class ScmMaterial extends AbstractMaterial implements SecretPara
     protected String userName;
     protected String password;
     protected String encryptedPassword;
-    private SecretParams secretParamsForPassword;
+    protected SecretParams secretParamsForPassword;
 
     public ScmMaterial(String typeName, GoCipher goCipher) {
         super(typeName);

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -435,7 +435,7 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
         GitMaterialConfig config = (GitMaterialConfig) config();
         config.setShallowClone(value);
         GitMaterial gitMaterial = new GitMaterial(config);
-        gitMaterial.url = this.url;
+        gitMaterial.secretParamsForPassword = this.secretParamsForPassword;
 
         return gitMaterial;
     }

--- a/domain/src/main/java/com/thoughtworks/go/domain/EnvironmentVariable.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/EnvironmentVariable.java
@@ -93,7 +93,9 @@ public class EnvironmentVariable extends PersistentObject {
     }
 
     public String getDisplayValue() {
-        if (isSecure()) return "****";
+        if (isSecure()) {
+            return "****";
+        }
         return getValue();
     }
 

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
@@ -725,6 +725,24 @@ public class GitMaterialTest {
         }
     }
 
+    @Nested
+    class WithShallowClone {
+        @Test
+        void shouldCopyOverSecretResolvedParams() {
+            GitMaterial gitMaterial = new GitMaterial("http://exampele.com");
+            gitMaterial.setPassword("{{SECRET:[secret_config_id][git_password]}}");
+            gitMaterial.getSecretParams().findFirst("git_password").ifPresent(param -> param.setValue("resolved-password"));
+
+            assertThat(gitMaterial.passwordForCommandLine()).isEqualTo("resolved-password");
+            assertThat(gitMaterial.isShallowClone()).isFalse();
+
+            GitMaterial copyWithShallowClone = gitMaterial.withShallowClone(true);
+
+            assertThat(copyWithShallowClone.passwordForCommandLine()).isEqualTo("resolved-password");
+            assertThat(copyWithShallowClone.isShallowClone()).isTrue();
+        }
+    }
+
     private void assertWorkingCopyNotCheckedOut(File localWorkingDir) {
         assertThat(localWorkingDir.listFiles()).isEqualTo(new File[]{new File(localWorkingDir, ".git")});
     }

--- a/domain/src/test/java/com/thoughtworks/go/domain/EnvironmentVariableTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/EnvironmentVariableTest.java
@@ -18,25 +18,25 @@ package com.thoughtworks.go.domain;
 import com.thoughtworks.go.config.EnvironmentVariableConfig;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 
-public class EnvironmentVariableTest {
+class EnvironmentVariableTest {
     @Test
-    public void shouldCreateEnvironmentVariableFromEnvironmentVariableConfig() {
+    void shouldCreateEnvironmentVariableFromEnvironmentVariableConfig() {
         final EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig("foo", "bar");
-        assertThat(new EnvironmentVariable(environmentVariableConfig), is(new EnvironmentVariable("foo", "bar")));
+        assertThat(new EnvironmentVariable(environmentVariableConfig)).isEqualTo(new EnvironmentVariable("foo", "bar"));
 
         final EnvironmentVariableConfig secureEnvironmentVariableConfig = new EnvironmentVariableConfig(new GoCipher(), "foo", "bar", true);
-        assertThat(new EnvironmentVariable(secureEnvironmentVariableConfig), is(new EnvironmentVariable("foo", "bar", true)));
+        assertThat(new EnvironmentVariable(secureEnvironmentVariableConfig)).isEqualTo(new EnvironmentVariable("foo", "bar", true));
     }
 
     @Test
-    public void addTo_shouldAddEnvironmentVariableToEnvironmentVariableContext() {
+    void addTo_shouldAddEnvironmentVariableToEnvironmentVariableContext() {
         final EnvironmentVariableContext environmentVariableContext = mock(EnvironmentVariableContext.class);
         final EnvironmentVariable environmentVariable = new EnvironmentVariable("foo", "bar");
 
@@ -46,7 +46,7 @@ public class EnvironmentVariableTest {
     }
 
     @Test
-    public void addToIfExists_shouldAddEnvironmentVariableToEnvironmentVariableContextWhenVariableIsAlreadyExistInContext() {
+    void addToIfExists_shouldAddEnvironmentVariableToEnvironmentVariableContextWhenVariableIsAlreadyExistInContext() {
         final EnvironmentVariableContext environmentVariableContext = mock(EnvironmentVariableContext.class);
         final EnvironmentVariable environmentVariable = new EnvironmentVariable("foo", "bar");
 
@@ -58,7 +58,7 @@ public class EnvironmentVariableTest {
     }
 
     @Test
-    public void addToIfExists_shouldNotAddEnvironmentVariableToEnvironmentVariableContextWhenVariableIDoesNotExistInContext() {
+    void addToIfExists_shouldNotAddEnvironmentVariableToEnvironmentVariableContextWhenVariableIDoesNotExistInContext() {
         final EnvironmentVariableContext environmentVariableContext = mock(EnvironmentVariableContext.class);
         final EnvironmentVariable environmentVariable = new EnvironmentVariable("foo", "bar");
 
@@ -69,17 +69,27 @@ public class EnvironmentVariableTest {
         verify(environmentVariableContext, times(0)).setProperty("foo", "bar", false);
     }
 
-    @Test
-    public void getDisplayValue_shouldReturnMaskedValueIfVariableIsSecure() {
-        final EnvironmentVariable environmentVariable = new EnvironmentVariable("foo", "bar", true);
+    @Nested
+    class GetDisplayValue {
+        @Test
+        void shouldReturnMaskedValueIfVariableIsSecure() {
+            final EnvironmentVariable environmentVariable = new EnvironmentVariable("foo", "bar", true);
 
-        assertThat(environmentVariable.getDisplayValue(), is("****"));
-    }
+            assertThat(environmentVariable.getDisplayValue()).isEqualTo("****");
+        }
 
-    @Test
-    public void getDisplayValue_shouldReturnOriginalValueIfVariableIsNotSecure() {
-        final EnvironmentVariable environmentVariable = new EnvironmentVariable("foo", "bar", false);
+        @Test
+        void shouldReturnMaskedValueIfVariableIsSecretParam() {
+            final EnvironmentVariable environmentVariable = new EnvironmentVariable("foo", "{{SECRET:[secret_config_id][token]}}", false);
 
-        assertThat(environmentVariable.getDisplayValue(), is("bar"));
+            assertThat(environmentVariable.getDisplayValue()).isEqualTo("{{SECRET:[secret_config_id][token]}}");
+        }
+
+        @Test
+        void shouldReturnOriginalValueIfVariableIsNotSecure() {
+            final EnvironmentVariable environmentVariable = new EnvironmentVariable("foo", "bar", false);
+
+            assertThat(environmentVariable.getDisplayValue()).isEqualTo("bar");
+        }
     }
 }

--- a/domain/src/test/java/com/thoughtworks/go/domain/EnvironmentVariablesTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/EnvironmentVariablesTest.java
@@ -19,30 +19,28 @@ import com.thoughtworks.go.config.EnvironmentVariableConfig;
 import com.thoughtworks.go.config.EnvironmentVariablesConfig;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-public class EnvironmentVariablesTest {
+class EnvironmentVariablesTest {
 
     @Test
-    public void add_shouldAddEnvironmentVariable() {
+    void add_shouldAddEnvironmentVariable() {
         final EnvironmentVariables environmentVariables = new EnvironmentVariables();
-        assertThat(environmentVariables, hasSize(0));
+        assertThat(environmentVariables).hasSize(0);
 
         environmentVariables.add("foo", "bar");
 
-        assertThat(environmentVariables, hasSize(1));
-        assertThat(environmentVariables, contains(new EnvironmentVariable("foo", "bar")));
+        assertThat(environmentVariables).hasSize(1);
+        assertThat(environmentVariables).containsExactly(new EnvironmentVariable("foo", "bar"));
     }
 
     @Test
-    public void toEnvironmentVariables_shouldConvertEnvironmentVariablesConfigToEnvironmentVariable() {
+    void toEnvironmentVariables_shouldConvertEnvironmentVariablesConfigToEnvironmentVariable() {
         final EnvironmentVariablesConfig environmentVariableConfigs = new EnvironmentVariablesConfig(Arrays.asList(
                 new EnvironmentVariableConfig("foo", "bar"),
                 new EnvironmentVariableConfig(new GoCipher(), "baz", "car", true)
@@ -50,14 +48,11 @@ public class EnvironmentVariablesTest {
 
         final EnvironmentVariables environmentVariables = EnvironmentVariables.toEnvironmentVariables(environmentVariableConfigs);
 
-        assertThat(environmentVariables, containsInAnyOrder(
-                new EnvironmentVariable("foo", "bar", false),
-                new EnvironmentVariable("baz", "car", true)
-        ));
+        assertThat(environmentVariables).contains(new EnvironmentVariable("foo", "bar", false), new EnvironmentVariable("baz", "car", true));
     }
 
     @Test
-    public void addTo_shouldAddEnvironmentVariablesToEnvironmentVariableContext() {
+    void addTo_shouldAddEnvironmentVariablesToEnvironmentVariableContext() {
         final EnvironmentVariableContext environmentVariableContext = mock(EnvironmentVariableContext.class);
         final EnvironmentVariables environmentVariables = new EnvironmentVariables(
                 new EnvironmentVariable("foo", "bar"),
@@ -71,7 +66,7 @@ public class EnvironmentVariablesTest {
     }
 
     @Test
-    public void addToIfExists_shouldAddEnvironmentVariableToEnvironmentVariableContext() {
+    void addToIfExists_shouldAddEnvironmentVariableToEnvironmentVariableContext() {
         final EnvironmentVariableContext environmentVariableContext = mock(EnvironmentVariableContext.class);
         final EnvironmentVariables environmentVariables = new EnvironmentVariables(
                 new EnvironmentVariable("foo", "bar"),
@@ -88,19 +83,19 @@ public class EnvironmentVariablesTest {
     }
 
     @Test
-    public void shouldGetOnlyInsecureValues() {
+    void shouldGetOnlyInsecureValues() {
         EnvironmentVariables variables = new EnvironmentVariables(
                 new EnvironmentVariable("key1", "value1", true),
                 new EnvironmentVariable("key2", "value2")
         );
 
-        assertThat(variables.getInsecureEnvironmentVariableOrDefault("key1", "def1"), is("def1"));
-        assertThat(variables.getInsecureEnvironmentVariableOrDefault("key2", null), is("value2"));
-        assertThat(variables.getInsecureEnvironmentVariableOrDefault("key3", null), is(nullValue()));
+        assertThat(variables.getInsecureEnvironmentVariableOrDefault("key1", "def1")).isEqualTo("def1");
+        assertThat(variables.getInsecureEnvironmentVariableOrDefault("key2", null)).isEqualTo("value2");
+        assertThat(variables.getInsecureEnvironmentVariableOrDefault("key3", null)).isNull();
     }
 
     @Test
-    public void shouldOverrideWithProvidedOverrideValues() {
+    void shouldOverrideWithProvidedOverrideValues() {
         EnvironmentVariables variables = new EnvironmentVariables(
                 new EnvironmentVariable("key1", "value1"),
                 new EnvironmentVariable("key2", "value2")
@@ -112,8 +107,8 @@ public class EnvironmentVariablesTest {
 
         variables.overrideWith(variablesForOverride);
 
-        assertThat(variables.getInsecureEnvironmentVariableOrDefault("key1", null), is("value1"));
-        assertThat(variables.getInsecureEnvironmentVariableOrDefault("key2", null), is("value2-new"));
-        assertThat(variables.getInsecureEnvironmentVariableOrDefault("key3", null), is(nullValue()));
+        assertThat(variables.getInsecureEnvironmentVariableOrDefault("key1", null)).isEqualTo("value1");
+        assertThat(variables.getInsecureEnvironmentVariableOrDefault("key2", null)).isEqualTo("value2-new");
+        assertThat(variables.getInsecureEnvironmentVariableOrDefault("key3", null)).isNull();
     }
 }

--- a/domain/src/test/java/com/thoughtworks/go/helper/MaterialsMother.java
+++ b/domain/src/test/java/com/thoughtworks/go/helper/MaterialsMother.java
@@ -15,9 +15,6 @@
  */
 package com.thoughtworks.go.helper;
 
-import java.util.Arrays;
-import java.util.List;
-
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.materials.*;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
@@ -26,18 +23,17 @@ import com.thoughtworks.go.config.materials.mercurial.HgMaterial;
 import com.thoughtworks.go.config.materials.perforce.P4Material;
 import com.thoughtworks.go.config.materials.svn.SvnMaterial;
 import com.thoughtworks.go.config.materials.tfs.TfsMaterial;
-import com.thoughtworks.go.domain.materials.Material;
 import com.thoughtworks.go.domain.config.Configuration;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
-import com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother;
-import com.thoughtworks.go.domain.packagerepository.PackageDefinition;
-import com.thoughtworks.go.domain.packagerepository.PackageDefinitionMother;
-import com.thoughtworks.go.domain.packagerepository.PackageRepository;
-import com.thoughtworks.go.domain.packagerepository.PackageRepositoryMother;
+import com.thoughtworks.go.domain.materials.Material;
+import com.thoughtworks.go.domain.packagerepository.*;
 import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.domain.scm.SCMMother;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.command.UrlArgument;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class MaterialsMother {
 
@@ -151,7 +147,7 @@ public class MaterialsMother {
         return new Materials(gitMaterial(url, submoduleFolder, branch));
     }
 
-    public static ScmMaterial gitMaterial(String url) {
+    public static GitMaterial gitMaterial(String url) {
         return gitMaterial(url, null, null);
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/exceptions/RulesViolationException.java
+++ b/server/src/main/java/com/thoughtworks/go/server/exceptions/RulesViolationException.java
@@ -16,8 +16,18 @@
 
 package com.thoughtworks.go.server.exceptions;
 
+import static java.lang.String.format;
+
 public class RulesViolationException extends RuntimeException {
     public RulesViolationException(String message) {
         super(message);
+    }
+
+    public static void throwSecretConfigNotFound(String entityType, String entityName, String secretConfigId) {
+        throw new RulesViolationException(format("%s '%s' is referring to none existing secret config '%s'.", entityType, entityName, secretConfigId));
+    }
+
+    public static void throwCannotRefer(String entityType, String entityName, String secretConfigId) {
+        throw new RulesViolationException(format("%s '%s' does not have permission to refer to secrets using SecretConfig: '%s'", entityType, entityName, secretConfigId));
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/exceptions/RulesViolationException.java
+++ b/server/src/main/java/com/thoughtworks/go/server/exceptions/RulesViolationException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.exceptions;
+
+public class RulesViolationException extends RuntimeException {
+    public RulesViolationException(String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/EnvironmentConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EnvironmentConfigService.java
@@ -109,6 +109,10 @@ public class EnvironmentConfigService implements ConfigChangedListener {
         return null;
     }
 
+    public EnvironmentConfig environmentForPipeline(String pipelineName) {
+        return environments.findEnvironmentForPipeline(new CaseInsensitiveString(pipelineName));
+    }
+
     public EnvironmentVariableContext environmentVariableContextFor(String pipelineName) {
         EnvironmentConfig environment = environments.findEnvironmentForPipeline(new CaseInsensitiveString(pipelineName));
         if (environment != null) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/MaterialService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/MaterialService.java
@@ -19,6 +19,7 @@ import com.thoughtworks.go.config.SecretParamAware;
 import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.materials.PackageMaterial;
 import com.thoughtworks.go.config.materials.PluggableSCMMaterial;
+import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
 import com.thoughtworks.go.config.materials.git.GitMaterial;
@@ -152,7 +153,7 @@ public class MaterialService {
 
     private void resolveSecretParams(Material material) {
         if ((material instanceof SecretParamAware) && ((SecretParamAware) material).hasSecretParams()) {
-            this.secretParamResolver.resolve(((SecretParamAware) material).getSecretParams());
+            this.secretParamResolver.resolve((ScmMaterial) material);
         }
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/RulesService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/RulesService.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.PipelineConfigs;
+import com.thoughtworks.go.config.SecretConfig;
+import com.thoughtworks.go.config.SecretParams;
+import com.thoughtworks.go.config.materials.ScmMaterial;
+import com.thoughtworks.go.server.exceptions.RulesViolationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static java.lang.String.format;
+
+@Service
+public class RulesService {
+    private GoConfigService goConfigService;
+
+    @Autowired
+    public RulesService(GoConfigService goConfigService) {
+        this.goConfigService = goConfigService;
+    }
+
+    public boolean validateSecretConfigReferences(ScmMaterial scmMaterial) {
+        SecretParams secretParams = scmMaterial.getSecretParams();
+        secretParams.forEach(secretParam -> {
+            SecretConfig secretConfig = goConfigService.cruiseConfig().getSecretConfigs().find(secretParam.getSecretConfigId());
+            List<CaseInsensitiveString> pipelines = goConfigService.pipelinesWithMaterial(scmMaterial.getFingerprint());
+            pipelines.forEach(pipeline -> {
+                PipelineConfigs group = goConfigService.findGroupByPipeline(pipeline);
+                if (!secretConfig.canRefer(PipelineConfigs.class, group.getGroup())) {
+                    throw new RulesViolationException(format("Material with url: '%s' in Pipeline: '%s' and Pipeline Group: '%s'" +
+                                    " does not have permission to refer to Secrets using SecretConfig: '%s'",
+                            scmMaterial.getUrl(), pipeline, group.getGroup(), secretConfig.getId()));
+                }
+            });
+        });
+
+        return true;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/RulesService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/RulesService.java
@@ -16,21 +16,24 @@
 
 package com.thoughtworks.go.server.service;
 
-import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.PipelineConfigs;
-import com.thoughtworks.go.config.SecretConfig;
-import com.thoughtworks.go.config.SecretParams;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.ScmMaterial;
-import com.thoughtworks.go.server.exceptions.RulesViolationException;
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.remote.work.BuildAssignment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import static com.thoughtworks.go.server.exceptions.RulesViolationException.throwCannotRefer;
+import static com.thoughtworks.go.server.exceptions.RulesViolationException.throwSecretConfigNotFound;
 import static java.lang.String.format;
 
 @Service
 public class RulesService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RulesService.class);
     private GoConfigService goConfigService;
 
     @Autowired
@@ -39,20 +42,47 @@ public class RulesService {
     }
 
     public boolean validateSecretConfigReferences(ScmMaterial scmMaterial) {
+        List<CaseInsensitiveString> pipelines = goConfigService.pipelinesWithMaterial(scmMaterial.getFingerprint());
         SecretParams secretParams = scmMaterial.getSecretParams();
-        secretParams.forEach(secretParam -> {
-            SecretConfig secretConfig = goConfigService.cruiseConfig().getSecretConfigs().find(secretParam.getSecretConfigId());
-            List<CaseInsensitiveString> pipelines = goConfigService.pipelinesWithMaterial(scmMaterial.getFingerprint());
-            pipelines.forEach(pipeline -> {
-                PipelineConfigs group = goConfigService.findGroupByPipeline(pipeline);
-                if (!secretConfig.canRefer(PipelineConfigs.class, group.getGroup())) {
-                    throw new RulesViolationException(format("Material with url: '%s' in Pipeline: '%s' and Pipeline Group: '%s'" +
-                                    " does not have permission to refer to Secrets using SecretConfig: '%s'",
-                            scmMaterial.getUrl(), pipeline, group.getGroup(), secretConfig.getId()));
-                }
-            });
+        pipelines.forEach(pipeline -> {
+            PipelineConfigs group = goConfigService.findGroupByPipeline(pipeline);
+            String errorMessagePrefix = format("Material with url: '%s' in Pipeline: '%s' and Pipeline Group:", scmMaterial.getUriForDisplay(), pipeline);
+            validateSecretConfigReferences(secretParams, group.getClass(), group.getGroup(), errorMessagePrefix);
         });
 
         return true;
+    }
+
+    public boolean validateSecretConfigReferences(EnvironmentConfig environmentConfig) {
+        SecretParams secretParams = environmentConfig.getSecretParams();
+        validateSecretConfigReferences(secretParams, environmentConfig.getClass(), environmentConfig.name().toString(), "Environment");
+        return true;
+    }
+
+    public void validateSecretConfigReferences(BuildAssignment buildAssignment) {
+        SecretParams secretParams = buildAssignment.getSecretParams();
+        if (secretParams.isEmpty()) {
+            LOGGER.debug("No secret params available in build assignment {}.", buildAssignment.getJobIdentifier());
+            return;
+        }
+
+        JobIdentifier jobIdentifier = buildAssignment.getJobIdentifier();
+        PipelineConfigs group = goConfigService.findGroupByPipeline(new CaseInsensitiveString(jobIdentifier.getPipelineName()));
+        String errorMessagePrefix = format("Job: '%s' in Pipeline: '%s' and Pipeline Group:", jobIdentifier.getBuildName(), jobIdentifier.getPipelineName());
+        validateSecretConfigReferences(secretParams, group.getClass(), group.getGroup(), errorMessagePrefix);
+    }
+
+    private void validateSecretConfigReferences(SecretParams secretParams, Class<? extends Validatable> entityClass, String entityName, String entityNameOrErrorMessagePrefix) {
+        secretParams.forEach(secretParam -> {
+            SecretConfig secretConfig = goConfigService.cruiseConfig().getSecretConfigs().find(secretParam.getSecretConfigId());
+
+            if (secretConfig == null) {
+                throwSecretConfigNotFound(entityNameOrErrorMessagePrefix, entityName, secretParam.getSecretConfigId());
+            }
+
+            if (!secretConfig.canRefer(entityClass, entityName)) {
+                throwCannotRefer(entityNameOrErrorMessagePrefix, entityName, secretParam.getSecretConfigId());
+            }
+        });
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/SecretParamResolver.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/SecretParamResolver.java
@@ -16,9 +16,8 @@
 
 package com.thoughtworks.go.server.service;
 
-import com.thoughtworks.go.config.SecretConfig;
-import com.thoughtworks.go.config.SecretParam;
-import com.thoughtworks.go.config.SecretParams;
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.plugin.access.secrets.SecretsExtension;
 import com.thoughtworks.go.plugin.domain.secrets.Secret;
 import org.slf4j.Logger;
@@ -39,12 +38,21 @@ public class SecretParamResolver {
     private static final Logger LOGGER = LoggerFactory.getLogger(SecretParamResolver.class);
     private SecretsExtension secretsExtension;
     private GoConfigService goConfigService;
+    private RulesService rulesService;
 
     @Autowired
-    public SecretParamResolver(SecretsExtension secretsExtension, GoConfigService goConfigService) {
+    public SecretParamResolver(SecretsExtension secretsExtension, GoConfigService goConfigService, RulesService rulesService) {
         this.secretsExtension = secretsExtension;
         this.goConfigService = goConfigService;
+        this.rulesService = rulesService;
     }
+
+    public void resolve(ScmMaterial scmMaterial) {
+        rulesService.validateSecretConfigReferences(scmMaterial);
+
+        resolve(scmMaterial.getSecretParams());
+    }
+
 
     public void resolve(SecretParams secretParams) {
         if (secretParams == null || secretParams.isEmpty()) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/SecretParamResolver.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/SecretParamResolver.java
@@ -16,10 +16,14 @@
 
 package com.thoughtworks.go.server.service;
 
-import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.EnvironmentConfig;
+import com.thoughtworks.go.config.SecretConfig;
+import com.thoughtworks.go.config.SecretParam;
+import com.thoughtworks.go.config.SecretParams;
 import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.plugin.access.secrets.SecretsExtension;
 import com.thoughtworks.go.plugin.domain.secrets.Secret;
+import com.thoughtworks.go.remote.work.BuildAssignment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,8 +57,17 @@ public class SecretParamResolver {
         resolve(scmMaterial.getSecretParams());
     }
 
+    public void resolve(BuildAssignment buildAssignment) {
+        rulesService.validateSecretConfigReferences(buildAssignment);
+        resolve(buildAssignment.getSecretParams());
+    }
 
-    public void resolve(SecretParams secretParams) {
+    public void resolve(EnvironmentConfig environmentConfig) {
+        rulesService.validateSecretConfigReferences(environmentConfig);
+        resolve(environmentConfig.getSecretParams());
+    }
+
+    protected void resolve(SecretParams secretParams) {
         if (secretParams == null || secretParams.isEmpty()) {
             LOGGER.debug("No secret params to resolve.");
             return;

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -1768,13 +1768,14 @@ class ConfigConverterTest {
     }
 
     @Test
-    void shouldConvertEnvironmentVariableConfigWhenSecure() {
+    void shouldConvertEnvironmentVariableConfigWhenSecure() throws CryptoException {
         EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig("key1", null);
         environmentVariableConfig.setIsSecure(true);
-        environmentVariableConfig.setEncryptedValue("plain-text-password");
+        String encryptedValue = new GoCipher().encrypt("plain-text-password");
+        environmentVariableConfig.setEncryptedValue(encryptedValue);
         CREnvironmentVariable result = configConverter.environmentVariableConfigToCREnvironmentVariable(environmentVariableConfig);
         assertThat(result.hasEncryptedValue()).isTrue();
-        assertThat(result.getEncryptedValue()).isEqualTo("plain-text-password");
+        assertThat(result.getEncryptedValue()).isEqualTo(encryptedValue);
         assertThat(result.getValue()).isNull();
         assertThat(result.getName()).isEqualTo("key1");
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/BuildAssignmentServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/BuildAssignmentServiceTest.java
@@ -345,7 +345,7 @@ class BuildAssignmentServiceTest {
             when(scheduledPipelineLoader.pipelineWithPasswordAwareBuildCauseByBuildId(anyLong())).thenReturn(pipeline);
             when(goConfigService.artifactStores()).thenReturn(new ArtifactStores());
             when(environmentConfigService.environmentVariableContextFor(anyString())).thenReturn(new EnvironmentVariableContext());
-            doThrow(new SecretResolutionFailureException("Failed resolving params for keys: 'key1'")).when(secretParamResolver).resolve(any());
+            doThrow(new SecretResolutionFailureException("Failed resolving params for keys: 'key1'")).when(secretParamResolver).resolve(any(SecretParams.class));
             when(jobInstanceService.buildById(jobPlan1.getJobId())).thenReturn(jobInstance);
             when(agentInstance.getUuid()).thenReturn("agent_uuid");
             when(jobInstance.getState()).thenReturn(JobState.Completed);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
@@ -26,8 +26,9 @@ import com.thoughtworks.go.presentation.environment.EnvironmentPipelineModel;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.*;
@@ -35,18 +36,17 @@ import java.util.*;
 import static com.thoughtworks.go.helper.EnvironmentConfigMother.*;
 import static com.thoughtworks.go.helper.PipelineConfigMother.pipelineConfig;
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.*;
 
-public class EnvironmentConfigServiceTest {
+class EnvironmentConfigServiceTest {
     private GoConfigService mockGoConfigService;
     private EnvironmentConfigService environmentConfigService;
     private SecurityService securityService;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         mockGoConfigService = mock(GoConfigService.class);
         securityService = mock(SecurityService.class);
         EntityHashingService entityHashingService = mock(EntityHashingService.class);
@@ -54,13 +54,13 @@ public class EnvironmentConfigServiceTest {
     }
 
     @Test
-    public void shouldRegisterAsACruiseConfigChangeListener() throws Exception {
+    void shouldRegisterAsACruiseConfigChangeListener() {
         environmentConfigService.initialize();
         Mockito.verify(mockGoConfigService).register(environmentConfigService);
     }
 
     @Test
-    public void shouldGetEditablePartOfEnvironmentConfig() throws Exception {
+    void shouldGetEditablePartOfEnvironmentConfig() {
         String uat = "uat";
 
         BasicEnvironmentConfig local = new BasicEnvironmentConfig(new CaseInsensitiveString("uat"));
@@ -81,11 +81,11 @@ public class EnvironmentConfigServiceTest {
 
         when(mockGoConfigService.getConfigForEditing()).thenReturn(cruiseConfig);
 
-        assertThat(environmentConfigService.getEnvironmentForEdit(uat), is(expectedToEdit));
+        assertThat(environmentConfigService.getEnvironmentForEdit(uat)).isEqualTo(expectedToEdit);
     }
 
     @Test
-    public void shouldReturnAllTheLocalEnvironments() throws Exception {
+    void shouldReturnAllTheLocalEnvironments() {
         String uat = "uat";
 
         BasicEnvironmentConfig local = new BasicEnvironmentConfig(new CaseInsensitiveString("uat"));
@@ -106,11 +106,11 @@ public class EnvironmentConfigServiceTest {
 
         when(mockGoConfigService.getConfigForEditing()).thenReturn(cruiseConfig);
 
-        assertThat(environmentConfigService.getAllLocalEnvironments(), is(expectedToEdit));
+        assertThat(environmentConfigService.getAllLocalEnvironments()).isEqualTo(expectedToEdit);
     }
 
     @Test
-    public void shouldReturnAllTheMergedEnvironments() throws Exception {
+    void shouldReturnAllTheMergedEnvironments() {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         CruiseConfig config = new BasicCruiseConfig();
         BasicEnvironmentConfig env = new BasicEnvironmentConfig(new CaseInsensitiveString("foo"));
@@ -122,60 +122,60 @@ public class EnvironmentConfigServiceTest {
         environmentConfigService.sync(environments);
         when(mockGoConfigService.getMergedConfigForEditing()).thenReturn(config);
 
-        assertThat(environmentConfigService.getAllMergedEnvironments(), is(asList(env)));
-        assertThat(result.isSuccessful(), is(true));
+        assertThat(environmentConfigService.getAllMergedEnvironments()).isEqualTo(asList(env));
+        assertThat(result.isSuccessful()).isTrue();
     }
 
     @Test
-    public void shouldFilterWhenAgentIsNotInAnEnvironment() throws Exception {
+    void shouldFilterWhenAgentIsNotInAnEnvironment() {
         environmentConfigService.sync(environments("uat", "prod"));
 
         List<JobPlan> filtered = environmentConfigService.filterJobsByAgent(jobs("no-env", "uat", "prod"), "no-env-uuid");
 
-        assertThat(filtered.size(), is(1));
-        assertThat(filtered.get(0).getPipelineName(), is("no-env-pipeline"));
+        assertThat(filtered.size()).isEqualTo(1);
+        assertThat(filtered.get(0).getPipelineName()).isEqualTo("no-env-pipeline");
     }
 
     @Test
-    public void shouldFilterWhenAgentIsInTheSameEnvironment() throws Exception {
+    void shouldFilterWhenAgentIsInTheSameEnvironment() {
         environmentConfigService.sync(environments("uat", "prod"));
 
         List<JobPlan> filtered = environmentConfigService.filterJobsByAgent(jobs("no-env", "uat", "prod"), "uat-agent");
 
-        assertThat(filtered.size(), is(1));
-        assertThat(filtered.get(0).getPipelineName(), is("uat-pipeline"));
+        assertThat(filtered.size()).isEqualTo(1);
+        assertThat(filtered.get(0).getPipelineName()).isEqualTo("uat-pipeline");
     }
 
     @Test
-    public void shouldFilterWhenAgentIsInMultipleEnvironments() throws Exception {
+    void shouldFilterWhenAgentIsInMultipleEnvironments() {
         environmentConfigService.sync(environments("uat", "prod"));
 
         List<JobPlan> filtered = environmentConfigService.filterJobsByAgent(jobs("no-env", "uat", "prod"), EnvironmentConfigMother.OMNIPRESENT_AGENT);
 
-        assertThat(filtered.size(), is(2));
-        assertThat(filtered.get(0).getPipelineName(), is("uat-pipeline"));
-        assertThat(filtered.get(1).getPipelineName(), is("prod-pipeline"));
+        assertThat(filtered.size()).isEqualTo(2);
+        assertThat(filtered.get(0).getPipelineName()).isEqualTo("uat-pipeline");
+        assertThat(filtered.get(1).getPipelineName()).isEqualTo("prod-pipeline");
     }
 
     @Test
-    public void shouldFilterWhenAgentIsInAnotherEnvironment() throws Exception {
+    void shouldFilterWhenAgentIsInAnotherEnvironment() {
         environmentConfigService.sync(environments("uat", "prod"));
 
         List<JobPlan> filtered = environmentConfigService.filterJobsByAgent(jobs("no-env", "prod"), "uat-agent");
 
-        assertThat(filtered.size(), is(0));
+        assertThat(filtered.size()).isEqualTo(0);
     }
 
     @Test
-    public void shouldFindPipelinesNamesForAGivenEnvironmentName() throws Exception {
+    void shouldFindPipelinesNamesForAGivenEnvironmentName() {
         environmentConfigService.sync(environments("uat", "prod"));
-        assertThat(environmentConfigService.pipelinesFor(new CaseInsensitiveString("uat")).size(), is(1));
-        assertThat(environmentConfigService.pipelinesFor(new CaseInsensitiveString("uat")), hasItem(new CaseInsensitiveString("uat-pipeline")));
-        assertThat(environmentConfigService.pipelinesFor(new CaseInsensitiveString("prod")), hasItem(new CaseInsensitiveString("prod-pipeline")));
+        assertThat(environmentConfigService.pipelinesFor(new CaseInsensitiveString("uat")).size()).isEqualTo(1);
+        assertThat(environmentConfigService.pipelinesFor(new CaseInsensitiveString("uat"))).contains(new CaseInsensitiveString("uat-pipeline"));
+        assertThat(environmentConfigService.pipelinesFor(new CaseInsensitiveString("prod"))).contains(new CaseInsensitiveString("prod-pipeline"));
     }
 
     @Test
-    public void shouldFindAgentsForPipelineUnderEnvironment() throws Exception {
+    void shouldFindAgentsForPipelineUnderEnvironment() {
         environmentConfigService.sync(environments("uat", "prod"));
         AgentConfig agentUnderEnv = new AgentConfig("uat-agent", "localhost", "127.0.0.1");
         AgentConfig omnipresentAgent = new AgentConfig(EnvironmentConfigMother.OMNIPRESENT_AGENT, "localhost", "127.0.0.2");
@@ -183,13 +183,13 @@ public class EnvironmentConfigServiceTest {
         Mockito.when(mockGoConfigService.agentByUuid("uat-agent")).thenReturn(agentUnderEnv);
         Mockito.when(mockGoConfigService.agentByUuid(EnvironmentConfigMother.OMNIPRESENT_AGENT)).thenReturn(omnipresentAgent);
 
-        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("uat-pipeline")).size(), is(2));
-        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("uat-pipeline")), hasItem(agentUnderEnv));
-        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("uat-pipeline")), hasItem(omnipresentAgent));
+        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("uat-pipeline")).size()).isEqualTo(2);
+        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("uat-pipeline"))).contains(agentUnderEnv);
+        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("uat-pipeline"))).contains(omnipresentAgent);
     }
 
     @Test
-    public void shouldFindAgentsForPipelineUnderNoEnvironment() throws Exception {
+    void shouldFindAgentsForPipelineUnderNoEnvironment() {
         environmentConfigService.sync(environments("uat", "prod"));
         AgentConfig noEnvAgent = new AgentConfig("no-env-agent", "localhost", "127.0.0.1");
 
@@ -199,12 +199,12 @@ public class EnvironmentConfigServiceTest {
         Mockito.when(mockGoConfigService.agents()).thenReturn(agents);
 
 
-        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("no-env-pipeline")).size(), is(1));
-        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("no-env-pipeline")), hasItem(noEnvAgent));
+        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("no-env-pipeline")).size()).isEqualTo(1);
+        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("no-env-pipeline"))).contains(noEnvAgent);
     }
 
     @Test
-    public void shouldListEnvironmentVariablesDefinedForAnEnvironment() throws Exception {
+    void shouldListEnvironmentVariablesDefinedForAnEnvironment() {
         EnvironmentsConfig environmentConfigs = new EnvironmentsConfig();
         BasicEnvironmentConfig environment = environment("uat");
         environment.addEnvironmentVariable("Var1", "Value1");
@@ -214,21 +214,21 @@ public class EnvironmentConfigServiceTest {
 
         EnvironmentVariableContext environmentVariableContext = environmentConfigService.environmentVariableContextFor("uat-pipeline");
 
-        assertThat(environmentVariableContext.getProperties().size(), is(3));
-        assertThat(environmentVariableContext.getProperty("GO_ENVIRONMENT_NAME"), is("uat"));
-        assertThat(environmentVariableContext.getProperty("Var1"), is("Value1"));
-        assertThat(environmentVariableContext.getProperty("Var2"), is("Value2"));
-        assertNull(environmentConfigService.environmentVariableContextFor("non-existent-pipeline"));
+        assertThat(environmentVariableContext.getProperties().size()).isEqualTo(3);
+        assertThat(environmentVariableContext.getProperty("GO_ENVIRONMENT_NAME")).isEqualTo("uat");
+        assertThat(environmentVariableContext.getProperty("Var1")).isEqualTo("Value1");
+        assertThat(environmentVariableContext.getProperty("Var2")).isEqualTo("Value2");
+        assertThat(environmentConfigService.environmentVariableContextFor("non-existent-pipeline")).isNull();
     }
 
     @Test
-    public void shouldReturnNullEnvironmentVariablesIfThePipelineDoesNotBelongToAnEnvironment() throws Exception {
+    void shouldReturnNullEnvironmentVariablesIfThePipelineDoesNotBelongToAnEnvironment() {
         environmentConfigService.sync(environments("uat", "prod"));
-        assertNull(environmentConfigService.environmentVariableContextFor("pipeline-with-no-environment"));
+        assertThat(environmentConfigService.environmentVariableContextFor("pipeline-with-no-environment")).isNull();
     }
 
     @Test
-    public void shouldListAllEnvironmentVariablesDefinedForAConfigRepoEnvironment() throws Exception {
+    void shouldListAllEnvironmentVariablesDefinedForAConfigRepoEnvironment() {
         EnvironmentsConfig environmentConfigs = new EnvironmentsConfig();
 
         BasicEnvironmentConfig localPart = environment("uat");
@@ -241,15 +241,15 @@ public class EnvironmentConfigServiceTest {
 
         EnvironmentVariableContext environmentVariableContext = environmentConfigService.environmentVariableContextFor("uat-pipeline");
 
-        assertThat(environmentVariableContext.getProperties().size(), is(4));
-        assertThat(environmentVariableContext.getProperty("GO_ENVIRONMENT_NAME"), is("uat"));
-        assertThat(environmentVariableContext.getProperty("Var1"), is("Value1"));
-        assertThat(environmentVariableContext.getProperty("Var2"), is("Value2"));
-        assertThat(environmentVariableContext.getProperty("remote-var1"), is("remote-value-1"));
+        assertThat(environmentVariableContext.getProperties().size()).isEqualTo(4);
+        assertThat(environmentVariableContext.getProperty("GO_ENVIRONMENT_NAME")).isEqualTo("uat");
+        assertThat(environmentVariableContext.getProperty("Var1")).isEqualTo("Value1");
+        assertThat(environmentVariableContext.getProperty("Var2")).isEqualTo("Value2");
+        assertThat(environmentVariableContext.getProperty("remote-var1")).isEqualTo("remote-value-1");
     }
 
     @Test
-    public void shouldListAllEnvironmentVariablesDefinedForRemoteOnlyEnvironment() throws Exception {
+    void shouldListAllEnvironmentVariablesDefinedForRemoteOnlyEnvironment() {
         EnvironmentsConfig environmentConfigs = new EnvironmentsConfig();
         BasicEnvironmentConfig remotePart = remote("uat");
         remotePart.addEnvironmentVariable("remote-var1", "remote-value-1");
@@ -258,52 +258,52 @@ public class EnvironmentConfigServiceTest {
 
         EnvironmentVariableContext environmentVariableContext = environmentConfigService.environmentVariableContextFor("uat-pipeline");
 
-        assertThat(environmentVariableContext.getProperties().size(), is(2));
-        assertThat(environmentVariableContext.getProperty("GO_ENVIRONMENT_NAME"), is("uat"));
-        assertThat(environmentVariableContext.getProperty("remote-var1"), is("remote-value-1"));
+        assertThat(environmentVariableContext.getProperties().size()).isEqualTo(2);
+        assertThat(environmentVariableContext.getProperty("GO_ENVIRONMENT_NAME")).isEqualTo("uat");
+        assertThat(environmentVariableContext.getProperty("remote-var1")).isEqualTo("remote-value-1");
     }
 
     @Test
-    public void shouldReturnEnvironmentNames() throws Exception {
+    void shouldReturnEnvironmentNames() {
         environmentConfigService.sync(environments("uat", "prod"));
         List<CaseInsensitiveString> environmentNames = environmentConfigService.environmentNames();
-        assertThat(environmentNames.size(), is(2));
-        assertThat(environmentNames, hasItem(new CaseInsensitiveString("uat")));
-        assertThat(environmentNames, hasItem(new CaseInsensitiveString("prod")));
+        assertThat(environmentNames.size()).isEqualTo(2);
+        assertThat(environmentNames).contains(new CaseInsensitiveString("uat"));
+        assertThat(environmentNames).contains(new CaseInsensitiveString("prod"));
     }
 
     @Test
-    public void shouldReturnEnvironmentsForAnAgent() {
+    void shouldReturnEnvironmentsForAnAgent() {
         environmentConfigService.sync(environments("uat", "prod"));
         Set<String> envForUat = environmentConfigService.environmentsFor("uat-agent");
-        assertThat(envForUat.size(), is(1));
-        assertThat(envForUat, hasItem("uat"));
+        assertThat(envForUat.size()).isEqualTo(1);
+        assertThat(envForUat).contains("uat");
         Set<String> envForProd = environmentConfigService.environmentsFor("prod-agent");
-        assertThat(envForProd.size(), is(1));
-        assertThat(envForProd, hasItem("prod"));
+        assertThat(envForProd.size()).isEqualTo(1);
+        assertThat(envForProd).contains("prod");
         Set<String> envForOmniPresent = environmentConfigService.environmentsFor(EnvironmentConfigMother.OMNIPRESENT_AGENT);
-        assertThat(envForOmniPresent.size(), is(2));
-        assertThat(envForOmniPresent, hasItem("uat"));
-        assertThat(envForOmniPresent, hasItem("prod"));
+        assertThat(envForOmniPresent.size()).isEqualTo(2);
+        assertThat(envForOmniPresent).contains("uat");
+        assertThat(envForOmniPresent).contains("prod");
     }
 
     @Test
-    public void shouldReturnEnvironmentConfigsForAnAgent() {
+    void shouldReturnEnvironmentConfigsForAnAgent() {
         environmentConfigService.sync(environments("uat", "prod"));
         Set<EnvironmentConfig> envForUat = environmentConfigService.environmentConfigsFor("uat-agent");
-        assertThat(envForUat.size(), is(1));
-        assertThat(envForUat, hasItem(environment("uat")));
+        assertThat(envForUat.size()).isEqualTo(1);
+        assertThat(envForUat).contains(environment("uat"));
         Set<EnvironmentConfig> envForProd = environmentConfigService.environmentConfigsFor("prod-agent");
-        assertThat(envForProd.size(), is(1));
-        assertThat(envForProd, hasItem(environment("prod")));
+        assertThat(envForProd.size()).isEqualTo(1);
+        assertThat(envForProd).contains(environment("prod"));
         Set<EnvironmentConfig> envForOmniPresent = environmentConfigService.environmentConfigsFor(EnvironmentConfigMother.OMNIPRESENT_AGENT);
-        assertThat(envForOmniPresent.size(), is(2));
-        assertThat(envForOmniPresent, hasItem(environment("uat")));
-        assertThat(envForOmniPresent, hasItem(environment("prod")));
+        assertThat(envForOmniPresent.size()).isEqualTo(2);
+        assertThat(envForOmniPresent).contains(environment("uat"));
+        assertThat(envForOmniPresent).contains(environment("prod"));
     }
 
     @Test
-    public void shouldCreateANewEnvironment() {
+    void shouldCreateANewEnvironment() {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         List<String> selectedAgents = new ArrayList<>();
         Username user = new Username(new CaseInsensitiveString("user"));
@@ -312,11 +312,11 @@ public class EnvironmentConfigServiceTest {
         when(mockGoConfigService.hasEnvironmentNamed(new CaseInsensitiveString(environmentName))).thenReturn(false);
         environmentConfigService.createEnvironment(env(environmentName, new ArrayList<>(), new ArrayList<>(), selectedAgents), user, result);
 
-        assertThat(result.isSuccessful(), is(true));
+        assertThat(result.isSuccessful()).isTrue();
     }
 
     @Test
-    public void shouldCreateANewEnvironmentWithAgentsAndNoPipelines() {
+    void shouldCreateANewEnvironmentWithAgentsAndNoPipelines() {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         Username user = new Username(new CaseInsensitiveString("user"));
         when(securityService.isUserAdmin(user)).thenReturn(true);
@@ -325,13 +325,13 @@ public class EnvironmentConfigServiceTest {
 
         environmentConfigService.createEnvironment(env(environmentName, new ArrayList<>(), new ArrayList<>(), Arrays.asList(new String[]{"agent-guid-1"})), user, result);
 
-        assertThat(result.isSuccessful(), is(true));
+        assertThat(result.isSuccessful()).isTrue();
         BasicEnvironmentConfig envConfig = new BasicEnvironmentConfig(new CaseInsensitiveString(environmentName));
         envConfig.addAgent("agent-guid-1");
     }
 
     @Test
-    public void shouldCreateANewEnvironmentWithEnvironmentVariables() {
+    void shouldCreateANewEnvironmentWithEnvironmentVariables() {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         List<String> selectedAgents = new ArrayList<>();
         Username user = new Username(new CaseInsensitiveString("user"));
@@ -342,7 +342,7 @@ public class EnvironmentConfigServiceTest {
         environmentVariables.addAll(Arrays.asList(envVar("SHELL", "/bin/zsh"), envVar("HOME", "/home/cruise")));
         environmentConfigService.createEnvironment(env(environmentName, new ArrayList<>(), environmentVariables, selectedAgents), user, result);
 
-        assertThat(result.isSuccessful(), is(true));
+        assertThat(result.isSuccessful()).isTrue();
         BasicEnvironmentConfig expectedConfig = new BasicEnvironmentConfig(new CaseInsensitiveString(environmentName));
         expectedConfig.addEnvironmentVariable("SHELL", "/bin/zsh");
         expectedConfig.addEnvironmentVariable("HOME", "/home/cruise");
@@ -356,7 +356,7 @@ public class EnvironmentConfigServiceTest {
     }
 
     @Test
-    public void shouldCreateANewEnvironmentWithPipelineSelections() {
+    void shouldCreateANewEnvironmentWithPipelineSelections() {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         Username user = new Username(new CaseInsensitiveString("user"));
         when(securityService.isUserAdmin(user)).thenReturn(true);
@@ -365,14 +365,14 @@ public class EnvironmentConfigServiceTest {
         List<String> selectedPipelines = asList("first", "second");
         environmentConfigService.createEnvironment(env(environmentName, selectedPipelines, new ArrayList<>(), new ArrayList<>()), user, result);
 
-        assertThat(result.isSuccessful(), is(true));
+        assertThat(result.isSuccessful()).isTrue();
         BasicEnvironmentConfig config = new BasicEnvironmentConfig(new CaseInsensitiveString(environmentName));
         config.addPipeline(new CaseInsensitiveString("first"));
         config.addPipeline(new CaseInsensitiveString("second"));
     }
 
     @Test
-    public void getAllLocalPipelinesForUser_shouldReturnAllPipelinesToWhichAlongWithTheEnvironmentsToWhichTheyBelong() {
+    void getAllLocalPipelinesForUser_shouldReturnAllPipelinesToWhichAlongWithTheEnvironmentsToWhichTheyBelong() {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         Username user = new Username(new CaseInsensitiveString("user"));
 
@@ -386,12 +386,12 @@ public class EnvironmentConfigServiceTest {
         List<EnvironmentPipelineModel> pipelines = environmentConfigService.getAllLocalPipelinesForUser(user);
 
 
-        assertThat(pipelines.size(), is(2));
-        assertThat(pipelines, is(asList(new EnvironmentPipelineModel("bar"), new EnvironmentPipelineModel("foo", "foo-env"))));
+        assertThat(pipelines.size()).isEqualTo(2);
+        assertThat(pipelines).isEqualTo(asList(new EnvironmentPipelineModel("bar"), new EnvironmentPipelineModel("foo", "foo-env")));
     }
 
     @Test
-    public void getAllLocalPipelinesForUser_shouldReturnOnlyLocalPipelines() {
+    void getAllLocalPipelinesForUser_shouldReturnOnlyLocalPipelines() {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         Username user = new Username(new CaseInsensitiveString("user"));
 
@@ -405,12 +405,12 @@ public class EnvironmentConfigServiceTest {
         List<EnvironmentPipelineModel> pipelines = environmentConfigService.getAllLocalPipelinesForUser(user);
 
 
-        assertThat(pipelines.size(), is(2));
-        assertThat(pipelines, is(asList(new EnvironmentPipelineModel("bar"), new EnvironmentPipelineModel("foo", "foo-env"))));
+        assertThat(pipelines.size()).isEqualTo(2);
+        assertThat(pipelines).isEqualTo(asList(new EnvironmentPipelineModel("bar"), new EnvironmentPipelineModel("foo", "foo-env")));
     }
 
     @Test
-    public void getAllRemotePipelinesForUserInEnvironment_shouldReturnOnlyRemotelyAssignedPipelinesWhichUserHasPermsToView() {
+    void getAllRemotePipelinesForUserInEnvironment_shouldReturnOnlyRemotelyAssignedPipelinesWhichUserHasPermsToView() {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         Username user = new Username(new CaseInsensitiveString("user"));
 
@@ -427,12 +427,12 @@ public class EnvironmentConfigServiceTest {
         List<EnvironmentPipelineModel> pipelines = environmentConfigService.getAllRemotePipelinesForUserInEnvironment(user, fooEnv);
 
 
-        assertThat(pipelines.size(), is(1));
-        assertThat(pipelines, is(asList(new EnvironmentPipelineModel("foo", "foo-env"))));
+        assertThat(pipelines.size()).isEqualTo(1);
+        assertThat(pipelines).isEqualTo(asList(new EnvironmentPipelineModel("foo", "foo-env")));
     }
 
     @Test
-    public void shouldReturnEnvironmentConfigForEdit() {
+    void shouldReturnEnvironmentConfigForEdit() {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         CruiseConfig config = new BasicCruiseConfig();
         BasicEnvironmentConfig env = new BasicEnvironmentConfig(new CaseInsensitiveString("foo"));
@@ -443,12 +443,12 @@ public class EnvironmentConfigServiceTest {
         environments.add(env);
         environmentConfigService.sync(environments);
         when(mockGoConfigService.getMergedConfigForEditing()).thenReturn(config);
-        assertThat(environmentConfigService.getMergedEnvironmentforDisplay("foo", result).getConfigElement(), is(env));
-        assertThat(result.isSuccessful(), is(true));
+        assertThat(environmentConfigService.getMergedEnvironmentforDisplay("foo", result).getConfigElement()).isEqualTo(env);
+        assertThat(result.isSuccessful()).isTrue();
     }
 
     @Test
-    public void shouldReturnResultWithMessageThatConfigWasMerged_WhenMergingEnvironmentChanges_NewUpdateEnvironmentMethod() {
+    void shouldReturnResultWithMessageThatConfigWasMerged_WhenMergingEnvironmentChanges_NewUpdateEnvironmentMethod() {
         String environmentName = "env_name";
         EnvironmentConfig environmentConfig = new BasicEnvironmentConfig(new CaseInsensitiveString(environmentName));
         Username user = new Username(new CaseInsensitiveString("user"));
@@ -460,12 +460,12 @@ public class EnvironmentConfigServiceTest {
         String md5 = "md5";
         environmentConfigService.updateEnvironment(environmentConfig.name().toString(), environmentConfig, user, md5, result);
 
-        assertTrue(result.isSuccessful());
-        assertThat(result.message(), is("Updated environment 'env_name'."));
+        assertThat(result.isSuccessful()).isTrue();
+        assertThat(result.message()).isEqualTo("Updated environment 'env_name'.");
     }
 
     @Test
-    public void shouldReturnResultWithMessageThatConfigisUpdated_WhenUpdatingLatestConfiguration_NewUpdateEnvironmentMethod() {
+    void shouldReturnResultWithMessageThatConfigisUpdated_WhenUpdatingLatestConfiguration_NewUpdateEnvironmentMethod() {
         String environmentName = "env_name";
         EnvironmentConfig environmentConfig = new BasicEnvironmentConfig(new CaseInsensitiveString(environmentName));
         Username user = new Username(new CaseInsensitiveString("user"));
@@ -476,26 +476,52 @@ public class EnvironmentConfigServiceTest {
         String md5 = "md5";
         environmentConfigService.updateEnvironment(environmentConfig.name().toString(), environmentConfig, user, md5, result);
 
-        assertTrue(result.isSuccessful());
-        assertThat(result.message(), is("Updated environment 'env_name'."));
+        assertThat(result.isSuccessful()).isTrue();
+        assertThat(result.message()).isEqualTo("Updated environment 'env_name'.");
     }
 
     @Test
-    public void shouldReturnEnvironmentConfig() throws Exception {
+    void shouldReturnEnvironmentConfig() {
         String environmentName = "foo-environment";
         String pipelineName = "up42";
         environmentConfigService.sync(environmentsConfig(environmentName, pipelineName));
         EnvironmentConfig expectedEnvironmentConfig = new BasicEnvironmentConfig(new CaseInsensitiveString(environmentName));
         expectedEnvironmentConfig.addPipeline(new CaseInsensitiveString(pipelineName));
-        assertThat(environmentConfigService.getEnvironmentConfig(environmentName), is(expectedEnvironmentConfig));
+        assertThat(environmentConfigService.getEnvironmentConfig(environmentName)).isEqualTo(expectedEnvironmentConfig);
     }
 
-    @Test(expected = RecordNotFoundException.class)
-    public void shouldThrowExceptionWhenEnvironmentIsAbsent() throws Exception {
+    @Test
+    void shouldThrowExceptionWhenEnvironmentIsAbsent() {
         String environmentName = "foo-environment";
         String pipelineName = "up42";
         environmentConfigService.sync(environmentsConfig(environmentName, pipelineName));
-        environmentConfigService.getEnvironmentConfig("invalid-environment-name");
+        assertThatCode(() -> environmentConfigService.getEnvironmentConfig("invalid-environment-name"))
+                .isInstanceOf(RecordNotFoundException.class);
+    }
+
+    @Nested
+    class EnvironmentForPipeline {
+        @Test
+        void shouldReturnEnvironmentForGivenPipeline() {
+            String environmentName = "foo-environment";
+            String pipelineName = "up42";
+            EnvironmentsConfig environmentsConfig = environmentsConfig(environmentName, pipelineName);
+            environmentConfigService.sync(environmentsConfig);
+
+            assertThat(environmentConfigService.environmentForPipeline("up42"))
+                    .isEqualTo(environmentsConfig.get(0));
+        }
+
+        @Test
+        void shouldReturnNullIfPipelineIsNotAssociatedWithEnvironment() {
+            String environmentName = "foo-environment";
+            String pipelineName = "up42";
+            EnvironmentsConfig environmentConfig = environmentsConfig(environmentName, pipelineName);
+            environmentConfigService.sync(environmentConfig);
+
+            assertThat(environmentConfigService.environmentForPipeline("foo"))
+                    .isNull();
+        }
     }
 
     private EnvironmentsConfig environmentsConfig(String envName, String pipelineName) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialExpansionServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialExpansionServiceTest.java
@@ -197,11 +197,11 @@ public class MaterialExpansionServiceTest {
             SecretParams secretParams = invocation.getArgument(0);
             secretParams.get(0).setValue("pass1");
             return null;
-        }).when(secretParamResolver).resolve(any());
+        }).when(secretParamResolver).resolve(any(SecretParams.class));
 
         materialExpansionService.expandForScheduling(svn, new Materials());
 
-        verify(secretParamResolver).resolve(any());
+        verify(secretParamResolver).resolve(any(SecretParams.class));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialExpansionServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialExpansionServiceTest.java
@@ -194,14 +194,15 @@ public class MaterialExpansionServiceTest {
         when(materialConfigConverter.toMaterials(new MaterialConfigs(svn.config(), expectedExternalSvnMaterial.config()))).thenReturn(new Materials(svn, expectedExternalSvnMaterial));
 
         doAnswer(invocation -> {
-            SecretParams secretParams = invocation.getArgument(0);
+            SvnMaterial svnMaterial = invocation.getArgument(0);
+            SecretParams secretParams = svnMaterial.getSecretParams();
             secretParams.get(0).setValue("pass1");
             return null;
-        }).when(secretParamResolver).resolve(any(SecretParams.class));
+        }).when(secretParamResolver).resolve(svn);
 
         materialExpansionService.expandForScheduling(svn, new Materials());
 
-        verify(secretParamResolver).resolve(any(SecretParams.class));
+        verify(secretParamResolver).resolve(svn);
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialServiceTest.java
@@ -283,17 +283,15 @@ public class MaterialServiceTest {
         GitMaterial gitMaterial = spy(new GitMaterial("https://example.com"));
         MaterialService spy = spy(materialService);
         GitPoller gitPoller = mock(GitPoller.class);
-        SecretParams secretParams = mock(SecretParams.class);
 
         doReturn(GitMaterial.class).when(spy).getMaterialClass(gitMaterial);
         doReturn(true).when(gitMaterial).hasSecretParams();
-        doReturn(secretParams).when(gitMaterial).getSecretParams();
         doReturn(gitPoller).when(spy).getPollerImplementation(gitMaterial);
         when(gitPoller.latestModification(any(), any(), any())).thenReturn(new ArrayList<>());
 
         spy.latestModification(gitMaterial, null, null);
 
-        verify(secretParamResolver).resolve(secretParams);
+        verify(secretParamResolver).resolve(gitMaterial);
     }
 
     @Test
@@ -306,13 +304,12 @@ public class MaterialServiceTest {
 
         doReturn(toBeReturned).when(spy).getMaterialClass(gitMaterial);
         doReturn(true).when(gitMaterial).hasSecretParams();
-        doReturn(secretParams).when(gitMaterial).getSecretParams();
         doReturn(gitPoller).when(spy).getPollerImplementation(gitMaterial);
         when(gitPoller.modificationsSince(any(), any(), any(), any())).thenReturn(new ArrayList<>());
 
         spy.modificationsSince(gitMaterial, null, null, null);
 
-        verify(secretParamResolver).resolve(secretParams);
+        verify(secretParamResolver).resolve(gitMaterial);
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/RulesServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/RulesServiceTest.java
@@ -18,29 +18,44 @@ package com.thoughtworks.go.server.service;
 
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
+import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.config.materials.git.GitMaterial;
 import com.thoughtworks.go.config.rules.Allow;
 import com.thoughtworks.go.config.rules.Rules;
-import com.thoughtworks.go.domain.PipelineGroups;
-import com.thoughtworks.go.helper.GoConfigMother;
+import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.domain.buildcause.BuildCause;
+import com.thoughtworks.go.domain.builder.Builder;
+import com.thoughtworks.go.domain.builder.CommandBuilder;
+import com.thoughtworks.go.domain.builder.NullBuilder;
+import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.helper.PipelineConfigMother;
+import com.thoughtworks.go.remote.work.BuildAssignment;
+import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.exceptions.RulesViolationException;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.thoughtworks.go.config.rules.SupportedEntity.ENVIRONMENT;
+import static com.thoughtworks.go.helper.GoConfigMother.configWithSecretConfig;
+import static com.thoughtworks.go.helper.GoConfigMother.defaultCruiseConfig;
+import static com.thoughtworks.go.helper.MaterialsMother.gitMaterial;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-public class RulesServiceTest {
+class RulesServiceTest {
     @Mock
-    GoConfigService goConfigService;
-    RulesService rulesService;
+    private GoConfigService goConfigService;
+    private RulesService rulesService;
 
     @BeforeEach
     void setUp() {
@@ -50,7 +65,7 @@ public class RulesServiceTest {
     }
 
     @Nested
-    class validateSecretConfigReferences_forMaterials {
+    class ForMaterials {
         @Test
         void shouldErrorOutIfMaterialDoesNotHavePermissionToReferASecretConfig() {
             GitMaterial gitMaterial = new GitMaterial("http://example.com");
@@ -61,7 +76,7 @@ public class RulesServiceTest {
 
             PipelineConfig up42 = PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs(gitMaterial.config()));
             PipelineConfigs defaultGroup = PipelineConfigMother.createGroup("some_group", up42);
-            CruiseConfig cruiseConfig = GoConfigMother.configWithSecretConfig(secretConfig);
+            CruiseConfig cruiseConfig = configWithSecretConfig(secretConfig);
             cruiseConfig.setGroup(new PipelineGroups(defaultGroup));
 
             when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
@@ -71,7 +86,7 @@ public class RulesServiceTest {
             assertThatCode(() -> rulesService.validateSecretConfigReferences(gitMaterial))
                     .isInstanceOf(RulesViolationException.class)
                     .hasMessage("Material with url: 'http://example.com' in Pipeline: 'up42' and " +
-                            "Pipeline Group: 'some_group' does not have permission to refer to Secrets using SecretConfig: 'secret_config_id'");
+                            "Pipeline Group: 'some_group' does not have permission to refer to secrets using SecretConfig: 'secret_config_id'");
         }
 
         @Test
@@ -86,7 +101,7 @@ public class RulesServiceTest {
             PipelineConfig up43 = PipelineConfigMother.pipelineConfig("up43", new MaterialConfigs(gitMaterial.config()));
             PipelineConfigs defaultGroup = PipelineConfigMother.createGroup("default", up42);
             PipelineConfigs someGroup = PipelineConfigMother.createGroup("some_group", up43);
-            CruiseConfig cruiseConfig = GoConfigMother.configWithSecretConfig(secretConfig);
+            CruiseConfig cruiseConfig = configWithSecretConfig(secretConfig);
             cruiseConfig.setGroup(new PipelineGroups(defaultGroup, someGroup));
 
             when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
@@ -97,7 +112,7 @@ public class RulesServiceTest {
             assertThatCode(() -> rulesService.validateSecretConfigReferences(gitMaterial))
                     .isInstanceOf(RulesViolationException.class)
                     .hasMessage("Material with url: 'http://example.com' in Pipeline: 'up43' and " +
-                            "Pipeline Group: 'some_group' does not have permission to refer to Secrets using SecretConfig: 'secret_config_id'");
+                            "Pipeline Group: 'some_group' does not have permission to refer to secrets using SecretConfig: 'secret_config_id'");
         }
 
         @Test
@@ -110,7 +125,7 @@ public class RulesServiceTest {
 
             PipelineConfig up42 = PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs(gitMaterial.config()));
             PipelineConfigs defaultGroup = PipelineConfigMother.createGroup("default", up42);
-            CruiseConfig cruiseConfig = GoConfigMother.configWithSecretConfig(secretConfig);
+            CruiseConfig cruiseConfig = configWithSecretConfig(secretConfig);
             cruiseConfig.setGroup(new PipelineGroups(defaultGroup));
 
             when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
@@ -120,5 +135,202 @@ public class RulesServiceTest {
             assertThat(rulesService.validateSecretConfigReferences(gitMaterial)).isEqualTo(true);
 
         }
+
+        @Test
+        void shouldErrorOutWhenMaterialIsReferringToNoneExistingSecretConfig() {
+            GitMaterial gitMaterial = new GitMaterial("http://example.com");
+            gitMaterial.setPassword("{{SECRET:[secret_config_id][password]}}");
+
+            PipelineConfig up42 = PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs(gitMaterial.config()));
+            PipelineConfig up43 = PipelineConfigMother.pipelineConfig("up43", new MaterialConfigs(gitMaterial.config()));
+            PipelineConfigs defaultGroup = PipelineConfigMother.createGroup("default", up42);
+            PipelineConfigs someGroup = PipelineConfigMother.createGroup("some_group", up43);
+            CruiseConfig cruiseConfig = defaultCruiseConfig();
+            cruiseConfig.setGroup(new PipelineGroups(defaultGroup, someGroup));
+
+            when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
+            when(goConfigService.pipelinesWithMaterial(gitMaterial.getFingerprint())).thenReturn(asList(new CaseInsensitiveString("up42"), new CaseInsensitiveString("up43")));
+            when(goConfigService.findGroupByPipeline(new CaseInsensitiveString("up42"))).thenReturn(defaultGroup);
+            when(goConfigService.findGroupByPipeline(new CaseInsensitiveString("up43"))).thenReturn(someGroup);
+
+            assertThatCode(() -> rulesService.validateSecretConfigReferences(gitMaterial))
+                    .isInstanceOf(RulesViolationException.class)
+                    .hasMessage("Material with url: 'http://example.com' in Pipeline: 'up42' and Pipeline Group: 'default'" +
+                            " is referring to none existing secret config 'secret_config_id'.");
+        }
+
+        @Test
+        void shouldBeValidIfMaterialPasswordIsNotDefinedUsingSecretParams() {
+            GitMaterial gitMaterial = new GitMaterial("http://example.com");
+            gitMaterial.setPassword("badger");
+
+            PipelineConfig up42 = PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs(gitMaterial.config()));
+            PipelineConfigs defaultGroup = PipelineConfigMother.createGroup("default", up42);
+            CruiseConfig cruiseConfig = defaultCruiseConfig();
+            cruiseConfig.setGroup(new PipelineGroups(defaultGroup));
+
+            when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
+            when(goConfigService.pipelinesWithMaterial(gitMaterial.getFingerprint())).thenReturn(asList(new CaseInsensitiveString("up42")));
+            when(goConfigService.findGroupByPipeline(any())).thenReturn(defaultGroup);
+
+            assertThat(rulesService.validateSecretConfigReferences(gitMaterial)).isEqualTo(true);
+        }
+    }
+
+    @Nested
+    class ForBuildAssignment {
+        @Test
+        void shouldBeValidIfJobInBuildAssignmentDoesNotHaveAnythingDefinedUsingSecretParams() {
+            JobIdentifier identifier = new JobIdentifier("Up42", 1, "1", "test", "1", "unit_test", 123L);
+            EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
+            environmentVariableContext.setProperty("Test", "some env", false);
+
+            BuildAssignment buildAssigment = createAssignment(environmentVariableContext, identifier);
+
+            PipelineConfig up42 = PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs());
+            PipelineConfigs defaultGroup = PipelineConfigMother.createGroup("default", up42);
+            CruiseConfig cruiseConfig = defaultCruiseConfig();
+            cruiseConfig.setGroup(new PipelineGroups(defaultGroup));
+
+            rulesService.validateSecretConfigReferences(buildAssigment);
+
+            verifyZeroInteractions(goConfigService);
+        }
+
+        @Test
+        void shouldValidateIfAJobInBuildAssignmentHasPermissionToReferASecretConfig() {
+            Rules rules = new Rules(new Allow("refer", "pipeline_group", "default"));
+            SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.file", rules);
+
+            JobIdentifier identifier = new JobIdentifier("up42", 1, "1", "test", "1", "unit_test", 123L);
+            EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
+            environmentVariableContext.setProperty("Token", "{{SECRET:[secret_config_id][password]}}", false);
+
+            BuildAssignment buildAssigment = createAssignment(environmentVariableContext, identifier);
+
+            PipelineConfig up42 = PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs());
+            PipelineConfigs defaultGroup = PipelineConfigMother.createGroup("default", up42);
+            CruiseConfig cruiseConfig = configWithSecretConfig(secretConfig);
+            cruiseConfig.setGroup(new PipelineGroups(defaultGroup));
+
+            when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
+            when(goConfigService.findGroupByPipeline(new CaseInsensitiveString(identifier.getPipelineName()))).thenReturn(defaultGroup);
+
+            assertThatCode(() -> rulesService.validateSecretConfigReferences(buildAssigment)).isNull();
+
+            verify(goConfigService, atLeastOnce()).findGroupByPipeline(new CaseInsensitiveString("up42"));
+        }
+
+        @Test
+        void shouldErrorOutIfAJobInBuildAssignmentDoesNotHavePermissionToReferASecretConfig() {
+            Rules rules = new Rules(new Allow("refer", "pipeline_group", "default"));
+            SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.file", rules);
+
+            JobIdentifier identifier = new JobIdentifier("up42", 1, "1", "test", "1", "unit_test", 123L);
+            EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
+            environmentVariableContext.setProperty("Token", "{{SECRET:[secret_config_id][password]}}", false);
+
+            BuildAssignment buildAssigment = createAssignment(environmentVariableContext, identifier);
+
+            PipelineConfig up42 = PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs());
+            PipelineConfigs defaultGroup = PipelineConfigMother.createGroup("some_group", up42);
+            CruiseConfig cruiseConfig = configWithSecretConfig(secretConfig);
+            cruiseConfig.setGroup(new PipelineGroups(defaultGroup));
+
+            when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
+            when(goConfigService.findGroupByPipeline(new CaseInsensitiveString(identifier.getPipelineName()))).thenReturn(defaultGroup);
+
+            assertThatCode(() -> rulesService.validateSecretConfigReferences(buildAssigment))
+                    .isInstanceOf(RulesViolationException.class)
+                    .hasMessage("Job: 'unit_test' in Pipeline: 'up42' and Pipeline Group: 'some_group' does not have " +
+                            "permission to refer to secrets using SecretConfig: 'secret_config_id'");
+        }
+
+        @Test
+        void shouldErrorOutWhenJobPlanIsReferringToNoneExistingSecretConfig() {
+            JobIdentifier jobIdentifier = new JobIdentifier("up42", 1, null, null, null, "job1");
+            PipelineConfig up42 = PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs());
+            PipelineConfigs defaultGroup = PipelineConfigMother.createGroup("some_group", up42);
+            CruiseConfig cruiseConfig = defaultCruiseConfig();
+            cruiseConfig.setGroup(new PipelineGroups(defaultGroup));
+            EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
+            environmentVariableContext.setProperty("Token", "{{SECRET:[secret_config_id][password]}}", false);
+
+            BuildAssignment buildAssigment = createAssignment(environmentVariableContext, jobIdentifier);
+
+            when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
+            when(goConfigService.findGroupByPipeline(new CaseInsensitiveString(jobIdentifier.getPipelineName()))).thenReturn(defaultGroup);
+
+            assertThatCode(() -> rulesService.validateSecretConfigReferences(buildAssigment))
+                    .isInstanceOf(RulesViolationException.class)
+                    .hasMessage("Job: 'job1' in Pipeline: 'up42' and Pipeline Group: 'some_group' is referring to none existing secret config 'secret_config_id'.");
+        }
+
+        private BuildAssignment createAssignment(EnvironmentVariableContext environmentVariableContext, JobIdentifier identifier) {
+            ScmMaterial gitMaterial = gitMaterial("https://example.org");
+            MaterialRevision gitRevision = new MaterialRevision(gitMaterial, new Modification());
+            BuildCause buildCause = BuildCause.createManualForced(new MaterialRevisions(gitRevision), Username.ANONYMOUS);
+
+            JobPlan plan = defaultJobPlan(new EnvironmentVariables(), new EnvironmentVariables(), identifier);
+            List<Builder> builders = new ArrayList<>();
+            builders.add(new CommandBuilder("ls", "", null, new RunIfConfigs(), new NullBuilder(), ""));
+            return BuildAssignment.create(plan, buildCause, builders, null, environmentVariableContext, new ArtifactStores());
+        }
+    }
+
+    @Nested
+    class ForEnvironmentConfig {
+        @Test
+        void shouldBeValidIfEnvironmentConfigDoesNotHaveEnvironmentVariableDefinedUsingSecretParams() {
+            BasicEnvironmentConfig environmentConfig = new BasicEnvironmentConfig(new CaseInsensitiveString("dev"));
+
+            boolean result = rulesService.validateSecretConfigReferences(environmentConfig);
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void shouldBeValidIfEnvironmentConfigCanReferToASecretConfig() {
+            BasicEnvironmentConfig environmentConfig = new BasicEnvironmentConfig(new CaseInsensitiveString("dev"));
+            environmentConfig.addEnvironmentVariable("Token", "{{SECRET:[secret_config_id][token]}}");
+            Allow allow = new Allow("refer", ENVIRONMENT.getType(), "dev");
+            CruiseConfig cruiseConfig = configWithSecretConfig(new SecretConfig("secret_config_id", "cd.go.secret.file", new Rules(allow)));
+
+            when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
+
+            boolean result = rulesService.validateSecretConfigReferences(environmentConfig);
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void shouldErrorOutWhenEnvironmentConfigCannotReferToASecretConfig() {
+            BasicEnvironmentConfig environmentConfig = new BasicEnvironmentConfig(new CaseInsensitiveString("dev"));
+            environmentConfig.addEnvironmentVariable("Token", "{{SECRET:[secret_config_id][token]}}");
+            CruiseConfig cruiseConfig = configWithSecretConfig(new SecretConfig("secret_config_id", "cd.go.secret.file"));
+
+            when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
+
+            assertThatCode(() -> rulesService.validateSecretConfigReferences(environmentConfig))
+                    .isInstanceOf(RulesViolationException.class)
+                    .hasMessage("Environment 'dev' does not have permission to refer to secrets using SecretConfig: 'secret_config_id'");
+        }
+
+        @Test
+        void shouldErrorOutWhenEnvironmentConfigIsReferringToNoneExistingSecretConfig() {
+            BasicEnvironmentConfig environmentConfig = new BasicEnvironmentConfig(new CaseInsensitiveString("dev"));
+            environmentConfig.addEnvironmentVariable("Token", "{{SECRET:[secret_config_id][token]}}");
+
+            when(goConfigService.cruiseConfig()).thenReturn(defaultCruiseConfig());
+
+            assertThatCode(() -> rulesService.validateSecretConfigReferences(environmentConfig))
+                    .isInstanceOf(RulesViolationException.class)
+                    .hasMessage("Environment 'dev' is referring to none existing secret config 'secret_config_id'.");
+        }
+    }
+
+    private JobPlan defaultJobPlan(EnvironmentVariables variables, EnvironmentVariables triggerVariables, JobIdentifier jobIdentifier) {
+        return new DefaultJobPlan(new Resources(), new ArrayList<>(), new ArrayList<>(), -1, jobIdentifier, null,
+                variables, triggerVariables, null, null);
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/RulesServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/RulesServiceTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.materials.MaterialConfigs;
+import com.thoughtworks.go.config.materials.git.GitMaterial;
+import com.thoughtworks.go.config.rules.Allow;
+import com.thoughtworks.go.config.rules.Rules;
+import com.thoughtworks.go.domain.PipelineGroups;
+import com.thoughtworks.go.helper.GoConfigMother;
+import com.thoughtworks.go.helper.PipelineConfigMother;
+import com.thoughtworks.go.server.exceptions.RulesViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class RulesServiceTest {
+    @Mock
+    GoConfigService goConfigService;
+    RulesService rulesService;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+
+        rulesService = new RulesService(goConfigService);
+    }
+
+    @Nested
+    class validateSecretConfigReferences_forMaterials {
+        @Test
+        void shouldErrorOutIfMaterialDoesNotHavePermissionToReferASecretConfig() {
+            GitMaterial gitMaterial = new GitMaterial("http://example.com");
+            gitMaterial.setPassword("{{SECRET:[secret_config_id][password]}}");
+
+            Rules rules = new Rules(new Allow("refer", "pipeline_group", "default"));
+            SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.file", rules);
+
+            PipelineConfig up42 = PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs(gitMaterial.config()));
+            PipelineConfigs defaultGroup = PipelineConfigMother.createGroup("some_group", up42);
+            CruiseConfig cruiseConfig = GoConfigMother.configWithSecretConfig(secretConfig);
+            cruiseConfig.setGroup(new PipelineGroups(defaultGroup));
+
+            when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
+            when(goConfigService.pipelinesWithMaterial(gitMaterial.getFingerprint())).thenReturn(asList(new CaseInsensitiveString("up42")));
+            when(goConfigService.findGroupByPipeline(any())).thenReturn(defaultGroup);
+
+            assertThatCode(() -> rulesService.validateSecretConfigReferences(gitMaterial))
+                    .isInstanceOf(RulesViolationException.class)
+                    .hasMessage("Material with url: 'http://example.com' in Pipeline: 'up42' and " +
+                            "Pipeline Group: 'some_group' does not have permission to refer to Secrets using SecretConfig: 'secret_config_id'");
+        }
+
+        @Test
+        void forAMaterialReferredInMultiplePipelineGroups_shouldErrorOutEvenIfOneOfThePipelineDoesNotHavePermissionToReferASecretConfig() {
+            GitMaterial gitMaterial = new GitMaterial("http://example.com");
+            gitMaterial.setPassword("{{SECRET:[secret_config_id][password]}}");
+
+            Rules rules = new Rules(new Allow("refer", "pipeline_group", "default"));
+            SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.file", rules);
+
+            PipelineConfig up42 = PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs(gitMaterial.config()));
+            PipelineConfig up43 = PipelineConfigMother.pipelineConfig("up43", new MaterialConfigs(gitMaterial.config()));
+            PipelineConfigs defaultGroup = PipelineConfigMother.createGroup("default", up42);
+            PipelineConfigs someGroup = PipelineConfigMother.createGroup("some_group", up43);
+            CruiseConfig cruiseConfig = GoConfigMother.configWithSecretConfig(secretConfig);
+            cruiseConfig.setGroup(new PipelineGroups(defaultGroup, someGroup));
+
+            when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
+            when(goConfigService.pipelinesWithMaterial(gitMaterial.getFingerprint())).thenReturn(asList(new CaseInsensitiveString("up42"), new CaseInsensitiveString("up43")));
+            when(goConfigService.findGroupByPipeline(new CaseInsensitiveString("up42"))).thenReturn(defaultGroup);
+            when(goConfigService.findGroupByPipeline(new CaseInsensitiveString("up43"))).thenReturn(someGroup);
+
+            assertThatCode(() -> rulesService.validateSecretConfigReferences(gitMaterial))
+                    .isInstanceOf(RulesViolationException.class)
+                    .hasMessage("Material with url: 'http://example.com' in Pipeline: 'up43' and " +
+                            "Pipeline Group: 'some_group' does not have permission to refer to Secrets using SecretConfig: 'secret_config_id'");
+        }
+
+        @Test
+        void shouldValidateIfMaterialHasPermissionToReferASecretConfig() {
+            GitMaterial gitMaterial = new GitMaterial("http://example.com");
+            gitMaterial.setPassword("{{SECRET:[secret_config_id][password]}}");
+
+            Rules rules = new Rules(new Allow("refer", "pipeline_group", "default"));
+            SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.file", rules);
+
+            PipelineConfig up42 = PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs(gitMaterial.config()));
+            PipelineConfigs defaultGroup = PipelineConfigMother.createGroup("default", up42);
+            CruiseConfig cruiseConfig = GoConfigMother.configWithSecretConfig(secretConfig);
+            cruiseConfig.setGroup(new PipelineGroups(defaultGroup));
+
+            when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
+            when(goConfigService.pipelinesWithMaterial(gitMaterial.getFingerprint())).thenReturn(asList(new CaseInsensitiveString("up42")));
+            when(goConfigService.findGroupByPipeline(any())).thenReturn(defaultGroup);
+
+            assertThat(rulesService.validateSecretConfigReferences(gitMaterial)).isEqualTo(true);
+
+        }
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/SecretParamResolverTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/SecretParamResolverTest.java
@@ -16,20 +16,31 @@
 
 package com.thoughtworks.go.server.service;
 
-import com.thoughtworks.go.config.SecretConfig;
-import com.thoughtworks.go.config.SecretParam;
-import com.thoughtworks.go.config.SecretParams;
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.config.materials.git.GitMaterial;
+import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.domain.buildcause.BuildCause;
+import com.thoughtworks.go.domain.builder.Builder;
+import com.thoughtworks.go.domain.builder.CommandBuilder;
+import com.thoughtworks.go.domain.builder.NullBuilder;
+import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.plugin.access.secrets.SecretsExtension;
 import com.thoughtworks.go.plugin.domain.secrets.Secret;
+import com.thoughtworks.go.remote.work.BuildAssignment;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 
+import static com.thoughtworks.go.helper.MaterialsMother.gitMaterial;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
@@ -57,23 +68,7 @@ class SecretParamResolverTest {
     @Nested
     class ResolveSecretsForMaterials {
         @Test
-        void shouldResolveSecretParamsForASCMMaterial() {
-            GitMaterial gitMaterial = new GitMaterial("http://example.com");
-            gitMaterial.setPassword("{{SECRET:[secret_config_id][password]}}");
-
-            SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.file");
-            when(goConfigService.cruiseConfig())
-                    .thenReturn(GoConfigMother.configWithSecretConfig(secretConfig));
-            when(secretsExtension.lookupSecrets("cd.go.file", secretConfig, new HashSet<>(asList("password"))))
-                    .thenReturn(asList(new Secret("password", "some-password")));
-
-            secretParamResolver.resolve(gitMaterial);
-
-            assertThat(gitMaterial.passwordForCommandLine()).isEqualTo("some-password");
-        }
-
-        @Test
-        void shouldValidateIfMaterialsHavePersmissionToReferToAGivenSecretConfig() {
+        void shouldResolveSecretParams_IfAMaterialCanReferToASecretConfig() {
             GitMaterial gitMaterial = new GitMaterial("http://example.com");
             gitMaterial.setPassword("{{SECRET:[secret_config_id][password]}}");
 
@@ -86,10 +81,11 @@ class SecretParamResolverTest {
             secretParamResolver.resolve(gitMaterial);
 
             verify(rulesService).validateSecretConfigReferences(gitMaterial);
+            assertThat(gitMaterial.passwordForCommandLine()).isEqualTo("some-password");
         }
 
         @Test
-        void shouldErrorOutIfMaterialsDoNotHavePermissionToReferToASecretConfig() {
+        void shouldErrorOut_IfMaterialsDoNotHavePermissionToReferToASecretConfig() {
             GitMaterial gitMaterial = new GitMaterial("http://example.com");
             gitMaterial.setPassword("{{SECRET:[secret_config_id][password]}}");
 
@@ -102,7 +98,93 @@ class SecretParamResolverTest {
             verifyZeroInteractions(secretsExtension);
         }
     }
-    
+
+    @Nested
+    class ResolveSecretsForBuildAssignment {
+        @Test
+        void shouldResolveSecretParams_IfBuildAssignmentCanReferSecretConfig() {
+            EnvironmentVariables jobEnvironmentVariables = new EnvironmentVariables();
+            jobEnvironmentVariables.add("Token", "{{SECRET:[secret_config_id][password]}}");
+            BuildAssignment buildAssigment = createAssignment(null, jobEnvironmentVariables);
+
+            SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.file");
+            when(goConfigService.cruiseConfig())
+                    .thenReturn(GoConfigMother.configWithSecretConfig(secretConfig));
+            when(secretsExtension.lookupSecrets("cd.go.file", secretConfig, new HashSet<>(asList("password"))))
+                    .thenReturn(asList(new Secret("password", "some-password")));
+
+            secretParamResolver.resolve(buildAssigment);
+
+            verify(rulesService).validateSecretConfigReferences(buildAssigment);
+            assertThat(buildAssigment.getSecretParams().get(0).getValue()).isEqualTo("some-password");
+        }
+
+        @Test
+        void shouldErrorOut_IfBuildAssignmentDoNotHavePermissionToReferToASecretConfig() {
+            EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
+            environmentVariableContext.setProperty("Token", "{{SECRET:[secret_config_id][password]}}", false);
+
+            BuildAssignment buildAssigment = createAssignment(environmentVariableContext);
+
+            doThrow(new RuntimeException()).when(rulesService).validateSecretConfigReferences(buildAssigment);
+
+            assertThatCode(() -> secretParamResolver.resolve(buildAssigment))
+                    .isInstanceOf(RuntimeException.class);
+
+            verifyZeroInteractions(goConfigService);
+            verifyZeroInteractions(secretsExtension);
+        }
+
+        private BuildAssignment createAssignment(EnvironmentVariableContext environmentVariableContext) {
+            return createAssignment(environmentVariableContext, new EnvironmentVariables());
+        }
+
+        private BuildAssignment createAssignment(EnvironmentVariableContext environmentVariableContext, EnvironmentVariables jobEnvironmentVariables) {
+            ScmMaterial gitMaterial = gitMaterial("https://example.org");
+            MaterialRevision gitRevision = new MaterialRevision(gitMaterial, new Modification());
+            BuildCause buildCause = BuildCause.createManualForced(new MaterialRevisions(gitRevision), Username.ANONYMOUS);
+
+            JobPlan plan = defaultJobPlan(jobEnvironmentVariables, new EnvironmentVariables());
+            List<Builder> builders = new ArrayList<>();
+            builders.add(new CommandBuilder("ls", "", null, new RunIfConfigs(), new NullBuilder(), ""));
+            return BuildAssignment.create(plan, buildCause, builders, null, environmentVariableContext, new ArtifactStores());
+        }
+    }
+
+    @Nested
+    class ResolveEnvironmentConfig {
+        @Test
+        void shouldResolveSecretParams_IfJobPlanCanReferSecretConfig() {
+            BasicEnvironmentConfig environmentConfig = new BasicEnvironmentConfig(new CaseInsensitiveString("dev"));
+            environmentConfig.addEnvironmentVariable("key", "{{SECRET:[secret_config_id][password]}}");
+
+            SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.file");
+            when(goConfigService.cruiseConfig())
+                    .thenReturn(GoConfigMother.configWithSecretConfig(secretConfig));
+            when(secretsExtension.lookupSecrets("cd.go.file", secretConfig, new HashSet<>(asList("password"))))
+                    .thenReturn(asList(new Secret("password", "some-password")));
+
+            secretParamResolver.resolve(environmentConfig);
+
+            verify(rulesService).validateSecretConfigReferences(environmentConfig);
+            assertThat(environmentConfig.getSecretParams().get(0).getValue()).isEqualTo("some-password");
+        }
+
+        @Test
+        void shouldErrorOut_IfJobPlanDoNotHavePermissionToReferToASecretConfig() {
+            BasicEnvironmentConfig environmentConfig = new BasicEnvironmentConfig(new CaseInsensitiveString("dev"));
+            environmentConfig.addEnvironmentVariable("key", "{{SECRET:[secret_config_id][password]}}");
+
+            doThrow(new RuntimeException()).when(rulesService).validateSecretConfigReferences(environmentConfig);
+
+            assertThatCode(() -> secretParamResolver.resolve(environmentConfig))
+                    .isInstanceOf(RuntimeException.class);
+
+            verifyZeroInteractions(goConfigService);
+            verifyZeroInteractions(secretsExtension);
+        }
+    }
+
     @Test
     void shouldResolveSecretParamsOfVariousSecretConfig() {
         final SecretParams allSecretParams = new SecretParams(
@@ -152,5 +234,11 @@ class SecretParamResolverTest {
         assertThat(allSecretParams).hasSize(2);
         assertThat(allSecretParams.get(0).getValue()).isEqualTo("some-username");
         assertThat(allSecretParams.get(1).getValue()).isEqualTo("some-username");
+    }
+
+    private JobPlan defaultJobPlan(EnvironmentVariables variables, EnvironmentVariables triggerVariables) {
+        JobIdentifier identifier = new JobIdentifier("Up42", 1, "1", "test", "1", "unit_test", 123L);
+        return new DefaultJobPlan(new Resources(), new ArrayList<>(), new ArrayList<>(), -1, identifier, null,
+                variables, triggerVariables, null, null);
     }
 }

--- a/server/webapp/WEB-INF/rails/spec/presenters/api_v1/shared/environment_variable_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/presenters/api_v1/shared/environment_variable_representer_spec.rb
@@ -46,7 +46,7 @@ describe ApiV1::Shared::EnvironmentVariableRepresenter do
   it 'should deserialize an ambiguous encrypted variable (with both value and encrypted_value) to a variable with errors' do
     config    = EnvironmentVariableConfig.new
     presenter = ApiV1::Shared::EnvironmentVariableRepresenter.new(config)
-    config = presenter.from_hash(name: 'PASSWORD', secure: true, value: 'plainText', encrypted_value: 'c!ph3rt3xt')
+    config = presenter.from_hash(name: 'PASSWORD', secure: true, value: 'plainText', encrypted_value: GoCipher.new.encrypt('c!ph3rt3xt'))
     expect(config.errors.getAllOn('value').to_a).to eq(['You may only specify `value` or `encrypted_value`, not both!'])
     expect(config.errors.getAllOn('encryptedValue').to_a).to eq(['You may only specify `value` or `encrypted_value`, not both!'])
   end
@@ -59,7 +59,7 @@ describe ApiV1::Shared::EnvironmentVariableRepresenter do
 
     config    = EnvironmentVariableConfig.new
     presenter = ApiV1::Shared::EnvironmentVariableRepresenter.new(config)
-    config = presenter.from_hash(name: 'PASSWORD', secure: true, encrypted_value: 'c!ph3rt3xt')
+    config = presenter.from_hash(name: 'PASSWORD', secure: true, encrypted_value: GoCipher.new.encrypt('c!ph3rt3xt'))
     expect(config.errors).to be_empty
   end
 


### PR DESCRIPTION
- Validate if, environment variables defined in environment config can refer to a secret config
- Validate if environment variables defined in the pipeline config can refer to  a secret config
- Validate if the material in the pipeline config can refer to a secret config
- Fail build if any of the above-mentioned configs cannot refer to secret config and update the job console log