### PR TITLE
Removing base.jar from verify jar task as it is not being used

### DIFF
--- a/server-launcher/build.gradle
+++ b/server-launcher/build.gradle
@@ -261,7 +261,6 @@ task verifyFatJar(type: VerifyJarTask) {
       "defaultCommandSnippets.zip"
     ],
     "lib"         : [
-      "base-${project.version}.jar",
       "bcpkix-jdk15on-${project.versions.bouncyCastle}.jar",
       "bcprov-jdk15on-${project.versions.bouncyCastle}.jar",
       "commons-io-${project.versions.commonsIO}.jar",


### PR DESCRIPTION
Earlier server launcher was using javasysmon-wrapper, and it was using base module. Since we removed the javasysmon-wrapper module, base.jar is no longer required by the server launcher.

