### PR TITLE
Use `<IdentifierInputField/>` in the add pipeline forms wherever a name is needed

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/job_editor.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/job_editor.tsx
@@ -17,8 +17,8 @@
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
 import {Job} from "models/pipeline_configs/job";
+import {IdentifierInputField} from "views/components/forms/common_validating_inputs";
 import {Form, FormBody} from "views/components/forms/form";
-import {TextField} from "views/components/forms/input_fields";
 import {IDENTIFIER_FORMAT_HELP_MESSAGE} from "./messages";
 
 interface Attrs {
@@ -29,7 +29,7 @@ export class JobEditor extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs>) {
     return <FormBody>
       <Form last={true} compactForm={true}>
-        <TextField label="Job Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} placeholder="e.g., run-unit-tests" property={vnode.attrs.job.name} errorText={vnode.attrs.job.errors().errorsForDisplay("name")} required={true}/>
+        <IdentifierInputField label="Job Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} placeholder="e.g., run-unit-tests" property={vnode.attrs.job.name} errorText={vnode.attrs.job.errors().errorsForDisplay("name")} required={true}/>
       </Form>
     </FormBody>;
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/pipeline_info_editor.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/pipeline_info_editor.tsx
@@ -21,8 +21,9 @@ import * as stream from "mithril/stream";
 import {PipelineConfig} from "models/pipeline_configs/pipeline_config";
 import {DefaultCache, PipelineGroupCache} from "models/pipeline_configs/pipeline_groups_cache";
 import {TemplateCache} from "models/pipeline_configs/templates_cache";
+import {IdentifierInputField} from "views/components/forms/common_validating_inputs";
 import {Form, FormBody} from "views/components/forms/form";
-import {Option, SelectField, SelectFieldOptions, TextField} from "views/components/forms/input_fields";
+import {Option, SelectField, SelectFieldOptions} from "views/components/forms/input_fields";
 import {AdvancedSettings} from "views/pages/pipelines/advanced_settings";
 import {TemplateEditor} from "views/pages/pipelines/template_editor";
 import {IDENTIFIER_FORMAT_HELP_MESSAGE} from "./messages";
@@ -51,7 +52,7 @@ export class PipelineInfoEditor extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs>) {
     return <FormBody>
       <Form last={true} compactForm={true}>
-        <TextField label="Pipeline Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} placeholder="e.g., My-New-Pipeline" property={vnode.attrs.pipelineConfig.name} errorText={vnode.attrs.pipelineConfig.errors().errorsForDisplay("name")} required={true}/>
+        <IdentifierInputField label="Pipeline Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} placeholder="e.g., My-New-Pipeline" property={vnode.attrs.pipelineConfig.name} errorText={vnode.attrs.pipelineConfig.errors().errorsForDisplay("name")} required={true}/>
       <AdvancedSettings forceOpen={this.hasErrors(vnode)}>
         <SelectField label="Pipeline Group" property={vnode.attrs.pipelineConfig.group} errorText={vnode.attrs.pipelineConfig.errors().errorsForDisplay("group")} required={true}>
           <SelectFieldOptions selected={this.selectedGroup(vnode)} items={this.pipelineGroups()}/>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/stage_editor.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/stage_editor.tsx
@@ -17,8 +17,8 @@
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
 import {Stage} from "models/pipeline_configs/stage";
+import {IdentifierInputField} from "views/components/forms/common_validating_inputs";
 import {Form, FormBody} from "views/components/forms/form";
-import {TextField} from "views/components/forms/input_fields";
 import {SwitchBtn} from "views/components/switch/index";
 import {TooltipSize} from "views/components/tooltip";
 import * as Tooltip from "views/components/tooltip";
@@ -35,7 +35,7 @@ export class StageEditor extends MithrilViewComponent<Attrs> {
 
     return <FormBody>
       <Form last={true} compactForm={true}>
-        <TextField label="Stage Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} placeholder="e.g., Test-and-Report" property={stage.name} errorText={stage.errors().errorsForDisplay("name")} required={true}/>
+        <IdentifierInputField label="Stage Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} placeholder="e.g., Test-and-Report" property={stage.name} errorText={stage.errors().errorsForDisplay("name")} required={true}/>
 
         <AdvancedSettings>
           <SwitchBtn label={<div>


### PR DESCRIPTION
Makes the name fields validate format in real-time to provide a more helpful user experience on the add pipeline flow.