### PR TITLE
Updated rules validation on MDU

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/MaterialConfigs.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/MaterialConfigs.java
@@ -30,6 +30,7 @@ import com.thoughtworks.go.util.ArtifactLogUtil;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @ConfigTag("materials")
 @ConfigCollection(MaterialConfig.class)
@@ -406,5 +407,16 @@ public class MaterialConfigs extends BaseCollection<MaterialConfig> implements V
 
     public boolean hasDependencyMaterial(PipelineConfig pipeline) {
         return findDependencyMaterial(pipeline.name()) != null;
+    }
+
+    public MaterialConfig getByMaterialFingerPrint(String materialFingerprint) {
+        List<MaterialConfig> materialConfigs = this
+                .stream()
+                .filter(materialConfig -> materialConfig.getFingerprint().equals(materialFingerprint))
+                .collect(Collectors.toList());
+        if (!materialConfigs.isEmpty()) {
+            return materialConfigs.get(0);
+        }
+        return null;
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/MaterialConfigsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/MaterialConfigsTest.java
@@ -246,6 +246,13 @@ Above scenario allowed
     }
 
     @Test
+    public void shouldReturnNullWhenMaterialNotFoundForTheGivenMaterialFingerPrint() {
+        CruiseConfig cruiseConfig = new BasicCruiseConfig();
+        PipelineConfig pipeline = goConfigMother.addPipeline(cruiseConfig, "pipeline1", "stage", "build");
+        assertThat(pipeline.materialConfigs().getByMaterialFingerPrint("invalid"), is(nullValue()));
+    }
+
+    @Test
     public void shouldFailIfMultipleMaterialsDoNotHaveDestinationFolderSet() {
         HgMaterialConfig materialConfigOne = hg("http://url1", null);
         materialConfigOne.setConfigAttributes(Collections.singletonMap(ScmMaterialConfig.FOLDER, "folder"));
@@ -360,7 +367,7 @@ Above scenario allowed
     }
 
     @Test
-    public void shouldReturnMaterialBasedOnPiplineUniqueFingerPrint() {
+    public void shouldReturnMaterialBasedOnPipelineUniqueFingerPrint() {
         CruiseConfig cruiseConfig = new BasicCruiseConfig();
         PipelineConfig pipeline1 = goConfigMother.addPipeline(cruiseConfig, "pipeline1", "stage", "build");
         HgMaterialConfig expectedMaterial = MaterialConfigsMother.hgMaterialConfig();
@@ -369,6 +376,19 @@ Above scenario allowed
         pipeline1.addMaterialConfig(MaterialConfigsMother.svnMaterialConfig("url", "folder"));
 
         MaterialConfig actualMaterialConfig = pipeline1.materialConfigs().getByFingerPrint(expectedMaterial.getPipelineUniqueFingerprint());
+        assertThat(actualMaterialConfig, is(expectedMaterial));
+    }
+
+    @Test
+    public void shouldReturnMaterialBasedOnMaterialFingerPrint() {
+        CruiseConfig cruiseConfig = new BasicCruiseConfig();
+        PipelineConfig pipeline1 = goConfigMother.addPipeline(cruiseConfig, "pipeline1", "stage", "build");
+        HgMaterialConfig expectedMaterial = MaterialConfigsMother.hgMaterialConfig();
+        pipeline1.addMaterialConfig(expectedMaterial);
+        pipeline1.addMaterialConfig(MaterialConfigsMother.gitMaterialConfig("url"));
+        pipeline1.addMaterialConfig(MaterialConfigsMother.svnMaterialConfig("url", "folder"));
+
+        MaterialConfig actualMaterialConfig = pipeline1.materialConfigs().getByMaterialFingerPrint(expectedMaterial.getFingerprint());
         assertThat(actualMaterialConfig, is(expectedMaterial));
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/exceptions/RulesViolationException.java
+++ b/server/src/main/java/com/thoughtworks/go/server/exceptions/RulesViolationException.java
@@ -24,10 +24,10 @@ public class RulesViolationException extends RuntimeException {
     }
 
     public static void throwSecretConfigNotFound(String entityType, String entityName, String secretConfigId) {
-        throw new RulesViolationException(format("%s '%s' is referring to none existing secret config '%s'.", entityType, entityName, secretConfigId));
+        throw new RulesViolationException(format("%s '%s' is referring to none-existent secret config '%s'.", entityType, entityName, secretConfigId));
     }
 
     public static void throwCannotRefer(String entityType, String entityName, String secretConfigId) {
-        throw new RulesViolationException(format("%s '%s' does not have permission to refer to secrets using SecretConfig: '%s'", entityType, entityName, secretConfigId));
+        throw new RulesViolationException(format("%s '%s' does not have permission to refer to secrets using secret config '%s'", entityType, entityName, secretConfigId));
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
@@ -65,6 +65,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.StringReader;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.thoughtworks.go.config.validation.GoConfigValidity.*;
 import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEditPipeline;
@@ -1080,6 +1081,21 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
 
     public ConfigElementImplementationRegistry getRegistry() {
         return registry;
+    }
+
+    public PipelineConfig findPipelineByName(CaseInsensitiveString pipelineName) {
+        List<PipelineConfig> pipelineConfigs = getAllPipelineConfigs()
+                .stream()
+                .filter((pipelineConfig) -> pipelineConfig.getName().equals(pipelineName))
+                .collect(Collectors.toList());
+        if (!pipelineConfigs.isEmpty()) {
+            return pipelineConfigs.get(0);
+        }
+        return null;
+    }
+
+    public SecretConfig getSecretConfigById(String secretConfigId) {
+        return this.cruiseConfig().getSecretConfigs().find(secretConfigId);
     }
 
     public abstract class XmlPartialSaver<T> {


### PR DESCRIPTION
Original PR: #6555  
 - MDU will go through if there exists at least one material which can refer to the secret config specified
 - MDU will throw `RulesViolationException` if all the pipeline which utilizes the material with the same fingerprint violates the secret config rules.

#### Preview

<img width="1389" alt="Screen Shot 2019-06-21 at 3 02 24 PM" src="https://user-images.githubusercontent.com/41165891/59915390-2322ad80-943a-11e9-8a63-4e1094884b23.png">
