### PR TITLE
Ensure that preflight checks set a config origin on the rendered partial configs

### DIFF
--- a/api/api-config-repo-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepooperations/ConfigRepoOperationsControllerV1Test.groovy
+++ b/api/api-config-repo-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepooperations/ConfigRepoOperationsControllerV1Test.groovy
@@ -22,6 +22,7 @@ import com.thoughtworks.go.config.*
 import com.thoughtworks.go.config.exceptions.EntityType
 import com.thoughtworks.go.config.exceptions.GoConfigInvalidException
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException
+import com.thoughtworks.go.config.remote.EphemeralConfigOrigin
 import com.thoughtworks.go.config.remote.PartialConfig
 import com.thoughtworks.go.plugin.access.configrepo.InvalidPartialConfigException
 import com.thoughtworks.go.server.service.ConfigRepoService
@@ -120,6 +121,19 @@ class ConfigRepoOperationsControllerV1Test implements SecurityServiceTrait, Cont
         assertThatResponse().
           isNotFound().
           hasJsonMessage(EntityType.ConfigRepo.notFoundMessage(REPO_ID))
+      }
+
+      @Test
+      void "sets ad-hoc config origin on resultant partial config"() {
+        def plugin = mock(ConfigRepoPlugin.class)
+        def partialConfig = mock(PartialConfig.class)
+
+        when(plugin.parseContent(any() as Map<String, String>, any() as PartialConfigLoadContext)).thenReturn(partialConfig)
+        when(pluginService.partialConfigProviderFor(PLUGIN_ID)).thenReturn(plugin)
+
+        postWithApiHeader(controller.controllerPath("$PREFLIGHT_PATH?pluginId=$PLUGIN_ID"), [:])
+
+        verify(partialConfig).setOrigins(any(EphemeralConfigOrigin))
       }
 
       @Test

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/EphemeralConfigOrigin.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/EphemeralConfigOrigin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.remote;
+
+public class EphemeralConfigOrigin implements ConfigOrigin {
+    private String streamName;
+
+    public EphemeralConfigOrigin(String streamName) {
+        this.streamName = streamName;
+    }
+
+    @Override
+    public boolean canEdit() {
+        return false;
+    }
+
+    @Override
+    public boolean isLocal() {
+        return false;
+    }
+
+    @Override
+    public String displayName() {
+        return streamName;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
@@ -967,7 +967,7 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
         return clonedConfigForEdit();
     }
 
-    private CruiseConfig clonedConfigForEdit() {
+    public CruiseConfig clonedConfigForEdit() {
         return cloner.deepClone(getConfigForEditing());
     }
 


### PR DESCRIPTION
This fixes https://github.com/gocd/gocd/issues/6566 where preflight validation would give different results than in actuality. Specificially, if a pipeline defined in a configrepo referenced another pipeline in a separate config repo, the validation would fail because GoCD assumed that the preflighted repo was local instead of remote. (A validation exists such that a pipeline defined locally in cruise-config.xml cannot depend on a pipeline defined in a config repo).

To fix this, we set an ephemeral config origin (that asserts itself as "remote") during preflight on the partial config so that it is not miscategorized as being locally defined.