### PR TITLE
Fix for world-writable files in go-agent and go-server packages.

### DIFF
--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -318,6 +318,11 @@ def configureLinuxPackage(DefaultTask packageTask, InstallerType installerType, 
             List<String> segments = fcd.relativePath.segments
             segments.remove(0)
             fcd.relativePath = new RelativePath(!fcd.isDirectory(), (segments as String[]))
+            // Remove write access of JRE files for user group `others`.
+            // Perform `&` operation on existing mode with `0775`.
+            // eg. if existing mode is `0777`, the mode will be changed to `0775` after following operation
+            // eg. if existing mode is `0477`, the mode will be changed to `0475` after following operation
+            fcd.setMode(fcd.getMode() & 0775)
           }
           includeEmptyDirs = false
         }


### PR DESCRIPTION
Issue: 

The latest edition(>= 19.6.0) of the go-agent and go-server packages contain world-writable files (JRE files which are bundled with GoCD for Linux installers). This creates a potential security issue anywhere that GoCD is installed.

Solution:
Removed write access of JRE files for user group `others`.
eg. if the existing mode is `0777`, the mode will be changed to `0775`.