### PR TITLE
Fixed the issue in reloading plugin view in secret management SPA

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/modals.tsx
@@ -118,7 +118,7 @@ export abstract class SecretConfigModal extends EntityModal<SecretConfig> {
           <AngularPluginNew
             pluginInfoSettings={Stream(pluginSettings)}
             configuration={this.entity().properties()}
-            key={this.entity().id()} />
+            key={pluginInfo.id} />
         </div>
       </div>
       <RulesWidget rules={this.entity().rules} resourceAutocompleteHelper={this.resourceAutocompleteHelper} />


### PR DESCRIPTION
- The issue was introduced after the mithril upgrade. We had used the entity id as a key
  which was wrong as on change of plugin id the angular view should be recreated.

- Changed the key value to  plugin id as the view should reload on change of the plugin

#### step to reproduce the issue

1. Install two secret management plugins
2. Click on "Add" button
3. View for the first plugin will be rendered just fine
4. Change the plugin and it will render the error on plugin view
