### PR TITLE
Removing default title from tooltip icon 

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
@@ -13,19 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {HTMLAttributes} from "jsx/dom";
+
 import _ from "lodash";
 import m from "mithril";
 
-import {MithrilViewComponent} from "jsx/mithril-component";
-
 import classnames from "classnames";
+import {HTMLAttributes} from "jsx/dom";
+import {MithrilViewComponent} from "jsx/mithril-component";
 import styles from "./index.scss";
 
 export interface Attrs extends HTMLAttributes {
   onclick?: (e: MouseEvent) => void;
   disabled?: boolean;
   iconOnly?: boolean;
+  title?: string;
 }
 
 class Icon extends MithrilViewComponent<Attrs> {
@@ -39,22 +40,23 @@ class Icon extends MithrilViewComponent<Attrs> {
   }
 
   view(vnode: m.Vnode<Attrs>) {
+    const title = "string" === typeof vnode.attrs.title ? vnode.attrs.title : this.title;
     if (vnode.attrs.iconOnly) {
       return (
-        <i title={this.title}
+        <i title={title}
            data-test-id={`${this.title}-icon`}
            data-test-disabled-element={vnode.attrs.disabled}
            class={classnames(this.name, {disabled: vnode.attrs.disabled})}
            {...vnode.attrs}/>
       );
-    }
+  }
 
     return (
-      <button title={this.title}
+      <button title={title}
               data-test-disabled-element={vnode.attrs.disabled}
               class={(classnames(styles.btnIcon, {disabled: vnode.attrs.disabled}))}
               {...vnode.attrs}>
-        <i class={classnames(this.name)}/>
+        <i class={this.name}/>
       </button>
     );
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/tooltip/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/tooltip/index.tsx
@@ -49,7 +49,7 @@ class Tooltip extends MithrilViewComponent<Attrs> {
 
     return (
       <div data-test-id="tooltip-wrapper" class={styles.tooltipWrapper}>
-        {m(this.tooltipType, {iconOnly: true})}
+        {m(this.tooltipType, {iconOnly: true, title: ""})}
         <div data-test-id="tooltip-content"
              class={classnames(styles.tooltipContent, size)}>
           <p>{vnode.attrs.content}</p>


### PR DESCRIPTION
The title can cover tooltip and isn't helpful.
![image](https://user-images.githubusercontent.com/3814794/63142197-b80ad880-bf9d-11e9-9738-881901db9965.png)
