### PR TITLE
Reroute API calls invoking the "latest" version using `application/vnd.go.cd+json`

### DIFF
--- a/api/api-base/src/main/java/com/thoughtworks/go/api/spring/RerouteLatestApisImpl.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/spring/RerouteLatestApisImpl.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.api.spring;
+
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
+import com.thoughtworks.go.api.ApiVersion;
+import com.thoughtworks.go.spark.RerouteLatestApis;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ReflectionUtils;
+import spark.*;
+import spark.route.HttpMethod;
+import spark.route.Routes;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+import static com.thoughtworks.go.api.ApiVersion.LATEST_VERSION_MIMETYPE;
+
+@Component
+public class RerouteLatestApisImpl implements RerouteLatestApis {
+
+    public List<?> routeList() {
+        Service service = getService();
+
+        // reflection equivalent of:
+        // Routes routes = service.routes
+        Routes routes = getField(service, "routes");
+
+        // reflection equivalent of:
+        // List<RouteEntry> routesList = routes.routes
+        List<?> routesList = getField(routes, "routes");
+
+        // return a copy of the array, instead of the reference
+        return new ArrayList<>(routesList);
+    }
+
+    // ignore some "special" paths
+    private boolean shouldIgnore(String acceptHeader) {
+        return acceptHeader.equals("*/*");
+    }
+
+    private Service getService() {
+        // reflection equivalent of:
+        // Service service = Spark.getInstance()
+        Method getInstanceMethod = ReflectionUtils.findMethod(Spark.class, "getInstance");
+        ReflectionUtils.makeAccessible(getInstanceMethod);
+        return (Service) ReflectionUtils.invokeMethod(getInstanceMethod, null);
+    }
+
+    private static <T> T getField(Object o, String fieldName) {
+        Field field = ReflectionUtils.findField(o.getClass(), fieldName);
+        ReflectionUtils.makeAccessible(field);
+        return (T) ReflectionUtils.getField(field, o);
+    }
+
+    @Override
+    public void registerLatest() {
+        List<?> routes = routeList();
+
+        // get all known paths and versions corresponding to each path
+        Multimap<String, ApiVersion> pathToVersionsMap = LinkedHashMultimap.create();
+
+        routes.forEach(eachRouteEntry /* of type RouteEntry*/ -> {
+            String path = getField(eachRouteEntry, "path");
+            String acceptedType = getField(eachRouteEntry, "acceptedType");
+            if (shouldIgnore(acceptedType)) {
+                return;
+            }
+
+            ApiVersion version = ApiVersion.parse(acceptedType);
+
+            pathToVersionsMap.put(path, version);
+        });
+
+
+        routes.forEach(eachRouteEntry -> {
+            HttpMethod httpMethod = getField(eachRouteEntry, "httpMethod");
+            String path = getField(eachRouteEntry, "path");
+            String acceptedType = getField(eachRouteEntry, "acceptedType");
+            Object target = getField(eachRouteEntry, "target");
+
+            if (shouldIgnore(acceptedType)) {
+                return;
+            }
+
+            // get the api versions for this path
+            Collection<ApiVersion> apiVersions = pathToVersionsMap.get(path);
+            // get the max version supported by this path
+            ApiVersion maxVersion = apiVersions.stream().max(Comparator.naturalOrder()).orElseThrow(() -> new IllegalArgumentException("Unable to lookup apiversion for " + path));
+
+            // if this route corresponds to the latest version, then also register that route with latest version.
+            if (maxVersion.mimeType().equals(acceptedType)) {
+                Service service = getService();
+                if (target instanceof Route) {
+                    service.addRoute(httpMethod, RouteImpl.create(path, LATEST_VERSION_MIMETYPE, (Route) target));
+                } else if (target instanceof Filter) {
+                    service.addFilter(httpMethod, new FilterImpl(path, LATEST_VERSION_MIMETYPE, ((Filter) target)) {
+                        @Override
+                        public void handle(Request request, Response response) throws Exception {
+                            ((Filter) target).handle(request, response);
+                        }
+                    });
+                } else {
+                    throw new IllegalArgumentException("Unexpected target type " + target.getClass());
+                }
+            }
+
+        });
+    }
+}

--- a/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/RerouteLatestApisImplTest.groovy
+++ b/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/RerouteLatestApisImplTest.groovy
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.api.spring
+
+import com.thoughtworks.go.config.exceptions.HttpException
+import com.thoughtworks.go.spark.SparkController
+import com.thoughtworks.go.spark.mocks.TestApplication
+import com.thoughtworks.go.spark.mocks.TestSparkPreFilter
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import spark.ExceptionHandler
+import spark.Filter
+import spark.Route
+import spark.servlet.SparkFilter
+
+import javax.servlet.FilterConfig
+
+import static org.assertj.core.api.Assertions.assertThat
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.when
+import static org.mockito.MockitoAnnotations.initMocks
+import static spark.Spark.*
+
+class RerouteLatestApisImplTest {
+
+  @Mock
+  Filter apiv11BeforeFilter1
+  @Mock
+  Filter apiv11BeforeFilter2
+  @Mock
+  Filter apiv11AfterFilter1
+  @Mock
+  Filter apiv11AfterFilter2
+
+  @Mock
+  ExceptionHandler<HttpException> apiv11ExceptionHandler1
+  @Mock
+  Route apiv11GetMethod
+
+  @Mock
+  Filter apiv10BeforeFilter1
+  @Mock
+  Filter apiv10BeforeFilter2
+  @Mock
+  Filter apiv10AfterFilter1
+  @Mock
+  Filter apiv10AfterFilter2
+  @Mock
+  ExceptionHandler<HttpException> apiv10ExceptionHandler1
+  @Mock
+  Route apiv10GetMethod
+
+  @Mock
+  Filter apiv1BeforeFilter1
+  @Mock
+  Filter apiv1BeforeFilter2
+  @Mock
+  Route apiv1GetMethod
+
+  @Mock
+  ExceptionHandler<Exception> apiv1ExceptionHandler1
+
+  private SparkController controller1
+  private SparkController controller2
+  private SparkController controller3
+
+  private TestApplication testApplication
+  private TestSparkPreFilter preFilter
+
+  @BeforeEach
+  void setUp() {
+    initMocks(this)
+
+    controller1 = new SparkController() {
+      @Override
+      String controllerBasePath() {
+        return "/foo"
+      }
+
+      @Override
+      void setupRoutes() {
+        path(controllerBasePath(), { ->
+          // some filters
+          before("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11BeforeFilter1)
+          before("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11BeforeFilter2)
+
+          get("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11GetMethod)
+
+          after("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11AfterFilter1)
+          after("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11AfterFilter2)
+
+          // some exception handlers
+          exception(HttpException.class, apiv11ExceptionHandler1)
+        })
+      }
+    }
+
+    controller2 = new SparkController() {
+      @Override
+      String controllerBasePath() {
+        return "/foo"
+      }
+
+      @Override
+      void setupRoutes() {
+        path(controllerBasePath(), { ->
+          // some filters
+          before("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10BeforeFilter1)
+          before("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10BeforeFilter2)
+
+          get("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10GetMethod)
+
+          after("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10AfterFilter2)
+          after("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10AfterFilter1)
+
+          // some exception handlers
+          exception(HttpException.class, apiv10ExceptionHandler1)
+        })
+      }
+    }
+
+    controller3 = new SparkController() {
+      @Override
+      String controllerBasePath() {
+        return "/something-else"
+      }
+
+      @Override
+      void setupRoutes() {
+        path(controllerBasePath(), { ->
+          // some filters
+          before("/bar", "application/vnd.go.cd." + "v1" + "+json", apiv1BeforeFilter1)
+          before("/bar", "application/vnd.go.cd." + "v1" + "+json", apiv1BeforeFilter2)
+
+          get("/bar", "application/vnd.go.cd." + "v1" + "+json", apiv1GetMethod)
+
+          // some exception handlers
+          exception(Exception.class, apiv1ExceptionHandler1)
+        })
+      }
+    }
+
+    testApplication = new TestApplication(controller1, controller2, controller3)
+
+    def filterConfig = mock(FilterConfig.class)
+    when(filterConfig.getInitParameter(SparkFilter.APPLICATION_CLASS_PARAM)).thenReturn(TestApplication.class.getName())
+
+    preFilter = new TestSparkPreFilter(testApplication)
+    preFilter.init(filterConfig)
+  }
+
+  @AfterEach
+  void tearDown() {
+    preFilter.destroy()
+  }
+
+  @Test
+  void routeAssertions() {
+    assertThat(new RerouteLatestApisImpl().routeList()).hasSize(16)
+  }
+
+  @Test
+  void shouldRegisterLatestRoutes() {
+    // original route list
+    RerouteLatestApisImpl rerouteLatestApis = new RerouteLatestApisImpl()
+    assertThat(rerouteLatestApis.routeList()).hasSize(16)
+
+    rerouteLatestApis.registerLatest()
+
+    // add 5 routes for `/foo/bar`
+    // add 3 routes for `/something-else/bar`
+    assertThat(rerouteLatestApis.routeList()).hasSize(24)
+  }
+}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -119,6 +119,7 @@ configurations {
   // this dependency is a "provided" dependency
   compile.exclude(group: 'ch.qos.logback', module: 'logback-classic')
   runtime.exclude(group: 'ch.qos.logback', module: 'logback-classic')
+  apiBase.exclude(group: 'ch.qos.logback', module: 'logback-classic')
   api.exclude(group: 'ch.qos.logback', module: 'logback-classic')
   spark.exclude(group: 'ch.qos.logback', module: 'logback-classic')
 }
@@ -131,6 +132,7 @@ project.ext.railsClasspath = project.sourceSets.test.runtimeClasspath +
   project.sourceSets.sharedTest.runtimeClasspath +
   project.sourceSets.fastUnitTest.runtimeClasspath +
   project.configurations.spark +
+  project.configurations.apiBase +
   project.rootProject.findProject(':test:test-utils').files("resource-include-in-all-projects")
 
 project.ext.jrubyOptimizationJvmArgs = [
@@ -236,6 +238,7 @@ project.ext.testSystemProperties = props
 dependencies {
   jrubyGems group: 'rubygems', name: 'bundler', version: '1.17.2'
 
+  apiBase project(':api:api-base')
   api project(':api').subprojects
   spark project(':spark').subprojects
   compile project(':addon-api:database')

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/api/ApiVersion.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/api/ApiVersion.java
@@ -15,6 +15,14 @@
  */
 package com.thoughtworks.go.api;
 
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 public enum ApiVersion {
     v1(),
     v2(),
@@ -23,7 +31,26 @@ public enum ApiVersion {
     v5(),
     v6(),
     v7(),
-    v8();
+    v8(),
+    v9(),
+    v10(),
+    v11();
+
+    public static final String LATEST_VERSION_MIMETYPE = "application/vnd.go.cd+json";
+
+    private static Set<String> VALID_HEADERS =
+            ImmutableSet.<String>builder()
+                    .add(LATEST_VERSION_MIMETYPE)
+                    .addAll(Arrays.stream(ApiVersion.values()).map(ApiVersion::mimeType).collect(Collectors.toSet()))
+                    .build();
+
+    private static Map<String, ApiVersion> HEADER_TO_VERSION_MAP = new LinkedHashMap<>();
+
+    static {
+        Arrays.stream(ApiVersion.values()).forEach(apiVersion -> {
+            HEADER_TO_VERSION_MAP.put(apiVersion.mimeType(), apiVersion);
+        });
+    }
 
     private final String mimeType;
 
@@ -33,5 +60,14 @@ public enum ApiVersion {
 
     public String mimeType() {
         return this.mimeType;
+    }
+
+    public static ApiVersion parse(String mimeType) {
+        return HEADER_TO_VERSION_MAP.get(mimeType);
+    }
+
+
+    public static boolean isValid(String mimeType) {
+        return VALID_HEADERS.contains(mimeType);
     }
 }

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/RerouteLatestApis.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/RerouteLatestApis.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.spark;
+
+public interface RerouteLatestApis {
+    void registerLatest();
+}

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/SparkPreFilter.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/SparkPreFilter.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.spark;
 
+import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.server.util.ServletHelper;
 import com.thoughtworks.go.spark.spring.Application;
 import org.springframework.web.context.WebApplicationContext;
@@ -66,7 +67,8 @@ public class SparkPreFilter extends SparkFilter {
             return true;
         }
 
-        return !acceptHeader.matches("application/vnd\\.go\\.cd\\.v(\\d+)\\+json");
+
+        return !ApiVersion.isValid(acceptHeader);
     }
 
     private String getAcceptHeader(HttpServletRequest req) {

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/Application.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/Application.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.spark.spring;
 
+import com.thoughtworks.go.spark.RerouteLatestApis;
 import com.thoughtworks.go.spark.RoutesHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -25,10 +26,11 @@ import spark.servlet.SparkApplication;
 public class Application implements SparkApplication {
 
     @Autowired
-    public Application(SparkSpringController... controllers) {
+    public Application(RerouteLatestApis rerouteLatestApis, SparkSpringController... controllers) {
         ServletFlag.runFromServlet();
         RoutesHelper routesHelper = new RoutesHelper(controllers);
         routesHelper.init();
+        rerouteLatestApis.registerLatest();
     }
 
     @Override

--- a/spark/spark-base/src/test/java/com/thoughtworks/go/spark/mocks/TestApplication.java
+++ b/spark/spark-base/src/test/java/com/thoughtworks/go/spark/mocks/TestApplication.java
@@ -33,8 +33,8 @@ public class TestApplication implements SparkApplication {
 
     private final RoutesHelper routesHelper;
 
-    public TestApplication(SparkController sparkController) {
-        routesHelper = new RoutesHelper(sparkController);
+    public TestApplication(SparkController... sparkControllers) {
+        routesHelper = new RoutesHelper(sparkControllers);
     }
 
     @Override


### PR DESCRIPTION
Introduce a component that *introspects* all spark routes
to determine the latest versions of each path and adds a
route to listen to "latest" version specified in the header.

For rails, I've simply modified the `routes.rb` to sniff additional
headers.

Fixes #6620