### PR TITLE
Updated user information stored in DB

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/providers/AbstractPluginAuthenticationProvider.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/providers/AbstractPluginAuthenticationProvider.java
@@ -119,7 +119,7 @@ public abstract class AbstractPluginAuthenticationProvider<T extends Credentials
 
             User user = ensureDisplayNamePresent(response.getUser());
             if (user != null) {
-                userService.addUserIfDoesNotExist(toDomainUser(user));
+                userService.addOrUpdateUser(toDomainUser(user));
 
                 pluginRoleService.updatePluginRoles(pluginId, user.getUsername(), CaseInsensitiveString.list(response.getRoles()));
                 LOGGER.debug("Successfully authenticated user: `{}` using the authorization plugin: `{}`", user.getUsername(), pluginId);

--- a/server/src/main/java/com/thoughtworks/go/server/service/UserService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/UserService.java
@@ -36,6 +36,9 @@ import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.util.TriState;
 import com.thoughtworks.go.util.comparator.AlphaAsciiCollectionComparator;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionStatus;
@@ -49,6 +52,7 @@ import static org.apache.commons.lang3.StringUtils.join;
 
 @Service
 public class UserService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserService.class);
     private final UserDao userDao;
     private final SecurityService securityService;
     private final GoConfigService goConfigService;
@@ -403,14 +407,35 @@ public class UserService {
         public abstract Comparator<UserModel> forColumn(SortableColumn column);
     }
 
-    public void addUserIfDoesNotExist(User user) {
+    public void addOrUpdateUser(User user) {
         synchronized (enableUserMutex) {
-            if (!(user.isAnonymous() || userExists(user))) {
-                assertUnknownUsersAreAllowedToLogin(user.getUsername());
-
-                userDao.saveOrUpdate(user);
+            if (!user.isAnonymous()) {
+                LOGGER.debug("User [{}] is not anonymous", user.getName());
+                User foundUser = userDao.findUser(user.getName());
+                if ((foundUser instanceof NullUser)) {
+                    LOGGER.debug("User [{}] is not present in the DB.", user.getName());
+                    assertUnknownUsersAreAllowedToLogin(user.getUsername());
+                    LOGGER.debug("Adding user [{}] to the DB.", user.getName());
+                    userDao.saveOrUpdate(user);
+                } else if (isUserUpdated(user, foundUser)) {
+                    foundUser.setDisplayName(user.getDisplayName());
+                    foundUser.setEmail(user.getEmail());
+                    userDao.saveOrUpdate(foundUser);
+                }
             }
         }
+    }
+
+    private boolean isUserUpdated(User newUser, User originalUser) {
+        boolean hasEmailChanged = !StringUtils.equals(originalUser.getEmail(), newUser.getEmail());
+        boolean hasDisplayNameChanged = !StringUtils.equals(originalUser.getDisplayName(), newUser.getDisplayName());
+        if (hasEmailChanged) {
+            LOGGER.debug("User [{}] has an email change. Updating the same in the DB.", originalUser.getName());
+        }
+        if (hasDisplayNameChanged) {
+            LOGGER.debug("User [{}] has a display name change. Updating the same in the DB.", originalUser.getName());
+        }
+        return hasEmailChanged || hasDisplayNameChanged;
     }
 
     public void withEnableUserMutex(Runnable runnable) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/providers/PasswordBasedPluginAuthenticationProviderTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/providers/PasswordBasedPluginAuthenticationProviderTest.java
@@ -239,7 +239,7 @@ class PasswordBasedPluginAuthenticationProviderTest {
 
             AuthenticationResponse response = new AuthenticationResponse(new User(USERNAME, "display-name", "test@test.com"), Collections.emptyList());
 
-            doThrow(new OnlyKnownUsersAllowedException(USERNAME, "Please ask the administrator to add you to GoCD.")).when(userService).addUserIfDoesNotExist(any());
+            doThrow(new OnlyKnownUsersAllowedException(USERNAME, "Please ask the administrator to add you to GoCD.")).when(userService).addOrUpdateUser(any());
             when(authorizationExtension.authenticateUser(PLUGIN_ID_2, USERNAME, PASSWORD, securityConfig.securityAuthConfigs().findByPluginId(PLUGIN_ID_2), securityConfig.getPluginRoles(PLUGIN_ID_2))).thenReturn(response);
 
             thrown.expect(OnlyKnownUsersAllowedException.class);
@@ -371,7 +371,7 @@ class PasswordBasedPluginAuthenticationProviderTest {
 
             AuthenticationResponse response = new AuthenticationResponse(new User(USERNAME, "display-name", "test@test.com"), Collections.emptyList());
 
-            doThrow(new OnlyKnownUsersAllowedException(USERNAME, "Please ask the administrator to add you to GoCD.")).when(userService).addUserIfDoesNotExist(any());
+            doThrow(new OnlyKnownUsersAllowedException(USERNAME, "Please ask the administrator to add you to GoCD.")).when(userService).addOrUpdateUser(any());
             when(authorizationExtension.authenticateUser(PLUGIN_ID_2, USERNAME, PASSWORD, securityConfig.securityAuthConfigs().findByPluginId(PLUGIN_ID_2), securityConfig.getPluginRoles(PLUGIN_ID_2))).thenReturn(response);
 
             thrown.expect(OnlyKnownUsersAllowedException.class);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/providers/WebBasedPluginAuthenticationProviderTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/providers/WebBasedPluginAuthenticationProviderTest.java
@@ -141,7 +141,7 @@ class WebBasedPluginAuthenticationProviderTest {
             authenticationProvider.authenticate(CREDENTIALS, PLUGIN_ID);
 
             ArgumentCaptor<com.thoughtworks.go.domain.User> argumentCaptor = ArgumentCaptor.forClass(com.thoughtworks.go.domain.User.class);
-            verify(userService).addUserIfDoesNotExist(argumentCaptor.capture());
+            verify(userService).addOrUpdateUser(argumentCaptor.capture());
 
             com.thoughtworks.go.domain.User capturedUser = argumentCaptor.getValue();
             assertThat(capturedUser.getUsername().getUsername().toString())
@@ -231,7 +231,7 @@ class WebBasedPluginAuthenticationProviderTest {
             authenticationProvider.authenticate(CREDENTIALS, PLUGIN_ID);
 
             inOrder.verify(authorizationExtension).authenticateUser(eq(PLUGIN_ID), eq(CREDENTIALS.getCredentials()), anyList(), anyList());
-            inOrder.verify(userService).addUserIfDoesNotExist(any(com.thoughtworks.go.domain.User.class));
+            inOrder.verify(userService).addOrUpdateUser(any(com.thoughtworks.go.domain.User.class));
             inOrder.verify(pluginRoleService).updatePluginRoles(PLUGIN_ID, user.getUsername(), asList(new CaseInsensitiveString("admin")));
             inOrder.verify(authorityGranter).authorities(user.getUsername());
         }
@@ -242,7 +242,7 @@ class WebBasedPluginAuthenticationProviderTest {
             AuthenticationResponse authenticationResponse = new AuthenticationResponse(user, asList("admin"));
 
             when(authorizationExtension.authenticateUser(PLUGIN_ID, CREDENTIALS.getCredentials(), singletonList(githubSecurityAuthconfig), emptyList())).thenReturn(authenticationResponse);
-            doThrow(new OnlyKnownUsersAllowedException("username", "Please ask the administrator to add you to GoCD.")).when(userService).addUserIfDoesNotExist(any());
+            doThrow(new OnlyKnownUsersAllowedException("username", "Please ask the administrator to add you to GoCD.")).when(userService).addOrUpdateUser(any());
 
             thrown.expect(OnlyKnownUsersAllowedException.class);
             thrown.expectMessage("Please ask the administrator to add you to GoCD.");
@@ -303,7 +303,7 @@ class WebBasedPluginAuthenticationProviderTest {
             AuthenticationResponse authenticationResponse = new AuthenticationResponse(user, asList("admin"));
 
             when(authorizationExtension.authenticateUser(PLUGIN_ID, CREDENTIALS.getCredentials(), singletonList(githubSecurityAuthconfig), emptyList())).thenReturn(authenticationResponse);
-            doThrow(new OnlyKnownUsersAllowedException("username", "Please ask the administrator to add you to GoCD.")).when(userService).addUserIfDoesNotExist(any());
+            doThrow(new OnlyKnownUsersAllowedException("username", "Please ask the administrator to add you to GoCD.")).when(userService).addOrUpdateUser(any());
 
             thrown.expect(OnlyKnownUsersAllowedException.class);
             thrown.expectMessage("Please ask the administrator to add you to GoCD.");


### PR DESCRIPTION
Issue: #6832
Description: The user information stored in GoCD DB should get updated on successful authentication.
 - On Successful Authentication of any user in GoCD, we originally use to add the user if it does not exist.
   Updated this flow and added additional check for change in either display name or email. If either of them have changed, we will update the DB entry to reflect the same

