### PR TITLE
Fixed agent analytics issue on agents SPA

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/agents/agent_row_widget.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/agents/agent_row_widget.js.msx
@@ -77,7 +77,7 @@ export const AgentRowWidget = {
         if (p.extensions().analytics) {
           const agentAnalytics = p.extensions().analytics.capabilities().supportedAgentAnalytics();
           if (agentAnalytics.length > 0) {
-            agentAnalyticsPlugins[p.id] = agentAnalytics;
+            agentAnalyticsPlugins[p.id()] = agentAnalytics;
           }
         }
       });


### PR DESCRIPTION
The `AgentAnalyticsWidget` was expecting the plugin id as a string but was passed as Stream of string. 
