### PR TITLE
Add url utils to DRY up some query param parsing code

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/helpers/spec/url_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/spec/url_spec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {queryParamAsString} from "../url";
+
+describe("URL helpers", () => {
+  it("queryParamAsString() parses params in any postion", () => {
+    const search = "?foo=bar&baz=foo&quu=baz";
+
+    expect(queryParamAsString(search, "foo")).toBe("bar");
+    expect(queryParamAsString(search, "quu")).toBe("baz");
+    expect(queryParamAsString(search, "baz")).toBe("foo");
+  });
+
+  it("queryParamAsString() takes the last value of repeated keys", () => {
+    const search = "?baz=one&baz=two&baz=three";
+
+    expect(queryParamAsString(search, "baz")).toBe("three");
+  });
+
+  it("queryParamAsString() handles missing keys", () => {
+    const search = "?foo=1";
+
+    expect(queryParamAsString(search, "baz")).toBe("");
+  });
+
+  it("queryParamAsString() handles empty values", () => {
+    expect(queryParamAsString("?baz", "baz")).toBe("");
+    expect(queryParamAsString("?baz=", "baz")).toBe("");
+    expect(queryParamAsString("?", "baz")).toBe("");
+    expect(queryParamAsString("&", "baz")).toBe("");
+    expect(queryParamAsString("", "baz")).toBe("");
+  });
+
+  it("queryParamAsString() handles numbers", () => {
+    expect(queryParamAsString("?foo=0", "foo")).toBe("0"); // falsey values do not collapse to empty string
+    expect(queryParamAsString("?foo=1", "foo")).toBe("1");
+  });
+
+  it("queryParamAsString() handles booleans", () => {
+    expect(queryParamAsString("?foo=false", "foo")).toBe("false"); // falsey values do not collapse to empty string
+    expect(queryParamAsString("?foo=true", "foo")).toBe("true");
+  });
+
+  it("queryParamAsString() handles enumerables", () => {
+    expect(queryParamAsString("?foo[]", "foo")).toBe(`[""]`);
+    expect(queryParamAsString("?foo[]=", "foo")).toBe(`[""]`);
+    expect(queryParamAsString("?foo[0]=&foo[1]=", "foo")).toBe(`["",""]`);
+    expect(queryParamAsString("?foo[0]=a&foo[1]=b", "foo")).toBe(`["a","b"]`);
+    expect(queryParamAsString("?foo[bar]=baz", "foo")).toBe(`{"bar":"baz"}`);
+  });
+});

--- a/server/webapp/WEB-INF/rails/webpack/helpers/url.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/url.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import m from "mithril";
+
+/**
+ * Retrieves a query parameter by name and converts the value to a string
+ *
+ * @param search: the search query string; this is generally `window.location.search`
+ * @param name: the name of the query param to retrieve
+ *
+ * @returns the query param value as a string; if not present or null, returns an empty string
+ */
+export function queryParamAsString(search: string, name: string): string {
+  // this can be a number of things (number, boolean, etc) so cannot just check for falsey-ness
+  const value = m.parseQueryString(search)[name];
+
+  if (null === value || void 0 === value) {
+    return "";
+  }
+
+  if ("string" === typeof value) {
+    return value;
+  }
+
+  return JSON.stringify(value);
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines.tsx
@@ -15,6 +15,7 @@
  */
 
 // utils
+import {queryParamAsString} from "helpers/url";
 import _ from "lodash";
 import m from "mithril";
 import {Page, PageState} from "views/pages/page";
@@ -49,9 +50,10 @@ export class PipelineCreatePage extends Page {
 
   oninit(vnode: m.Vnode) {
     this.pageState = PageState.OK;
-    const group = m.parseQueryString(window.location.search).group;
-    if ("" !== String(group || "").trim()) {
-      this.model.pipeline.group(group as string);
+    const group = queryParamAsString(window.location.search, "group").trim();
+
+    if ("" !== group) {
+      this.model.pipeline.group(group);
     }
   }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines_as_code.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines_as_code.tsx
@@ -14,16 +14,22 @@
  * limitations under the License.
  */
 
+// utils
+import {queryParamAsString} from "helpers/url";
 import m from "mithril";
 import Stream from "mithril/stream";
+
+// models
 import {Material, MaterialAttributes} from "models/materials/types";
+import {PipelineConfigVM} from "views/pages/pipelines/pipeline_config_view_model";
+
+// components
 import {BuilderForm} from "views/pages/pac/builder_form";
 import {DownloadAction} from "views/pages/pac/download_action";
 import {PreviewPane} from "views/pages/pac/preview_pane";
 import {Page, PageState} from "views/pages/page";
 import {FillableSection} from "views/pages/pipelines/fillable_section";
 import {MaterialEditor} from "views/pages/pipelines/material_editor";
-import {PipelineConfigVM} from "views/pages/pipelines/pipeline_config_view_model";
 
 export class PipelinesAsCodeCreatePage extends Page {
   private model = new PipelineConfigVM();
@@ -34,9 +40,10 @@ export class PipelinesAsCodeCreatePage extends Page {
 
   oninit(vnode: m.Vnode) {
     this.pageState = PageState.OK;
-    const group = m.parseQueryString(window.location.search).group;
-    if ("" !== String(group || "").trim()) {
-      this.model.pipeline.group(group as string);
+    const group = queryParamAsString(window.location.search, "group").trim();
+
+    if ("" !== group) {
+      this.model.pipeline.group(group);
     }
   }
 


### PR DESCRIPTION
Adds a util method that wraps `m. parseQueryString()` to ensure we always get a `string`. This is used in the add pipeline pages.