### PR TITLE
Environments Get API returns 304 (Not Modified) when appropriate If-None-Match header is specified. (#6682)

### DIFF
--- a/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2.java
+++ b/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2.java
@@ -113,8 +113,12 @@ public class EnvironmentsControllerV2 extends ApiController implements SparkSpri
 
         EnvironmentConfig environmentConfig = fetchEntityFromConfig(environmentName);
 
-        setEtagHeader(environmentConfig, response);
+        String etag = etagFor(environmentConfig);
+        if (fresh(request, etag)) {
+            return notModified(response);
+        }
 
+        setEtagHeader(environmentConfig, response);
         return writerForTopLevelObject(request, response,
                 outputWriter -> EnvironmentRepresenter.toJSON(outputWriter, environmentConfig));
     }

--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2Test.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2Test.groovy
@@ -120,6 +120,44 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
           .isNotFound()
           .hasJsonMessage(controller.entityType.notFoundMessage("env1"))
       }
+
+      @Test
+      void 'should render not modified when ETag matches'() {
+        def env1 = new BasicEnvironmentConfig(new CaseInsensitiveString("env1"))
+        env1.addAgent("agent1")
+        env1.addAgent("agent2")
+        env1.addEnvironmentVariable("JAVA_HOME", "/bin/java")
+        env1.addPipeline(new CaseInsensitiveString("Pipeline1"))
+        env1.addPipeline(new CaseInsensitiveString("Pipeline2"))
+
+        when(entityHashingService.md5ForEntity(env1)).thenReturn("md5-hash")
+        when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(env1)
+
+        getWithApiHeader(controller.controllerPath("env1"), ['if-none-match': 'md5-hash'])
+
+        assertThatResponse()
+          .isNotModified()
+      }
+
+      @Test
+      void 'should return 200 when ETag doesn\'t matche'() {
+        def env1 = new BasicEnvironmentConfig(new CaseInsensitiveString("env1"))
+        env1.addAgent("agent1")
+        env1.addAgent("agent2")
+        env1.addEnvironmentVariable("JAVA_HOME", "/bin/java")
+        env1.addPipeline(new CaseInsensitiveString("Pipeline1"))
+        env1.addPipeline(new CaseInsensitiveString("Pipeline2"))
+
+        when(entityHashingService.md5ForEntity(env1)).thenReturn("md5-hash")
+        when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(env1)
+
+        getWithApiHeader(controller.controllerPath("env1"), ['if-none-match': 'md5-old-hash'])
+
+        assertThatResponse()
+          .isOk()
+          .hasEtag('"md5-hash"')
+          .hasBodyWithJsonObject(env1, EnvironmentRepresenter)
+      }
     }
   }
 


### PR DESCRIPTION
The API used to render an ETag, but never consume it to return a 304 instead.