### PR TITLE
Fix Elastic Profiles and Cluster Profiles modal sizing (#6715)

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/counts/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/counts/index.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as _ from "lodash";
 import * as m from "mithril";
 import * as s from "underscore.string";
 import * as styles from "./index.scss";
+
+const classnames = bind(styles);
 
 export interface CountsAttr {
   label: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/ellipsize/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/ellipsize/index.tsx
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 
 import {MithrilComponent} from "jsx/mithril-component";
 import * as m from "mithril";
 import {Stream} from "mithril/stream";
 import * as stream from "mithril/stream";
 import * as styles from "./index.scss";
+
+const classnames = bind(styles);
 
 interface Attrs {
   text: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/forms/form.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/forms/form.tsx
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
 import * as styles from "./forms.scss";
+
+const classnames = bind(styles);
 
 interface Attrs {
   dataTestId?: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/forms/input_fields.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/forms/input_fields.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import * as clipboard from "clipboard-polyfill";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as _ from "lodash";
@@ -26,6 +26,8 @@ import * as Buttons from "views/components/buttons";
 import {EncryptedValue} from "views/components/forms/encrypted_value";
 import {SwitchBtn} from "views/components/switch";
 import * as styles from "./forms.scss";
+
+const classnames = bind(styles);
 
 export interface RequiredFieldAttr {
   required?: boolean;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/index.tsx
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as _ from "lodash";
 import * as m from "mithril";
 import * as s from "underscore.string";
 import * as styles from "./index.scss";
+
+const classnames = bind(styles);
 
 export interface Attrs {
   data: Map<string, m.Children>;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/entity_modal.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/entity_modal.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {ApiResult, ErrorResponse, ObjectWithEtag, SuccessResponse} from "helpers/api_request_builder";
 import _ = require("lodash");
 import * as m from "mithril";
@@ -28,6 +28,8 @@ import {FlashMessage, MessageType} from "views/components/flash_message";
 import {Modal, ModalState, Size} from "views/components/modal/index";
 import * as foundationStyles from "views/pages/new_plugins/foundation_hax.scss";
 import * as styles from "./index.scss";
+
+const foundationClassNames = bind(foundationStyles);
 
 export abstract class EntityModal<T extends ValidatableMixin> extends Modal {
   protected entity: Stream<T>;
@@ -71,7 +73,7 @@ export abstract class EntityModal<T extends ValidatableMixin> extends Modal {
       </div> : null;
     return [
       flashMessage,
-      <div class={classnames(foundationStyles.foundationGridHax, foundationStyles.foundationFormHax)}>
+      <div className={foundationClassNames(foundationStyles.foundationGridHax, foundationStyles.foundationFormHax)}>
         {this.modalBody()}
       </div>
     ];

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as _ from "lodash";
 import * as m from "mithril";
@@ -23,6 +23,8 @@ import * as styles from "./index.scss";
 import {ModalManager} from "./modal_manager";
 
 const uuid4 = require("uuid/v4");
+
+const classnames = bind(styles);
 
 //todo: Remove extraLargeHackForEAProfiles once we fix plugins view to provide the modal container dimensions
 export enum Size {small, medium, large, extraLargeHackForEaProfiles}

--- a/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_modal.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_modal.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import * as m from "mithril";
 import {Stream} from "mithril/stream";
 import {
@@ -24,6 +24,7 @@ import * as s from "underscore.string";
 import {Modal, Size} from "../modal";
 import * as styles from "./server_health_messages_count_widget.scss";
 
+const classnames    = bind(styles);
 const TimeFormatter = require("helpers/time_formatter");
 
 export class ServerHealthMessagesModal extends Modal {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.tsx
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
 import * as styles from "./index.scss";
+
+const classnames = bind(styles);
 
 interface SiteHeaderLinkAttrs {
   isNavLink?: boolean;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/spinner/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/spinner/index.tsx
@@ -15,8 +15,10 @@
  */
 import * as m from "mithril";
 
-import classnames from "classnames";
-import * as styles from "./index.scss";
+import {bind} from 'classnames/bind';
+import * as styles from './index.scss';
+
+const classnames = bind(styles);
 
 import {MithrilViewComponent} from "jsx/mithril-component";
 

--- a/server/webapp/WEB-INF/rails/webpack/views/components/tab/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/tab/index.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {MithrilComponent} from "jsx/mithril-component";
 import * as m from "mithril";
 import {Stream} from "mithril/stream";
 import * as stream from "mithril/stream";
 import * as styles from "./index.scss";
+
+const classnames = bind(styles);
 
 interface Attrs {
   tabs: m.Child[] | any;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/index.tsx
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {MithrilComponent, MithrilViewComponent} from "jsx/mithril-component";
 import * as _ from "lodash";
 import * as m from "mithril";
 import * as s from "underscore.string";
 import * as styles from "./index.scss";
+
+const classnames = bind(styles);
 
 export abstract class TableSortHandler {
   private __currentSortedColumnIndex: number = -1;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/tooltip/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/tooltip/index.tsx
@@ -17,10 +17,12 @@
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
 
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {InfoCircle, QuestionCircle} from "views/components/icons";
 import * as Icons from "views/components/icons";
 import * as styles from "./index.scss";
+
+const classnames = bind(styles);
 
 export enum TooltipSize {
   small,

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profile_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profile_widget.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import * as Routes from "gen/ts-routes";
 import {MithrilComponent} from "jsx/mithril-component";
 import * as _ from "lodash";
@@ -37,6 +37,7 @@ import {Attrs as ElasticProfilesWidgetAttrs, ElasticProfilesWidget} from "views/
 import {AddOperation, CloneOperation, DeleteOperation, EditOperation} from "views/pages/page_operations";
 import * as styles from ".//index.scss";
 
+const classnames = bind(styles);
 export type ClusterProfileOperations = EditOperation<ClusterProfile> & DeleteOperation<string> & AddOperation<void> & CloneOperation<ClusterProfile>;
 
 export interface Attrs extends ElasticProfilesWidgetAttrs {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profiles_modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profiles_modals.tsx
@@ -15,7 +15,7 @@
  */
 const AngularPluginNew = require("views/shared/angular_plugin_new");
 
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {ApiResult, ErrorResponse, ObjectWithEtag} from "helpers/api_request_builder";
 import * as _ from "lodash";
 import * as m from "mithril";
@@ -35,6 +35,8 @@ import {Modal, Size} from "views/components/modal";
 import {Spinner} from "views/components/spinner";
 import * as styles from "views/pages/elastic_profiles/index.scss";
 import * as foundationStyles from "views/pages/new_plugins/foundation_hax.scss";
+
+const foundationClassNames = bind(foundationStyles);
 
 export enum ModalType {
   edit, create
@@ -148,7 +150,7 @@ export abstract class BaseClusterProfileModal extends Modal {
         </div>
         <div>
           {errorSection}
-          <div class={classnames(foundationStyles.foundationGridHax, foundationStyles.foundationFormHax)}>
+          <div className={foundationClassNames(foundationStyles.foundationGridHax, foundationStyles.foundationFormHax)}>
             <div class="row collapse" data-test-id="cluster-profile-properties-form">
               {clusterProfileForm}
             </div>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/elastic_agent_profiles_modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/elastic_agent_profiles_modals.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {ApiResult, ErrorResponse, ObjectWithEtag} from "helpers/api_request_builder";
 import * as m from "mithril";
 import {Stream} from "mithril/stream";
@@ -33,6 +33,7 @@ import {Table} from "views/components/table";
 import * as styles from "views/pages/elastic_profiles/index.scss";
 import * as foundationStyles from "views/pages/new_plugins/foundation_hax.scss";
 
+const foundationClassNames = bind(foundationStyles);
 const AngularPluginNew     = require("views/shared/angular_plugin_new");
 import * as _ from "lodash";
 
@@ -125,7 +126,7 @@ abstract class BaseElasticProfileModal extends Modal {
     const elasticProfileConfigurations = (elasticAgentExtension as ElasticAgentSettings).profileSettings;
 
     return (
-      <div class={classnames(foundationStyles.foundationGridHax, foundationStyles.foundationFormHax)}>
+      <div class={foundationClassNames(foundationStyles.foundationGridHax, foundationStyles.foundationFormHax)}>
         <div>
           <FormHeader>
             <FlashMessage type={MessageType.alert} message={this.noClusterProfileError}/>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_header.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_header.tsx
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
 import {NotificationCenter} from "views/components/notification_center";
 import {ServerHealthSummary} from "views/components/server_health_summary/server_health_summary";
 import SiteMenu, {SiteSubNavItem} from "views/components/site_menu";
 import * as styles from "./site_header.scss";
+
+const classnames          = bind(styles);
 
 export interface Attrs {
   isAnonymous: boolean;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
 import * as css from "./advanced_settings.scss";
+
+const cls = bind(css);
 
 interface Attrs {
   forceOpen?: boolean;
@@ -40,7 +42,7 @@ export class AdvancedSettings extends MithrilViewComponent<Attrs> {
   }
 
   view(vnode: m.Vnode<Attrs>): m.Children | void | null {
-    return <dl class={classnames(css.advancedSettings, {[css.lockOpen]: vnode.attrs.forceOpen})}>
+    return <dl class={cls(css.advancedSettings, {[css.lockOpen]: vnode.attrs.forceOpen})}>
       <dt class={css.summary}>Advanced Settings</dt>
       <dd class={css.details}>{vnode.children}</dd>
     </dl>;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/roles/role_modal_body.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/roles/role_modal_body.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as _ from "lodash";
 import * as m from "mithril";
@@ -28,6 +28,8 @@ import {Spinner} from "views/components/spinner";
 import * as foundationStyles from "views/pages/new_plugins/foundation_hax.scss";
 import {GoCDRoleModalBodyWidget, PluginRoleModalBodyWidget} from "views/pages/roles/role_modal_body_widget";
 import * as styles from "./index.scss";
+
+const foundationClassNames = bind(foundationStyles);
 
 export enum Action {
   NEW, CLONE, EDIT
@@ -94,7 +96,7 @@ export class RoleModalBody extends MithrilViewComponent<RoleModalAttrs> {
                                  role={vnode.attrs.role()}/>);
     }
 
-    return (<div class={classnames(foundationStyles.foundationGridHax, foundationStyles.foundationFormHax)}>
+    return (<div class={foundationClassNames(foundationStyles.foundationGridHax, foundationStyles.foundationFormHax)}>
         {mayBeTypeSelector}
         {roleWidget}
       </div>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/add_user_modal.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/add_user_modal.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import * as _ from "lodash";
 import * as m from "mithril";
 import * as stream from "mithril/stream";
@@ -28,6 +28,8 @@ import {Modal, Size} from "views/components/modal";
 import {Spinner} from "views/components/spinner";
 import {Table} from "views/components/table";
 import * as styles from "views/pages/users/index.scss";
+
+const classnames = bind(styles);
 
 export class UserSearchModal extends Modal {
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/user_actions_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/user_actions_widget.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
 import {Stream} from "mithril/stream";
@@ -43,6 +43,8 @@ import {
 } from "views/components/forms/input_fields";
 import {DeleteOperation, DisableOperation, EnableOperation} from "views/pages/page_operations";
 import * as styles from "./index.scss";
+
+const classnames = bind(styles);
 
 export interface HasRoleSelection {
   rolesSelection: Stream<Map<GoCDRole, TriStateCheckbox>>;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/users_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/users_widget.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import classnames from "classnames";
+import {bind} from "classnames/bind";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as _ from "lodash";
 import * as m from "mithril";
@@ -27,6 +27,8 @@ import {
 } from "views/pages/users/super_admin_toggle_widget";
 import {State as UserActionsState, UsersActionsWidget} from "views/pages/users/user_actions_widget";
 import * as styles from "./index.scss";
+
+const classnames = bind(styles);
 
 export interface Attrs extends UserActionsState, SuperAdminPrivilegeSwitchAttrs, RequiresUserViewHelper {
 


### PR DESCRIPTION
Fixes: #6715

Revert "Use `classnames` instead of `classnames/bind` since we are ac…tually using it like plain old `classnames` anyway."

This reverts commit af1bb43a9ed6ba2f119e15dac12106db179b93ed.

----
Classes applied to the modal when styles are bound with classnames (using: `classnames.bind`):
```
index__overlay___IyXVO index__extra-large-hack-for-EA-profiles___157i3
```

Classes applied to the modal when NO styles are bound with classnames:
```
index__overlay___IyXVO extraLargeHackForEaProfiles
```

