### PR TITLE
Fix upgradeApi gradle task to appropriately generate component scan package name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1337,7 +1337,7 @@ task upgradeApi {
       includeEmptyDirs = false
     }
 
-    addPackageToSpringClasspathScanning(newPackagePrefix)
+    addPackageToSpringClasspathScanning("$newPackagePrefix.${apiName.replaceAll(~/[^a-zA-Z]/, '')}")
     addProjectToSettingsGradle(newProjectName, it)
     addProjectToGitIgnore(newProjectName)
   }


### PR DESCRIPTION
#### Example of security-auth-config API
##### Before Fix:
```<context:component-scan base-package="com.thoughtworks.go.apiv2"/>```

##### After Fix:
```<context:component-scan base-package="com.thoughtworks.go.apiv2.securityauthconfig"/>```