### PR TITLE
Fix newSPA gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -843,7 +843,7 @@ task newSPA {
       * limitations under the License.
       """.stripIndent().trim()
 
-    String javaOrJavaScriptLicencseHeader = "/*\n${licenseHeader.lines().collect{eachLine -> " ${eachLine}"}.join("\n")}\n */\n\n"
+    String javaOrJavaScriptLicencseHeader = "/*\n${licenseHeader.split('\n').collect{eachLine -> " ${eachLine}"}.join("\n")}\n */\n\n"
 
 
     file("${mountPoint}/${spaName}.tsx").withWriter { out ->


### PR DESCRIPTION
`./gradlew newSPA -PspaName=new-agents` command used to fail with following error:

```
➜  gocd git:(fix-new-spa-task) ./gradlew newSPA -PspaName=new-agents
> Task :newSPA FAILED

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/ganeshp/projects/gocd/gocd/build.gradle' line: 846

* What went wrong:
Execution failed for task ':newSPA'.
> No signature of method: java.lang.String.lines() is applicable for argument types: () values: []
  Possible solutions: minus(java.util.regex.Pattern), minus(java.lang.Object), find(), size(), size(), find(java.lang.CharSequence)

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.2.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 2s
1 actionable task: 1 executed
```

---

`licenseHeader.lines()` is a missing method, instead use `licenseHeader.split('\n')`