### PR TITLE
Reduce GoCD Server and Agent Docker Image size

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
@@ -18,6 +18,9 @@
 ###############################################################################################
 
 FROM alpine:latest as gocd-agent-unzip
+
+ARG UID=1000
+
 <#if useFromArtifact >
 COPY go-agent-${fullVersion}.zip /tmp/go-agent-${fullVersion}.zip
 <#else>
@@ -28,7 +31,7 @@ RUN \
 </#if>
 
 RUN unzip /tmp/go-agent-${fullVersion}.zip -d /
-RUN mv /go-agent-${goVersion} /go-agent
+RUN mv /go-agent-${goVersion} /go-agent && chown -R ${r"${UID}"}:0 /go-agent && chmod -R g=u /go-agent
 
 FROM ${distro.name()}:${distroVersion.releaseName}
 MAINTAINER ThoughtWorks, Inc. <support@thoughtworks.com>
@@ -90,8 +93,8 @@ COPY --chown=go:root agent-bootstrapper-logback-include.xml agent-launcher-logba
 COPY --chown=root:root dockerd-sudo /etc/sudoers.d/dockerd-sudo
 </#if>
 
-RUN chown -R go:root /go-agent /docker-entrypoint.d /go /godata /docker-entrypoint.sh \
-    && chmod -R g=u /go-agent /docker-entrypoint.d /go /godata /docker-entrypoint.sh
+RUN chown -R go:root /docker-entrypoint.d /go /godata /docker-entrypoint.sh \
+    && chmod -R g=u /docker-entrypoint.d /go /godata /docker-entrypoint.sh
 
 <#if distro.name() == "docker">
   COPY --chown=root:root run-docker-daemon.sh /

--- a/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
@@ -18,6 +18,7 @@
 ###############################################################################################
 
 FROM alpine:latest as gocd-server-unzip
+ARG UID=1000
 <#if useFromArtifact >
 COPY go-server-${fullVersion}.zip /tmp/go-server-${fullVersion}.zip
 <#else>
@@ -27,7 +28,7 @@ RUN \
   curl --fail --location --silent --show-error "https://download.gocd.org/binaries/${fullVersion}/generic/go-server-${fullVersion}.zip" > /tmp/go-server-${fullVersion}.zip
 </#if>
 RUN unzip /tmp/go-server-${fullVersion}.zip -d /
-RUN mv /go-server-${goVersion} /go-server
+RUN mv /go-server-${goVersion} /go-server && chown -R ${r"${UID}"}:0 /go-server && chmod -R g=u /go-server
 
 FROM ${distro.name()}:${distroVersion.releaseName}
 MAINTAINER ThoughtWorks, Inc. <support@thoughtworks.com>
@@ -89,8 +90,8 @@ COPY --chown=go:root logback-include.xml /go-server/config/logback-include.xml
 COPY --chown=go:root install-gocd-plugins /usr/local/sbin/install-gocd-plugins
 COPY --chown=go:root git-clone-config /usr/local/sbin/git-clone-config
 
-RUN chown -R go:root /go-server /docker-entrypoint.d /go-working-dir /godata /docker-entrypoint.sh \
-    && chmod -R g=u /go-server /docker-entrypoint.d /go-working-dir /godata /docker-entrypoint.sh
+RUN chown -R go:root /docker-entrypoint.d /go-working-dir /godata /docker-entrypoint.sh \
+    && chmod -R g=u /docker-entrypoint.d /go-working-dir /godata /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 


### PR DESCRIPTION
* Perform chmod and chown operations on go-{agent,server} dirs as part of
  the same docker layer (same as of unzip jar layer)
