### PR TITLE
Fix arguments for `git submodule foreach --recursive`

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitVersion.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitVersion.java
@@ -29,8 +29,9 @@ public class GitVersion {
             "git version (\\d+)\\.(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(.*)", Pattern.CASE_INSENSITIVE);
 
     private final Version version;
-    private final static Version MINIMUM_SUPPORTED_VERSION = Version.create(1,9,0);
+    private final static Version MINIMUM_SUPPORTED_VERSION = Version.create(1, 9, 0);
     private final static Version SUBMODULE_DEPTH_SUPPORT = Version.create(2, 10, 0);
+    private final static Version SUBMODULE_FOREACH_RECURSIVE_BREAK = Version.create(2, 22, 0);
 
     private GitVersion(Version parsedVersion) {
         this.version = parsedVersion;
@@ -56,6 +57,10 @@ public class GitVersion {
 
     public boolean supportsSubmoduleDepth() {
         return version.compareTo(SUBMODULE_DEPTH_SUPPORT) >= 0;
+    }
+
+    public boolean requiresSubmoduleCommandFix() {
+        return version.compareTo(SUBMODULE_FOREACH_RECURSIVE_BREAK) >= 0;
     }
 
     public Version getVersion() {

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
@@ -25,6 +25,7 @@ import com.thoughtworks.go.domain.MaterialInstance;
 import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.MaterialRevisions;
 import com.thoughtworks.go.domain.materials.*;
+import com.thoughtworks.go.domain.materials.git.GitCommand;
 import com.thoughtworks.go.domain.materials.git.GitTestRepo;
 import com.thoughtworks.go.domain.materials.git.GitVersion;
 import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
@@ -154,12 +155,17 @@ public class GitMaterialTest {
 
         @Test
         void shouldGetLatestModificationUsingPassword() {
+            GitCommand git = new GitCommand(null, new File(""), GitMaterialConfig.DEFAULT_BRANCH, false, null);
+
             GitMaterial gitMaterial = new GitMaterial("http://username:password@0.0.0.0");
             try {
                 gitMaterial.latestModification(workingDir, new TestSubprocessExecutionContext());
                 fail("should throw exception because url is not reachable");
             } catch (Exception e) {
-                assertThat(e.getMessage()).contains("******");
+                if (!git.version().requiresSubmoduleCommandFix()) {
+                    //ugly hack for git >= 2.22. The error message has changed and shows 'connection refused' without any password
+                    assertThat(e.getMessage()).contains("******");
+                }
                 assertThat(e.getMessage()).doesNotContain("password");
             }
         }

--- a/domain/src/test/java/com/thoughtworks/go/domain/materials/git/GitVersionTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/materials/git/GitVersionTest.java
@@ -61,4 +61,10 @@ public class GitVersionTest {
         GitVersion version = GitVersion.parse("git version 1.5.0.1");
         assertThat(version.isMinimumSupportedVersionOrHigher()).isFalse();
     }
+
+    @Test
+    void shouldReturnTrueIfVersionRequiresSubmoduleCommandFix() {
+        GitVersion version = GitVersion.parse("git version 2.22.0");
+        assertThat(version.requiresSubmoduleCommandFix()).isTrue();
+    }
 }


### PR DESCRIPTION
Parsing the command following `git submodule foreach --recursive` has changed in Git 2.22.
This was causing the command `git submodule foreach --recursive git clean -dffx` to fail, because git thinks that `-d` is part of the arguments for `foreach`