### PR TITLE
Fix for linux installers

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeServer.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeServer.groovy
@@ -88,8 +88,8 @@ class InstallerTypeServer implements InstallerType {
   @Override
   Map<String, Object> getConfigFiles() {
     [
-      '/usr/share/go-server/wrapper-config/wrapper.conf'           : [mode: 0640, owner: 'root', group: 'go', ownedByPackage: true],
-      '/usr/share/go-server/wrapper-config/wrapper-properties.conf': [mode: 0640, owner: 'root', group: 'go', ownedByPackage: true],
+      '/usr/share/go-server/wrapper-config/wrapper.conf'           : [mode: 0640, owner: 'root', group: 'go', ownedByPackage: true, confFile: true],
+      '/usr/share/go-server/wrapper-config/wrapper-properties.conf': [mode: 0640, owner: 'root', group: 'go', ownedByPackage: true, confFile: true],
     ]
   }
 


### PR DESCRIPTION
Issue: #6827 

Description:
Added missing flag `confFile` in `InstallerTypeServer` for server installers.
