### PR TITLE
Fixes issue # 6585

### DIFF
--- a/server/webapp/WEB-INF/rails/app/views/admin/pipelines/_basic_new_pipeline_fields.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/pipelines/_basic_new_pipeline_fields.html.erb
@@ -9,7 +9,7 @@
         <div class="form_item_block">
             <%= scope[:form].label com.thoughtworks.go.config.PipelineConfigs::GROUP, 'Pipeline Group Name' -%>
             <% if is_user_a_group_admin? %>
-                <%= scope[:form].select com.thoughtworks.go.config.PipelineConfigs::GROUP, @groups_list, {:selected => @group_name} %>
+                <%= scope[:form].select com.thoughtworks.go.config.PipelineConfigs::GROUP, @groups_list, {:selected => @group_name}, {:id => 'pipeline_group_name_text_field'} %>
             <% else %>
                 <%= scope[:form].text_field com.thoughtworks.go.config.PipelineConfigs::GROUP, :value => @group_name, :class => "required pattern_match", :id => 'pipeline_group_name_text_field' -%>
             <% end %>


### PR DESCRIPTION
Issue: #6585 
- when a group admin user visits the new pipeline page (old one), the group
   name is populated as a dropdown instead of text-field (for a normal user)
 - the check_connection takes in the id of the pipeline group field, and dynamically
   takes the current value - gave the same id to both the fields discussed above