### PR TITLE
Fix issues with config repo partial config structure display

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/defined_structures.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/defined_structures.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {ApiRequestBuilder, ApiResult, ApiVersion} from "helpers/api_request_builder";
+import {ApiRequestBuilder, ApiVersion} from "helpers/api_request_builder";
 import SparkRoutes from "helpers/spark_routes";
 import * as _ from "lodash";
 import {Stream} from "mithril/stream";
@@ -49,17 +49,8 @@ export class DefinedStructures implements NamedTree {
     );
   }
 
-  static fetch(repoId: string): Promise<DefinedStructures> {
-    return new Promise<DefinedStructures>((resolve, reject) => {
-      ApiRequestBuilder.GET(SparkRoutes.configRepoDefinedConfigsPath(repoId), ApiVersion.v2).
-        then((result: ApiResult<string>) => {
-          result.do((resp) => {
-            resolve(DefinedStructures.fromJSON(JSON.parse(resp.body)));
-          }, (error) => {
-            reject(error);
-          });
-        }).catch(reject);
-    });
+  static fetch(repoId: string, etag?: string) {
+    return ApiRequestBuilder.GET(SparkRoutes.configRepoDefinedConfigsPath(repoId), ApiVersion.v2, { etag });
   }
 
   name(): string {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repo_attribute_helper.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repo_attribute_helper.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as _ from "lodash";
+import {ConfigRepo, humanizedMaterialAttributeName} from "models/config_repos/types";
+
+export function resolveHumanReadableAttributes(obj: object) {
+  const attrs  = new Map();
+  const keys   = Object.keys(obj).map(humanizedMaterialAttributeName);
+  const values = Object.values(obj);
+
+  keys.forEach((key, index) => attrs.set(key, values[index]));
+  return attrs;
+}
+
+export function allAttributes(repo: ConfigRepo): Map<string, string> {
+  const initial            = new Map([["Type", repo.material().type()]]);
+  const filteredAttributes = _.reduce(repo.material().attributes(),
+    resolveKeyValueForAttribute,
+    initial);
+  return _.reduce(repo.configuration(),
+    (accumulator, value) => resolveKeyValueForAttribute(accumulator, value.value, value.key),
+    filteredAttributes
+  );
+}
+
+function resolveKeyValueForAttribute(accumulator: Map<string, string>, value: any, key: string) {
+  if (key.startsWith("__") || key === "autoUpdate") {
+    return accumulator;
+  }
+
+  let renderedValue = value;
+
+  const renderedKey = humanizedMaterialAttributeName(key);
+
+  // test for value being a stream
+  if (_.isFunction(value)) {
+    value = value();
+  }
+
+  // test for value being an EncryptedPassword
+  if (value && value.valueForDisplay) {
+    renderedValue = value.valueForDisplay();
+  }
+  accumulator.set(renderedKey, _.isFunction(renderedValue) ? renderedValue() : renderedValue);
+  return accumulator;
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repo_view_model.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repo_view_model.ts
@@ -60,7 +60,7 @@ class CRResultCache extends AbstractObjCache<DefinedStructures> {
 
   empty() {
     // don't dump contents, just force a fresh set of data
-    // this.etag = stream();
+    this.etag = stream();
   }
 }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/defined_structs.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/defined_structs.scss
@@ -25,7 +25,7 @@ $stage-color:          #4ad9d9;
 $fg-color:             #023550;
 $label-color-group:    #dee;
 $label-color-pipeline: #ede7f3;
-$label-color-env:    #ffe099;
+$label-color-env:      #ffe099;
 
 @mixin type-label {
   display:          inline-block;
@@ -38,7 +38,25 @@ $label-color-env:    #ffe099;
 }
 
 .loading {
-  padding: 5px 10px;
+  padding: 10px 0;
+  font-size: 18px;
+}
+
+.spin {
+  @include icon-before($type: $fa-var-spinner, $margin: 0);
+  display:      inline-block;
+  margin-right: 10px;
+  animation: rotate 1s linear infinite;
+
+  @keyframes rotate {
+    from {
+      transform: rotate(0deg);
+    }
+
+    to {
+      transform: rotate(359deg);
+    }
+  }
 }
 
 .group {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/defined_structs.scss.d.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/defined_structs.scss.d.ts
@@ -6,6 +6,8 @@ export const treeChild: string;
 export const treeChildren: string;
 export const treeChildrenLabel: string;
 export const loading: string;
+export const spin: string;
+export const rotate: string;
 export const group: string;
 export const groupDatum: string;
 export const environment: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repo_attribute_helper_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repo_attribute_helper_spec.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ConfigRepo} from "models/config_repos/types";
+import {allAttributes, resolveHumanReadableAttributes} from "../config_repo_attribute_helper";
+
+describe("ConfigRepo attribute util functions", () => {
+  it("resolveHumanReadableAttributes() emits a new attribute map with human-friendly keys", () => {
+    const map = resolveHumanReadableAttributes({
+      autoUpdate: true,
+      branch: true,
+      checkExternals: true,
+      domain: true,
+      encryptedPassword: true,
+      name: true,
+      projectPath: true,
+      url: true,
+      username: true,
+      password: true,
+      port: true,
+      useTickets: true,
+      view: true,
+      emailAddress: true,
+      revision: true,
+      comment: true,
+      modifiedTime: true,
+      file_pattern: true,
+      this_key_is_not_modified_at_all: true,
+    });
+
+    expect(Array.from(map.keys()).sort()).toEqual([
+      "Auto update",
+      "Branch",
+      "Check Externals",
+      "Comment",
+      "Domain",
+      "Email",
+      "File Pattern",
+      "Host and port",
+      "Material Name",
+      "Modified Time",
+      "Password",
+      "Project Path",
+      "Revision",
+      "URL",
+      "Use tickets",
+      "Username",
+      "View",
+      "this_key_is_not_modified_at_all",
+    ].sort());
+  });
+
+  it("allAttributes() extracts material and custom configuration attributes from a ConfigRepo", () => {
+    const repo = ConfigRepo.fromJSON({
+      material: {
+        type: "git",
+        attributes: {
+          url: "https://example.com/git/my-repo",
+          name: "foo",
+          username: "bob",
+          encrypted_password: "AES:foo:bar",
+          auto_update: true,
+          branch: "master",
+          destination: ""
+        }
+      },
+      configuration: [{
+        key: "file_pattern",
+        value: "*.json"
+      }],
+      parse_info: {},
+      id: "my-repo",
+      plugin_id: "json.config.plugin",
+      material_update_in_progress: false
+    });
+
+    const map = allAttributes(repo);
+
+    const expectations: { [key: string]: string } = {
+      "Type": "git",
+      "Material Name": "foo",
+      "destination": "",
+      "Username": "bob",
+      "Password": "**********",
+      "URL": "https://example.com/git/my-repo",
+      "Branch": "master",
+      "File Pattern": "*.json",
+    };
+
+    const keys = Object.keys(expectations);
+
+    for (const k of keys) {
+      expect(map.has(k)).toBe(true, `missing key ${k}`);
+      expect(map.get(k)).toBe(expectations[k], `wrong value at key ${k}`);
+    }
+  });
+});

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repo_view_model_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repo_view_model_spec.ts
@@ -1,0 +1,82 @@
+/*
+* Copyright 2019 ThoughtWorks, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import SparkRoutes from "helpers/spark_routes";
+import * as stream from "mithril/stream";
+import {Stream} from "mithril/stream";
+import {ConfigRepo} from "models/config_repos/types";
+import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
+import {FlashContainer, RequiresPluginInfos, SaveOperation} from "views/pages/page_operations";
+import {ConfigRepoVM} from "../config_repo_view_model";
+import {mockResultsCache} from "./test_data";
+
+describe("ConfigRepoVM", () => {
+  it("fetches data on the expand event", () => {
+    const vm = createVm();
+    expect(vm.results.prime).not.toHaveBeenCalled();
+
+    vm.notify("expand");
+
+    expect(vm.results.prime).toHaveBeenCalled();
+  });
+
+  it("invalidates and updates data on refresh event", () => {
+    const vm = createVm();
+
+    expect(vm.results.invalidate).not.toHaveBeenCalled();
+
+    vm.notify("refresh");
+
+    expect(vm.results.invalidate).toHaveBeenCalled();
+  });
+
+  it("reparseRepo() triggers reparse update invalidates the results cache", (done) => {
+    jasmine.Ajax.withMock(() => {
+      jasmine.Ajax.stubRequest(SparkRoutes.configRepoTriggerUpdatePath("my-repo"), undefined, 'POST').andReturn({
+        responseText:    JSON.stringify({message: `OK`}),
+        responseHeaders: {
+          'Content-Type': 'application/vnd.go.cd.v2+json'
+        },
+        status:          201
+      });
+
+      const vm = createVm();
+      const event = { stopPropagation: jasmine.createSpy("stopPropagation") };
+
+      expect(vm.results.invalidate).not.toHaveBeenCalled();
+
+      vm.reparseRepo(event).catch(done.fail).finally(() => {
+        expect(event.stopPropagation).toHaveBeenCalled();
+        expect(vm.results.invalidate).toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+});
+
+function createVm() {
+  return new ConfigRepoVM(new ConfigRepo("my-repo"), new MockResources(), mockResultsCache({}));
+}
+
+class MockResources implements FlashContainer, RequiresPluginInfos, SaveOperation {
+  // tslint:disable-next-line no-empty
+  flash = { clear() {}, success() {}, alert() {} };
+  pluginInfos: Stream<Array<PluginInfo<any>>> = stream();
+  // tslint:disable-next-line no-empty
+  onError() {}
+  // tslint:disable-next-line no-empty
+  onSuccessfulSave() {}
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repo_view_model_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repo_view_model_spec.ts
@@ -33,7 +33,7 @@ describe("ConfigRepoVM", () => {
     expect(vm.results.prime).toHaveBeenCalled();
   });
 
-  it("invalidates and updates data on refresh event", () => {
+  it("invalidates data on refresh event", () => {
     const vm = createVm();
 
     expect(vm.results.invalidate).not.toHaveBeenCalled();
@@ -43,7 +43,7 @@ describe("ConfigRepoVM", () => {
     expect(vm.results.invalidate).toHaveBeenCalled();
   });
 
-  it("reparseRepo() triggers reparse update invalidates the results cache", (done) => {
+  it("reparseRepo() triggers a reparse on configRepo and invalidates the results cache", (done) => {
     jasmine.Ajax.withMock(() => {
       jasmine.Ajax.stubRequest(SparkRoutes.configRepoTriggerUpdatePath("my-repo"), undefined, 'POST').andReturn({
         responseText:    JSON.stringify({message: `OK`}),

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/test_data.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/test_data.ts
@@ -14,11 +14,45 @@
  * limitations under the License.
  */
 
+import {ObjectCache} from "models/base/cache";
+import {DefinedStructures} from "models/config_repos/defined_structures";
 import {ConfigRepo} from "models/config_repos/types";
 import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
 import * as uuid from "uuid/v4";
 
-export function createConfigRepoParsedWithError(overrides?: any) {
+class MockCache implements ObjectCache<DefinedStructures> {
+  ready: () => boolean;
+  contents: () => DefinedStructures;
+  failureReason: () => string | undefined;
+  prime: (onSuccess: () => void, onError?: () => void) => void = jasmine.createSpy("cache.prime");
+  invalidate: () => void = jasmine.createSpy("cache.invalidate");
+
+  constructor(options: MockedResultsData) {
+    this.failureReason = () => options.failureReason;
+    this.contents = () => ("content" in options) ? options.content! : emptyTree();
+    this.ready = () => ("ready" in options) ? !!options.ready : true;
+  }
+
+  failed(): boolean {
+    return !!this.failureReason();
+  }
+}
+
+export interface MockedResultsData {
+  content?: DefinedStructures;
+  failureReason?: string;
+  ready?: boolean;
+}
+
+export function emptyTree() {
+  return new DefinedStructures([], []);
+}
+
+export function mockResultsCache(options: MockedResultsData) {
+  return new MockCache(options);
+}
+
+export function createConfigRepoParsedWithError(overrides?: any): ConfigRepo {
   const parameters = {
     id: uuid(),
     repoId: uuid(),
@@ -69,7 +103,7 @@ export function createConfigRepoParsedWithError(overrides?: any) {
   });
 }
 
-export function createConfigRepoParsed(overrides?: any) {
+export function createConfigRepoParsed(overrides?: any): ConfigRepo {
   const parameters = {
     id: uuid(),
     repoId: uuid(),
@@ -119,7 +153,7 @@ export function createConfigRepoParsed(overrides?: any) {
   });
 }
 
-export function createConfigRepoWithError(id?: string, repoId?: string) {
+export function createConfigRepoWithError(id?: string, repoId?: string): ConfigRepo {
   id = id || uuid();
   return ConfigRepo.fromJSON({
                                material: {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/page_operations.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/page_operations.ts
@@ -16,6 +16,7 @@
 import * as m from "mithril";
 import {Stream} from "mithril/stream";
 import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
+import {FlashProvider} from "views/components/flash_message";
 
 export interface SaveOperation {
   onSuccessfulSave: (msg: m.Children) => void;
@@ -42,14 +43,18 @@ export interface AddOperation<T> {
   onAdd: (e: MouseEvent) => void;
 }
 
-export interface RequiresPluginInfos {
-  pluginInfos: Stream<Array<PluginInfo<any>>>;
-}
-
 export interface EnableOperation<T> {
   onEnable: (obj: T, e: MouseEvent) => void;
 }
 
 export interface DisableOperation<T> {
   onDisable: (obj: T, e: MouseEvent) => void;
+}
+
+export interface RequiresPluginInfos {
+  pluginInfos: Stream<Array<PluginInfo<any>>>;
+}
+
+export interface FlashContainer {
+  flash: FlashProvider;
 }


### PR DESCRIPTION
Fixes #6471

See comment for one of the behaviors this fixes: https://github.com/gocd/gocd/issues/6471#issuecomment-506049805

  - Ensures that the resultant structure is displayed after first parse (prior to this, it just left a persistent loading message)
  - Ensures that we update the diplayed structure after forcing a reparse

Prerequisite to these fixes are significant refactoring of the ConfigRepoWidget:

  - Move a lot of the button actions/event handlers into ConfigRepoVM so that
    we are able to control/orchestrate event-driven flows
  - The ConfigRepos page widget now maintains a list of ConfigRepoVM instances
    on data fetch/refresh
  - Abstract the config repo result cache into the ConfigRepoVM as well
  - Extract utility methods into its own importable module