### PR TITLE
SecretParamResolver errors out for invalid secret config id #000

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/exceptions/SecretResolutionFailureException.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/exceptions/SecretResolutionFailureException.java
@@ -33,6 +33,10 @@ public class SecretResolutionFailureException extends RuntimeException {
         return new SecretResolutionFailureException(format("Expected plugin to resolve secret param(s) `%s` using secret config `%s` but plugin sent additional secret param(s) `%s`.", csv(secretsToResolve), secretConfigId, csv(unwantedSecrets)));
     }
 
+    public static SecretResolutionFailureException withInvalidSecretConfigId(String secretConfigId) {
+        return new SecretResolutionFailureException(format("Cannot resolve secrets, the secret param is configured with secret config id: `%s` which is invalid. ", secretConfigId));
+    }
+
     private static String csv(Set<String> secretsToResolve) {
         return String.join(", ", secretsToResolve);
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/SecretParamResolver.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/SecretParamResolver.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.server.service;
 
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.ScmMaterial;
+import com.thoughtworks.go.plugin.access.exceptions.SecretResolutionFailureException;
 import com.thoughtworks.go.plugin.access.secrets.SecretsExtension;
 import com.thoughtworks.go.plugin.domain.secrets.Secret;
 import com.thoughtworks.go.remote.work.BuildAssignment;
@@ -84,6 +85,10 @@ public class SecretParamResolver {
         return (secretConfigId, secretParamsToResolve) -> {
             Map<String, List<SecretParam>> secretParamMap = secretParamsToResolve.stream().collect(groupingBy(SecretParam::getKey, Collectors.toList()));
             final SecretConfig secretConfig = goConfigService.cruiseConfig().getSecretConfigs().find(secretConfigId);
+
+            if (secretConfig == null) {
+                throw SecretResolutionFailureException.withInvalidSecretConfigId(secretConfigId);
+            }
 
             LOGGER.debug("Resolving secret params '{}' using secret config '{}'", secretParamMap.keySet(), secretConfig.getId());
             List<Secret> resolvedSecrets = secretsExtension.lookupSecrets(secretConfig.getPluginId(), secretConfig, secretParamMap.keySet());


### PR DESCRIPTION
* Previously secret params were validated(by applying rules) on config
  save and that would ensure a valid secret config id in a secret param.
  Since we have moved to applying rules at runtime, a secret_param can
  be configured with a secret config id which can be invalid.
* Added check to verify presence of secret config id before secret
  resolution.