### PR TITLE
Prevent NPE when trying to add a pipeline via templates when no templates exist

### DIFF
--- a/server/webapp/WEB-INF/rails/app/assets/stylesheets/patterns/_forms.scss
+++ b/server/webapp/WEB-INF/rails/app/assets/stylesheets/patterns/_forms.scss
@@ -93,6 +93,8 @@ input[type="text"].error,
     -webkit-box-shadow: inset 0 0 5px rgba(0,0,0,0.2);
   float: left;
 }
+
+.fieldset .error,
 .fieldWithErrors label,
 .field_with_errors label {
   color: #A40000;

--- a/server/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
@@ -53,6 +53,7 @@ module Admin
         include ::ConfigUpdate::CheckCanCreatePipeline
         include ::ConfigUpdate::CruiseConfigNode
         include ::ConfigUpdate::LoadConfig
+        include ::Admin::PipelinesHelper
 
         def initialize params, user, security_service, pipeline, package_definition_service, pluggable_task_service
           super(params, user, security_service)

--- a/server/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
@@ -66,11 +66,14 @@ module Admin
         end
 
         def update(cruise_config)
-          if(!@pipeline.hasTemplate())
+          if !use_template?(params)
             task = @pipeline.getFirstStageConfig().getJobs().first().getTasks().first()
             @pluggable_task_service.validate(task) if task.instance_of? com.thoughtworks.go.config.pluggabletask.PluggableTask
             @pluggable_task_service.validate(task.cancelTask()) if (!task.cancelTask().nil?) && (task.cancelTask().instance_of? com.thoughtworks.go.config.pluggabletask.PluggableTask)
+          elsif !@pipeline.hasTemplate()
+            @pipeline.addError(PipelineConfig::TEMPLATE_NAME, "Template name must be specified.")
           end
+
           if @pipeline.material_configs.size() > 0 && @pipeline.material_configs.get(0).type == PackageMaterialConfig::TYPE
             handle_package_material_creation_or_association(cruise_config)
           end
@@ -99,11 +102,15 @@ module Admin
         assert_load(:task_view_models, task_view_service.getTaskViewModels()) if !@update_result.isSuccessful()
         assert_load(:pipeline, @subject)
 
-        if !@update_result.isSuccessful() && !@pipeline.hasTemplate()
+        if !@update_result.isSuccessful() && !use_template?(params)
           task = @pipeline.getFirstStageConfig().getJobs().first().getTasks().first()
           task_view_model = task_view_service.getViewModel(task, 'new')
           task_view_model1 = task_view_service.getModelOfType(@task_view_models, task.getTaskType())
           task_view_model1.setModel(task_view_model.getModel())
+        end
+
+        if use_template?(params) && !@pipeline.hasTemplate()
+          @pipeline.addError(PipelineConfig::TEMPLATE_NAME, "Template name must be specified.")
         end
 
         group = save_action.group
@@ -297,4 +304,3 @@ module Admin
 
   end
 end
-

--- a/server/webapp/WEB-INF/rails/app/helpers/admin/pipelines_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/admin/pipelines_helper.rb
@@ -22,5 +22,9 @@ module Admin
       job_configs = JobConfigs.new([JobConfig.new(CaseInsensitiveString.new("defaultJob"), ResourceConfigs.new, ArtifactConfigs.new, com.thoughtworks.go.config.Tasks.new([AntTask.new].to_java(Task)))].to_java(JobConfig))
       StageConfig.new(CaseInsensitiveString.new("defaultStage"), job_configs)
     end
+
+    def use_template?(params)
+      "configurationType_template" == params.try(:[], :pipeline_group).try(:[], :pipeline).try(:[], :configurationType)
+    end
   end
 end

--- a/server/webapp/WEB-INF/rails/app/helpers/pipelines_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/pipelines_helper.rb
@@ -73,10 +73,6 @@ module PipelinesHelper
     end
   end
 
-  def use_template?(params)
-    "configurationType_template" == params.try(:[], :pipeline_group).try(:[], :pipeline).try(:[], :configurationType)
-  end
-
   def pipeline_instance_identifier(pim)
     "#{pim.getName()}_#{pim.getCounter()}"
   end

--- a/server/webapp/WEB-INF/rails/app/helpers/pipelines_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/pipelines_helper.rb
@@ -73,6 +73,10 @@ module PipelinesHelper
     end
   end
 
+  def use_template?(params)
+    "configurationType_template" == params.try(:[], :pipeline_group).try(:[], :pipeline).try(:[], :configurationType)
+  end
+
   def pipeline_instance_identifier(pim)
     "#{pim.getName()}_#{pim.getCounter()}"
   end

--- a/server/webapp/WEB-INF/rails/app/views/admin/pipelines/_stage_form.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/pipelines/_stage_form.html.erb
@@ -5,9 +5,10 @@
         </div>
         <div class="form_item checkbox_row define_or_template">
             <label>Configuration Type</label>
-            <%= p_f.radio_button com.thoughtworks.go.config.PipelineConfig::CONFIGURATION_TYPE, com.thoughtworks.go.config.PipelineConfig::CONFIGURATION_TYPE_STAGES, :id => "pipeline_configurationType_stages", :title => 'Define Stages' %>
+            <% checked_templates = use_template?(params) %>
+            <%= p_f.radio_button com.thoughtworks.go.config.PipelineConfig::CONFIGURATION_TYPE, com.thoughtworks.go.config.PipelineConfig::CONFIGURATION_TYPE_STAGES, :id => "pipeline_configurationType_stages", :title => 'Define Stages', :checked => !checked_templates %>
             <%= label_tag("pipeline_configurationType_stages", 'Define Stages') -%>
-            <%= p_f.radio_button com.thoughtworks.go.config.PipelineConfig::CONFIGURATION_TYPE, com.thoughtworks.go.config.PipelineConfig::CONFIGURATION_TYPE_TEMPLATE, :id => "pipeline_configurationType_template", :title => 'Use Template' %>
+            <%= p_f.radio_button com.thoughtworks.go.config.PipelineConfig::CONFIGURATION_TYPE, com.thoughtworks.go.config.PipelineConfig::CONFIGURATION_TYPE_TEMPLATE, :id => "pipeline_configurationType_template", :title => 'Use Template', :checked => checked_templates %>
             <%= label_tag("pipeline_configurationType_template", 'Use Template') -%>
         </div>
 

--- a/server/webapp/WEB-INF/rails/app/views/admin/pipelines/_stage_form.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/pipelines/_stage_form.html.erb
@@ -5,7 +5,7 @@
         </div>
         <div class="form_item checkbox_row define_or_template">
             <label>Configuration Type</label>
-            <% checked_templates = use_template?(params) %>
+            <% checked_templates = use_template?(params) || @pipeline.hasTemplate() %>
             <%= p_f.radio_button com.thoughtworks.go.config.PipelineConfig::CONFIGURATION_TYPE, com.thoughtworks.go.config.PipelineConfig::CONFIGURATION_TYPE_STAGES, :id => "pipeline_configurationType_stages", :title => 'Define Stages', :checked => !checked_templates %>
             <%= label_tag("pipeline_configurationType_stages", 'Define Stages') -%>
             <%= p_f.radio_button com.thoughtworks.go.config.PipelineConfig::CONFIGURATION_TYPE, com.thoughtworks.go.config.PipelineConfig::CONFIGURATION_TYPE_TEMPLATE, :id => "pipeline_configurationType_template", :title => 'Use Template', :checked => checked_templates %>

--- a/server/webapp/WEB-INF/rails/app/views/admin/pipelines/_template_form.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/pipelines/_template_form.html.erb
@@ -1,6 +1,7 @@
 <div id="select_template_container">
-  <%- if scope[:template_list].size()== 0 %>
-      <div class="information">There are no templates configured</div>
+  <%= error_message_on(scope[:pipeline], com.thoughtworks.go.config.PipelineConfig::TEMPLATE_NAME, :css_class => "error") %>
+  <%- if scope[:template_list].size() == 0 %>
+      <div class="<%= scope[:pipeline].errors().on(com.thoughtworks.go.config.PipelineConfig::TEMPLATE_NAME).nil? ? "information" : "warnings" %>">There are no templates configured</div>
   <% else %>
       <div class="fieldset">
         <div class="form_item">


### PR DESCRIPTION
Fixes https://github.com/gocd/gocd/issues/6468 (well, a peripheral error discovered here)

  - Remember radio button state over POST (previously always reset to "use stages")
  - Display an error indicating that a template must be selected
  - Render the "no templates exist" message as a warning when an error on `templateName` is present