### PR TITLE
Adding '2.0' to analytics supported version

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsPluginConstants.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsPluginConstants.java
@@ -16,12 +16,13 @@
 package com.thoughtworks.go.plugin.access.analytics;
 
 import com.thoughtworks.go.plugin.access.analytics.V1.AnalyticsMessageConverterV1;
+import com.thoughtworks.go.plugin.access.analytics.V2.AnalyticsMessageConverterV2;
 
 import java.util.Arrays;
 import java.util.List;
 
 public interface AnalyticsPluginConstants {
-    List<String> SUPPORTED_VERSIONS = Arrays.asList(AnalyticsMessageConverterV1.VERSION);
+    List<String> SUPPORTED_VERSIONS = Arrays.asList(AnalyticsMessageConverterV1.VERSION, AnalyticsMessageConverterV2.VERSION);
 
     String REQUEST_PREFIX = "go.cd.analytics";
     String REQUEST_GET_PLUGIN_ICON = REQUEST_PREFIX + ".get-icon";

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtensionTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtensionTest.java
@@ -42,6 +42,7 @@ import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -63,7 +64,7 @@ public class AnalyticsExtensionTest {
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, ANALYTICS_EXTENSION, Arrays.asList("1.0"))).thenReturn("1.0");
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, ANALYTICS_EXTENSION, Arrays.asList("1.0", "2.0"))).thenReturn("1.0", "2.0");
         when(pluginManager.isPluginOfType(ANALYTICS_EXTENSION, PLUGIN_ID)).thenReturn(true);
 
         analyticsExtension = new AnalyticsExtension(pluginManager, extensionsRegistry);
@@ -139,6 +140,12 @@ public class AnalyticsExtensionTest {
         when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ANALYTICS_EXTENSION), requestArgumentCaptor.capture())).thenReturn(new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, "{}"));
 
         analyticsExtension.getStaticAssets(PLUGIN_ID);
+    }
+
+    @Test
+    public void shouldVerifyGoSupportedVersion() {
+        assertTrue(analyticsExtension.goSupportedVersions().contains("1.0"));
+        assertTrue(analyticsExtension.goSupportedVersions().contains("2.0"));
     }
 
     private void assertRequest(GoPluginApiRequest goPluginApiRequest, String extensionName, String version, String requestName, String requestBody) {


### PR DESCRIPTION
Description:

* The contract between '1.0' and '2.0' of analytics hasn't changed except for
  support for new types of anylytics. When '2.0' was introduced it was not
  added as a supported version which was a mistake. Since '1.0' is deprecated
  now, adding support for '2.0'




