### PR TITLE
Accessibility for tooltips

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
@@ -27,6 +27,7 @@ export interface Attrs extends HTMLAttributes {
   disabled?: boolean;
   iconOnly?: boolean;
   title?: string;
+  describedBy?: string;
 }
 
 class Icon extends MithrilViewComponent<Attrs> {
@@ -47,6 +48,7 @@ class Icon extends MithrilViewComponent<Attrs> {
            data-test-id={`${this.title}-icon`}
            data-test-disabled-element={vnode.attrs.disabled}
            class={classnames(this.name, {disabled: vnode.attrs.disabled})}
+           aria-describedby={vnode.attrs.describedBy}
            {...vnode.attrs}/>
       );
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/tooltip/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/tooltip/index.tsx
@@ -49,10 +49,10 @@ class Tooltip extends MithrilViewComponent<Attrs> {
 
     return (
       <div data-test-id="tooltip-wrapper" class={styles.tooltipWrapper}>
-        {m(this.tooltipType, {iconOnly: true, title: ""})}
+        {m(this.tooltipType, {iconOnly: true, title: "", describedBy: "tooltip-desc"})}
         <div data-test-id="tooltip-content"
              class={classnames(styles.tooltipContent, size)}>
-          <p>{vnode.attrs.content}</p>
+          <p role="tooltip" id="tooltip-desc">{vnode.attrs.content}</p>
         </div>
       </div>);
   }


### PR DESCRIPTION
We removed the title from the icon for tooltips as part of #6764 
This is to make them accessible by screen-readers