### PR TITLE
Add Non root container info in Dockerhub readme

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-agent/README.md.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/README.md.ftl
@@ -101,7 +101,8 @@ If you run several agents container, you will need to overwrite the `VOLUME_DIR`
 </#if>
 
 # Running GoCD Containers as Non Root
-Starting from GoCD release `v19.6.0`, GoCD containers run as non-root user, by default. The Dockerized GoCD application will run as `go:root` (`uid:1000`, `gid:0`) user instead of running as `root:root` (`uid:0`, `gid:0`). For more information, checkout [Running Dockerized GoCD Containers as Non Root](https://www.gocd.org/2019/06/25/GoCD-non-root-containers/) blog post.
+
+With release `v19.6.0`, GoCD containers will as non-root user, by default. The Dockerized GoCD application will run with user `go` (uid: `1000`) and group `root` (gid: `0`) instead of running as user `root` (uid: `0`) and group `root` (gid: `0`). For more information, checkout [Running Dockerized GoCD Containers as Non Root](https://www.gocd.org/2019/06/25/GoCD-non-root-containers/) blog post.
 
 # Troubleshooting
 

--- a/buildSrc/src/main/resources/gocd-docker-agent/README.md.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/README.md.ftl
@@ -100,6 +100,9 @@ In this case, as the docker deamon will be the one mounting the volumes you defi
 If you run several agents container, you will need to overwrite the `VOLUME_DIR` environment variable to have a different path for your `/godata` for each of your gocd agent containers (to avoid issues). For example, if the volume on your host for the first container is `/go-agent1/godata`, you will set the `VOLUME_DIR` environment data on your container to `/go-agent1/godata` and the `docker-entrypoint.sh` script will automatically manage it and make sure the agent stores its configuration, logs and pipelines there.
 </#if>
 
+# Running GoCD Containers as Non Root
+Starting from GoCD release `v19.6.0`, GoCD containers run as non-root user, by default. The Dockerized GoCD application will run as `go:root` (`uid:1000`, `gid:0`) user instead of running as `root:root` (`uid:0`, `gid:0`). For more information, checkout [Running Dockerized GoCD Containers as Non Root](https://www.gocd.org/2019/06/25/GoCD-non-root-containers/) blog post.
+
 # Troubleshooting
 
 ## The GoCD agent does not connect to the server

--- a/buildSrc/src/main/resources/gocd-docker-agent/README.md.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/README.md.ftl
@@ -102,7 +102,7 @@ If you run several agents container, you will need to overwrite the `VOLUME_DIR`
 
 # Running GoCD Containers as Non Root
 
-With release `v19.6.0`, GoCD containers will as non-root user, by default. The Dockerized GoCD application will run with user `go` (uid: `1000`) and group `root` (gid: `0`) instead of running as user `root` (uid: `0`) and group `root` (gid: `0`). For more information, checkout [Running Dockerized GoCD Containers as Non Root](https://www.gocd.org/2019/06/25/GoCD-non-root-containers/) blog post.
+With release `v19.6.0`, GoCD containers will run as non-root user, by default. The Dockerized GoCD application will run with user `go` (uid: `1000`) and group `root` (gid: `0`) instead of running as user `root` (uid: `0`) and group `root` (gid: `0`). For more information, checkout [Running Dockerized GoCD Containers as Non Root](https://www.gocd.org/2019/06/25/GoCD-non-root-containers/) blog post.
 
 # Troubleshooting
 

--- a/buildSrc/src/main/resources/gocd-docker-server/README.md.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/README.md.ftl
@@ -147,7 +147,7 @@ docker inspect --format='{{(index (index .NetworkSettings.Ports "8154/tcp") 0).H
 
 # Running GoCD Containers as Non Root
 
-With release `v19.6.0`, GoCD containers will as non-root user, by default. The Dockerized GoCD application will run with user `go` (uid: `1000`) and group `root` (gid: `0`) instead of running as user `root` (uid: `0`) and group `root` (gid: `0`). For more information, checkout [Running Dockerized GoCD Containers as Non Root](https://www.gocd.org/2019/06/25/GoCD-non-root-containers/) blog post.
+With release `v19.6.0`, GoCD containers will run as non-root user, by default. The Dockerized GoCD application will run with user `go` (uid: `1000`) and group `root` (gid: `0`) instead of running as user `root` (uid: `0`) and group `root` (gid: `0`). For more information, checkout [Running Dockerized GoCD Containers as Non Root](https://www.gocd.org/2019/06/25/GoCD-non-root-containers/) blog post.
 
 # Troubleshooting
 

--- a/buildSrc/src/main/resources/gocd-docker-server/README.md.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/README.md.ftl
@@ -146,7 +146,8 @@ docker inspect --format='{{(index (index .NetworkSettings.Ports "8154/tcp") 0).H
 ```
 
 # Running GoCD Containers as Non Root
-Starting from GoCD release `v19.6.0`, GoCD containers run as non-root user, by default. The Dockerized GoCD application will run as `go:root` (`uid:1000`, `gid:0`) user instead of running as `root:root` (`uid:0`, `gid:0`). For more information, checkout [Running Dockerized GoCD Containers as Non Root](https://www.gocd.org/2019/06/25/GoCD-non-root-containers/) blog post.
+
+With release `v19.6.0`, GoCD containers will as non-root user, by default. The Dockerized GoCD application will run with user `go` (uid: `1000`) and group `root` (gid: `0`) instead of running as user `root` (uid: `0`) and group `root` (gid: `0`). For more information, checkout [Running Dockerized GoCD Containers as Non Root](https://www.gocd.org/2019/06/25/GoCD-non-root-containers/) blog post.
 
 # Troubleshooting
 

--- a/buildSrc/src/main/resources/gocd-docker-server/README.md.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/README.md.ftl
@@ -145,6 +145,9 @@ docker inspect --format='{{(index (index .NetworkSettings.Ports "8153/tcp") 0).H
 docker inspect --format='{{(index (index .NetworkSettings.Ports "8154/tcp") 0).HostPort}}' server
 ```
 
+# Running GoCD Containers as Non Root
+Starting from GoCD release `v19.6.0`, GoCD containers run as non-root user, by default. The Dockerized GoCD application will run as `go:root` (`uid:1000`, `gid:0`) user instead of running as `root:root` (`uid:0`, `gid:0`). For more information, checkout [Running Dockerized GoCD Containers as Non Root](https://www.gocd.org/2019/06/25/GoCD-non-root-containers/) blog post.
+
 # Troubleshooting
 
 ## The GoCD server does not come up


### PR DESCRIPTION
* Include Non root docker container info into Dockerhub readme of
  GoCD server and GoCD agent