### PR TITLE
Fixes for linux package installers

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeAgent.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeAgent.groovy
@@ -79,8 +79,8 @@ class InstallerTypeAgent implements InstallerType {
   @Override
   Map<String, Object> getConfigFiles() {
     [
-      '/usr/share/go-agent/wrapper-config/wrapper.conf'           : [mode: 0640, owner: 'root', group: 'go', ownedByPackage: true],
-      '/usr/share/go-agent/wrapper-config/wrapper-properties.conf': [mode: 0640, owner: 'root', group: 'go', ownedByPackage: true],
+      '/usr/share/go-agent/wrapper-config/wrapper.conf'           : [mode: 0640, owner: 'root', group: 'go', ownedByPackage: true, confFile: true],
+      '/usr/share/go-agent/wrapper-config/wrapper-properties.conf': [mode: 0640, owner: 'root', group: 'go', ownedByPackage: true, confFile: true],
     ]
   }
 

--- a/installers/linux/deb/after-upgrade.sh.erb
+++ b/installers/linux/deb/after-upgrade.sh.erb
@@ -38,6 +38,7 @@
       echo "The contents of /etc/default/<%= name %> have been migrated to /usr/share/<%= name %>/wrapper-config/wrapper-properties.conf"
       echo "The following lines have been appended to /usr/share/<%= name %>/wrapper-config/wrapper-properties.conf:"
       cat "${MIGRATION_FILE}" | sed -e 's/^/  /g'
+      rm -rf "${MIGRATION_FILE}"
     fi
 
     if [ -e /var/run/<%= name %>-running-check-from-deb-package ]; then

--- a/installers/linux/rpm/after-upgrade.sh.erb
+++ b/installers/linux/rpm/after-upgrade.sh.erb
@@ -41,6 +41,7 @@
       echo "The contents of /etc/default/<%= name %> have been migrated to /usr/share/<%= name %>/wrapper-config/wrapper-properties.conf"
       echo "The following lines have been appended to /usr/share/<%= name %>/wrapper-config/wrapper-properties.conf:"
       cat "${MIGRATION_FILE}" | sed -e 's/^/  /g'
+      rm -rf "${MIGRATION_FILE}"
     fi
 
     if [ -e %{_localstatedir}/lib/rpm-state/<%= name %>/running ]; then

--- a/installers/linux/shared/partials/_go-server-config-migration.sh.erb
+++ b/installers/linux/shared/partials/_go-server-config-migration.sh.erb
@@ -22,6 +22,8 @@
 
             . "/etc/default/<%= name %>"
 
+            mv "/etc/default/<%= name %>" "/etc/default/<%= name %>.pre-migration"
+
             # these variables are not to be exported (even if users explicitly `export`ed them), so we filter them out
             env | sort | grep -v -E "^(GO_SERVER_PORT|GO_SERVER_SSL_PORT|SERVER_WORK_DIR|SERVER_MEM|SERVER_MAX_MEM|SERVER_MAX_PERM_GEN|GO_SERVER_PORT|GO_SERVER_SSL_PORT|GO_SERVER_SYSTEM_PROPERTIES|GO_JAVA_HOME)=" > $NEW_ENV_FILE
 


### PR DESCRIPTION
Issue: #6827 

Description:

1. `fpm` requires option `--config-files` to avoid overriding config files while upgrading. This option was not getting applied for `wrapper.conf` and `wrapper-properties.conf`
The issue was maily because of the `permissions.confFile` check. So, added `confFile` flag on both `wrapper.conf` and `wrapper-properties.conf`

2. While migrating from version `< 19.6.0`, temporary migration file is created (eg. To migrate properties from `/etc/default/go-agent` to `/usr/share/go-agent/wrapper-config/wrapper-properties.conf`)
     These files were not getting deleted after the upgrade. Added code to delete these file
3. Take backup of configuration file for GoCD versions `< 19.6.0`(eg. `/etc/default/go-agent` to `/etc/default/go-agent.pre-migration`)
     PS: This is already in place for agent installers, but was missing for server installers