### PR TITLE
Delete pluggable scm API (#4967)

### DIFF
--- a/api/api-scms-v1/src/main/java/com/thoughtworks/go/apiv1/scms/SCMControllerV1.java
+++ b/api/api-scms-v1/src/main/java/com/thoughtworks/go/apiv1/scms/SCMControllerV1.java
@@ -82,6 +82,7 @@ public class SCMControllerV1 extends ApiController implements SparkSpringControl
             post("", mimeType, this::create);
             get(Routes.SCM.ID, mimeType, this::show);
             put(Routes.SCM.ID, mimeType, this::update);
+            delete(Routes.SCM.ID, mimeType, this::destroy);
         });
     }
 
@@ -109,7 +110,7 @@ public class SCMControllerV1 extends ApiController implements SparkSpringControl
         return writerForTopLevelObject(request, response, writer -> SCMRepresenter.toJSON(writer, scm));
     }
 
-    public String create(Request request, Response response) throws IOException {
+    public String create(Request request, Response response) {
         SCM scmFromRequest = buildEntityFromRequestBody(request, false);
 
         scmFromRequest.ensureIdExists();
@@ -123,7 +124,7 @@ public class SCMControllerV1 extends ApiController implements SparkSpringControl
         return handleCreateOrUpdateResponse(request, response, scmFromRequest, result);
     }
 
-    public String update(Request request, Response response) throws IOException {
+    public String update(Request request, Response response) {
         final String materialName = request.params(MATERIAL_NAME);
         final SCM existingSCM = fetchEntityFromConfig(materialName);
         final SCM scmFromRequest = buildEntityFromRequestBody(request);
@@ -141,6 +142,15 @@ public class SCMControllerV1 extends ApiController implements SparkSpringControl
         pluggableScmService.updatePluggableScmMaterial(currentUsername(), scmFromRequest, operationResult, getIfMatch(request));
 
         return handleCreateOrUpdateResponse(request, response, scmFromRequest, operationResult);
+    }
+
+    public String destroy(Request request, Response response) throws IOException {
+        final String materialName = request.params(MATERIAL_NAME);
+        SCM scm = fetchEntityFromConfig(materialName);
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        pluggableScmService.deletePluggableSCM(currentUsername(), scm, result);
+
+        return renderHTTPOperationResult(result, request, response);
     }
 
     @Override

--- a/api/api-scms-v1/src/test/groovy/com/thoughtworks/go/apiv1/scms/SCMControllerV1Test.groovy
+++ b/api/api-scms-v1/src/test/groovy/com/thoughtworks/go/apiv1/scms/SCMControllerV1Test.groovy
@@ -552,7 +552,7 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
       }
 
       @Test
-      void 'should return 404 if the scm does not exists'() {
+      void 'should return 404 if the scm does not exist'() {
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(null)
         putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'wrong-md5'], [:])
 
@@ -665,6 +665,92 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
             ],
             errors           : [id: ["Invalid id specified."]]
           ]
+        ]
+
+        assertThatResponse()
+          .isUnprocessableEntity()
+          .hasContentType(controller.mimeType)
+          .hasJsonBody(new JsonBuilder(expectedResponseBody).toString())
+      }
+    }
+  }
+
+  @Nested
+  class Destroy {
+    @Nested
+    class Security implements SecurityTestTrait, GroupAdminUserSecurity {
+
+      @Override
+      String getControllerMethodUnderTest() {
+        return "destroy"
+      }
+
+      @Override
+      void makeHttpCall() {
+        deleteWithApiHeader(controller.controllerPath('/foobar'))
+      }
+    }
+
+    @Nested
+    class AsGroupAdmin {
+      @BeforeEach
+      void setUp() {
+        enableSecurity()
+        loginAsGroupAdmin()
+      }
+
+      @Test
+      void 'should delete scm successfully'() {
+        SCM existingSCM = SCMMother.create("scm1", "foobar", "plugin1", "v1.0", new Configuration(
+          ConfigurationPropertyMother.create("key1", false, "value1"),
+          ConfigurationPropertyMother.create("key2", true, "secret"),
+        ))
+
+        when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
+
+        deleteWithApiHeader(controller.controllerPath("/foobar"))
+
+        assertThatResponse()
+          .isOk()
+          .hasContentType(controller.mimeType)
+      }
+
+      @Test
+      void 'should return 404 if the scm does not exist'() {
+        when(scmService.findPluggableScmMaterial("foobar")).thenReturn(null)
+        deleteWithApiHeader(controller.controllerPath("/foobar"))
+
+        assertThatResponse()
+          .isNotFound()
+          .hasContentType(controller.mimeType)
+          .hasJsonMessage(controller.entityType.notFoundMessage("foobar"))
+      }
+
+      @Test
+      void 'should return 422 for validation error'() {
+        SCM existingSCM = SCMMother.create("scm1", "foobar", "plugin1", "v1.0", new Configuration(
+          ConfigurationPropertyMother.create("key1", false, "value1"),
+          ConfigurationPropertyMother.create("key2", true, "secret"),
+        ))
+
+        when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
+
+        when(scmService.deletePluggableSCM(
+          Mockito.any() as Username,
+          Mockito.any() as SCM,
+          Mockito.any() as LocalizedOperationResult,
+          )
+        ).then(
+          {
+            InvocationOnMock invocation ->
+              HttpLocalizedOperationResult result = invocation.getArguments()[2]
+              result.unprocessableEntity("validation failed")
+          })
+
+        deleteWithApiHeader(controller.controllerPath("/foobar"))
+
+        def expectedResponseBody = [
+          message: "validation failed"
         ]
 
         assertThatResponse()

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BasicCruiseConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BasicCruiseConfig.java
@@ -1504,6 +1504,22 @@ public class BasicCruiseConfig implements CruiseConfig {
         return groups.canDeletePluggableSCMMaterial(scmConfig);
     }
 
+    @Override
+    public List<CaseInsensitiveString> pipelinesAssociatedWithPluggableSCM(SCM scmConfig) {
+        List<CaseInsensitiveString> pipelines = new ArrayList<>();
+        if (scmConfig != null) {
+            for (PipelineConfig pipelineConfig : getAllPipelineConfigs()) {
+                for (PluggableSCMMaterialConfig pluggableSCMMaterialConfig : pipelineConfig.pluggableSCMMaterialConfigs()) {
+                    if (pluggableSCMMaterialConfig.getScmId().equals(scmConfig.getId())) {
+                        pipelines.add(pipelineConfig.getName());
+                        break;
+                    }
+                }
+            }
+        }
+        return pipelines;
+    }
+
     public List<PipelineConfig> getAllLocalPipelineConfigs() {
         return strategy.getAllLocalPipelineConfigs(false);
     }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/CruiseConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/CruiseConfig.java
@@ -253,6 +253,8 @@ public interface CruiseConfig extends Validatable, ConfigOriginTraceable {
 
     boolean canDeletePluggableSCMMaterial(SCM scmConfig);
 
+    List<CaseInsensitiveString> pipelinesAssociatedWithPluggableSCM(SCM scmConfig);
+
     List<PipelineConfig> getAllLocalPipelineConfigs();
 
     void setPartials(List<PartialConfig> partials);

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeleteSCMConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeleteSCMConfigCommand.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.update;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.exceptions.GoConfigInvalidException;
+import com.thoughtworks.go.domain.scm.SCM;
+import com.thoughtworks.go.domain.scm.SCMs;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.materials.PluggableScmService;
+import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
+
+import java.util.List;
+
+import static com.thoughtworks.go.i18n.LocalizedMessage.cannotDeleteResourceBecauseOfDependentPipelines;
+
+public class DeleteSCMConfigCommand extends SCMConfigCommand {
+
+    public DeleteSCMConfigCommand(SCM globalScmConfig, PluggableScmService pluggableScmService, LocalizedOperationResult result, Username currentUser, GoConfigService goConfigService) {
+        super(globalScmConfig, pluggableScmService, goConfigService, currentUser, result);
+    }
+
+    @Override
+    public void update(CruiseConfig modifiedConfig) {
+        SCM scm = findSCM(modifiedConfig);
+        SCMs scms = modifiedConfig.getSCMs();
+        scms.removeSCM(scm.getId());
+        modifiedConfig.setSCMs(scms);
+    }
+
+    @Override
+    public boolean isValid(CruiseConfig preprocessedConfig) {
+        preprocessedGlobalScmConfig = globalScmConfig;
+        if (!preprocessedConfig.canDeletePluggableSCMMaterial(globalScmConfig)) {
+            List<CaseInsensitiveString> pipelinesWithPluggableScm = preprocessedConfig.pipelinesAssociatedWithPluggableSCM(globalScmConfig);
+            result.unprocessableEntity(cannotDeleteResourceBecauseOfDependentPipelines("pluggable_scm", globalScmConfig.getName(), CaseInsensitiveString.toStringList(pipelinesWithPluggableScm)));
+            throw new GoConfigInvalidException(preprocessedConfig, String.format("The scm '%s' is being referenced by pipeline(s): %s", globalScmConfig.getName(), pipelinesWithPluggableScm));
+        }
+
+        return true;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/config/update/SCMConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/SCMConfigCommand.java
@@ -25,6 +25,7 @@ import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.materials.PluggableScmService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
+import com.thoughtworks.go.serverhealth.HealthStateType;
 
 import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
@@ -32,7 +33,7 @@ public abstract class SCMConfigCommand implements EntityConfigUpdateCommand<SCM>
     protected final SCM globalScmConfig;
     protected final LocalizedOperationResult result;
     private final PluggableScmService pluggableScmService;
-    private SCM preprocessedGlobalScmConfig;
+    protected SCM preprocessedGlobalScmConfig;
     protected final GoConfigService goConfigService;
     protected final Username currentUser;
 
@@ -80,5 +81,16 @@ public abstract class SCMConfigCommand implements EntityConfigUpdateCommand<SCM>
             return false;
         }
         return true;
+    }
+
+    SCM findSCM(CruiseConfig cruiseConfig) {
+        SCMs scms = cruiseConfig.getSCMs();
+        SCM existingSCM = scms.find(globalScmConfig.getSCMId());
+        if (existingSCM == null) {
+            result.notFound(EntityType.SCM.notFoundMessage(globalScmConfig.getSCMId()), HealthStateType.notFound());
+            throw new NullPointerException(String.format("The pluggable scm material with id '%s' is not found.", globalScmConfig.getSCMId()));
+        } else {
+            return existingSCM;
+        }
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdateSCMConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdateSCMConfigCommand.java
@@ -46,7 +46,6 @@ public class UpdateSCMConfigCommand extends SCMConfigCommand {
 
     }
 
-
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
         return super.canContinue(cruiseConfig) && isRequestFresh(cruiseConfig);
@@ -61,16 +60,4 @@ public class UpdateSCMConfigCommand extends SCMConfigCommand {
 
         return freshRequest;
     }
-
-    private SCM findSCM(CruiseConfig modifiedConfig) {
-        SCMs scms = modifiedConfig.getSCMs();
-        SCM existingSCM = scms.find(globalScmConfig.getSCMId());
-        if (existingSCM == null) {
-            result.notFound(EntityType.SCM.notFoundMessage(globalScmConfig.getSCMId()), HealthStateType.notFound());
-            throw new NullPointerException(String.format("The pluggable scm material with id '%s' is not found.", globalScmConfig.getSCMId()));
-        } else {
-            return existingSCM;
-        }
-    }
-
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/materials/PluggableScmService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/materials/PluggableScmService.java
@@ -16,7 +16,9 @@
 package com.thoughtworks.go.server.service.materials;
 
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
+import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.update.CreateSCMConfigCommand;
+import com.thoughtworks.go.config.update.DeleteSCMConfigCommand;
 import com.thoughtworks.go.config.update.UpdateSCMConfigCommand;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
 import com.thoughtworks.go.domain.scm.SCM;
@@ -129,6 +131,14 @@ public class PluggableScmService {
     public void updatePluggableScmMaterial(final Username currentUser, final SCM globalScmConfig, final LocalizedOperationResult result, String md5) {
         UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(globalScmConfig, this, goConfigService, currentUser, result, md5, entityHashingService);
         update(currentUser, result, command);
+    }
+
+    public void deletePluggableSCM(final Username currentUser, final SCM globalScmConfig, final LocalizedOperationResult result) {
+        DeleteSCMConfigCommand command = new DeleteSCMConfigCommand(globalScmConfig, this,  result, currentUser, goConfigService);
+        update(currentUser, result, command);
+        if (result.isSuccessful()) {
+            result.setMessage(EntityType.SCM.deleteSuccessful(globalScmConfig.getName()));
+        }
     }
 
     private void update(Username currentUser, LocalizedOperationResult result, EntityConfigUpdateCommand command) {

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteSCMConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteSCMConfigCommandTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.update;
+
+import com.thoughtworks.go.config.BasicCruiseConfig;
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.config.exceptions.EntityType;
+import com.thoughtworks.go.config.materials.PluggableSCMMaterialConfig;
+import com.thoughtworks.go.domain.config.*;
+import com.thoughtworks.go.domain.scm.SCM;
+import com.thoughtworks.go.helper.GoConfigMother;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.materials.PluggableScmService;
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class DeleteSCMConfigCommandTest {
+
+    @Mock
+    private PluggableScmService pluggableScmService;
+
+    @Mock
+    private GoConfigService goConfigService;
+
+    private HttpLocalizedOperationResult result;
+    private Username currentUser;
+    private BasicCruiseConfig cruiseConfig;
+    private SCM scmConfig;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setup() {
+        initMocks(this);
+        currentUser = new Username(new CaseInsensitiveString("user"));
+        cruiseConfig = new GoConfigMother().defaultCruiseConfig();
+        scmConfig = new SCM("id", "name");
+        result = new HttpLocalizedOperationResult();
+    }
+
+
+    @Test
+    public void shouldDeleteTemplateFromTheGivenConfig() throws Exception {
+        cruiseConfig.getSCMs().add(scmConfig);
+        DeleteSCMConfigCommand command = new DeleteSCMConfigCommand(scmConfig, pluggableScmService, result, currentUser, goConfigService);
+        assertThat(cruiseConfig.getSCMs().contains(scmConfig), is(true));
+        command.update(cruiseConfig);
+        assertThat(cruiseConfig.getSCMs().contains(scmConfig), is(false));
+    }
+
+    @Test
+    public  void shouldValidateWhetherSCMIsAssociatedWithPipelines() {
+        PipelineConfig pipelineConfig = new GoConfigMother().addPipeline(cruiseConfig, "p1", "s1", "j1");
+        pipelineConfig.addMaterialConfig(new PluggableSCMMaterialConfig(scmConfig.getSCMId()));
+        DeleteSCMConfigCommand command = new DeleteSCMConfigCommand(scmConfig, pluggableScmService, result, currentUser, goConfigService);
+
+        thrown.expectMessage("The scm 'name' is being referenced by pipeline(s): [p1]");
+        assertThat(command.isValid(cruiseConfig), is(false));
+    }
+
+
+    @Test
+    public void shouldThrowAnExceptionIfSCMIsNotFound() throws Exception {
+        SCM scm = new SCM("non-existent-id", new PluginConfiguration("non-existent-plugin-id", "1"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key1"),new ConfigurationValue("value1"))));
+        DeleteSCMConfigCommand command = new DeleteSCMConfigCommand(scm, pluggableScmService, result, currentUser, goConfigService);
+        thrown.expect(NullPointerException.class);
+        thrown.expectMessage("The pluggable scm material with id 'non-existent-id' is not found.");
+        command.update(cruiseConfig);
+    }
+
+    @Test
+    public void shouldNotContinueWithConfigSaveIfUserIsUnauthorized() {
+        when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
+        when(goConfigService.isGroupAdministrator(currentUser.getUsername())).thenReturn(false);
+
+        SCM scm = new SCM("id", new PluginConfiguration("plugin-id", "1"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key1"),new ConfigurationValue("value1"))));
+        DeleteSCMConfigCommand command = new DeleteSCMConfigCommand(scm, pluggableScmService, result, currentUser, goConfigService);
+
+        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(result.message(), is(EntityType.SCM.forbiddenToEdit(scm.getId(), currentUser.getUsername())));
+    }
+
+    @Test
+    public void shouldContinueWithConfigSaveIfUserIsAdmin() {
+        when(goConfigService.isUserAdmin(currentUser)).thenReturn(true);
+        when(goConfigService.isGroupAdministrator(currentUser.getUsername())).thenReturn(false);
+
+        SCM scm = new SCM("id", new PluginConfiguration("plugin-id", "1"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key1"),new ConfigurationValue("value1"))));
+        DeleteSCMConfigCommand command = new DeleteSCMConfigCommand(scm, pluggableScmService, result, currentUser, goConfigService);
+
+        assertThat(command.canContinue(cruiseConfig), is(true));
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/materials/PluggableScmServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/materials/PluggableScmServiceTest.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.server.service.materials;
 
 import com.thoughtworks.go.ClearSingleton;
+import com.thoughtworks.go.config.update.DeleteSCMConfigCommand;
 import com.thoughtworks.go.domain.config.Configuration;
 import com.thoughtworks.go.domain.config.ConfigurationValue;
 import com.thoughtworks.go.domain.config.PluginConfiguration;
@@ -27,8 +28,10 @@ import com.thoughtworks.go.plugin.api.config.Property;
 import com.thoughtworks.go.plugin.api.response.Result;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationError;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -205,6 +208,16 @@ public class PluggableScmServiceTest {
         when(goConfigService.getSCMs()).thenReturn(scms);
 
         assertNull(pluggableScmService.findPluggableScmMaterial("bar"));
+    }
+
+    @Test
+    public void shouldDeleteSCMConfigIfValid() {
+        doNothing().when(goConfigService).updateConfig(any(), any());
+        SCM scm = new SCM("id", "name");
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        pluggableScmService.deletePluggableSCM(new Username("admin"), scm, result);
+
+        assertThat(result.isSuccessful(), is(true));
     }
 
     @Test


### PR DESCRIPTION
Request:
```
curl -i 'https://ci.example.com/go/api/admin/scms/pluggable.scm.name' \
      -u 'admin:badger' \
      -H 'Accept:application/vnd.go.cd.v1+json' \
      -X DELETE
```

Response:
```
Scm deleted successfully if valid
Associated pipelines list
```

The API is accessible to admins and group admins. Just like the other SCM APIs.