### PR TITLE
Updated rules validation on MDU

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/exceptions/RulesViolationException.java
+++ b/server/src/main/java/com/thoughtworks/go/server/exceptions/RulesViolationException.java
@@ -24,7 +24,7 @@ public class RulesViolationException extends RuntimeException {
     }
 
     public static void throwSecretConfigNotFound(String entityType, String entityName, String secretConfigId) {
-        throw new RulesViolationException(format("%s '%s' is referring to none existing secret config '%s'.", entityType, entityName, secretConfigId));
+        throw new RulesViolationException(format("%s '%s' is referring to none-existent secret config '%s'.", entityType, entityName, secretConfigId));
     }
 
     public static void throwCannotRefer(String entityType, String entityName, String secretConfigId) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/RulesService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/RulesService.java
@@ -20,12 +20,16 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.remote.work.BuildAssignment;
+import com.thoughtworks.go.server.exceptions.RulesViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.thoughtworks.go.server.exceptions.RulesViolationException.throwCannotRefer;
 import static com.thoughtworks.go.server.exceptions.RulesViolationException.throwSecretConfigNotFound;
@@ -44,13 +48,42 @@ public class RulesService {
     public boolean validateSecretConfigReferences(ScmMaterial scmMaterial) {
         List<CaseInsensitiveString> pipelines = goConfigService.pipelinesWithMaterial(scmMaterial.getFingerprint());
         SecretParams secretParams = scmMaterial.getSecretParams();
-        pipelines.forEach(pipeline -> {
-            PipelineConfigs group = goConfigService.findGroupByPipeline(pipeline);
-            String errorMessagePrefix = format("Material with url: '%s' in Pipeline: '%s' and Pipeline Group:", scmMaterial.getUriForDisplay(), pipeline);
-            validateSecretConfigReferences(secretParams, group.getClass(), group.getGroup(), errorMessagePrefix);
-        });
 
+        List<String> missingSecretConfigs = secretParams.stream()
+                .filter(secretParam -> goConfigService.cruiseConfig().getSecretConfigs().find(secretParam.getSecretConfigId()) == null)
+                .map(SecretParam::getSecretConfigId)
+                .collect(Collectors.toList());
+
+        if (!missingSecretConfigs.isEmpty()) {
+            throwSecretConfigNotFound("ScmMaterial", scmMaterial.getUriForDisplay(), String.join(", ", missingSecretConfigs));
+        }
+
+        HashMap<CaseInsensitiveString, List<String>> pipelinesWithViolatedSecretConfigIds = new HashMap<>();
+        secretParams.stream()
+                .map(secretParam -> goConfigService.cruiseConfig().getSecretConfigs().find(secretParam.getSecretConfigId()))
+                .forEach(secretConfig -> {
+                    pipelines.forEach(pipelineName -> {
+                        PipelineConfigs group = goConfigService.findGroupByPipeline(pipelineName);
+                        if (!secretConfig.canRefer(group.getClass(), group.getGroup())) {
+                            if (!pipelinesWithViolatedSecretConfigIds.containsKey(pipelineName)) {
+                                pipelinesWithViolatedSecretConfigIds.put(pipelineName, new ArrayList<>());
+                            }
+                            LOGGER.error("[Material Update] Failure", format("Pipeline '%s' does not have permission to refer to secrets using SecretConfig: '%s'", pipelineName.toString(), secretConfig.getId()));
+                            pipelinesWithViolatedSecretConfigIds.get(pipelineName).add(secretConfig.getId());
+
+                        }
+                    });
+                });
+
+        if (pipelinesWithViolatedSecretConfigIds.size() == pipelines.size()) {
+            String secretConfigId = secretParams.get(0).getSecretConfigId();
+            String errorMessage = format("Material with url: '%s' does not have permissions to refer to secret config with id: '%s'. The pipelines which use this material are: '%s'", scmMaterial.getUriForDisplay(), secretConfigId, pipelinesWithViolatedSecretConfigIds.keySet().toString());
+            LOGGER.error("[Material Update] Failure", errorMessage);
+            throw new RulesViolationException(errorMessage);
+        }
         return true;
+
+
     }
 
     public boolean validateSecretConfigReferences(EnvironmentConfig environmentConfig) {


### PR DESCRIPTION
Epic: #5830 

 - MDU will go through if there exists at least one material which can refer to the secret config
    in question
 - MDU will throw `RulesViolationException` if all the pipeline which utilizes this material violates the 
   rules defined.

### Scenarios

 1. A material URL utilized in 2 different pipeline groups referring to the same secret config.
     - if the secret config can be accessed by both, the MDU will go through.
     - if the secret config can be accessed by only one of them, the MDU will go through.
     - if the secret config can't be accessed by either of them, the MDU will fail.

 2. A material URL utilized in 2 different pipeline groups referring to different secret config. In this case, the MDU going through will be dependent on which material went through the process. 
     - if the secret param present in the material can access either of the pipeline group, it will go through, otherwise not.