### PR TITLE
Validate as you type `name` component. Follows rules for identifiers (e.g., pipeline name, stage name, config repo id, etc)

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/forms/common_validating_inputs.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/forms/common_validating_inputs.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MithrilComponent} from "jsx/mithril-component";
+import * as m from "mithril";
+import {TextFieldAttrs} from "./input_fields";
+import {LiveValidatingInputField} from "./live_validating_input";
+
+const ID_RE = /^([-a-zA-Z0-9_])([-a-zA-Z0-9_.]{0,254})$/;
+const NEG_ID_BODY_RE = /[^-a-zA-Z0-9_.]/;
+const NEG_ID_HEAD_RE = /[^-a-zA-Z0-9_]/;
+
+interface State {
+  valid(s: string): string | undefined;
+}
+
+export class IdentifierInputField extends MithrilComponent<TextFieldAttrs, State> {
+  static INVALID_CHARS = "Only letters, numbers, hyphens, underscores, and periods are allowed.";
+  static INVALID_START = "The first character must be a letter, number, hyphen, or underscore.";
+  static TOO_LONG = "The maximum length is 255 characters.";
+  static INVALID_FALLBACK = "This does not match the correct format.";
+  static MISSING = "This field cannot be empty.";
+
+  oninit(vnode: m.Vnode<TextFieldAttrs, State>) {
+    vnode.state.valid = (val) => {
+      if (!val) {
+        if (vnode.attrs.required) {
+          return IdentifierInputField.MISSING;
+        }
+        return;
+      }
+
+      if (!ID_RE.test(val)) {
+        if (NEG_ID_BODY_RE.test(val)) {
+          return IdentifierInputField.INVALID_CHARS;
+        }
+
+        if (NEG_ID_HEAD_RE.test(val[0])) {
+          return IdentifierInputField.INVALID_START;
+        }
+
+        if (val.length > 255) {
+          return IdentifierInputField.TOO_LONG;
+        }
+
+        // we really shouldn't get here. placing here for paranoia.
+        return IdentifierInputField.INVALID_FALLBACK;
+      }
+    };
+  }
+
+  view(vnode: m.Vnode<TextFieldAttrs, State>) {
+    const attrs = Object.assign({ validator: vnode.state.valid }, vnode.attrs);
+
+    return <LiveValidatingInputField {...attrs} />;
+  }
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/components/forms/input_fields.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/forms/input_fields.tsx
@@ -246,7 +246,12 @@ function bindingAttributes<T>(attrs: BindingsAttr<T> & ReadonlyAttr,
   };
 
   if (!attrs.readonly) {
+    const existingHandler = (attrs as any)[eventName];
     bindingAttributes[eventName] = (evt: any) => {
+      if ("function" === typeof existingHandler) {
+        existingHandler(evt);
+      }
+
       attrs.property(evt.currentTarget[propertyAttribute]);
       if (attrs.onchange) {
         attrs.onchange(evt);
@@ -313,19 +318,24 @@ export abstract class FormField<T, V = {}> extends MithrilViewComponent<BaseAttr
   protected abstract renderInputField(vnode: m.Vnode<BaseAttrs<T> & V>): m.Children;
 }
 
-export type TextFieldAttrs = BaseAttrs<string> & RequiredFieldAttr & PlaceholderAttr;
+export interface TextFieldAttrs extends BaseAttrs<string>, RequiredFieldAttr, PlaceholderAttr {
+  type?: string;
+}
+
 export type NumberFieldAttrs = BaseAttrs<number> & RequiredFieldAttr & PlaceholderAttr;
 
 export class TextField extends FormField<string, RequiredFieldAttr & PlaceholderAttr> {
-
   renderInputField(vnode: m.Vnode<TextFieldAttrs>) {
-    return (
-      <input type="text"
-             class={classnames(styles.formControl)}
-             {...this.defaultAttributes(vnode.attrs)}
-             {...this.bindingAttributes(vnode.attrs, "oninput", "value")}
-      />
-    );
+    const baseAttrs: { [key: string]: string } = {
+      type: vnode.attrs.type || "text",
+      class: styles.formControl
+    };
+
+    return <input
+      {...baseAttrs}
+      {...this.defaultAttributes(vnode.attrs)}
+      {...this.bindingAttributes(vnode.attrs, "oninput", "value")}
+    />;
   }
 
   protected defaultAttributes(attrs: TextFieldAttrs) {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/forms/live_validating_input.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/forms/live_validating_input.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MithrilComponent} from "jsx/mithril-component";
+import * as m from "mithril";
+import {TextField, TextFieldAttrs} from "views/components/forms/input_fields";
+
+export interface LiveInputAttrs extends TextFieldAttrs {
+  validator: (value: string) => string | undefined;
+}
+
+interface State {
+  errors(): string | undefined;
+}
+
+export class LiveValidatingInputField extends MithrilComponent<LiveInputAttrs, State> {
+  oncreate(vnode: m.VnodeDOM<LiveInputAttrs, State>) {
+    const dom = vnode.dom.querySelector("input") as HTMLInputElement;
+    const validator = vnode.attrs.validator;
+
+    vnode.state.errors = () => (dom.validationMessage || vnode.attrs.errorText);
+
+    if ("function" === typeof validator) {
+      dom.addEventListener("input", (e) => {
+        dom.setCustomValidity(validator(dom.value) || "");
+
+        if (!!dom.validationMessage) {
+          dom.dispatchEvent(new Event("invalid", { bubbles: false, cancelable: true }));
+        }
+        m.redraw();
+      });
+    }
+  }
+
+  view(vnode: m.Vnode<LiveInputAttrs, State>) {
+    const attrs = Object.assign({}, vnode.attrs);
+
+    delete attrs.validator;
+
+    if ("function" === typeof vnode.state.errors) {
+      attrs.errorText = vnode.state.errors(); // injects validator error message, falling back to vnode.attrs.errorText
+    }
+
+    return <TextField {...attrs}/>;
+  }
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/components/forms/spec/common_validating_inputs_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/forms/spec/common_validating_inputs_spec.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {asSelector} from "helpers/css_proxies";
+import * as _ from "lodash";
+import * as m from "mithril";
+import * as stream from "mithril/stream";
+import {Stream} from "mithril/stream";
+import {TestHelper} from "views/pages/spec/test_helper";
+import {IdentifierInputField} from "../common_validating_inputs";
+import * as css from "../forms.scss";
+
+describe("Common Validating Input Fields:", () => {
+  const helper = new TestHelper();
+  const sel = asSelector(css);
+
+  describe("IdentifierInputField", () => {
+    const data: Stream<string> = stream();
+    const required: Stream<boolean> = stream();
+
+    beforeEach(() => {
+      data("");
+      required(false);
+    });
+
+    afterEach(() => helper.unmount());
+
+    it("allows valid input", (done) => {
+      helper.mount(() => <IdentifierInputField property={data} required={required()}/>);
+
+      const input = helper.q("input") as HTMLInputElement;
+      expect(input).toBeInDOM();
+
+      input.addEventListener("invalid", () => done.fail("should be valid"));
+      helper.oninput(input, "Good-Name");
+
+      setTimeout(() => {
+        expect(input.validationMessage).toBe("");
+        expect(helper.q(sel.formErrorText)).not.toBeInDOM();
+        done();
+      }, 0);
+    });
+
+    it("allows empty input when required is false", (done) => {
+      required(false);
+      helper.mount(() => <IdentifierInputField property={data} required={required()}/>);
+
+      const input = helper.q("input") as HTMLInputElement;
+      expect(input).toBeInDOM();
+
+      input.addEventListener("invalid", () => done.fail("should be valid"));
+      helper.oninput(input, "");
+
+      setTimeout(() => {
+        expect(input.validationMessage).toBe("");
+        expect(helper.q(sel.formErrorText)).not.toBeInDOM();
+        done();
+      }, 0);
+    });
+
+    it("refutes empty input when required is true", (done) => {
+      required(true);
+      helper.mount(() => <IdentifierInputField property={data} required={required()}/>);
+
+      const input = helper.q("input") as HTMLInputElement;
+      expect(input).toBeInDOM();
+
+      input.addEventListener("invalid", () => {
+        expect(input.validationMessage).toBe(IdentifierInputField.MISSING);
+
+        setTimeout(() => {
+          expect(helper.text(sel.formErrorText)).toBe(IdentifierInputField.MISSING);
+          done();
+        }, 0);
+      });
+
+      helper.oninput(input, "");
+    });
+
+    it("refutes values with invalid chars", (done) => {
+      helper.mount(() => <IdentifierInputField property={data} required={required()}/>);
+
+      const input = helper.q("input") as HTMLInputElement;
+      expect(input).toBeInDOM();
+
+      input.addEventListener("invalid", () => {
+        expect(input.validationMessage).toBe(IdentifierInputField.INVALID_CHARS);
+
+        setTimeout(() => {
+          expect(helper.text(sel.formErrorText)).toBe(IdentifierInputField.INVALID_CHARS);
+          done();
+        }, 0);
+      });
+
+      helper.oninput(input, "bad name?");
+    });
+
+    it("refutes values when first character is a period", (done) => {
+      helper.mount(() => <IdentifierInputField property={data} required={required()}/>);
+
+      const input = helper.q("input") as HTMLInputElement;
+      expect(input).toBeInDOM();
+
+      input.addEventListener("invalid", () => {
+        expect(input.validationMessage).toBe(IdentifierInputField.INVALID_START);
+
+        setTimeout(() => {
+          expect(helper.text(sel.formErrorText)).toBe(IdentifierInputField.INVALID_START);
+          done();
+        }, 0);
+      });
+
+      helper.oninput(input, ".why-me");
+    });
+
+    it("refutes values that are too long", (done) => {
+      helper.mount(() => <IdentifierInputField property={data} required={required()}/>);
+
+      const input = helper.q("input") as HTMLInputElement;
+      expect(input).toBeInDOM();
+
+      input.addEventListener("invalid", () => {
+        expect(input.validationMessage).toBe(IdentifierInputField.TOO_LONG);
+
+        setTimeout(() => {
+          expect(helper.text(sel.formErrorText)).toBe(IdentifierInputField.TOO_LONG);
+          done();
+        }, 0);
+      });
+
+      helper.oninput(input, _.repeat("a", 256));
+    });
+  });
+});

--- a/server/webapp/WEB-INF/rails/webpack/views/components/forms/spec/live_validating_input_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/forms/spec/live_validating_input_spec.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {asSelector} from "helpers/css_proxies";
+import * as m from "mithril";
+import * as stream from "mithril/stream";
+import {TestHelper} from "views/pages/spec/test_helper";
+import * as css from "../forms.scss";
+import {LiveValidatingInputField} from "../live_validating_input";
+
+describe("LiveValidatingInputField", () => {
+  const data = stream("");
+  const sel = asSelector(css);
+  const helper = new TestHelper();
+
+  function onlyNumbers(value: string) {
+    if (value && /\D/.test(value)) {
+      return "Only enter numbers";
+    }
+  }
+
+  beforeEach(() => {
+    data("");
+    helper.mount(() => <LiveValidatingInputField label="type here pls." property={data} validator={onlyNumbers}/>);
+  });
+
+  afterEach(() => helper.unmount());
+
+  it("should fire `invalid` event and display an error message when the value fails the validator function", (done) => {
+    helper.q("input[type]").addEventListener("invalid", (e) => {
+      expect((e.target as HTMLInputElement).validationMessage).toBe("Only enter numbers");
+
+      setTimeout(() => {
+        expect(helper.text(sel.formErrorText)).toBe("Only enter numbers");
+        done();
+      }, 0);
+    });
+
+    helper.oninput("input[type]", "hi");
+  });
+
+  it("allows valid input", (done) => {
+    const input = helper.q("input");
+    expect(input).toBeInDOM();
+
+    input.addEventListener("invalid", () => done.fail("should be valid"));
+    helper.oninput(input, "8675309");
+
+    setTimeout(() => {
+      expect(helper.q(sel.formErrorText)).not.toBeInDOM();
+      done();
+    }, 0);
+  });
+
+});

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
@@ -15,8 +15,8 @@
  */
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
-import * as stream from "mithril/stream";
 import {Stream} from "mithril/stream";
+import * as stream from "mithril/stream";
 import {TriStateCheckbox} from "models/tri_state_checkbox";
 import {ButtonGroup, ButtonIcon} from "views/components/buttons";
 import * as Buttons from "views/components/buttons/index";
@@ -24,6 +24,7 @@ import {CollapsiblePanel} from "views/components/collapsible_panel";
 import {Ellipsize} from "views/components/ellipsize";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {AutocompleteField, SuggestionProvider} from "views/components/forms/autocomplete";
+import {IdentifierInputField} from "views/components/forms/common_validating_inputs";
 import {EncryptedValue} from "views/components/forms/encrypted_value";
 import {Form} from "views/components/forms/form";
 import {
@@ -65,6 +66,7 @@ export class KitchenSink extends MithrilViewComponent<null> {
   view(vnode: m.Vnode<null>) {
     const model: Stream<string> = stream();
     const textValue: Stream<string> = stream();
+    const name: Stream<string> = stream();
 
     return (
       <div>
@@ -263,6 +265,10 @@ export class KitchenSink extends MithrilViewComponent<null> {
             return "Only numbers are allowed! You'd better settle down, you rebel, you!";
           }
         }} />
+
+        <h3>Validate-as-you-type Name field (just a special case of LiveValidatingInputField)</h3>
+
+        <IdentifierInputField label={`GoCD identier (a.k.a., "name")`} property={name}/>
 
         <h3>Dynamic autocomplete</h3>
         <AutocompleteField label="Dynamic" property={model} provider={this.provider}/>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
@@ -15,8 +15,8 @@
  */
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
-import {Stream} from "mithril/stream";
 import * as stream from "mithril/stream";
+import {Stream} from "mithril/stream";
 import {TriStateCheckbox} from "models/tri_state_checkbox";
 import {ButtonGroup, ButtonIcon} from "views/components/buttons";
 import * as Buttons from "views/components/buttons/index";
@@ -34,6 +34,7 @@ import {
   TextField,
   TriStateCheckboxField
 } from "views/components/forms/input_fields";
+import {LiveValidatingInputField} from "views/components/forms/live_validating_input";
 import {HeaderPanel} from "views/components/header_panel";
 import {IconGroup} from "views/components/icons";
 import * as Icons from "views/components/icons/index";
@@ -63,6 +64,8 @@ export class KitchenSink extends MithrilViewComponent<null> {
 
   view(vnode: m.Vnode<null>) {
     const model: Stream<string> = stream();
+    const textValue: Stream<string> = stream();
+
     return (
       <div>
         <HeaderPanel title="Kitchen Sink" sectionName={"Admin"}/>
@@ -252,6 +255,15 @@ export class KitchenSink extends MithrilViewComponent<null> {
           "Content for two"]}/>
 
         <br/>
+
+        <h3>Validate-as-you-type field (i.e., LiveValidatingInputField)</h3>
+
+        <LiveValidatingInputField label="Enter some numbers. But if you're adventurous, try any other character -- oh my, the suspense!" property={textValue} validator={(s) => {
+          if (!(/^\d*$/.test(s))) {
+            return "Only numbers are allowed! You'd better settle down, you rebel, you!";
+          }
+        }} />
+
         <h3>Dynamic autocomplete</h3>
         <AutocompleteField label="Dynamic" property={model} provider={this.provider}/>
 


### PR DESCRIPTION
A validate-as-you-type component would be more helpful to the user when entering names. Generally, users don't realize that names actually follow a format and can't have spaces after they submit. This provides earlier, more helpful feedback.