### PR TITLE
New pipeline button dropdown

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -20,6 +20,7 @@ public class Toggles {
     public static String BROWSER_CONSOLE_LOG_WS = "browser_console_log_ws_key";
     public static String ALLOW_EMPTY_PIPELINE_GROUPS_DASHBOARD = "allow_empty_pipeline_groups_dashboard";
     public static String TEST_DRIVE = "test_drive";
+    public static String NEW_PIPELINE_DROPDOWN = "new_pipeline_dropdown";
 
     private static FeatureToggleService service;
 

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -17,6 +17,11 @@
       "value": false
     },
     {
+      "key": "new_pipeline_dropdown",
+      "description": "Makes the button for new pipeline on the dashboard a dropdown so can select add pipeline with pipelines as code",
+      "value": false
+    },
+    {
       "key": "allow_empty_pipeline_groups_dashboard",
       "description": "Coupled with queryParam allowEmpty=true will show empty pipeline groups on the dashboard.",
       "value": false

--- a/server/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -181,6 +181,35 @@ body {
   margin:        5px;
 }
 
+.new-pipeline-selector {
+  position: relative;
+  float:    right;
+
+  &:hover {
+    .new-pipeline-items {
+      display: block;
+    }
+  }
+}
+
+.new-pipeline-items {
+  list-style-type: none;
+  cursor:          default;
+  display:         none;
+  position:        absolute;
+  right:           0;
+  background:      #fff;
+  border:          1px solid #d6e0e2;
+  border-radius:   0 0 3px 3px;
+  width:           100%;
+}
+
+.new-pipeline-item {
+  &:hover {
+    background: rgba(0, 0, 0, 0.2);
+  }
+}
+
 .pipeline {
   position: relative;
 }

--- a/server/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -34,6 +34,10 @@ export default class {
     return `/go/admin/pipelines/create`;
   }
 
+  static createPipelineAsCodePath(): string {
+    return `/go/admin/pipelines/as-code`;
+  }
+
   static pipelineConfigCreatePath(): string {
     return `/go/api/admin/pipelines`;
   }

--- a/server/webapp/WEB-INF/rails/webpack/models/dashboard/dashboard_groups.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/dashboard/dashboard_groups.js
@@ -108,7 +108,8 @@ class PipelineGroup extends Group {
     return {
       show: `${Routes.pipelineGroupsPath()}#group-${this.name}`,
       edit: Routes.pipelineGroupEditPath(this.name),
-      new: `${SparkRoutes.newCreatePipelinePath()}?group=${this.name}`
+      new: `${SparkRoutes.newCreatePipelinePath()}?group=${this.name}`,
+      asCode: `${SparkRoutes.createPipelineAsCodePath()}?group=${this.name}`
     };
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/single_page_apps/new_dashboard.js
+++ b/server/webapp/WEB-INF/rails/webpack/single_page_apps/new_dashboard.js
@@ -28,6 +28,7 @@ const PersonalizeVM   = require('views/dashboard/models/personalization_vm');
 $(() => {
   const dashboardElem              = $('#dashboard');
   const showEmptyPipelineGroups    = JSON.parse(dashboardElem.attr('data-show-empty-pipeline-groups'));
+  const newPipelineDropdown        = JSON.parse(dashboardElem.attr('data-new-pipeline-dropdown'));
   const shouldShowAnalyticsIcon    = JSON.parse(dashboardElem.attr('data-should-show-analytics-icon'));
   const pluginsSupportingAnalytics = {};
 
@@ -198,6 +199,7 @@ $(() => {
           showSpinner,
           pluginsSupportingAnalytics,
           shouldShowAnalyticsIcon,
+          newPipelineDropdown,
           vm:                   dashboardVM,
           doCancelPolling:      () => repeater().stop(),
           doRefreshImmediately: () => repeater().restart()

--- a/server/webapp/WEB-INF/rails/webpack/views/dashboard/dashboard_groups_widget.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/dashboard/dashboard_groups_widget.js.msx
@@ -33,14 +33,39 @@ const GroupHeading = {
               aria-label={vm.label()}>{vm.name || "Pipelines not in any Environment"}</f.link>
       {vm.name && <f.link class="edit_config dashboard-group_edit-config" disabled={!vm.canAdminister} href={paths.edit}
                           tooltipText={vm.tooltipForEdit()} title={vm.titleForEdit()} aria-label={vm.ariaLabelForEdit()}/>}
-      { vm.canAdminister && paths.new ? <Buttons.Primary align="right"
-                                            icon={Buttons.ButtonIcon.ADD}
-                                            disabled={!vm.canAdminister}
-                                            aria-label={vm.ariaLabelForNewPipeline()}
-                                            title={vm.titleForNewPipeline()}
-                                            onclick={this.goToAddPipeline.bind(null, paths.new)}>
-                             New Pipeline
-                           </Buttons.Primary> : "" }
+      { vm.canAdminister && paths.new && !vnode.attrs.newPipelineDropdown ?
+        <Buttons.Primary align="right"
+            icon={Buttons.ButtonIcon.ADD}
+            disabled={!vm.canAdminister}
+            aria-label={vm.ariaLabelForNewPipeline()}
+            title={vm.titleForNewPipeline()}
+            onclick={this.goToAddPipeline.bind(null, paths.new)}>
+            New Pipeline
+          </Buttons.Primary> :
+          <Dropdown vm={vm}/>
+      }
+    </div>;
+  }
+};
+
+const Dropdown = {
+  view(vnode) {
+    const vm = vnode.attrs.vm;
+    const paths = vm.routes();
+
+    return <div class="new-pipeline-selector">
+      <Buttons.Primary
+        icon       = {Buttons.ButtonIcon.ADD}
+        disabled   = {!vm.canAdminister}
+        aria-label = {vm.ariaLabelForNewPipeline()}
+        title      = {vm.titleForNewPipeline()}>
+        New Pipeline
+      </Buttons.Primary>
+
+      <ul class="new-pipeline-items">
+        <li class="new-pipeline-item"><a href={paths.new}>Add manually</a></li>
+        <li class="new-pipeline-item"><a href={paths.asCode}>Add pipeline as code</a></li>
+      </ul>
     </div>;
   }
 };

--- a/server/webapp/WEB-INF/rails/webpack/views/dashboard/dashboard_groups_widget.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/dashboard/dashboard_groups_widget.js.msx
@@ -27,23 +27,27 @@ const GroupHeading = {
   view(vnode) {
     const vm    = vnode.attrs.vm;
     const paths = vm.routes();
+    let addPipeline = "";
 
-    return <div class="dashboard-group_title">
-      <f.link disabled={!vm.canAdminister} href={paths.show} class="dashboard-group_name"
-              aria-label={vm.label()}>{vm.name || "Pipelines not in any Environment"}</f.link>
-      {vm.name && <f.link class="edit_config dashboard-group_edit-config" disabled={!vm.canAdminister} href={paths.edit}
-                          tooltipText={vm.tooltipForEdit()} title={vm.titleForEdit()} aria-label={vm.ariaLabelForEdit()}/>}
-      { vm.canAdminister && paths.new && !vnode.attrs.newPipelineDropdown ?
-        <Buttons.Primary align="right"
+    if (vm.canAdminister && paths.new) {
+      vnode.attrs.newPipelineDropdown ?
+        addPipeline = <Dropdown vm={vm}/> :
+        addPipeline = <Buttons.Primary align="right"
             icon={Buttons.ButtonIcon.ADD}
             disabled={!vm.canAdminister}
             aria-label={vm.ariaLabelForNewPipeline()}
             title={vm.titleForNewPipeline()}
             onclick={this.goToAddPipeline.bind(null, paths.new)}>
             New Pipeline
-          </Buttons.Primary> :
-          <Dropdown vm={vm}/>
-      }
+          </Buttons.Primary>;
+    }
+
+    return <div class="dashboard-group_title">
+      <f.link disabled={!vm.canAdminister} href={paths.show} class="dashboard-group_name"
+              aria-label={vm.label()}>{vm.name || "Pipelines not in any Environment"}</f.link>
+      {vm.name && <f.link class="edit_config dashboard-group_edit-config" disabled={!vm.canAdminister} href={paths.edit}
+                          tooltipText={vm.tooltipForEdit()} title={vm.titleForEdit()} aria-label={vm.ariaLabelForEdit()}/>}
+      { addPipeline }
     </div>;
   }
 };

--- a/server/webapp/WEB-INF/rails/webpack/views/dashboard/dashboard_widget.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/dashboard/dashboard_widget.js.msx
@@ -86,6 +86,7 @@ const DashboardWidget = {
 
           {messageView}
           <DashboardGroupsWidget scheme={vm.scheme()}
+                                 newPipelineDropdown={args.newPipelineDropdown}
                                  invalidateEtag={vm.invalidateEtag}
                                  resolver={dashboard} {...sharedGroupArgs}
                                  groups={vm.filteredGroups(personalizeVM.currentFilter())}/>

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/NewDashboardController.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/NewDashboardController.java
@@ -71,6 +71,7 @@ public class NewDashboardController implements SparkController {
         HashMap<Object, Object> object = new HashMap<Object, Object>() {{
             put("viewTitle", "Dashboard");
             put("showEmptyPipelineGroups", Toggles.isToggleOn(Toggles.ALLOW_EMPTY_PIPELINE_GROUPS_DASHBOARD));
+            put("newPipelineDropdown", Toggles.isToggleOn(Toggles.NEW_PIPELINE_DROPDOWN));
             put("shouldShowAnalyticsIcon", showAnalyticsIcon());
         }};
         return new ModelAndView(object, "new_dashboard/index.ftlh");

--- a/spark/spark-spa/src/main/resources/freemarker/new_dashboard/index.ftlh
+++ b/spark/spark-spa/src/main/resources/freemarker/new_dashboard/index.ftlh
@@ -16,6 +16,7 @@
 
 <div id="dashboard" class="dashboard"
   data-show-empty-pipeline-groups="${showEmptyPipelineGroups?c}"
+  data-new-pipeline-dropdown="${newPipelineDropdown?c}"
   data-should-show-analytics-icon="${shouldShowAnalyticsIcon?c}">
   <span class="page-spinner"/>
 </div>


### PR DESCRIPTION
This PR makes the New Pipeline button into a dropdown so users can select between creating a pipeline via the pipelines as code page or the add pipeline wizard. 

This is meant for the test drive experience and therefore behind a toggle `new_pipeline_dropdown`.
Related issue #6649 
Design considerations & feedback as part of #6598