### PR TITLE
Fix for error generating job details in absence of cluster profile #000

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
@@ -19,6 +19,7 @@ import com.thoughtworks.go.config.AgentConfig;
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.Tabs;
 import com.thoughtworks.go.config.TrackingTool;
+import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.domain.Properties;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.plugin.access.elastic.ElasticAgentMetadataStore;
@@ -198,7 +199,12 @@ public class JobController {
             return;
         }
 
-        final String pluginId = jobAgentMetadata.clusterProfile().getPluginId();
+        ClusterProfile clusterProfile = jobAgentMetadata.clusterProfile();
+        if(clusterProfile == null) {
+            return;
+        }
+
+        final String pluginId = clusterProfile.getPluginId();
         final ElasticAgentPluginInfo pluginInfo = elasticAgentMetadataStore.getPluginInfo(pluginId);
 
         if (pluginInfo != null && pluginInfo.getCapabilities().supportsAgentStatusReport()) {


### PR DESCRIPTION
* Support for clusters was introduced in 19.3.0. Before upgrading the server
  if a job is building and assigned to an elastic agent, post upgrade
  the job will be missing cluster profile information. Hence upon
  opening the job details page the server would error out with 500.
  This commit fixes this issue.


