### PR TITLE
Order pipeline groups alphabetically

### DIFF
--- a/server/webapp/WEB-INF/rails/app/controllers/admin/pipeline_groups_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/admin/pipeline_groups_controller.rb
@@ -156,6 +156,8 @@ class Admin::PipelineGroupsController < AdminController
       target_groups.push(group.getGroup()) if group.findBy(pipeline_to_be_moved).nil?
     end
 
+    target_groups = target_groups.sort_by(&:downcase)
+
     @possible_groups = target_groups
     @pipeline_name = pipeline_to_be_moved.toString()
     @md5_match = match

--- a/server/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
@@ -286,6 +286,10 @@ module Admin
         group_array.push({:group => group})
         group_list.push(group)
       end
+
+      group_array = group_array.sort_by { |group| group[:group].downcase }
+      group_list = group_list.sort_by(&:downcase)
+
       assert_load :groups_json, group_array.to_json
       assert_load :groups_list, group_list
     end

--- a/server/webapp/WEB-INF/rails/spec/controllers/admin/pipeline_groups_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/admin/pipeline_groups_controller_spec.rb
@@ -100,7 +100,7 @@ describe Admin::PipelineGroupsController do
       allow(@go_config_service).to receive(:checkConfigFileValid).and_return(com.thoughtworks.go.config.validation.GoConfigValidity.valid())
       allow(@security_service).to receive(:isUserAdminOfGroup).and_return(true)
       @user = current_user
-      @groups = PipelineConfigMother.createGroups(["group1", "group2", "group3"].to_java(java.lang.String))
+      @groups = PipelineConfigMother.createGroups(["group1", "dev", "Docs", "group2", "ApiDocs", "group3", "api"].to_java(java.lang.String))
       @config = BasicCruiseConfig.new(@groups.to_a.to_java(PipelineConfigs))
       group_for_edit = ConfigForEdit.new(@groups.get(0), @config, @config)
       allow(@go_config_service).to receive(:loadGroupForEditing).and_return(group_for_edit)
@@ -188,10 +188,14 @@ describe Admin::PipelineGroupsController do
         expect(@security_service).to receive(:isUserAdminOfGroup).with(@user.getUsername(), "group1").and_return(true)
         expect(@security_service).to receive(:isUserAdminOfGroup).with(@user.getUsername(), "group2").and_return(false)
         expect(@security_service).to receive(:isUserAdminOfGroup).with(@user.getUsername(), "group3").and_return(true)
+        expect(@security_service).to receive(:isUserAdminOfGroup).with(@user.getUsername(), "dev").and_return(false)
+        expect(@security_service).to receive(:isUserAdminOfGroup).with(@user.getUsername(), "Docs").and_return(false)
+        expect(@security_service).to receive(:isUserAdminOfGroup).with(@user.getUsername(), "ApiDocs").and_return(false)
+        expect(@security_service).to receive(:isUserAdminOfGroup).with(@user.getUsername(), "api").and_return(false)
 
         get :index
 
-        expect(assigns[:groups]).to eq([@groups.get(0), @groups.get(2)])
+        expect(assigns[:groups]).to eq([@groups.get(0), @groups.get(5)])
       end
     end
 
@@ -395,7 +399,7 @@ describe Admin::PipelineGroupsController do
 
         get :possible_groups, params:{:pipeline_name => "pipeline_1", :config_md5 => "my_md5"}
 
-        expect(assigns[:possible_groups]).to eq(["group2", "group3"])
+        expect(assigns[:possible_groups]).to eq(["api", "ApiDocs", "dev", "Docs", "group2", "group3"])
         expect(assigns[:pipeline_name]).to eq("pipeline_1")
         expect(assigns[:md5_match]).to eq(true)
         assert_template "possible_groups"

--- a/server/webapp/WEB-INF/rails/spec/controllers/admin/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/admin/pipelines_controller_spec.rb
@@ -732,7 +732,7 @@ describe Admin::PipelinesController do
       @pipeline = PipelineConfigMother.pipelineConfig("foo.bar")
       @cruise_config.addPipeline("group1", @pipeline)
       expect(@go_config_service).to receive(:getConfigForEditing).and_return(@cruise_config)
-      expect(@security_service).to receive(:modifiableGroupsForUser).with(@user).and_return(["group1", "group2"])
+      expect(@security_service).to receive(:modifiableGroupsForUser).with(@user).and_return(["dev", "group1", "Docs", "group2", "ApiDocs", "api"])
       allow(@go_config_service).to receive(:registry)
     end
 
@@ -744,8 +744,8 @@ describe Admin::PipelinesController do
         expect(assigns[:pipeline]).to eq(clonedPipeline)
         expect(assigns[:pipeline_group]).to eq(BasicPipelineConfigs.new([clonedPipeline].to_java(PipelineConfig)))
         expect(assigns[:group_name]).to eq("group1")
-        expect(assigns[:groups_list]).to eq(["group1", "group2"])
-        expect(assigns[:groups_json]).to eq([{"group" => "group1"}, {"group" => "group2"}].to_json)
+        expect(assigns[:groups_list]).to eq(["api", "ApiDocs", "dev", "Docs", "group1", "group2"])
+        expect(assigns[:groups_json]).to eq([{"group" => "api"}, {"group" => "ApiDocs"}, {"group" => "dev"}, {"group" => "Docs"}, {"group" => "group1"}, {"group" => "group2"}].to_json)
         assert_template layout: false
       end
     end


### PR DESCRIPTION
Issue: #6567

Order pipeline group names case-insensitively and alphabetically while cloning the pipeline as well as moving pipeline to another group.