### PR TITLE
Do not hardcode schemaVersion in XML Loader specs

### DIFF
--- a/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
@@ -4428,7 +4428,7 @@ public class MagicalGoConfigXmlLoaderTest {
                         "   <deny action=\"refer\" type=\"*\">up43</deny>  \n" +
                         "  </rules>\n" +
                         " </secretConfig>\n" +
-                        "</secretConfigs>", 124);
+                        "</secretConfigs>", CONFIG_SCHEMA_VERSION);
 
         CruiseConfig config = xmlLoader.loadConfigHolder(content).config;
 


### PR DESCRIPTION
* Use GoConstants.CONFIG_SCHEMA_VERSION to always use to latest
  available schema version.
* Using hardcoded schema version would cause test failures upon
  next xml migration.