### PR TITLE
Draggable spec failure fix on Safari

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/spec/index_spec.tsx
@@ -132,7 +132,7 @@ describe("TableComponent", () => {
       const spy = jasmine.createSpy();
       helper.mount(() => <Table headers={headers} data={testdata()} draggable={true} dragHandler={spy}/>);
 
-      if (!(/(Chrome|Opera)/i.test(navigator.userAgent))) {
+      if (/(MSIE|Trident|Edge|Safari)/i.test(navigator.userAgent)) {
         return;
       }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/spec/index_spec.tsx
@@ -132,7 +132,7 @@ describe("TableComponent", () => {
       const spy = jasmine.createSpy();
       helper.mount(() => <Table headers={headers} data={testdata()} draggable={true} dragHandler={spy}/>);
 
-      if (/(MSIE|Trident|Edge)/i.test(navigator.userAgent)) {
+      if (!(/(Chrome|Opera)/i.test(navigator.userAgent))) {
         return;
       }
 


### PR DESCRIPTION
In our specs, we create a DataTransfer object to mimic the drag effect for testing.
The compatibility for the constructor is limited only to Chrome and Opera, so skipping the test
for all other

<img width="621" alt="Screen Shot 2019-07-16 at 10 04 43 AM" src="https://user-images.githubusercontent.com/41165891/61266365-2c8d0480-a7b1-11e9-9845-50a8778737dd.png">

Link: 
 - [Data Transfer Constructor](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/DataTransfer)
 - [Window.navigator](https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator#Examples)
