### PR TITLE
Feature toggle the Properties API (and tab)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
@@ -19,8 +19,8 @@ import com.thoughtworks.go.config.AgentConfig;
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.Tabs;
 import com.thoughtworks.go.config.TrackingTool;
-import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.Properties;
+import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.plugin.access.elastic.ElasticAgentMetadataStore;
 import com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo;
 import com.thoughtworks.go.server.dao.JobAgentMetadataDao;
@@ -57,36 +57,26 @@ import static com.thoughtworks.go.util.json.JsonHelper.addDeveloperErrorMessage;
 public class JobController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JobController.class);
-    @Autowired
     private JobInstanceService jobInstanceService;
-    @Autowired
     private AgentService agentService;
-    @Autowired
     private JobInstanceDao jobInstanceDao;
-    @Autowired
     private GoConfigService goConfigService;
-    @Autowired
     private PipelineService pipelineService;
-    @Autowired
     private RestfulService restfulService;
-    @Autowired
     private ArtifactsService artifactService;
-    @Autowired
     private PropertiesService propertiesService;
-    @Autowired
     private StageService stageService;
-    @Autowired
     private JobAgentMetadataDao jobAgentMetadataDao;
-    @Autowired
     private SystemEnvironment systemEnvironment;
 
     private ElasticAgentMetadataStore elasticAgentMetadataStore = ElasticAgentMetadataStore.instance();
-
+    private Boolean disallowPropertiesAccess;
 
     public JobController() {
     }
 
-    JobController(
+    @Autowired
+    public JobController(
             JobInstanceService jobInstanceService, AgentService agentService, JobInstanceDao jobInstanceDao,
             GoConfigService goConfigService, PipelineService pipelineService, RestfulService restfulService,
             ArtifactsService artifactService, PropertiesService propertiesService, StageService stageService,
@@ -102,6 +92,7 @@ public class JobController {
         this.stageService = stageService;
         this.jobAgentMetadataDao = jobAgentMetadataDao;
         this.systemEnvironment = systemEnvironment;
+        this.disallowPropertiesAccess = Boolean.valueOf(System.getenv().getOrDefault("GO_DISALLOW_PROPERTIES_ACCESS", "true"));
     }
 
     @RequestMapping(value = "/tab/build/recent", method = RequestMethod.GET)
@@ -192,6 +183,7 @@ public class JobController {
         data.put("useIframeSandbox", systemEnvironment.useIframeSandbox());
         data.put("isEditableViaUI", goConfigService.isPipelineEditable(jobDetail.getPipelineName()));
         data.put("isAgentAlive", goConfigService.hasAgent(jobDetail.getAgentUuid()));
+        data.put("disallowPropertiesAccess", disallowPropertiesAccess);
         addElasticAgentInfo(jobDetail, data);
         return new ModelAndView("build_detail/build_detail_page", data);
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/StageOrderService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/StageOrderService.java
@@ -23,7 +23,12 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class StageOrderService {
-    @Autowired private GoConfigService goConfigService;
+    private final GoConfigService goConfigService;
+
+    @Autowired
+    public StageOrderService(GoConfigService goConfigService) {
+        this.goConfigService = goConfigService;
+    }
 
     public StageConfig getNextStage(PipelineInfo pipeline, String stageName) {
         StageConfig nextStageFromHistory = nextStageFromHistory(pipeline, stageName);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/controller/PropertiesControllerTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/controller/PropertiesControllerTest.java
@@ -71,6 +71,7 @@ public class PropertiesControllerTest {
         fixture = new PipelineWithTwoStages(materialRepository, transactionTemplate, temporaryFolder);
         fixture.usingConfigHelper(configHelper).usingDbHelper(dbHelper).onSetUp();
         controller = new PropertiesController(propertiesService, restfulService, pipelineService, systemEnvironment);
+        controller.setDisallowPropertiesAccess(false);
         response = new MockHttpServletResponse();
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/controller/RestfulPropertiesControllerTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/controller/RestfulPropertiesControllerTest.java
@@ -86,6 +86,7 @@ public class RestfulPropertiesControllerTest {
 
         configHelper.addPipeline("pipeline", "stage", "build");
         propertiesController = new PropertiesController(propertiesService, restfulService, pipelineService, systemEnvironment);
+        propertiesController.setDisallowPropertiesAccess(false);
         request.addHeader("Confirm", "True");
     }
 

--- a/server/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
@@ -84,10 +84,12 @@
                       <a class="tab_button_body_match_text">materials</a>
                       <a>Materials</a>
                     </li>
-                    <li>
-                      <a class="tab_button_body_match_text">properties</a>
-                      <a>Properties</a>
-                    </li>
+                    #if (!$disallowPropertiesAccess)
+                      <li>
+                        <a class="tab_button_body_match_text">properties</a>
+                        <a>Properties</a>
+                      </li>
+                    #end
                       #foreach( $tab in $presenter.customizedTabs )
                         <li>
                           <a class="tab_button_body_match_text">$tab.name.toLowerCase()</a>


### PR DESCRIPTION
- Disables the "Properties" tab on the job detail page
- Disable all "GET" API calls for properties.

POST is still supported, for now, but will be removed in a couple of
releases. Additionally, the `<property/>` tag is rarely used. This is
used to extract metrics from XML reports (via XPATH) and publish them
using the API. Support for `<property/>` tag will be removed in a couple
of releases as well.

The properties API provides the ability for GoCD to store arbitrary
key-value-pair data associated with each build. The intent of this API
(at the time of developing this) was to be able to store arbitrary
metrics (like test count, coverage%, warning count, et.al.) and be
able to track progress of these metrics over time.

Fast forward to 2019, there are (much) better tools available that can
do just this.