### PR TITLE
Install procps on all docker distributions

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -144,7 +144,7 @@ enum Distro implements DistroBehavior {
     List<String> getInstallPrerequisitesCommands() {
       return [
         'apt-get update',
-        'apt-get install -y git subversion mercurial openssh-client bash unzip curl locales',
+        'apt-get install -y git subversion mercurial openssh-client bash unzip curl locales procps sysvinit-utils coreutils',
         'apt-get autoclean',
         'echo \'en_US.UTF-8 UTF-8\' > /etc/locale.gen && /usr/sbin/locale-gen'
       ]

--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -35,6 +35,12 @@ enum OsType {
       // for `pidof`
       fpmArgs += ['--depends', 'sysvinit-utils']
 
+      // for `ps`
+      fpmArgs += ['--depends', 'procps']
+
+      // for `su`
+      fpmArgs += ['--depends', 'login']
+
       // HACK: for debian packages :(, since manifests cannot contain fine grained ownership
       def tmpDir = project.file("${project.buildDir}/tmp")
       tmpDir.mkdirs()


### PR DESCRIPTION
* 'ps' is not available on debian starting from debian 9.
* Explicitly install procps to avoid failure due to missing 'ps' package.

##### failure logs before fix:
```
$ exec /usr/local/sbin/tini -- /go/bin/go-agent console
Unable to locate ps.
Please report this message along with the location of the command on your system.
```

##### Fix:
```
 exec /usr/local/sbin/tini -- /go/bin/go-agent console
set.AGENT_STARTUP_ARGS=%AGENT_STARTUP_ARGS% -Dgo.console.stdout=true %GOCD_AGENT_JVM_OPTS%
Running go-agent...
wrapper  | --> Wrapper Started as Console
```