### PR TITLE
#6299 - Introduce v2 of ConsoleLogRequestProcessor

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/ConsoleLogRequestProcessor.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/ConsoleLogRequestProcessor.java
@@ -24,6 +24,7 @@ import com.thoughtworks.go.plugin.infra.PluginRequestProcessorRegistry;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 import com.thoughtworks.go.server.service.ConsoleService;
 import com.thoughtworks.go.server.service.plugins.processor.console.v1.MessageHandlerForConsoleLogRequestProcessorImpl1_0;
+import com.thoughtworks.go.server.service.plugins.processor.console.v2.MessageHandlerForConsoleLogRequestProcessorImpl2_0;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.text.MessageFormat.format;
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 @Component
 public class ConsoleLogRequestProcessor implements GoPluginApiRequestProcessor {
@@ -43,7 +44,8 @@ public class ConsoleLogRequestProcessor implements GoPluginApiRequestProcessor {
     public static final String APPEND_TO_CONSOLE_LOG = "go.processor.console-log.append";
 
     public static final String VERSION_1 = "1.0";
-    private static final List<String> supportedVersions = singletonList(VERSION_1);
+    public static final String VERSION_2 = "2.0";
+    private static final List<String> supportedVersions = asList(VERSION_1, VERSION_2);
 
     private Map<String, MessageHandlerForConsoleLogRequestProcessor> versionToMessageHandlerMap;
     private ConsoleService consoleService;
@@ -53,6 +55,7 @@ public class ConsoleLogRequestProcessor implements GoPluginApiRequestProcessor {
         this.consoleService = consoleService;
         versionToMessageHandlerMap = new HashMap<>();
         versionToMessageHandlerMap.put(VERSION_1, new MessageHandlerForConsoleLogRequestProcessorImpl1_0());
+        versionToMessageHandlerMap.put(VERSION_2, new MessageHandlerForConsoleLogRequestProcessorImpl2_0());
 
         registry.registerProcessorFor(APPEND_TO_CONSOLE_LOG, this);
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/v2/ConsoleLogAppendRequest2_0.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/v2/ConsoleLogAppendRequest2_0.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.processor.console.v2;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.server.service.plugins.processor.console.ConsoleLogAppendRequest;
+
+public class ConsoleLogAppendRequest2_0 implements ConsoleLogAppendRequest {
+    private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+
+    @Expose
+    @SerializedName("pipeline_name")
+    private String pipelineName;
+
+    @Expose
+    @SerializedName("pipeline_counter")
+    private Integer pipelineCounter;
+
+    @Expose
+    @SerializedName("stage_name")
+    private String stageName;
+
+    @Expose
+    @SerializedName("stage_counter")
+    private String stageCounter;
+
+    @Expose
+    @SerializedName("job_name")
+    private String jobName;
+
+    @Expose
+    @SerializedName("text")
+    private String text;
+
+    public static ConsoleLogAppendRequest2_0 fromJSON(String json) {
+        return GSON.fromJson(json, ConsoleLogAppendRequest2_0.class);
+    }
+
+    @Override
+    public JobIdentifier jobIdentifier() {
+        return new JobIdentifier(pipelineName, pipelineCounter, null, stageName, stageCounter, jobName);
+    }
+
+    @Override
+    public String text() {
+        return text;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/v2/MessageHandlerForConsoleLogRequestProcessorImpl2_0.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/v2/MessageHandlerForConsoleLogRequestProcessorImpl2_0.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.processor.console.v2;
+
+import com.thoughtworks.go.server.service.plugins.processor.console.MessageHandlerForConsoleLogRequestProcessor;
+
+public class MessageHandlerForConsoleLogRequestProcessorImpl2_0 implements MessageHandlerForConsoleLogRequestProcessor {
+    @Override
+    public ConsoleLogAppendRequest2_0 deserializeConsoleLogAppendRequest(String requestBody) {
+        return ConsoleLogAppendRequest2_0.fromJSON(requestBody);
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/plugins/processor/console/v1/ConsoleLogRequestProcessorV1Test.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/plugins/processor/console/v1/ConsoleLogRequestProcessorV1Test.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.processor.console.v1;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.domain.exception.IllegalArtifactLocationException;
+import com.thoughtworks.go.plugin.api.request.DefaultGoApiRequest;
+import com.thoughtworks.go.plugin.api.response.DefaultGoApiResponse;
+import com.thoughtworks.go.plugin.api.response.GoApiResponse;
+import com.thoughtworks.go.plugin.infra.PluginRequestProcessorRegistry;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.service.ConsoleService;
+import com.thoughtworks.go.server.service.plugins.processor.console.ConsoleLogRequestProcessor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.thoughtworks.go.server.service.plugins.processor.console.ConsoleLogRequestProcessor.APPEND_TO_CONSOLE_LOG;
+import static com.thoughtworks.go.server.service.plugins.processor.console.ConsoleLogRequestProcessor.VERSION_1;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class ConsoleLogRequestProcessorV1Test {
+    @Mock
+    private PluginRequestProcessorRegistry pluginRequestProcessorRegistry;
+    @Mock
+    private ConsoleService consoleService;
+    @Mock
+    private GoPluginDescriptor pluginDescriptor;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    void shouldRouteMessageToConsoleService() throws IOException, IllegalArtifactLocationException {
+        Map<String, String> requestMap = new HashMap<>();
+        requestMap.put("pipelineName", "p1");
+        requestMap.put("pipelineCounter", "1");
+        requestMap.put("stageName", "s1");
+        requestMap.put("stageCounter", "2");
+        requestMap.put("jobName", "j1");
+        requestMap.put("text", "message1");
+
+        DefaultGoApiRequest goApiRequest = new DefaultGoApiRequest(APPEND_TO_CONSOLE_LOG, VERSION_1, null);
+        goApiRequest.setRequestBody(new GsonBuilder().create().toJson(requestMap));
+
+        final ConsoleLogRequestProcessor processor = new ConsoleLogRequestProcessor(pluginRequestProcessorRegistry, consoleService);
+        final GoApiResponse response = processor.process(pluginDescriptor, goApiRequest);
+
+        assertThat(response.responseCode(), is(DefaultGoApiResponse.SUCCESS_RESPONSE_CODE));
+
+        final JobIdentifier jobIdentifier = new JobIdentifier("p1", 1, null, "s1", "2", "j1");
+        verify(consoleService).appendToConsoleLog(jobIdentifier, "message1");
+    }
+
+    @Test
+    void shouldRespondWithAMessageIfSomethingGoesWrong() {
+        DefaultGoApiRequest goApiRequest = new DefaultGoApiRequest(APPEND_TO_CONSOLE_LOG, VERSION_1, null);
+        goApiRequest.setRequestBody("this_is_invalid_JSON");
+
+        final ConsoleLogRequestProcessor processor = new ConsoleLogRequestProcessor(pluginRequestProcessorRegistry, consoleService);
+        final GoApiResponse response = processor.process(pluginDescriptor, goApiRequest);
+
+        assertThat(response.responseCode(), is(DefaultGoApiResponse.INTERNAL_ERROR));
+
+        final Map responseContents = new Gson().fromJson(response.responseBody(), Map.class);
+        assertThat((String) responseContents.get("message"), containsString("Error:"));
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/plugins/processor/console/v2/ConsoleLogRequestProcessorV2Test.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/plugins/processor/console/v2/ConsoleLogRequestProcessorV2Test.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.server.service.plugins.processor.console.v1;
+package com.thoughtworks.go.server.service.plugins.processor.console.v2;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -35,15 +35,14 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.thoughtworks.go.server.service.plugins.processor.console.ConsoleLogRequestProcessor.APPEND_TO_CONSOLE_LOG;
-import static com.thoughtworks.go.server.service.plugins.processor.console.ConsoleLogRequestProcessor.VERSION_1;
+import static com.thoughtworks.go.server.service.plugins.processor.console.ConsoleLogRequestProcessor.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-public class ConsoleLogRequestProcessorTest {
+public class ConsoleLogRequestProcessorV2Test {
     @Mock
     private PluginRequestProcessorRegistry pluginRequestProcessorRegistry;
     @Mock
@@ -59,14 +58,14 @@ public class ConsoleLogRequestProcessorTest {
     @Test
     void shouldRouteMessageToConsoleService() throws IOException, IllegalArtifactLocationException {
         Map<String, String> requestMap = new HashMap<>();
-        requestMap.put("pipelineName", "p1");
-        requestMap.put("pipelineCounter", "1");
-        requestMap.put("stageName", "s1");
-        requestMap.put("stageCounter", "2");
-        requestMap.put("jobName", "j1");
+        requestMap.put("pipeline_name", "p1");
+        requestMap.put("pipeline_counter", "1");
+        requestMap.put("stage_name", "s1");
+        requestMap.put("stage_counter", "2");
+        requestMap.put("job_name", "j1");
         requestMap.put("text", "message1");
 
-        DefaultGoApiRequest goApiRequest = new DefaultGoApiRequest(APPEND_TO_CONSOLE_LOG, VERSION_1, null);
+        DefaultGoApiRequest goApiRequest = new DefaultGoApiRequest(APPEND_TO_CONSOLE_LOG, VERSION_2, null);
         goApiRequest.setRequestBody(new GsonBuilder().create().toJson(requestMap));
 
         final ConsoleLogRequestProcessor processor = new ConsoleLogRequestProcessor(pluginRequestProcessorRegistry, consoleService);
@@ -80,7 +79,7 @@ public class ConsoleLogRequestProcessorTest {
 
     @Test
     void shouldRespondWithAMessageIfSomethingGoesWrong() {
-        DefaultGoApiRequest goApiRequest = new DefaultGoApiRequest(APPEND_TO_CONSOLE_LOG, VERSION_1, null);
+        DefaultGoApiRequest goApiRequest = new DefaultGoApiRequest(APPEND_TO_CONSOLE_LOG, VERSION_2, null);
         goApiRequest.setRequestBody("this_is_invalid_JSON");
 
         final ConsoleLogRequestProcessor processor = new ConsoleLogRequestProcessor(pluginRequestProcessorRegistry, consoleService);


### PR DESCRIPTION
The only change from v1 is that it does not use camel case in its message.

Issue: #6299 + https://github.com/gocd/kubernetes-elastic-agents/pull/136#pullrequestreview-284638323

Description: v1 of ConsoleLogRequestProcessor used a message which looked like this:

```
{
  "pipelineName": "p1",
  "jobName": "j1",
  "pipelineCounter": "1",
  "stageName": "s1",
  "text": "message1",
  "stageCounter": "2"
}
```

v2 uses a message which looks like this:

```
{
  "pipeline-name": "p1",
  "stage-name": "s1",
  "pipeline-counter": "1",
  "job-name": "j1",
  "stage-counter": "2",
  "text": "message1"
}
```
