### PR TITLE
Fix Upgrade API gradle task to appropriately rename all files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1326,7 +1326,7 @@ task upgradeApi {
         segments.replaceAll({ String eachSegment ->
           if (eachSegment == "apiv${currentMaxApiVersion}") {
             return "apiv${apiVersion}"
-          } else if (eachSegment.endsWith("${oldControllerClassSuffix}.java")) {
+          } else if (eachSegment.contains("${oldControllerClassSuffix}")) {
             return eachSegment.replace(oldControllerClassSuffix, newControllerClassSuffix)
           } else {
             return eachSegment


### PR DESCRIPTION
* Rename ControllerV1Test.groovy to ControllerV2Test.groovy as well
* Modify filename check task to only check for "CONTROLLERNAME_CONTROLLERVERSION"
  instead of checking for file extension.