### PR TITLE
Material needs validation during `config_files` API call

### DIFF
--- a/api/api-pipelines-as-code-internal-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelinesascodeinternal/PipelinesAsCodeInternalControllerV1Test.groovy
+++ b/api/api-pipelines-as-code-internal-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelinesascodeinternal/PipelinesAsCodeInternalControllerV1Test.groovy
@@ -221,6 +221,26 @@ class PipelinesAsCodeInternalControllerV1Test implements SecurityServiceTrait, C
       }
 
       @Test
+      void 'rejects non-SCM materials'() {
+        when(configRepoService.hasConfigRepoByFingerprint(any(String))).thenReturn(false)
+        Map<String, String> plugins = new HashMap<>()
+        plugins.put("test", PLUGIN_ID)
+        when(defaultPluginInfoFinder.pluginDisplayNameToPluginId(any(String))).thenReturn(plugins)
+
+        postWithApiHeader(controller.controllerPath("config_files"), [:], [
+          type      : "dependency",
+          attributes: [
+            pipeline: "whatever",
+            stage   : "meh"
+          ]
+        ])
+
+        assertThatResponse()
+          .isUnprocessableEntity()
+          .hasJsonMessage("This material check requires an SCM repository; instead, supplied material was of type: DependencyMaterial")
+      }
+
+      @Test
       void 'validates material configuration and bubbles up any validation failures'() {
         when(configRepoService.hasConfigRepoByFingerprint(any(String))).thenReturn(false)
         Map<String, String> plugins = new HashMap<>()


### PR DESCRIPTION
The user should see any validation errors when submitting an incorrect/invalid MaterialConfig
(e.g., blank URL) to check for configrepo files.
