### PR TITLE
Fix Linux Installers (#6666)

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeAgent.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeAgent.groovy
@@ -70,6 +70,7 @@ class InstallerTypeAgent implements InstallerType {
       '/usr/share/doc/go-agent'           : [mode: 0755, owner: 'root', group: 'root', ownedByPackage: true],
       '/usr/share/go-agent/wrapper-config': [mode: 0750, owner: 'root', group: 'go', ownedByPackage: true],
       '/var/lib/go-agent'                 : [mode: 0750, owner: 'go', group: 'go', ownedByPackage: true],
+      '/var/lib/go-agent/run'             : [mode: 0750, owner: 'go', group: 'go', ownedByPackage: true],
       '/var/log/go-agent'                 : [mode: 0750, owner: 'go', group: 'go', ownedByPackage: true],
       '/var/run/go-agent'                 : [mode: 0750, owner: 'go', group: 'go', ownedByPackage: true]
     ]

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeServer.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeServer.groovy
@@ -78,6 +78,7 @@ class InstallerTypeServer implements InstallerType {
       '/usr/share/doc/go-server'           : [mode: 0755, owner: 'root', group: 'root', ownedByPackage: true],
       '/usr/share/go-server/wrapper-config': [mode: 0750, owner: 'root', group: 'go', ownedByPackage: true],
       '/var/lib/go-server'                 : [mode: 0750, owner: 'go', group: 'go', ownedByPackage: true],
+      '/var/lib/go-server/run'             : [mode: 0750, owner: 'go', group: 'go', ownedByPackage: true],
       '/var/log/go-server'                 : [mode: 0750, owner: 'go', group: 'go', ownedByPackage: true],
       '/var/run/go-server'                 : [mode: 0750, owner: 'go', group: 'go', ownedByPackage: true],
       '/etc/go'                            : [mode: 0750, owner: 'go', group: 'go', ownedByPackage: true],

--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -181,7 +181,7 @@ def configureLinuxPackage(DefaultTask packageTask, InstallerType installerType, 
             }
 
             if (eachLine == 'PIDDIR="."') {
-              eachLine = "PIDDIR=\"/var/run/${installerType.baseName}\""
+              eachLine = "PIDDIR=\"/var/lib/${installerType.baseName}/run\""
             }
 
             if (eachLine =~ /^#PASS_THROUGH=/ && installerType.allowPassthrough) {


### PR DESCRIPTION
* Change PIDDIR from /var/run/{go-agent,go-server} to /var/lib/{go-agent,go-server}/run