### PR TITLE
Build GoCD agent alpine 3.10 based docker image

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -26,7 +26,8 @@ enum Distro implements DistroBehavior {
       return [
         new DistroVersion(version: '3.7', releaseName: '3.7', eolDate: parseDate('2019-11-01')),
         new DistroVersion(version: '3.8', releaseName: '3.8', eolDate: parseDate('2020-05-01')),
-        new DistroVersion(version: '3.9', releaseName: '3.9', eolDate: parseDate('2021-01-01'))
+        new DistroVersion(version: '3.9', releaseName: '3.9', eolDate: parseDate('2021-01-01')),
+        new DistroVersion(version: '3.10', releaseName: '3.10', eolDate: parseDate('2022-06-01'))
       ]
     }
 


### PR DESCRIPTION
* Alpine 3.10 is released on 2019-06-19
* Release information: https://alpinelinux.org/posts/Alpine-3.10.0-released.html