### PR TITLE
[BUGFIX] Allow Add Pipeline page to render in older browsers

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/helpers/compat.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/compat.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// OK, so we don't support IE, but some SPAs won't even render in IE to display the
+// unsupported browser message in the first place because of JS errors. Implementing
+// working equivalents isn't so bad, so far, so may as well make it work in at least
+// IE 11 so GoCD isn't _totally_ broken.
+interface IEElement extends HTMLElement {
+  msMatchesSelector(sel: string): boolean;
+}
+
+interface IEWindow extends Window {
+  clipboardData: {
+    getData: (key: string) => string;
+  };
+}
+
+export function matches(el: Element, selector: string): boolean {
+  if ("function" === typeof el.matches) {
+    return el.matches(selector);
+  }
+
+  return (el as IEElement).msMatchesSelector(selector);
+}
+
+export function closest(el: Element, selector: string): Element | null {
+  if ("function" === typeof el.closest) {
+    return el.closest(selector);
+  }
+
+  let result: Element | null = el;
+
+  while (result && !matches(result, selector)) {
+    result = result.parentElement;
+  }
+
+  return result;
+}
+
+export function getClipboardAsPlaintext(e: ClipboardEvent): string {
+  if (e.clipboardData) {
+    return e.clipboardData.getData("text/plain");
+  }
+  return (window as IEWindow).clipboardData.getData("Text");
+}
+
+export function insertTextFromClipboard(text: string) {
+  if (document.queryCommandSupported("insertText")) {
+    document.execCommand("insertText", false, text);
+  } else {
+    const range = document.getSelection()!.getRangeAt(0);
+    range.deleteContents();
+    range.insertNode(document.createTextNode(text));
+  }
+}
+
+export function makeEvent(type: string, bubbles: boolean = true, cancelable: boolean = true): Event {
+  if ("function" === typeof Event) {
+      return new Event(type, { bubbles, cancelable });
+  }
+
+  const event = document.createEvent("Event");
+  event.initEvent(type, bubbles, cancelable);
+
+  return event;
+}

--- a/server/webapp/WEB-INF/rails/webpack/helpers/dom.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/dom.ts
@@ -46,7 +46,14 @@ export function el(tag: HTMLElement | string, options: any, children: Child | Ch
 }
 
 export function replaceWith<T extends ChildNode>(src: T, dst: T): T {
-  src.replaceWith(dst);
+  if ("function" === typeof src.replaceWith) {
+    src.replaceWith(dst);
+  } else {
+    if (src.parentElement) {
+      src.parentElement.replaceChild(dst, src);
+    }
+  }
+
   return dst;
 }
 


### PR DESCRIPTION
### Polyfill some basic functionality so that the add pipeline page (and maybe others?) will render at all in older browsers

Without these, some SPAs may appear completely blank due to JS errors. In such cases, users of old browsers won't even see the "unsupported browser" message in the first place. I don't think GoCD should appear _this_ broken if someone is using IE 11 which still has more market share than Edge at this time.

This commit polyfills an alternative to Proxy in `css_proxies.ts`, Element.matches, Element.closest, and some basic clipboard operations.

Also piggybacking a fix that removes formatting on `paste` in the add pipeline task terminal editor. Sorry about that cheap move :). Just going to slide that one in there...