### PR TITLE
Sync environments when a config repo is deleted

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigReposConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigReposConfig.java
@@ -141,6 +141,10 @@ public class ConfigReposConfig extends BaseCollection<ConfigRepoConfig> implemen
         return true;
     }
 
+    public boolean hasConfigRepo(String configRepoId) {
+        return this.getConfigRepo(configRepoId) != null;
+    }
+
     private boolean isLocal(ConfigOrigin from) {
         // we assume that configuration is local (from file or from UI) when origin is not specified
         if (from == null) {

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigReposConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigReposConfigTest.java
@@ -105,4 +105,17 @@ public class ConfigReposConfigTest {
         assertThat(repo1.errors().isEmpty(), is(true));
         assertThat(repo2.errors().isEmpty(), is(true));
     }
+
+    @Test
+    public void shouldReturnTrueIfContainsConfigRepoWithTheSpecifiedId() {
+        ConfigRepoConfig repo = new ConfigRepoConfig(git("http://git1"), "myplugin", "id");
+        repos.add(repo);
+
+        assertThat(repos.hasConfigRepo(repo.getId()), is(true));
+    }
+
+    @Test
+    public void shouldReturnFalseIfDoesNotContainTheConfigRepoWithTheSpecifiedId() {
+        assertThat(repos.hasConfigRepo("unknown"), is(false));
+    }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/EnvironmentConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EnvironmentConfigService.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.exceptions.GoConfigInvalidException;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
+import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.update.AddEnvironmentCommand;
 import com.thoughtworks.go.config.update.DeleteEnvironmentCommand;
 import com.thoughtworks.go.config.update.PatchEnvironmentCommand;
@@ -77,6 +78,15 @@ public class EnvironmentConfigService implements ConfigChangedListener {
             @Override
             public void onEntityConfigChange(EnvironmentConfig entity) {
                 sync(goConfigService.getEnvironments());
+            }
+        });
+
+        goConfigService.register(new EntityConfigChangedListener<ConfigRepoConfig>() {
+            @Override
+            public void onEntityConfigChange(ConfigRepoConfig entity) {
+                if(!goConfigService.getCurrentConfig().getConfigRepos().hasConfigRepo(entity.getId())) {
+                    sync(goConfigService.getEnvironments());
+                }
             }
         });
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
@@ -22,10 +22,10 @@ import com.thoughtworks.go.config.merge.MergeEnvironmentConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.helper.EnvironmentConfigMother;
+import com.thoughtworks.go.listener.EntityConfigChangedListener;
 import com.thoughtworks.go.presentation.environment.EnvironmentPipelineModel;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
-import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,8 @@ import org.mockito.Mockito;
 
 import java.util.*;
 
-import static com.thoughtworks.go.helper.EnvironmentConfigMother.*;
+import static com.thoughtworks.go.helper.EnvironmentConfigMother.environment;
+import static com.thoughtworks.go.helper.EnvironmentConfigMother.environments;
 import static com.thoughtworks.go.helper.PipelineConfigMother.pipelineConfig;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,6 +58,7 @@ class EnvironmentConfigServiceTest {
     void shouldRegisterAsACruiseConfigChangeListener() {
         environmentConfigService.initialize();
         Mockito.verify(mockGoConfigService).register(environmentConfigService);
+        verify(mockGoConfigService, times(3)).register(any(EntityConfigChangedListener.class));
     }
 
     @Test


### PR DESCRIPTION
 - Env Agent association were not deleted from env config service even if the config repo was deleted. This commit fixes this issue.

