### PR TITLE
Use jetty's defaults for ciphers and protocols.

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -172,7 +172,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<String> GO_SSL_TRANSPORT_PROTOCOL_TO_BE_USED_BY_AGENT = new GoStringSystemProperty("go.ssl.agent.protocol", "TLSv1.2");
     public static GoSystemProperty<String> GO_SSL_CERTS_ALGORITHM = new GoStringSystemProperty("go.ssl.cert.algorithm", "SHA512WITHRSA");
     public static GoSystemProperty<String> GO_SSL_CERTS_PUBLIC_KEY_ALGORITHM = new GoStringSystemProperty("go.ssl.cert.public-key.algorithm", "SHA256WithRSAEncryption");
-    public static GoSystemProperty<Boolean> GO_SSL_CONFIG_CLEAR_JETTY_DEFAULT_EXCLUSIONS = new GoBooleanSystemProperty("go.ssl.config.clear.default.exclusions", true);
+    public static GoSystemProperty<Boolean> GO_SSL_CONFIG_CLEAR_JETTY_DEFAULT_EXCLUSIONS = new GoBooleanSystemProperty("go.ssl.config.clear.default.exclusions", false);
     public static GoSystemProperty<String[]> GO_SSL_INCLUDE_CIPHERS = new GoStringArraySystemProperty("go.ssl.ciphers.include", null);
     public static GoSystemProperty<String[]> GO_SSL_EXCLUDE_CIPHERS = new GoStringArraySystemProperty("go.ssl.ciphers.exclude", null);
     public static GoSystemProperty<String[]> GO_SSL_INCLUDE_PROTOCOLS = new GoStringArraySystemProperty("go.ssl.protocols.include", null);

--- a/jetty9/src/main/java/com/thoughtworks/go/server/Jetty9Server.java
+++ b/jetty9/src/main/java/com/thoughtworks/go/server/Jetty9Server.java
@@ -255,9 +255,9 @@ public class Jetty9Server extends AppServer {
         webAppContext.setContextPath(systemEnvironment.getWebappContextPath());
 
         // delegate all logging to parent classloader to avoid initialization of loggers in multiple classloaders
-        webAppContext.addSystemClass("org.apache.log4j.");
-        webAppContext.addSystemClass("org.slf4j.");
-        webAppContext.addSystemClass("org.apache.commons.logging.");
+        webAppContext.getSystemClasspathPattern().add("org.apache.log4j.");
+        webAppContext.getSystemClasspathPattern().add("org.slf4j.");
+        webAppContext.getSystemClasspathPattern().add("org.apache.commons.logging.");
 
         webAppContext.setWar(getWarFile());
         webAppContext.setParentLoaderPriority(systemEnvironment.getParentLoaderPriority());


### PR DESCRIPTION
We were (before this commit) clearing away Jetty's default exclusion of
insecure protocols (currently SSLv1, SSLv2, SSLv3) and weak/insecure cipher
suites (MD5/SHA/SHA1, those without forward secrecy, etc.)

Since newer protocols and ciphers are added over time and older ones are
deprecated/removed, we'd like to defer this configuration to jetty.

This allows us to stay current with more modern and up-to-date security
settings by leaning on jetty, instead of us having to track all these
things ourselves.