### PR TITLE
Fixing styling for validation errors on add pipeline page

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/components.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/components.scss
@@ -36,6 +36,7 @@ $error-container-width: 450px;
 .actions {
   .save-btns {
     white-space: nowrap;
+    height: 35px;
   }
 
   .error-response {
@@ -43,6 +44,8 @@ $error-container-width: 450px;
     color: $go-danger;
     display: inline-block;
     max-width: $error-container-width;
+    white-space: normal;
+    float: left;
 
     &:empty {
       margin-right: 0;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/components.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/components.scss
@@ -36,11 +36,11 @@ $error-container-width: 450px;
 .actions {
   .save-btns {
     white-space: nowrap;
-    height: 35px;
   }
 
   .error-response {
     margin-right: 2ex;
+    margin-top: 7px;
     color: $go-danger;
     display: inline-block;
     max-width: $error-container-width;


### PR DESCRIPTION
Need to wrap the text without throwing off everything else

before:
![Screenshot_2019-06-04_at_11 46 26](https://user-images.githubusercontent.com/5726224/59308742-a122cf80-8c56-11e9-9568-feb048ae6e9b.png)



after:

<img width="1319" alt="Screen Shot 2019-06-11 at 14 56 18" src="https://user-images.githubusercontent.com/5726224/59309742-37f08b80-8c59-11e9-84e6-388b88bd4db2.png">


