### PR TITLE
Upgrade gradle-license-report from 1.7 to 1.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ buildscript {
     classpath 'org.owasp:dependency-check-gradle:5.2.1'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.22.0'
     classpath 'gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0'
-    classpath 'com.github.jk1:gradle-license-report:1.7'
+    classpath 'com.github.jk1:gradle-license-report:1.9'
   }
 }
 


### PR DESCRIPTION
Github Releases: https://github.com/jk1/Gradle-License-Report/releases