### PR TITLE
New agent spa: Fixed following issues with agent analytics after moving spa to TS 

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/models/shared/analytics_frame.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/analytics_frame.ts
@@ -37,7 +37,7 @@ export class Frame {
              url: this.url(),
              type: "GET",
              dataType: "json",
-             beforeSend: before
+             beforeSend: () => before && before()
            })
      .done((r) => {
        this.data(r.data);
@@ -45,11 +45,7 @@ export class Frame {
      })
      .fail((xhr) => {
        this.errors(xhr);
-     }).always(() => {
-      if (after) {
-        after();
-      }
-    });
+     }).always(() => after && after());
   }
 
   fetch(url: string, handler: (data: object | null, errors: JQuery.jqXHR | null) => void) {

--- a/server/webapp/WEB-INF/rails/webpack/rails-shared/plugin-endpoint-request-handler.js
+++ b/server/webapp/WEB-INF/rails/webpack/rails-shared/plugin-endpoint-request-handler.js
@@ -41,7 +41,7 @@
       PluginEndpoint.define({
         "go.cd.analytics.v1.fetch-analytics": function goCdAnalyticsV1FetchAnalytics(message, trans) {
           var meta   = message.head,
-              model  = models[meta.uid],
+              model  = models[meta.uid] || models.get(meta.uid),
               params = message.body,
               type   = params.type,
               metric = params.metric;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.tsx
@@ -34,8 +34,6 @@ export enum ModalState {
 }
 
 export abstract class Modal extends MithrilViewComponent<any> {
-  public id: string;
-  private readonly size: Size;
   protected closeModalOnOverlayClick: boolean = true;
   protected modalState                        = ModalState.OK;
 
@@ -44,6 +42,9 @@ export abstract class Modal extends MithrilViewComponent<any> {
     this.id   = `modal-${uuid4()}`;
     this.size = size;
   }
+
+  public id: string;
+  private readonly size: Size;
 
   abstract title(): string;
 
@@ -76,7 +77,6 @@ export abstract class Modal extends MithrilViewComponent<any> {
   }
 
   view() {
-    const spinner = this.isLoading() ? (<Spinner/>) : null;
     return <div class={classnames(styles.overlay, Size[this.size])}>
       <header class={styles.overlayHeader}>
         <h3 data-test-id="modal-title">{this.title()}</h3>
@@ -86,18 +86,10 @@ export abstract class Modal extends MithrilViewComponent<any> {
       <div
         class={classnames(styles.overlayContent, {[styles.spinnerWrapper]: this.isLoading()})}
         data-test-id="modal-body">
-        <div class={classnames({[styles.modalBodyOverlay]: this.isLoading()})}>
-          {spinner}
-        </div>
+        {this.spinner()}
         {this.body()}
       </div>
-      <footer class={styles.overlayFooter}>
-        {
-          _.forEach(_.reverse(this.buttons()), (button) => {
-            return button;
-          })
-        }
-      </footer>
+      {this.footer()}
     </div>;
   }
 
@@ -107,5 +99,29 @@ export abstract class Modal extends MithrilViewComponent<any> {
 
   protected isLoading() {
     return this.modalState === ModalState.LOADING;
+  }
+
+  private footer(): m.Children {
+    if (!this.buttons() || this.buttons().length === 0) {
+      return;
+    }
+
+    return <footer class={styles.overlayFooter}>
+      {
+        _.forEach(_.reverse(this.buttons()), (button) => {
+          return button;
+        })
+      }
+    </footer>;
+  }
+
+  private spinner(): m.Children {
+    if (!this.isLoading()) {
+      return;
+    }
+
+    return (<div class={classnames({[styles.modalBodyOverlay]: this.isLoading()})}>
+      <Spinner/>
+    </div>);
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/spec/index_spec.tsx
@@ -108,6 +108,15 @@ describe("Modal", () => {
     testModal.close();
   });
 
+  it("should not render the footer in absence of buttons", () => {
+    const testModal = aModalWithoutFooter();
+    testModal.render();
+    m.redraw.sync();
+
+    expect($(`.${styles.overlayFooter}`)).not.toBeInDOM();
+    testModal.close();
+  });
+
   function aModal() {
     return new (class TestModal extends Modal {
       constructor() {
@@ -120,6 +129,26 @@ describe("Modal", () => {
 
       title(): string {
         return "Test Modal";
+      }
+    })();
+  }
+
+  function aModalWithoutFooter() {
+    return new (class TestModal extends Modal {
+      constructor() {
+        super();
+      }
+
+      body(): m.Children {
+        return m("p", {id: "modal-inside"}, "Hello World!");
+      }
+
+      title(): string {
+        return "Test Modal";
+      }
+
+      buttons(): m.ChildArray {
+        return [];
       }
     })();
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/analytics/analytics_interaction_manager.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/analytics/analytics_interaction_manager.ts
@@ -20,10 +20,10 @@ import {AnalyticsNamespace} from "views/pages/analytics/analytics_namespace";
 const PluginEndpointRequestHandler = require("rails-shared/plugin-endpoint-request-handler");
 
 export namespace AnalyticsInteractionManager {
-  const models: { [key: string]: Frame } = {};
+  const models: Map<string, Frame> = new Map<string, Frame>();
 
   export function purge() {
-    Object.keys(models).forEach((name: string) => delete models[name]);
+    models.clear();
   }
 
   export function all() {
@@ -31,10 +31,7 @@ export namespace AnalyticsInteractionManager {
   }
 
   export function ns(name: string): AnalyticsNamespace {
-    const modelsForNamespace: Frame[] = Object.keys(models)
-                                              .filter((key: string) => key === name)
-                                              .map((key: string) => models[key]);
-    return new AnalyticsNamespace(name, modelsForNamespace);
+    return new AnalyticsNamespace(name, models);
   }
 
   export function ensure() {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/analytics/analytics_modal.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/analytics/analytics_modal.tsx
@@ -28,9 +28,9 @@ const PluginEndpoint = require("rails-shared/plugin-endpoint");
 type SupportedAnalyticsTypes = Agent;
 
 export abstract class AnalyticsModal<T extends SupportedAnalyticsTypes> extends Modal {
-  private readonly supportedAnalytics: { [key: string]: AnalyticsCapability[] };
   protected entity: T;
   protected namespace: AnalyticsNamespace;
+  private readonly supportedAnalytics: { [key: string]: AnalyticsCapability[] };
 
   constructor(entity: T,
               supportedAnalytics: { [key: string]: AnalyticsCapability[] },

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/analytics/analytics_modal.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/analytics/analytics_modal.tsx
@@ -61,5 +61,9 @@ export abstract class AnalyticsModal<T extends SupportedAnalyticsTypes> extends 
     return model;
   }
 
+  buttons(): m.ChildArray {
+    return [];
+  }
+
   protected abstract getUrlParams(): { [key: string]: string | number };
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/analytics/analytics_namespace.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/analytics/analytics_namespace.ts
@@ -19,13 +19,13 @@ import {Frame} from "models/shared/analytics_frame";
 import {AnalyticsCapability} from "models/shared/plugin_infos_new/analytics_plugin_capabilities";
 
 export class AnalyticsNamespace {
-  uid    = this.encodeUID;
-  unpack = this.decodeUID;
-  private readonly prefix: string;
+  readonly uid    = this.encodeUID;
+  readonly unpack = this.decodeUID;
+  private readonly models: Map<string, Frame>;
   private readonly name: string;
-  private readonly models: Frame[];
+  private readonly prefix: string;
 
-  constructor(name: string, models: Frame[]) {
+  constructor(name: string, models: Map<string, Frame>) {
     this.name   = name;
     this.models = models;
     this.prefix = `${encodeURIComponent(name)}:`;
@@ -52,7 +52,9 @@ export class AnalyticsNamespace {
   }
 
   all() {
-    return this.models;
+    return Object.keys(this.models)
+                 .filter((key: string) => key === this.name)
+                 .map((key: string) => this.models.get(key));
   }
 
   toUrl(uid: string, params: { [key: string]: string | number } = {}) {
@@ -61,12 +63,12 @@ export class AnalyticsNamespace {
   }
 
   modelFor(uid: string, extraParams: { [key: string]: string | number } = {}) {
-    let model = this.models.find((model: Frame) => model.uid === uid);
+    let model = this.models.get(uid);
 
     if (!model) {
       model = new Frame(uid);
       model.url(this.toUrl(uid, extraParams));
-      this.models.push(model);
+      this.models.set(uid, model);
     }
     return model;
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/analytics/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/analytics/index.scss
@@ -16,6 +16,7 @@
 
 .frame-wrapper {
   min-height: 200px;
+  height:     525px;
 }
 
 .iframe {


### PR DESCRIPTION
- Hide modal footer in absence of buttons
- Pass original models map to AnalyticsNamespace instead of copy
    - This is done as model PluginEndpointRequestHandler expect the caller to pass the original 
       reference and update the same while creating a new model for the agent.
    - Fixed issue where analytics were not getting rendered properly.