### PR TITLE
Adding a way around usage data 1 report a day

### DIFF
--- a/api/api-data-sharing-reporting-v2/src/main/java/com/thoughtworks/go/apiv2/datasharing/reporting/UsageStatisticsReportingControllerV2.java
+++ b/api/api-data-sharing-reporting-v2/src/main/java/com/thoughtworks/go/apiv2/datasharing/reporting/UsageStatisticsReportingControllerV2.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv2.datasharing.reporting.representers.UsageStatisticsReportingRepresenter;
 import com.thoughtworks.go.domain.UsageStatisticsReporting;
+import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.service.datasharing.DataSharingUsageStatisticsReportingService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.spark.Routes.DataSharing;
@@ -32,18 +33,21 @@ import spark.Response;
 
 import java.io.IOException;
 
+import static com.thoughtworks.go.server.service.datasharing.DataSharingUsageStatisticsReportingService.USAGE_DATA_IGNORE_LAST_UPDATED_AT;
 import static spark.Spark.*;
 
 @Component
 public class UsageStatisticsReportingControllerV2 extends ApiController implements SparkSpringController {
     private final ApiAuthenticationHelper apiAuthenticationHelper;
     private final DataSharingUsageStatisticsReportingService usageStatisticsReportingService;
+    private GoCache goCache;
 
     @Autowired
-    public UsageStatisticsReportingControllerV2(ApiAuthenticationHelper apiAuthenticationHelper, DataSharingUsageStatisticsReportingService UsageStatisticsReportingService) {
+    public UsageStatisticsReportingControllerV2(ApiAuthenticationHelper apiAuthenticationHelper, DataSharingUsageStatisticsReportingService UsageStatisticsReportingService, GoCache goCache) {
         super(ApiVersion.v2);
         this.apiAuthenticationHelper = apiAuthenticationHelper;
         this.usageStatisticsReportingService = UsageStatisticsReportingService;
+        this.goCache = goCache;
     }
 
     @Override
@@ -88,6 +92,7 @@ public class UsageStatisticsReportingControllerV2 extends ApiController implemen
         if (!result.isSuccessful()) {
             return renderHTTPOperationResult(result, request, response);
         }
+        goCache.put(USAGE_DATA_IGNORE_LAST_UPDATED_AT, false);
 
         response.status(204);
         return NOTHING;

--- a/api/api-data-sharing-reporting-v2/src/test/groovy/com/thoughtworks/go/apiv2/datasharing/reporting/UsageStatisticsReportingControllerV2Test.groovy
+++ b/api/api-data-sharing-reporting-v2/src/test/groovy/com/thoughtworks/go/apiv2/datasharing/reporting/UsageStatisticsReportingControllerV2Test.groovy
@@ -43,7 +43,7 @@ class UsageStatisticsReportingControllerV2Test implements SecurityServiceTrait, 
 
     @Override
     UsageStatisticsReportingControllerV2 createControllerInstance() {
-        new UsageStatisticsReportingControllerV2(new ApiAuthenticationHelper(securityService, goConfigService), service)
+        new UsageStatisticsReportingControllerV2(new ApiAuthenticationHelper(securityService, goConfigService), service, goCache)
     }
 
     @Nested

--- a/api/api-pipeline-config-v8/src/main/java/com/thoughtworks/go/apiv8/admin/pipelineconfig/PipelineConfigControllerV8.java
+++ b/api/api-pipeline-config-v8/src/main/java/com/thoughtworks/go/apiv8/admin/pipelineconfig/PipelineConfigControllerV8.java
@@ -51,6 +51,7 @@ import java.util.function.Consumer;
 
 import static com.thoughtworks.go.api.util.HaltApiResponses.*;
 import static com.thoughtworks.go.server.service.datasharing.DataSharingUsageDataService.SAVE_AND_RUN_CTA;
+import static com.thoughtworks.go.server.service.datasharing.DataSharingUsageStatisticsReportingService.USAGE_DATA_IGNORE_LAST_UPDATED_AT;
 import static java.lang.String.format;
 import static spark.Spark.*;
 
@@ -155,8 +156,9 @@ public class PipelineConfigControllerV8 extends ApiController implements SparkSp
         if (shouldPausePipeline(req)) {
             String pauseCause = getUserSpecifiedOrDefaultPauseCause(req);
             pipelinePauseService.pause(pipelineConfigFromRequest.name().toString(), pauseCause, userName);
-        } else if (Toggles.isToggleOn(Toggles.TEST_DRIVE)){
+        } else if (Toggles.isToggleOn(Toggles.TEST_DRIVE) && !goCache.getOrDefault(SAVE_AND_RUN_CTA, false)){
             goCache.put(SAVE_AND_RUN_CTA, true);
+            goCache.put(USAGE_DATA_IGNORE_LAST_UPDATED_AT, true);
         }
 
         return handleCreateOrUpdateResponse(req, res, pipelineConfigFromRequest, result);

--- a/server/src/main/java/com/thoughtworks/go/server/service/datasharing/DataSharingUsageStatisticsReportingService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/datasharing/DataSharingUsageStatisticsReportingService.java
@@ -16,8 +16,8 @@
 package com.thoughtworks.go.server.service.datasharing;
 
 import com.thoughtworks.go.domain.UsageStatisticsReporting;
+import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.dao.UsageStatisticsReportingSqlMapDao;
-import com.thoughtworks.go.server.service.datasharing.DataSharingSettingsService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.util.Clock;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -35,21 +35,26 @@ import static com.thoughtworks.go.util.DateUtils.isToday;
 public class DataSharingUsageStatisticsReportingService {
     private final UsageStatisticsReportingSqlMapDao usageStatisticsReportingSqlMapDao;
     private final Clock clock;
+    private GoCache goCache;
     private DataSharingSettingsService dataSharingSettingsService;
     private final SystemEnvironment systemEnvironment;
     private final Object mutexForReportingUsageData = new Object();
 
     private DateTime reportingStartedTime = null;
 
+    public static String USAGE_DATA_IGNORE_LAST_UPDATED_AT = "usage-data-ignore-last-updated-at";
+
     @Autowired
     public DataSharingUsageStatisticsReportingService(UsageStatisticsReportingSqlMapDao usageStatisticsReportingSqlMapDao,
                                                       DataSharingSettingsService dataSharingSettingsService,
                                                       SystemEnvironment systemEnvironment,
-                                                      Clock clock) {
+                                                      Clock clock,
+                                                      GoCache goCache) {
         this.usageStatisticsReportingSqlMapDao = usageStatisticsReportingSqlMapDao;
         this.dataSharingSettingsService = dataSharingSettingsService;
         this.systemEnvironment = systemEnvironment;
         this.clock = clock;
+        this.goCache = goCache;
     }
 
     public void initialize() {
@@ -74,8 +79,14 @@ public class DataSharingUsageStatisticsReportingService {
         loaded.setDataSharingServerUrl(systemEnvironment.getGoDataSharingServerUrl());
         loaded.setDataSharingGetEncryptionKeysUrl(systemEnvironment.getGoDataSharingGetEncryptionKeysUrl());
         boolean canReport = !isDevelopmentServer() && dataSharingSettingsService.get().allowSharing()
-                && !isToday(loaded.lastReportedAt()) && !isReportingInProgress();
-        loaded.canReport(canReport);
+                && !isReportingInProgress();
+
+        if (goCache.getOrDefault(USAGE_DATA_IGNORE_LAST_UPDATED_AT, false)) {
+            loaded.canReport(canReport);
+        } else {
+            loaded.canReport(canReport && !isToday(loaded.lastReportedAt()));
+        }
+
         return loaded;
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/datasharing/DataSharingUsageStatisticsReportingServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/datasharing/DataSharingUsageStatisticsReportingServiceTest.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.server.service.datasharing;
 
+import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.domain.DataSharingSettings;
 import com.thoughtworks.go.domain.UsageStatisticsReporting;
 import com.thoughtworks.go.server.dao.UsageStatisticsReportingSqlMapDao;
@@ -28,6 +29,7 @@ import org.mockito.Mock;
 import java.time.LocalDate;
 import java.util.Date;
 
+import static com.thoughtworks.go.server.service.datasharing.DataSharingUsageStatisticsReportingService.USAGE_DATA_IGNORE_LAST_UPDATED_AT;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
@@ -42,6 +44,8 @@ public class DataSharingUsageStatisticsReportingServiceTest {
     private DataSharingSettingsService dataSharingSettingsService;
     @Mock
     private SystemEnvironment systemEnvironment;
+    @Mock
+    private GoCache goCache;
     private String goUsageDataRemoteServerURL;
     private String goUsageDataGetEncryptionKeysURL;
     private DataSharingSettings dataSharingSetting;
@@ -50,11 +54,12 @@ public class DataSharingUsageStatisticsReportingServiceTest {
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        service = new DataSharingUsageStatisticsReportingService(usageStatisticsReportingSqlMapDao, dataSharingSettingsService, systemEnvironment, clock);
+        service = new DataSharingUsageStatisticsReportingService(usageStatisticsReportingSqlMapDao, dataSharingSettingsService, systemEnvironment, clock, goCache);
         goUsageDataRemoteServerURL = "https://datasharing.gocd.org";
         goUsageDataGetEncryptionKeysURL = "https://datasharing.gocd.org/encryption_keys";
         when(systemEnvironment.getGoDataSharingServerUrl()).thenReturn(goUsageDataRemoteServerURL);
         when(systemEnvironment.getGoDataSharingGetEncryptionKeysUrl()).thenReturn(goUsageDataGetEncryptionKeysURL);
+        when(goCache.getOrDefault(USAGE_DATA_IGNORE_LAST_UPDATED_AT, false)).thenReturn(false);
 
         dataSharingSetting = new DataSharingSettings();
         when(dataSharingSettingsService.get()).thenReturn(dataSharingSetting);

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/PipelinesController.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/PipelinesController.java
@@ -27,6 +27,7 @@ import spark.TemplateEngine;
 
 import java.util.HashMap;
 
+import static com.thoughtworks.go.server.service.datasharing.DataSharingUsageStatisticsReportingService.USAGE_DATA_IGNORE_LAST_UPDATED_AT;
 import static com.thoughtworks.go.spark.Routes.PipelineConfig.SPA_BASE;
 import static com.thoughtworks.go.spark.Routes.PipelineConfig.SPA_CREATE;
 import static com.thoughtworks.go.server.service.datasharing.DataSharingUsageDataService.ADD_PIPELINE_CTA;
@@ -61,8 +62,9 @@ public class PipelinesController implements SparkController {
             put("viewTitle", "Create a pipeline");
         }};
 
-        if(Toggles.isToggleOn(Toggles.TEST_DRIVE)) {
+        if(Toggles.isToggleOn(Toggles.TEST_DRIVE) && !goCache.getOrDefault(ADD_PIPELINE_CTA, false)) {
             goCache.put(ADD_PIPELINE_CTA, true);
+            goCache.put(USAGE_DATA_IGNORE_LAST_UPDATED_AT, true);
         }
 
         return new ModelAndView(object, null);


### PR DESCRIPTION
Need to do this for test drive metrics because we report before the
user can do anything, and won't report again for 24
hours.

We don't know how long they'll leave up the test drive instances, but it
seems reasonable to assume it'll only be for the length of time they're
test driving GoCD.

So, once the CTAs have been clicked, we allow for a single report
regardless of the when the last report was.

part of https://github.com/gocd/gocd/issues/6423

@arvindsv @marques-work 