### PR TITLE
Show config repo info for pipelines in dashboard

### DIFF
--- a/api/api-dashboard-v4/src/main/java/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenter.java
+++ b/api/api-dashboard-v4/src/main/java/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenter.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.api.base.OutputLinkWriter;
 import com.thoughtworks.go.api.base.OutputListWriter;
 import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.config.TrackingTool;
+import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.domain.PipelinePauseInfo;
 import com.thoughtworks.go.presentation.pipelinehistory.EmptyPipelineInstanceModel;
 import com.thoughtworks.go.server.dashboard.GoDashboardPipeline;
@@ -34,6 +35,7 @@ public class PipelineRepresenter {
     public static void toJSON(OutputWriter jsonOutputWriter, GoDashboardPipeline model, Username username) {
         String usernameString = username.getUsername().toString();
 
+        boolean isConfiguredFromConfigRepo = !model.isLocal();
         jsonOutputWriter
                 .addLinks(linksWriter -> addLinks(linksWriter, model))
                 .add("name", model.name().toString())
@@ -44,7 +46,14 @@ public class PipelineRepresenter {
                 .add("can_administer", model.canBeAdministeredBy(usernameString))
                 .add("can_unlock", model.canBeOperatedBy(usernameString))
                 .add("can_pause", model.canBeOperatedBy(usernameString))
-                .add("from_config_repo", !model.isLocal());
+                .add("from_config_repo", isConfiguredFromConfigRepo);
+
+        if (isConfiguredFromConfigRepo) {
+            RepoConfigOrigin configRepo = (RepoConfigOrigin) model.getOrigin();
+            jsonOutputWriter
+                    .add("config_repo_id", configRepo.getConfigRepo().getId())
+                    .add("config_repo_material_url", configRepo.getMaterial().getUriForDisplay());
+        }
 
         if (model.getTrackingTool().isPresent()) {
             TrackingTool trackingTool = model.getTrackingTool().get();

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenterTest.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenterTest.groovy
@@ -117,6 +117,22 @@ class PipelineRepresenterTest {
     ])
   }
 
+  @Test
+  void 'should render config repo details if the pipeline is defined using config repo'() {
+    def counter = mock(Counter.class)
+    when(counter.getNext()).thenReturn(1l)
+    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
+    def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
+    def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'p1l1', false, true, null), permissions, "grp", null, counter, origin, 0)
+    def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
+
+    def json = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })
+
+    json.remove("_links")
+    json.remove("_embedded")
+    assertThatJson(json).isEqualTo(pipelines_hash())
+  }
+
   @Nested
   class Authorization {
 
@@ -191,8 +207,9 @@ class PipelineRepresenterTest {
       can_administer        : false,
       can_unlock            : false,
       can_pause             : false,
-      from_config_repo      : true
+      from_config_repo      : true,
+      config_repo_id          : 'repo1',
+      config_repo_material_url: 'http://user:******@funk.com/blank'
     ]
   }
-
 }

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardPipeline.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardPipeline.java
@@ -132,4 +132,8 @@ public class GoDashboardPipeline {
     public Integer getdisplayOrderWeight() {
         return displayOrderWeight;
     }
+
+    public ConfigOrigin getOrigin() {
+        return origin;
+    }
 }

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -241,9 +241,10 @@ body {
 
 .dashboard {
   .tooltip {
-    left:  -100%;
-    top:   90%;
-    width: 10rem;
+    left:      -100%;
+    top:       90%;
+    width:     10rem;
+    word-wrap: break-word;
 
     &::before {
       left: 35%;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -333,6 +333,15 @@ body {
   }
 }
 
+
+.info_config {
+  @include icon-before($type: info-circle, $color: $grey);
+
+  &:before {
+    font-size: $pipeline_icons_size;
+  }
+}
+
 .edit_config {
   @include icon-before($type: gear);
 

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -307,15 +307,24 @@ body {
 .pipeline_locked {
   @include icon-before($type: lock);
 
-  overflow:  hidden;
-  width:     25px;
-  height:    25px;
-  font-size: $pipeline_icons_size;
-  color:     $icon-color;
-  cursor:    pointer;
+  overflow:   hidden;
+  width:      25px;
+  height:     25px;
+  font-size:  $pipeline_icons_size;
+  color:      $icon-color;
+  cursor:     pointer;
+  background: none;
+  margin:     0;
+  padding:    0;
+
+  &:focus {
+    color:      $icon-color;
+    background: none;
+  }
 
   &:hover {
-    color: $icon-hover-color;
+    color:      $icon-hover-color;
+    background: none;
   }
 
   &.disabled {

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipeline_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipeline_spec.js
@@ -169,7 +169,7 @@ describe("Dashboard", () => {
     it("should return pipeline config repo tooltip text for config repo pipelines", () => {
       pipelineJson   = pipelineJsonFor(defaultPauseInfo, true, true, true);
       const pipeline = new Pipeline(pipelineJson);
-      expect(pipeline.getSettingsDisabledTooltipText()).toEqual("Cannot edit pipeline defined in config repository.");
+      expect(pipeline.getSettingsDisabledTooltipText()).toEqual("Cannot edit pipeline defined in config repository: sample_config_repo with material url: https://foo:1234/go");
     });
 
     it("should return no permission tooltip text as default", () => {
@@ -300,35 +300,37 @@ describe("Dashboard", () => {
 
   const pipelineJsonFor = (pauseInfo, canPause = true, canOperate = true, fromConfigRepo = false) => {
     return {
-      "_links":                 {
-        "self":                 {
+      "_links":                   {
+        "self": {
           "href": "http://localhost:8153/go/api/pipelines/up42/history"
         },
-        "doc":                  {
+        "doc":  {
           "href": "https://api.go.cd/current/#pipelines"
         }
       },
-      "name":                   "up42",
-      "last_updated_timestamp": 1510299695473,
-      "locked":                 false,
-      "can_unlock":             true,
-      "pause_info":             pauseInfo,
-      "can_administer":         true,
-      "can_operate":            canOperate,
-      "can_pause":              canPause,
-      "from_config_repo":       fromConfigRepo,
-      "tracking_tool":          {
+      "name":                     "up42",
+      "last_updated_timestamp":   1510299695473,
+      "locked":                   false,
+      "can_unlock":               true,
+      "pause_info":               pauseInfo,
+      "can_administer":           true,
+      "can_operate":              canOperate,
+      "can_pause":                canPause,
+      "from_config_repo":         fromConfigRepo,
+      "config_repo_id":           "sample_config_repo",
+      "config_repo_material_url": "https://foo:1234/go",
+      "tracking_tool":            {
         "regex": "#(\\d+)",
         "link":  "http://example.com/${ID}/"
       },
-      "_embedded":              {
+      "_embedded":                {
         "instances": [
           {
             "_links":       {
-              "self":            {
+              "self": {
                 "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
               },
-              "doc":             {
+              "doc":  {
                 "href": "https://api.go.cd/current/#get-pipeline-instance"
               }
             },

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipeline_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipeline_spec.js
@@ -165,18 +165,6 @@ describe("Dashboard", () => {
       const pipeline = new Pipeline(pipelineJson);
       expect(pipeline.getPauseDisabledTooltipText()).toEqual("You do not have permission to unpause the pipeline.");
     });
-
-    it("should return pipeline config repo tooltip text for config repo pipelines", () => {
-      pipelineJson   = pipelineJsonFor(defaultPauseInfo, true, true, true);
-      const pipeline = new Pipeline(pipelineJson);
-      expect(pipeline.getSettingsDisabledTooltipText()).toEqual("Cannot edit pipeline defined in config repository: sample_config_repo with material url: https://foo:1234/go");
-    });
-
-    it("should return no permission tooltip text as default", () => {
-      pipelineJson   = pipelineJsonFor(defaultPauseInfo, true, true, false);
-      const pipeline = new Pipeline(pipelineJson);
-      expect(pipeline.getSettingsDisabledTooltipText()).toEqual("You do not have permission to edit the pipeline.");
-    });
   });
 
   describe("Pipeline Operations", () => {

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -26,8 +26,8 @@ import "jasmine-ajax";
 import * as simulateEvent from "simulate-event";
 
 describe("Dashboard Pipeline Widget", () => {
-  const body = document.body;
-  const pipelineName   = 'up42';
+  const body         = document.body;
+  const pipelineName = 'up42';
 
   let dashboardViewModel, dashboard, pipelinesJson, dashboardJSON, pipeline, doCancelPolling,
       doRefreshImmediately;
@@ -394,7 +394,7 @@ describe("Dashboard Pipeline Widget", () => {
         const pausePopupTextBox = helper.q('.reveal input', body);
         pausePopupTextBox.value = "test";
 
-        simulateEvent.simulate(pausePopupTextBox, 'keydown', { key: 'Enter' });
+        simulateEvent.simulate(pausePopupTextBox, 'keydown', {key: 'Enter'});
         m.redraw.sync();
 
         expect(helper.q(".reveal", body)).toBeFalsy();
@@ -406,7 +406,7 @@ describe("Dashboard Pipeline Widget", () => {
         helper.click('.pause');
         expect(helper.q(".reveal", body)).toBeInDOM();
 
-        simulateEvent.simulate(body, 'keydown', { key: 'Escape' });
+        simulateEvent.simulate(body, 'keydown', {key: 'Escape'});
         m.redraw.sync();
 
         expect(helper.q(".reveal", body)).toBeFalsy();
@@ -415,7 +415,7 @@ describe("Dashboard Pipeline Widget", () => {
       it("should not retain text entered when the pause popup is closed", () => {
         helper.click('.pause');
         expect(helper.q(".reveal", body)).toBeInDOM();
-        let pausePopupTextBox = helper.q('.reveal input', body);
+        let pausePopupTextBox   = helper.q('.reveal input', body);
         pausePopupTextBox.value = "test";
 
         helper.click('.reveal .secondary', body);

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -101,8 +101,8 @@ describe("Dashboard Pipeline Widget", () => {
       mount(false, {}, {}, true, true);
 
       expect(pipeline.canAdminister).toBe(false);
-      expect(helper.q('.edit_config')).toHaveClass('disabled');
-      expect(helper.q('.edit_config')).toHaveAttr('data-tooltip-id');
+      expect(helper.q('.info_config')).toHaveClass('disabled');
+      expect(helper.q('.info_config')).toHaveAttr('data-tooltip-id');
     });
 
     it('should disable pipeline settings for config repo pipelines', () => {
@@ -110,7 +110,7 @@ describe("Dashboard Pipeline Widget", () => {
       mount(true, {}, {}, true, true, true);
 
       expect(pipeline.isDefinedInConfigRepo()).toBe(true);
-      expect(helper.q('.edit_config')).toHaveClass('disabled');
+      expect(helper.q('.info_config')).toHaveClass('disabled');
     });
   });
 
@@ -157,7 +157,7 @@ describe("Dashboard Pipeline Widget", () => {
       it("should disable pipeline settings button for non admin users", () => {
         helper.unmount();
         mount(false);
-        expect(helper.q('.edit_config')).toHaveClass("disabled");
+        expect(helper.q('.info_config')).toHaveClass("disabled");
       });
 
       it("should render pipeline settings icon", () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/form_helper.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/form_helper.js.msx
@@ -23,7 +23,7 @@ import 'foundation-sites';
 
 
 function withAttr(attrName, callback1, context) {
-  return function(e) {
+  return function (e) {
     callback1.call(context || this, attrName in e.currentTarget ? e.currentTarget[attrName] : e.currentTarget.getAttribute(attrName));
   };
 }
@@ -315,9 +315,9 @@ export const f = {
       const args        = vnode.attrs;
       const tooltipText = deleteKeyAndReturnValue(args, "tooltipText");
       return (
-        <div style="position: relative; display: inline">
-          <a href="javascript:void(0)" onmouseover={ctrl.hasFocus.bind(ctrl, true)}
-             onmouseout={ctrl.hasFocus.bind(ctrl, false)}
+        <div style="position: relative; display: inline" onmouseover={ctrl.hasFocus.bind(ctrl, true)}
+             onmouseout={ctrl.hasFocus.bind(ctrl, false)}>
+          <a href="javascript:void(0)"
              class={compactClasses(vnode.attrs, 'has-tip')} {...vnode.attrs}
              data-hover-delay={100} data-tooltip-id={this.tooltipId}>
             {vnode.children}
@@ -330,7 +330,7 @@ export const f = {
   link: {
     view(vnode) {
       const disabled = vnode.attrs.disabled;
-      const args = _.assign({}, vnode.attrs);
+      const args     = _.assign({}, vnode.attrs);
 
       if (args.hasOwnProperty("disabled")) { // eslint-disable-line no-prototype-builtins
         delete args.disabled;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/dashboard/pipeline.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/dashboard/pipeline.js
@@ -44,6 +44,10 @@ export const Pipeline = function (info) {
 
   this.isDefinedInConfigRepo = () => info.from_config_repo;
 
+  this.getConfigRepoId = () => info.config_repo_id;
+
+  this.getConfigRepoMaterialUrl = () => info.config_repo_material_url;
+
   this.canOperate = info.can_operate;
 
   this.trackingTool = info.tracking_tool;
@@ -124,7 +128,7 @@ export const Pipeline = function (info) {
 
   this.getSettingsDisabledTooltipText = () => {
     if (self.isDefinedInConfigRepo()) {
-      return TooltipText.CONFIG_REPO_PIPELINE;
+      return `${TooltipText.CONFIG_REPO_PIPELINE}: ${self.getConfigRepoId()} with material url: ${self.getConfigRepoMaterialUrl()}`;
     }
     return TooltipText.NO_EDIT_PERMISSION;
   };
@@ -134,7 +138,7 @@ export const Pipeline = function (info) {
     PIPELINE_PAUSED:         "Cannot trigger pipeline - Pipeline is currently paused.",
     PIPELINE_LOCKED:         "Cannot trigger pipeline - Pipeline is currently locked.",
     FIRST_STAGE_IN_PROGRESS: "Cannot trigger pipeline - First stage is still in progress.",
-    CONFIG_REPO_PIPELINE:    "Cannot edit pipeline defined in config repository.",
+    CONFIG_REPO_PIPELINE:    "Cannot edit pipeline defined in config repository",
     NO_EDIT_PERMISSION:      "You do not have permission to edit the pipeline.",
     NO_UNLOCK_PERMISSION:    "You do not have permission to unlock the pipeline.",
     NO_PAUSE_PERMISSION:     "You do not have permission to pause the pipeline.",

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/dashboard/pipeline.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/dashboard/pipeline.js
@@ -126,11 +126,12 @@ export const Pipeline = function (info) {
     return TooltipText.NO_UNLOCK_PERMISSION;
   };
 
-  this.getSettingsDisabledTooltipText = () => {
-    if (self.isDefinedInConfigRepo()) {
-      return `${TooltipText.CONFIG_REPO_PIPELINE}: ${self.getConfigRepoId()} with material url: ${self.getConfigRepoMaterialUrl()}`;
-    }
+  this.noEditPermissionTooltipText = () => {
     return TooltipText.NO_EDIT_PERMISSION;
+  };
+
+  this.definedInConfigRepoTooltipText = () => {
+    return TooltipText.CONFIG_REPO_PIPELINE;
   };
 
   const TooltipText = {
@@ -138,7 +139,7 @@ export const Pipeline = function (info) {
     PIPELINE_PAUSED:         "Cannot trigger pipeline - Pipeline is currently paused.",
     PIPELINE_LOCKED:         "Cannot trigger pipeline - Pipeline is currently locked.",
     FIRST_STAGE_IN_PROGRESS: "Cannot trigger pipeline - First stage is still in progress.",
-    CONFIG_REPO_PIPELINE:    "Cannot edit pipeline defined in config repository",
+    CONFIG_REPO_PIPELINE:    "Pipeline defined in config repository.",
     NO_EDIT_PERMISSION:      "You do not have permission to edit the pipeline.",
     NO_UNLOCK_PERMISSION:    "You do not have permission to unlock the pipeline.",
     NO_PAUSE_PERMISSION:     "You do not have permission to pause the pipeline.",

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/pipeline_header_widget.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/pipeline_header_widget.js.msx
@@ -21,6 +21,33 @@ import {PipelineOperationsWidget} from "views/dashboard/pipeline_operations_widg
 import {PipelineAnalyticsWidget} from "views/dashboard/pipeline_analytics_widget";
 
 export const PipelineHeaderWidget = {
+
+  getSettingsDisabledTooltipText(pipeline) {
+    if (pipeline.isDefinedInConfigRepo()) {
+      const configRepoId = pipeline.getConfigRepoId();
+      return <div>
+        <div>{pipeline.definedInConfigRepoTooltipText()}</div>
+        <div>Id: <a href={`admin/config_repos#!${configRepoId}`}>{configRepoId}</a></div>
+        <div>Url: {pipeline.getConfigRepoMaterialUrl()}</div>
+      </div>;
+    }
+    return pipeline.noEditPermissionTooltipText();
+  },
+
+  pipelineLockButton(vnode, pipeline) {
+    if (!pipeline.isLocked) {
+      return;
+    }
+
+    if (pipeline.canUnlock) {
+      return <f.button onclick={vnode.state.unlock.bind(vnode.state, pipeline)} aria-label="Pipeline Locked"
+                     title="Pipeline Locked" class="pipeline_locked"/>;
+    }
+
+    return <f.button class="pipeline_locked disabled"
+                     tooltipText={pipeline.getLockDisabledTooltipText()}/>;
+  },
+
   oninit(vnode) {
     const self              = vnode.state;
     const operationMessages = vnode.attrs.operationMessages;
@@ -35,7 +62,7 @@ export const PipelineHeaderWidget = {
     };
   },
 
-  view: (vnode) => {
+  view(vnode) {
     const pipeline                   = vnode.attrs.pipeline;
     const pluginsSupportingAnalytics = vnode.attrs.pluginsSupportingAnalytics;
     const shouldShowAnalyticsIcon    = vnode.attrs.shouldShowAnalyticsIcon;
@@ -47,24 +74,14 @@ export const PipelineHeaderWidget = {
       settingsButton     = (<a class={`edit_config`} aria-label={`Edit Configuration for Pipeline ${pipeline.name}`}
                                title={'Edit Pipeline Configuration'} href={settingsPath}/>);
     } else {
-      settingsButton = (<f.link class="edit_config disabled" aria-label={pipeline.getSettingsDisabledTooltipText()}
-                                title={'Edit Configuration Disabled'}
-                                tooltipText={pipeline.getSettingsDisabledTooltipText()}/>);
+      settingsButton = (<f.link class="edit_config disabled" aria-label={this.getSettingsDisabledTooltipText(pipeline)}
+                                tooltipText={this.getSettingsDisabledTooltipText(pipeline)}/>);
     }
 
     if (shouldShowAnalyticsIcon) {
       $.each(pluginsSupportingAnalytics, (pluginId, metricId) => {
         analyticsIcons.push(<PipelineAnalyticsWidget pipeline={pipeline} pluginId={pluginId} metricId={metricId}/>);
       });
-    }
-
-    let pipelineLockButton;
-    if (pipeline.isLocked) {
-      pipelineLockButton = pipeline.canUnlock
-        ? (<button onclick={vnode.state.unlock.bind(vnode.state, pipeline)} aria-label="Pipeline Locked"
-                   title="Pipeline Locked" class="pipeline_locked"/>)
-        : (<f.button class="pipeline_locked disabled"
-                     tooltipText={pipeline.getLockDisabledTooltipText()}/>);
     }
 
     return (
@@ -74,7 +91,7 @@ export const PipelineHeaderWidget = {
           <div class="pipeline_actions">
             {analyticsIcons}
             {settingsButton}
-            {pipelineLockButton}
+            {this.pipelineLockButton(vnode, pipeline)}
           </div>
         </div>
         <PipelineOperationsWidget pipeline={vnode.attrs.pipeline}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/pipeline_header_widget.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/pipeline_header_widget.js.msx
@@ -74,7 +74,7 @@ export const PipelineHeaderWidget = {
       settingsButton     = (<a class={`edit_config`} aria-label={`Edit Configuration for Pipeline ${pipeline.name}`}
                                title={'Edit Pipeline Configuration'} href={settingsPath}/>);
     } else {
-      settingsButton = (<f.link class="edit_config disabled" aria-label={this.getSettingsDisabledTooltipText(pipeline)}
+      settingsButton = (<f.link class="info_config disabled" aria-label={this.getSettingsDisabledTooltipText(pipeline)}
                                 tooltipText={this.getSettingsDisabledTooltipText(pipeline)}/>);
     }
 


### PR DESCRIPTION
Issue: #6125 

Show config repo id and material URL for the pipelines defined using config repo on the dashboard.
This information will be available in the hover message on the settings icon.