### PR TITLE
Remove agent upgrade related debug logs (#5212) (#4469)

### DIFF
--- a/agent/src/main/java/com/thoughtworks/go/agent/service/AgentUpgradeService.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/service/AgentUpgradeService.java
@@ -104,10 +104,6 @@ public class AgentUpgradeService {
 
     private void validateMd5(String currentMd5, CloseableHttpResponse response, String agentContentMd5Header, String what) {
         final Header md5Header = response.getFirstHeader(agentContentMd5Header);
-        LOGGER.debug("[Agent Upgrade Validate MD5] validating MD5 for {}, currentMD5:{}, responseMD5:{}, headerKey:{}", what, currentMd5, md5Header, agentContentMd5Header);
-        if (md5Header == null) {
-            LOGGER.debug("[Agent Upgrade Validate MD5] Did not find {} MD5 header in response {}.", agentContentMd5Header, response);
-        }
         if (!"".equals(currentMd5)) {
             if (!currentMd5.equals(md5Header.getValue())) {
                 jvmExitter.jvmExit(what, currentMd5, md5Header.getValue());

--- a/server/src/main/java/com/thoughtworks/go/server/controller/AgentRegistrationController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/AgentRegistrationController.java
@@ -110,12 +110,6 @@ public class AgentRegistrationController {
 
     @RequestMapping(value = "/admin/latest-agent.status", method = {RequestMethod.HEAD, RequestMethod.GET})
     public void checkAgentStatus(HttpServletResponse response) {
-        LOG.debug("Processing '/admin/latest-agent.status' request with values [{}:{}], [{}:{}], [{}:{}], [{}:{}]",
-                SystemEnvironment.AGENT_CONTENT_MD5_HEADER, agentChecksum,
-                SystemEnvironment.AGENT_LAUNCHER_CONTENT_MD5_HEADER, agentLauncherChecksum,
-                SystemEnvironment.AGENT_PLUGINS_ZIP_MD5_HEADER, pluginsZip.md5(),
-                SystemEnvironment.AGENT_TFS_SDK_MD5_HEADER, tfsSdkChecksum);
-
         response.setHeader(SystemEnvironment.AGENT_CONTENT_MD5_HEADER, agentChecksum);
         response.setHeader(SystemEnvironment.AGENT_LAUNCHER_CONTENT_MD5_HEADER, agentLauncherChecksum);
         response.setHeader(SystemEnvironment.AGENT_PLUGINS_ZIP_MD5_HEADER, pluginsZip.md5());


### PR DESCRIPTION
* These logs were added to debug NPE issue #4469.
  As the issue #4469 is fixed, these debug logs can be removed.