### PR TITLE
[Bug] Template option & pipeline group dropdown broken for group admin (new add pipeline flow)

### DIFF
--- a/api/api-base/src/main/java/com/thoughtworks/go/api/ApiController.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/ApiController.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.api;
 
+import com.google.common.collect.Sets;
 import com.google.gson.reflect.TypeToken;
 import com.thoughtworks.go.api.util.GsonTransformer;
 import com.thoughtworks.go.api.util.MessageJson;
@@ -22,6 +23,7 @@ import com.thoughtworks.go.server.util.RequestUtils;
 import com.thoughtworks.go.spark.SparkController;
 import org.springframework.util.InvalidMimeTypeException;
 import org.springframework.util.MimeType;
+import spark.Filter;
 import spark.Request;
 import spark.Response;
 
@@ -106,4 +108,11 @@ public abstract class ApiController implements ControllerMethods, SparkControlle
         return map;
     }
 
+    protected static Filter onlyOn(Filter filter, String... allowedMethods) {
+        return (request, response) -> {
+            if (Sets.newHashSet(allowedMethods).contains(request.requestMethod())) {
+                filter.handle(request, response);
+            }
+        };
+    }
 }

--- a/api/api-pipeline-groups-v1/src/main/java/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1.java
+++ b/api/api-pipeline-groups-v1/src/main/java/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1.java
@@ -74,7 +74,8 @@ public class PipelineGroupsControllerV1 extends ApiController implements SparkSp
             before("/*", mimeType, this::setContentType);
             before("", mimeType, this::verifyContentType);
             before("/*", mimeType, this::verifyContentType);
-            before("", mimeType, apiAuthenticationHelper::checkAdminUserOrGroupAdminUserAnd403);
+            before("", mimeType, onlyOn(apiAuthenticationHelper::checkAdminUserAnd403, "POST"));
+            before("", mimeType, onlyOn(apiAuthenticationHelper::checkAdminUserOrGroupAdminUserAnd403, "GET", "HEAD"));
             before(Routes.PipelineGroupsAdmin.NAME_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupAdminUserAnd403);
 
             get("", mimeType, this::index);

--- a/api/api-pipeline-groups-v1/src/main/java/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1.java
+++ b/api/api-pipeline-groups-v1/src/main/java/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1.java
@@ -74,7 +74,7 @@ public class PipelineGroupsControllerV1 extends ApiController implements SparkSp
             before("/*", mimeType, this::setContentType);
             before("", mimeType, this::verifyContentType);
             before("/*", mimeType, this::verifyContentType);
-            before("", mimeType, apiAuthenticationHelper::checkAdminUserAnd403);
+            before("", mimeType, apiAuthenticationHelper::checkAdminUserOrGroupAdminUserAnd403);
             before(Routes.PipelineGroupsAdmin.NAME_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupAdminUserAnd403);
 
             get("", mimeType, this::index);

--- a/api/api-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1Test.groovy
+++ b/api/api-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1Test.groovy
@@ -67,7 +67,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
   @Nested
   class Index {
     @Nested
-    class Security implements SecurityTestTrait, AdminUserSecurity {
+    class Security implements SecurityTestTrait, GroupAdminUserSecurity {
 
       @Override
       String getControllerMethodUnderTest() {
@@ -81,15 +81,15 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
     }
 
     @Nested
-    class AsAdmin {
+    class AsGroupAdmin {
       @BeforeEach
       void setUp() {
         enableSecurity()
-        loginAsAdmin()
+        loginAsGroupAdmin()
       }
 
       @Test
-      void 'should list all pipeline groups'() {
+      void 'should list pipeline groups'() {
         def configs = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig('pipeline1'))
         configs.setGroup("group")
         def expectedPipelineGroups = new PipelineGroups([configs])

--- a/api/api-template-config-v4/src/main/java/com/thoughtworks/go/apiv4/admin/templateconfig/TemplateConfigControllerV4.java
+++ b/api/api-template-config-v4/src/main/java/com/thoughtworks/go/apiv4/admin/templateconfig/TemplateConfigControllerV4.java
@@ -17,7 +17,6 @@
 package com.thoughtworks.go.apiv4.admin.templateconfig;
 
 
-import com.google.common.collect.Sets;
 import com.thoughtworks.go.api.ApiController;
 import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.api.CrudController;
@@ -40,7 +39,6 @@ import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import spark.Filter;
 import spark.Request;
 import spark.Response;
 
@@ -118,14 +116,6 @@ public class TemplateConfigControllerV4 extends ApiController implements SparkSp
 
             exception(HttpException.class, this::httpException);
         });
-    }
-
-    public static Filter onlyOn(Filter filter, String... allowedMethods) {
-        return (request, response) -> {
-            if (Sets.newHashSet(allowedMethods).contains(request.requestMethod())) {
-                filter.handle(request, response);
-            }
-        };
     }
 
     public String index(Request req, Response res) throws IOException {

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
@@ -84,6 +84,7 @@ public class AuthorizeFilterChain extends FilterChainProxy {
                 // new controllers, so we say `ROLE_USER`, and let the controller handle authorization
                 .addAuthorityFilterChain("/api/admin/internal/*", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/admin/pipelines/**", apiAccessDeniedHandler, ROLE_USER)
+                .addAuthorityFilterChain("/api/admin/pipeline_groups/**", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/admin/export/**", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/admin/encrypt", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/admin/scms/**", apiAccessDeniedHandler, ROLE_USER)

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/template_editor_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/template_editor_spec.tsx
@@ -25,7 +25,7 @@ import {TemplateEditor} from "../template_editor";
 
 describe("AddPipeline: TemplateEditor", () => {
   const helper = new TestHelper();
-  const isUsingTemplate: Stream<boolean> = stream(false);
+  const isUsingTemplate: Stream<boolean> = stream();
   let config: PipelineConfig;
 
   beforeEach(() => {
@@ -39,36 +39,36 @@ describe("AddPipeline: TemplateEditor", () => {
   });
 
   it("should display flash when no templates are defined", () => {
-    helper.click(helper.byTestId("switch-paddle"));
+    helper.clickByDataTestId("switch-paddle");
     expect(isUsingTemplate()).toBeTruthy();
     const flash = helper.byTestId("flash-message-warning");
-    expect(flash).toBeTruthy();
+    expect(flash).toBeInDOM();
     expect(helper.text("code", flash)).toBe("There are no templates configured or you are unauthorized to view the existing templates. Add one via the templates page.");
   });
 
   it("should show dropdown of templates when defined", () => {
     helper.unmount();
     helper.mount(() => <TemplateEditor pipelineConfig={config} isUsingTemplate={isUsingTemplate} cache={new TestCache()}/>);
-    helper.click(helper.byTestId("switch-paddle"));
+    helper.clickByDataTestId("switch-paddle");
     expect(isUsingTemplate()).toBeTruthy();
     expect(config.template()).toBe("one");
     const dropdown = helper.byTestId("form-field-input-template");
-    expect(dropdown).toBeTruthy();
+    expect(dropdown).toBeInDOM();
     expect(helper.qa("option", dropdown).length).toBe(2);
 
-    helper.click(helper.byTestId("switch-paddle"));
+    helper.clickByDataTestId("switch-paddle");
     expect(isUsingTemplate()).toBe(false);
-    expect(config.template() === undefined).toBeTruthy();
+    expect(config.template()).toBeUndefined();
   });
 
   it("should not display dropdown and should display flash when cache fails to populate", () => {
     helper.unmount();
     helper.mount(() => <TemplateEditor pipelineConfig={config} isUsingTemplate={isUsingTemplate} cache={new FailedTestCache()}/>);
-    helper.click(helper.byTestId("switch-paddle"));
+    helper.clickByDataTestId("switch-paddle");
     expect(isUsingTemplate()).toBeTruthy();
 
     const flash = helper.byTestId("flash-message-warning");
-    expect(flash).toBeTruthy();
+    expect(flash).toBeInDOM();
     expect(helper.text("code", flash)).toBe("There are no templates configured or you are unauthorized to view the existing templates. Add one via the templates page.");
 
     const dropdown = helper.byTestId("form-field-input-template");

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/template_editor_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/template_editor_spec.tsx
@@ -43,7 +43,7 @@ describe("AddPipeline: TemplateEditor", () => {
     expect(isUsingTemplate()).toBeTruthy();
     const flash = helper.byTestId("flash-message-warning");
     expect(flash).toBeTruthy();
-    expect(helper.text("code", flash)).toBe("There are no pipeline templates configured. Add one via the templates page.");
+    expect(helper.text("code", flash)).toBe("There are no templates configured or you are unauthorized to view the existing templates. Add one via the templates page.");
   });
 
   it("should show dropdown of templates when defined", () => {
@@ -59,6 +59,20 @@ describe("AddPipeline: TemplateEditor", () => {
     helper.click(helper.byTestId("switch-paddle"));
     expect(isUsingTemplate()).toBe(false);
     expect(config.template() === undefined).toBeTruthy();
+  });
+
+  it("should not display dropdown and should display flash when cache fails to populate", () => {
+    helper.unmount();
+    helper.mount(() => <TemplateEditor pipelineConfig={config} isUsingTemplate={isUsingTemplate} cache={new FailedTestCache()}/>);
+    helper.click(helper.byTestId("switch-paddle"));
+    expect(isUsingTemplate()).toBeTruthy();
+
+    const flash = helper.byTestId("flash-message-warning");
+    expect(flash).toBeTruthy();
+    expect(helper.text("code", flash)).toBe("There are no templates configured or you are unauthorized to view the existing templates. Add one via the templates page.");
+
+    const dropdown = helper.byTestId("form-field-input-template");
+    expect(dropdown).not.toExist();
   });
 });
 
@@ -84,4 +98,17 @@ class EmptyTestCache implements TemplateCache<Option> {
   templates() { return []; }
   failureReason() { return undefined; }
   failed() { return false; }
+}
+
+class FailedTestCache implements TemplateCache<Option> {
+  ready() { return true; }
+  prime(onSuccess: () => void, onError?: () => void) { if (onError) {
+    onError();
+  }}
+  // tslint:disable-next-line
+  invalidate() {}
+  contents() { return []; }
+  templates() { return []; }
+  failureReason() { return "Unauthorized to perform this action"; }
+  failed() { return true; }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/template_editor.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/template_editor.tsx
@@ -43,6 +43,8 @@ export class TemplateEditor extends MithrilViewComponent<Attrs> {
 
     this.cache.prime(() => {
       this.templates(this.cache.templates());
+    }, () => {
+      this.templates([]);
     });
   }
 
@@ -66,7 +68,7 @@ export class TemplateEditor extends MithrilViewComponent<Attrs> {
       if (!this.templates().length) {
         return <FlashMessage type={errors.hasErrors("template") ? MessageType.alert : MessageType.warning}>
           <code>
-            There are no pipeline templates configured.
+            There are no templates configured or you are unauthorized to view the existing templates.
             Add one via the <a href="/go/admin/templates" title="Pipeline Templates">templates page</a>.
           </code>
         </FlashMessage>;
@@ -82,7 +84,7 @@ export class TemplateEditor extends MithrilViewComponent<Attrs> {
     const target = event.target as HTMLInputElement;
     if (target.checked) {
       pipelineConfig.stages().clear();
-      if (this.templates().length !== 0) {
+      if (this.templates() && this.templates().length !== 0) {
         pipelineConfig.template(this.templates()[0].id);
       }
     } else {


### PR DESCRIPTION
Fixes 2 issues found as part of #6475. 

- This fixes the template toggle on the new add pipeline page in the scenario where the call for available templates fails(ie if get a 403 when trying to retrieve templates because don't have template access).
- This also gives group admin's access to the pipeline groups index so we can populate the pipeline group dropdown on the new add pipeline page