### PR TITLE
Add `scmOnly` and `showAdvanced` attrs to `<MaterialEditor/>`

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
@@ -33,6 +33,8 @@ import {GitFields, HgFields, P4Fields, SvnFields, TfsFields} from "./scm_materia
 interface Attrs {
   material: Material;
   cache?: SuggestionCache;
+  showAdvanced?: boolean;
+  scmOnly?: boolean;
 }
 
 export class MaterialEditor extends MithrilViewComponent<Attrs> {
@@ -45,65 +47,74 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
   }
 
   view(vnode: m.Vnode<Attrs>) {
+    const attrs = vnode.attrs;
+    const showAdvanced = "showAdvanced" in attrs ? !!attrs.showAdvanced : true;
+    const scmOnly = !!attrs.scmOnly;
+
     return <FormBody>
       <SelectField label="Material Type" property={vnode.attrs.material.type} required={true}>
-        <SelectFieldOptions selected={vnode.attrs.material.type()} items={this.supportedMaterials()}/>
+        <SelectFieldOptions selected={vnode.attrs.material.type()} items={this.supportedMaterials(scmOnly)}/>
       </SelectField>
 
       <Form last={true} compactForm={true}>
-        {this.fieldsForType(vnode.attrs.material, this.cache)}
+        {this.fieldsForType(vnode.attrs.material, this.cache, showAdvanced)}
       </Form>
     </FormBody>;
   }
 
-  supportedMaterials(): Option[] {
-    return [
+  supportedMaterials(scmOnly: boolean): Option[] {
+    const options = [
       {id: "git", text: "Git"},
       {id: "hg", text: "Mercurial"},
       {id: "svn", text: "Subversion"},
       {id: "p4", text: "Perforce"},
       {id: "tfs", text: "Team Foundation Server"},
-      {id: "dependency", text: "Another Pipeline"},
     ];
+
+    if (!scmOnly) {
+      options.push({id: "dependency", text: "Another Pipeline"});
+    }
+
+    return options;
   }
 
-  fieldsForType(material: Material, cacheable: SuggestionCache): m.Children {
+  fieldsForType(material: Material, cacheable: SuggestionCache, showAdvanced: boolean): m.Children {
     switch (material.type()) {
       case "git":
         if (!(material.attributes() instanceof GitMaterialAttributes)) {
           material.attributes(new GitMaterialAttributes());
         }
-        return <GitFields material={material}/>;
+        return <GitFields material={material} showAdvanced={showAdvanced}/>;
         break;
       case "hg":
         if (!(material.attributes() instanceof HgMaterialAttributes)) {
           material.attributes(new HgMaterialAttributes());
         }
-        return <HgFields material={material}/>;
+        return <HgFields material={material} showAdvanced={showAdvanced}/>;
         break;
       case "svn":
         if (!(material.attributes() instanceof SvnMaterialAttributes)) {
           material.attributes(new SvnMaterialAttributes());
         }
-        return <SvnFields material={material}/>;
+        return <SvnFields material={material} showAdvanced={showAdvanced}/>;
         break;
       case "p4":
         if (!(material.attributes() instanceof P4MaterialAttributes)) {
           material.attributes(new P4MaterialAttributes());
         }
-        return <P4Fields material={material}/>;
+        return <P4Fields material={material} showAdvanced={showAdvanced}/>;
         break;
       case "tfs":
         if (!(material.attributes() instanceof TfsMaterialAttributes)) {
           material.attributes(new TfsMaterialAttributes());
         }
-        return <TfsFields material={material}/>;
+        return <TfsFields material={material} showAdvanced={showAdvanced}/>;
         break;
       case "dependency":
         if (!(material.attributes() instanceof DependencyMaterialAttributes)) {
           material.attributes(new DependencyMaterialAttributes());
         }
-        return <DependencyFields material={material} cache={cacheable}/>;
+        return <DependencyFields material={material} cache={cacheable} showAdvanced={showAdvanced}/>;
         break;
       default:
         break;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -28,6 +28,7 @@ import {IDENTIFIER_FORMAT_HELP_MESSAGE} from "./messages";
 interface Attrs {
   material: Material;
   cache: SuggestionCache;
+  showAdvanced: boolean;
 }
 
 interface State {
@@ -90,10 +91,16 @@ export class DependencyFields extends MithrilComponent<Attrs, State> {
       <SelectField label="Upstream Stage" property={mat.stage} errorText={this.errs(mat, "stage")} required={true}>
         <SelectFieldOptions selected={mat.stage()} items={vnode.state.stages()}/>
       </SelectField>,
-      <AdvancedSettings forceOpen={mat.errors().hasErrors("name")}>
-        <TextField label="Material Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} placeholder="A human-friendly label for this material" property={mat.name}/>
-      </AdvancedSettings>
+      this.advanced(mat, vnode.attrs.showAdvanced),
     ];
+  }
+
+  advanced(mat: DependencyMaterialAttributes, showAdvanced: boolean): m.Children {
+    if (showAdvanced) {
+      return <AdvancedSettings forceOpen={mat.errors().hasErrors("name")}>
+        <TextField label="Material Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} placeholder="A human-friendly label for this material" property={mat.name}/>
+      </AdvancedSettings>;
+    }
   }
 
   errs(attrs: MaterialAttributes, key: string): string {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
@@ -35,6 +35,7 @@ import {DESTINATION_DIR_HELP_MESSAGE, IDENTIFIER_FORMAT_HELP_MESSAGE} from "./me
 
 interface Attrs {
   material: Material;
+  showAdvanced: boolean;
 }
 
 abstract class ScmFields extends MithrilViewComponent<Attrs> {
@@ -47,7 +48,13 @@ abstract class ScmFields extends MithrilViewComponent<Attrs> {
     return [
       this.requiredFields(mattrs),
       <TestConnection material={vnode.attrs.material}/>,
-      <AdvancedSettings forceOpen={mattrs.errors().hasErrors("name") || mattrs.errors().hasErrors("destination")}>
+      this.advancedOptions(mattrs, vnode.attrs.showAdvanced),
+    ];
+  }
+
+  advancedOptions(mattrs: ScmMaterialAttributes, showAdvanced: boolean): m.Children {
+    if (showAdvanced) {
+      return <AdvancedSettings forceOpen={mattrs.errors().hasErrors("name") || mattrs.errors().hasErrors("destination")}>
         {this.extraFields(mattrs)}
         <TextField label={[
           "Alternate Checkout Path",
@@ -55,8 +62,8 @@ abstract class ScmFields extends MithrilViewComponent<Attrs> {
           <Tooltip.Help size={TooltipSize.medium} content={DESTINATION_DIR_HELP_MESSAGE}/>
         ]} property={mattrs.destination} errorText={this.errs(mattrs, "destination")}/>
         <TextField label="Material Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} placeholder="A human-friendly label for this material" property={mattrs.name} errorText={this.errs(mattrs, "name")}/>
-      </AdvancedSettings>
-    ];
+      </AdvancedSettings>;
+    }
   }
 
   abstract requiredFields(attrs: MaterialAttributes): m.Children;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -26,7 +26,7 @@ describe("AddPipeline: Non-SCM Material Fields", () => {
 
   it("DependencyFields structure", () => {
     const material = new Material("dependency", new DependencyMaterialAttributes());
-    helper.mount(() => <DependencyFields material={material} cache={new DummyCache()}/>);
+    helper.mount(() => <DependencyFields material={material} cache={new DummyCache()} showAdvanced={true}/>);
 
     assertLabelledInputsPresent({
       "upstream-pipeline": "Upstream Pipeline*",
@@ -35,14 +35,37 @@ describe("AddPipeline: Non-SCM Material Fields", () => {
     });
   });
 
+  it("does not display advanced settings when `showAdvanced` === false", () => {
+    const material = new Material("dependency", new DependencyMaterialAttributes());
+    helper.mount(() => <DependencyFields material={material} cache={new DummyCache()} showAdvanced={false}/>);
+
+    assertLabelledInputsPresent({
+      "upstream-pipeline": "Upstream Pipeline*",
+      "upstream-stage":    "Upstream Stage*",
+    });
+
+    assertLabelledInputsAbsent(
+      "material-name",
+    );
+  });
+
   function assertLabelledInputsPresent(idsToLabels: {[key: string]: string}) {
     const keys = Object.keys(idsToLabels);
     expect(keys.length > 0).toBe(true);
 
     for (const id of keys) {
-      expect(helper.byTestId(`form-field-label-${id}`)).toBeTruthy();
+      expect(helper.byTestId(`form-field-label-${id}`)).toBeInDOM();
       expect(helper.byTestId(`form-field-label-${id}`).textContent!.startsWith(idsToLabels[id])).toBe(true);
-      expect(helper.byTestId(`form-field-input-${id}`)).toBeTruthy();
+      expect(helper.byTestId(`form-field-input-${id}`)).toBeInDOM();
+    }
+  }
+
+  function assertLabelledInputsAbsent(...keys: string[]) {
+    expect(keys.length > 0).toBe(true);
+
+    for (const id of keys) {
+      expect(helper.byTestId(`form-field-label-${id}`)).toBe(null!);
+      expect(helper.byTestId(`form-field-input-${id}`)).toBe(null!);
     }
   }
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
@@ -33,7 +33,7 @@ describe("AddPipeline: SCM Material Fields", () => {
 
   it("GitFields structure", () => {
     const material = new Material("git", new GitMaterialAttributes());
-    helper.mount(() => <GitFields material={material}/>);
+    helper.mount(() => <GitFields material={material} showAdvanced={true}/>);
 
     assertLabelledInputsPresent({
       "repository-url":          "Repository URL*",
@@ -44,12 +44,12 @@ describe("AddPipeline: SCM Material Fields", () => {
       "material-name":           "Material Name",
     });
 
-    expect(helper.byTestId("test-connection-button")).toBeTruthy();
+    expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
 
   it("HgFields structure", () => {
     const material = new Material("hg", new HgMaterialAttributes());
-    helper.mount(() => <HgFields material={material}/>);
+    helper.mount(() => <HgFields material={material} showAdvanced={true}/>);
 
     assertLabelledInputsPresent({
       "repository-url":          "Repository URL*",
@@ -60,12 +60,12 @@ describe("AddPipeline: SCM Material Fields", () => {
       "material-name":           "Material Name",
     });
 
-    expect(helper.byTestId("test-connection-button")).toBeTruthy();
+    expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
 
   it("SvnFields structure", () => {
     const material = new Material("svn", new SvnMaterialAttributes());
-    helper.mount(() => <SvnFields material={material}/>);
+    helper.mount(() => <SvnFields material={material} showAdvanced={true}/>);
 
     assertLabelledInputsPresent({
       "repository-url":          "Repository URL*",
@@ -76,12 +76,12 @@ describe("AddPipeline: SCM Material Fields", () => {
       "material-name":           "Material Name",
     });
 
-    expect(helper.byTestId("test-connection-button")).toBeTruthy();
+    expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
 
   it("P4Fields structure", () => {
     const material = new Material("p4", new P4MaterialAttributes());
-    helper.mount(() => <P4Fields material={material}/>);
+    helper.mount(() => <P4Fields material={material} showAdvanced={true}/>);
 
     assertLabelledInputsPresent({
       "p4-protocol-host-port":     "P4 [Protocol:][Host:]Port*",
@@ -93,12 +93,12 @@ describe("AddPipeline: SCM Material Fields", () => {
       "material-name":             "Material Name",
     });
 
-    expect(helper.byTestId("test-connection-button")).toBeTruthy();
+    expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
 
   it("TfsFields structure", () => {
     const material = new Material("tfs", new TfsMaterialAttributes());
-    helper.mount(() => <TfsFields material={material}/>);
+    helper.mount(() => <TfsFields material={material} showAdvanced={true}/>);
 
     assertLabelledInputsPresent({
       "repository-url":          "Repository URL*",
@@ -110,7 +110,26 @@ describe("AddPipeline: SCM Material Fields", () => {
       "material-name":           "Material Name",
     });
 
-    expect(helper.byTestId("test-connection-button")).toBeTruthy();
+    expect(helper.byTestId("test-connection-button")).toBeInDOM();
+  });
+
+  it("does not display advanced settings when `showAdvanced` === false", () => {
+    const material = new Material("git", new GitMaterialAttributes());
+    helper.mount(() => <GitFields material={material} showAdvanced={false}/>);
+
+    assertLabelledInputsPresent({
+      "repository-url":          "Repository URL*"
+    });
+
+    assertLabelledInputsAbsent(
+      "repository-branch",
+      "username",
+      "password",
+      "alternate-checkout-path",
+      "material-name",
+    );
+
+    expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
 
   function assertLabelledInputsPresent(idsToLabels: {[key: string]: string}) {
@@ -118,9 +137,18 @@ describe("AddPipeline: SCM Material Fields", () => {
     expect(keys.length > 0).toBe(true);
 
     for (const id of keys) {
-      expect(helper.byTestId(`form-field-label-${id}`)).toBeTruthy();
+      expect(helper.byTestId(`form-field-label-${id}`)).toBeInDOM();
       expect(helper.byTestId(`form-field-label-${id}`).textContent!.startsWith(idsToLabels[id])).toBe(true);
-      expect(helper.byTestId(`form-field-input-${id}`)).toBeTruthy();
+      expect(helper.byTestId(`form-field-input-${id}`)).toBeInDOM();
+    }
+  }
+
+  function assertLabelledInputsAbsent(...keys: string[]) {
+    expect(keys.length > 0).toBe(true);
+
+    for (const id of keys) {
+      expect(helper.byTestId(`form-field-label-${id}`)).toBe(null!);
+      expect(helper.byTestId(`form-field-input-${id}`)).toBe(null!);
     }
   }
 });


### PR DESCRIPTION
Preemptively adding the ability to customize what material types and fields are seen in this component in preparation for PaC test drive flow.

This maintains the current API so no changes needed in existing usages.