### PR TITLE
Pipeline structure (internal) api

### DIFF
--- a/api/api-internal-pipeline-structure-v1/src/main/java/com/thoughtworks/go/apiv1/internalpipelinestructure/InternalPipelineStructureControllerV1.java
+++ b/api/api-internal-pipeline-structure-v1/src/main/java/com/thoughtworks/go/apiv1/internalpipelinestructure/InternalPipelineStructureControllerV1.java
@@ -21,8 +21,9 @@ import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv1.internalpipelinestructure.representers.InternalPipelineStructuresRepresenter;
 import com.thoughtworks.go.config.PipelineConfigs;
-import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.config.TemplatesConfig;
 import com.thoughtworks.go.server.service.PipelineConfigService;
+import com.thoughtworks.go.server.service.TemplateConfigService;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,12 +41,16 @@ public class InternalPipelineStructureControllerV1 extends ApiController impleme
 
     private final ApiAuthenticationHelper apiAuthenticationHelper;
     private final PipelineConfigService pipelineConfigService;
+    private final TemplateConfigService templateConfigService;
 
     @Autowired
-    public InternalPipelineStructureControllerV1(ApiAuthenticationHelper apiAuthenticationHelper, PipelineConfigService pipelineConfigService) {
+    public InternalPipelineStructureControllerV1(ApiAuthenticationHelper apiAuthenticationHelper,
+                                                 PipelineConfigService pipelineConfigService,
+                                                 TemplateConfigService templateConfigService) {
         super(ApiVersion.v1);
         this.apiAuthenticationHelper = apiAuthenticationHelper;
         this.pipelineConfigService = pipelineConfigService;
+        this.templateConfigService = templateConfigService;
     }
 
     @Override
@@ -71,9 +76,11 @@ public class InternalPipelineStructureControllerV1 extends ApiController impleme
     }
 
     public String index(Request request, Response response) throws IOException {
-        List<PipelineConfigs> groups = pipelineConfigService.viewableGroupsFor(currentUsername());
+        List<PipelineConfigs> groups = pipelineConfigService.viewableGroupsForUserIncludingConfigRepos(currentUsername());
 
-        return writerForTopLevelArray(request, response, outputWriter -> InternalPipelineStructuresRepresenter.toJSON(outputWriter, groups));
+        TemplatesConfig templateConfigs = templateConfigService.templateConfigsThatCanBeEditedBy(currentUsername());
+
+        return writerForTopLevelObject(request, response, outputWriter -> InternalPipelineStructuresRepresenter.toJSON(outputWriter, groups, templateConfigs));
     }
 
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
@@ -701,6 +701,10 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
         this.templateName = templateName;
     }
 
+    public void setTemplateName(String templateName) {
+        setTemplateName(new CaseInsensitiveString(templateName));
+    }
+
     public void setMingleConfig(MingleConfig mingleConfig) {
         this.mingleConfig = mingleConfig;
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineConfigService.java
@@ -141,8 +141,16 @@ public class PipelineConfigService {
     }
 
     public List<PipelineConfigs> viewableGroupsFor(Username username) {
+        return viewableGroups(username, goConfigService.cruiseConfig());
+    }
+
+    public List<PipelineConfigs> viewableGroupsForUserIncludingConfigRepos(Username username) {
+        return viewableGroups(username, goConfigService.getMergedConfigForEditing());
+    }
+
+    private List<PipelineConfigs> viewableGroups(Username username, CruiseConfig cruiseConfig) {
         ArrayList<PipelineConfigs> list = new ArrayList<>();
-        for (PipelineConfigs pipelineConfigs : goConfigService.cruiseConfig().getGroups()) {
+        for (PipelineConfigs pipelineConfigs : cruiseConfig.getGroups()) {
             if (securityService.hasViewPermissionForGroup(CaseInsensitiveString.str(username.getUsername()), pipelineConfigs.getGroup())) {
                 list.add(pipelineConfigs);
             }

--- a/server/src/main/java/com/thoughtworks/go/server/service/TemplateConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/TemplateConfigService.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.thoughtworks.go.i18n.LocalizedMessage.saveFailedWithReason;
 import static com.thoughtworks.go.serverhealth.HealthStateScope.GLOBAL;
@@ -184,7 +185,6 @@ public class TemplateConfigService {
         return findTemplate(templateName, result, goConfigService.getConfigHolder());
     }
 
-
     private boolean doesTemplateExist(String templateName, CruiseConfig cruiseConfig, HttpLocalizedOperationResult result) {
         TemplatesConfig templates = cruiseConfig.getTemplates();
         if (!templates.hasTemplateNamed(new CaseInsensitiveString(templateName))) {
@@ -225,5 +225,16 @@ public class TemplateConfigService {
             return null;
         }
         return configHolder.configForEdit.findTemplate(new CaseInsensitiveString(templateName));
+    }
+
+    public TemplatesConfig templateConfigsThatCanBeEditedBy(Username username) {
+        CruiseConfig cruiseConfig = goConfigService.cruiseConfig();
+
+        return cruiseConfig.getTemplates()
+                .stream()
+                .filter(templateConfig -> {
+                    return securityService.isAuthorizedToEditTemplate(templateConfig.name(),username);
+                })
+                .collect(Collectors.toCollection(TemplatesConfig::new));
     }
 }

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/api/mocks/MockHttpServletResponseAssert.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/api/mocks/MockHttpServletResponseAssert.groovy
@@ -36,15 +36,31 @@ class MockHttpServletResponseAssert extends com.thoughtworks.go.http.mocks.MockH
     return this
   }
 
+  /**
+   * Use {@link #hasBodyWithJsonObject(java.lang.Class, java.lang.Object [])} instead
+   */
+  @Deprecated
   MockHttpServletResponseAssert hasBodyWithJsonObject(Object expected, Class representer) throws UnsupportedEncodingException {
-    def expectedJson = toObjectString({ representer.toJSON(it , expected) })
+    return hasBodyWithJsonObject(representer, expected)
+  }
+
+  MockHttpServletResponseAssert hasBodyWithJsonObject(Class representer, Object... representerArgs) throws UnsupportedEncodingException {
+    def expectedJson = toObjectString({ representer.toJSON(it, *representerArgs) })
 
     JsonFluentAssert.assertThatJson(actual.getContentAsString()).isEqualTo(expectedJson)
     return this
   }
 
+  /**
+   * Use {@link #hasBodyWithJsonArray(java.lang.Class, java.lang.Object [])} instead
+   */
+  @Deprecated
   MockHttpServletResponseAssert hasBodyWithJsonArray(Object expected, Class representer) throws UnsupportedEncodingException {
-    def expectedJson = toArrayString({ representer.toJSON(it, expected) })
+    return hasBodyWithJsonArray(representer, expected)
+  }
+
+  MockHttpServletResponseAssert hasBodyWithJsonArray(Class representer, Object... representerArgs) throws UnsupportedEncodingException {
+    def expectedJson = toArrayString({ representer.toJSON(it, *representerArgs) })
 
     JsonFluentAssert.assertThatJson(actual.getContentAsString()).isEqualTo(expectedJson)
     return this


### PR DESCRIPTION
Introduces an internal api that represents the pipeline structure:

```
GET /go/api/internal/pipeline_structure
Accept: application/vnd.go.cd+json
```

```json
{
  "groups" : [ {
    "name" : "g1",
    "pipelines" : [ {
      "name" : "g1p1",
      "template_name" : "foo-template",
      "stages" : [ ]
    }]
  }, {
    "name" : "g2",
    "pipelines" : [ {
      "name" : "g2p1",
      "stages" : [ {
        "name" : "s1",
        "jobs" : [ "j1", "j2" ]
      } ]
    } ]
  } ],
  "templates" : [ {
    "name" : "foo-template",
    "stages" : [ {
      "name" : "s1",
      "jobs" : [ "j1", "j2" ]
    }, {
      "name" : "s2",
      "jobs" : [ "s2j1" ]
    } ]
  } ]
}
```