### PR TITLE
Allow configrepos to be linkable via URL

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/helpers/scheduler.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/scheduler.ts
@@ -14,17 +14,33 @@
  * limitations under the License.
  */
 
-import {RoutedPage} from "helpers/spa_base";
-import {ConfigReposPage} from "views/pages/config_repos";
+type fn = () => void;
 
-export class ConfigReposSPA extends RoutedPage {
+/** A simple task scheduler that ensures each task runs after the page `load` event has fired. */
+export class Scheduler {
+  private queue: fn[] = [];
+  private hasLoaded: boolean = false;
+
   constructor() {
-    super({
-      "": ConfigReposPage,
-      "/:id": ConfigReposPage
+    if ("complete" === document.readyState) {
+      this.hasLoaded = true;
+      return;
+    }
+
+    window.addEventListener("load", () => {
+      this.hasLoaded = true;
+
+      for (const fn of this.queue) {
+        fn();
+      }
     });
   }
-}
 
-// tslint:disable-next-line
-new ConfigReposSPA();
+  schedule(task: fn) {
+    if (this.hasLoaded) {
+      task();
+    } else {
+      this.queue.push(task);
+    }
+  }
+}

--- a/server/webapp/WEB-INF/rails/webpack/helpers/spec/scheduler_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/spec/scheduler_spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Scheduler} from "../scheduler";
+
+describe("Scheduler", () => {
+  // this is really the only thing that can be tested without some awkward hack; testing
+  // the exec delay until onload fires would be difficult
+  it("immediately runs a task once the page has loaded", (done) => {
+    const a = jasmine.createSpy("first()"),
+          b = jasmine.createSpy("second()"),
+          c = jasmine.createSpy("third()");
+
+    const scheduler = new Scheduler();
+
+    scheduler.schedule(a);
+    scheduler.schedule(b);
+    scheduler.schedule(c);
+
+    scheduler.schedule(() => {
+      expect(a).toHaveBeenCalled();
+      expect(b).toHaveBeenCalled();
+      expect(c).toHaveBeenCalled();
+      done();
+    });
+  });
+});

--- a/server/webapp/WEB-INF/rails/webpack/views/components/anchor/anchor.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/anchor/anchor.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Scheduler} from "helpers/scheduler";
+import {MithrilComponent} from "jsx/mithril-component";
+import m from "mithril";
+import headerStyles from "views/components/header_panel/index.scss";
+
+const headerSelector = `.${headerStyles.pageHeader}`;
+
+interface Attrs {
+  id: string;
+  sm: ScrollManager;
+  onnavigate?: () => void;
+}
+
+interface State {
+  dom: Element;
+}
+
+/** Represents a the stateful object to control the autoscroll criteria and scroll capability. */
+export interface ScrollManager {
+  getTarget(): string;
+  setTarget(target: string): void;
+  shouldScroll(criteria: string): boolean;
+  scrollToEl(dom: Element): void;
+}
+
+/**
+ * Roughly simulates the behavior of a named anchor, but does not actually
+ * generate any DOM elements. Rather, this component wraps and passes through
+ * existing components with new behavior to allow components to be programmatically
+ * (automatically?) scrolled into view through a `ScrollManager`.
+ */
+export class Anchor extends MithrilComponent<Attrs, State> {
+  private inited = false;
+
+  oncreate(vnode: m.VnodeDOM<Attrs, State>) {
+    vnode.state.dom = vnode.dom;
+    this.inited = true;
+  }
+
+  view(vnode: m.Vnode<Attrs, State>) {
+    const {id, sm} = vnode.attrs;
+    if (this.inited && sm.shouldScroll(id)) {
+      sm.scrollToEl(vnode.state.dom);
+
+      if ("function" === typeof vnode.attrs.onnavigate) {
+        vnode.attrs.onnavigate();
+      }
+    }
+    return vnode.children;
+  }
+}
+
+/**
+ * The main `ScrollManager` implementation that keeps track of a scroll target (a string
+ * identifier), used in `<Anchor/>`. It has facilities to automatically scroll to an
+ * arbitrary element, which when used in conjunction with `<Anchor/>`, will automatically
+ * scroll the page to the `<Anchor/>` represented by the scroll target identifier.
+ *
+ * This will typically be a singleton per SPA, but there is no restriction to do otherwise,
+ * depending on the needs of the application.
+ */
+export class AnchorVM implements ScrollManager {
+  private target: string = "";
+  private hasMoved: boolean = false;
+  private readonly scheduler = new Scheduler();
+
+  getTarget() {
+    return this.target;
+  }
+
+  setTarget(target: string) {
+    if (target !== this.target) {
+      this.target = target;
+      this.hasMoved = false;
+    }
+  }
+
+  /**
+   * Tests whether or not a specified identifier matches the scroll targer identifier. This is
+   * designed to be called during `view()`, thereby succeeding at most once per target change.
+   * This detail is important because `view()` may be run multiple times. By succeeding at most
+   * once per target change, this ensures that a scroll is only ever scheduled once upon updating
+   * the scroll target, even if the page redraws a few times in the meanwhile.
+   */
+  shouldScroll(criteria: string) {
+    const result = this.target === criteria && !this.hasMoved;
+    if (result) {
+      this.hasMoved = true;
+    }
+
+    return result;
+  }
+
+  /**
+   * Brings the top of `el` as close as possible to the bottom of the fixed-position page header. Visually,
+   * this is the "top" of the page.
+   */
+  scrollToEl(el: Element) {
+    this.scheduler.schedule(() => {
+      const headerBottom = document.querySelector(headerSelector)!.getBoundingClientRect().bottom;
+      const distance = el.getBoundingClientRect().top - (headerBottom + 10); // give a little extra space
+      window.scrollBy(0, distance);
+    });
+  }
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/components/anchor/spec/anchor_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/anchor/spec/anchor_spec.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import m from "mithril";
+import {stubAllMethods, TestHelper} from "views/pages/spec/test_helper";
+import {Anchor, AnchorVM, ScrollManager} from "../anchor";
+
+describe("Anchor", () => {
+  const helper = new TestHelper();
+
+  afterEach(() => helper.unmount());
+
+  it("fires onnavigate() when sm.shouldScroll() is true", () => {
+    const sm: ScrollManager = stubAllMethods(["getTarget", "setTarget", "shouldScroll", "scrollToEl"]);
+    (sm.shouldScroll as jasmine.Spy).and.returnValue(true);
+
+    const onnavigate: () => void = jasmine.createSpy("onnavigate()");
+
+    helper.mount(() => <Anchor id="foo" sm={sm} onnavigate={onnavigate}/>);
+
+    expect(sm.shouldScroll).toHaveBeenCalledWith("foo");
+    expect(sm.scrollToEl).toHaveBeenCalled();
+    expect(onnavigate).toHaveBeenCalled();
+  });
+
+  it("does not fire onnavigate() when sm.shouldScroll() is false", () => {
+    const sm: ScrollManager = stubAllMethods(["getTarget", "setTarget", "shouldScroll", "scrollToEl"]);
+    (sm.shouldScroll as jasmine.Spy).and.returnValue(false);
+
+    const onnavigate: () => void = jasmine.createSpy("onnavigate()");
+
+    helper.mount(() => <Anchor id="foo" sm={sm} onnavigate={onnavigate}/>);
+
+    expect(sm.shouldScroll).toHaveBeenCalledWith("foo");
+    expect(sm.scrollToEl).not.toHaveBeenCalled();
+    expect(onnavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("AnchorVM", () => {
+  it("getTarget() reports the target after setTarget() (yes, this is boring)", () => {
+    const vm = new AnchorVM();
+    expect(vm.getTarget()).toBe("");
+
+    vm.setTarget("foo");
+    expect(vm.getTarget()).toBe("foo");
+  });
+
+  it("shouldScroll() only reports true the first time it is called when the target matches", () => {
+    const vm = new AnchorVM();
+
+    vm.setTarget("foo");
+    expect(vm.getTarget()).toBe("foo");
+
+    expect(vm.shouldScroll("blah")).toBe(false); // doesn't match ID
+    expect(vm.shouldScroll("foo")).toBe(true); // matches!
+
+    // this should fail the second time so as to prevent multiple scrollToEl() calls when used with <Anchor/>
+    expect(vm.shouldScroll("foo")).toBe(false); // fails because it's a repeated call
+    expect(vm.getTarget()).toBe("foo"); // but the ID still matches
+  });
+});

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_widget_spec.tsx
@@ -19,6 +19,7 @@ import {Stream} from "mithril/stream";
 import stream from "mithril/stream";
 import {ConfigRepo} from "models/config_repos/types";
 import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
+import {ScrollManager} from "views/components/anchor/anchor";
 import * as collapsiblePanelStyles from "views/components/collapsible_panel/index.scss";
 import * as headerIconStyles from "views/components/header_icon/index.scss";
 import {ConfigRepoVM} from "views/pages/config_repos/config_repo_view_model";
@@ -30,7 +31,7 @@ import {
   createConfigRepoParsedWithError,
   createConfigRepoWithError
 } from "views/pages/config_repos/spec/test_data";
-import {TestHelper} from "views/pages/spec/test_helper";
+import {stubAllMethods, TestHelper} from "views/pages/spec/test_helper";
 
 describe("ConfigReposWidget", () => {
   let showDeleteModal: jasmine.Spy;
@@ -38,6 +39,7 @@ describe("ConfigReposWidget", () => {
   let reparseRepo: jasmine.Spy;
   let models: Stream<ConfigRepoVM[]>;
   let pluginInfos: Stream<Array<PluginInfo<any>>>;
+  let sm: ScrollManager;
 
   const helper = new TestHelper();
 
@@ -62,12 +64,14 @@ describe("ConfigReposWidget", () => {
     showDeleteModal = jasmine.createSpy("showDeleteModal");
     showEditModal   = jasmine.createSpy("showEditModal");
     reparseRepo     = jasmine.createSpy("reparseRepo");
+    sm              = stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl"]);
     models          = stream([] as ConfigRepoVM[]);
     pluginInfos     = stream([] as Array<PluginInfo<any>>);
 
     helper.mount(() => <ConfigReposWidget {...{
       models,
-      pluginInfos
+      pluginInfos,
+      sm
     }}/>);
   });
 


### PR DESCRIPTION
## Behavioral Expectations/Intent

Using mithril routes, a user should be able to link to a specific config repo on the config repos SPA using the config repo name/id.

### URL format:

`/go/admin/config_repos#!/:id` where the `:id` param is the configrepo ID (name).

Specifically, when navigating to a URL with a config repo ID:

- [x] The config repo matching the id should be scrolled to the top of the page, just under the page header, as far as allowed to by the document content length (i.e., for short content, there will be no scrolling as the entire body is viewable within the browser viewport)
- [x] The matching config repo should be expanded
- [x] If no repo matches, the SPA will act as if no ID was specified and fallback to the default view (as if the user navigated to `/go/admin/config_repos`)

## How this is wired up:

- The `ConfigReposSPA` is now a `RoutedPage`, which now implements the `#!/:repo-id` route
- The corresponding `ConfigReposPage` component reads the `:repo-id` param on `view()` and stores the value in a stateful object of type `ScrollManager`
- Within the `ConfigReposPage`, each `<ConfigRepoWidget/>` is now wrapped with an `<Anchor/>` component, which blesses the child component with the means to react to route changes by scrolling into view
    - Each `<Anchor/>` is associated with the `repo-id` and is also given a reference to the shared `ScrollManager`
    - The`ScrollManager` provides capabilities to detect when a route matches an `<Anchor/>` and to scroll the component DOM element to the top of the page, just under the global page header
    - Each `<Anchor/>` can also control the `<CollapsiblePanel/>` state on route change by way of an event-triggered callback
