### PR TITLE
Use absolute path for wrapper-properties.conf when copying agents

### DIFF
--- a/installers/go-agent/release/README-running-multiple-agents.md
+++ b/installers/go-agent/release/README-running-multiple-agents.md
@@ -59,6 +59,7 @@ Each agent needs to be configured to run in its own separate directory so that e
         sed -i -e "s@=go-agent\$@=${AGENT_ID}@g" \
               -e "s@/var/lib/go-agent@/var/lib/${AGENT_ID}@g" \
               -e "s@/var/log/go-agent@/var/log/${AGENT_ID}@g" \
+              -e "s@../wrapper-config/wrapper-properties.conf@/usr/share/${AGENT_ID}/wrapper-config/wrapper-properties.conf@g" \
                 /usr/share/${AGENT_ID}/wrapper-config/wrapper.conf
 
         if [ "${RUN_AS_SERVICE}" == "true" ]; then


### PR DESCRIPTION
Issue: wrapper-properties.conf file changes don't get honored for the multiple agents installed on the same machine using the provided bash script. 

Description:
Since we symlink the wrapper directory, the relative path seems to resolve to the original location of the wrapper-properties.conf. This change should allow each agent directory to use its own wrapper-properties.conf.

I've tested this out locally on an Ubuntu VM