### PR TITLE
Fixed the drag and drop issue on secretConfig modal

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/index.tsx
@@ -158,13 +158,13 @@ export class Table extends MithrilComponent<Attrs, State> {
       </thead>
       <tbody data-test-id="table-body">
       {
-        _.map(vnode.attrs.data, ((rows, index) => {
+        _.map(vnode.attrs.data, ((row, index) => {
           if (!vnode.attrs.draggable) {
             return (
               <tr key={index.toString()}
                   data-id={index}
                   data-test-id="table-row">
-                {_.map(rows, (row) => <td>{Table.renderedValue(row)}</td>)}
+                {_.map(row, (cell) => <td>{Table.renderedValue(cell)}</td>)}
               </tr>
             );
           }
@@ -183,12 +183,12 @@ export class Table extends MithrilComponent<Attrs, State> {
                 onmouseover={Table.disableEvent.bind(this)}>
                 <i class={styles.dragIcon}></i>
               </td>
-              {_.map(rows,
-                     ((row) => <td draggable={false}
-                                   ondragstart={Table.disableEvent.bind(this)}
-                                   ondragend={Table.disableEvent.bind(this)}
-                                   ondragover={Table.disableEvent.bind(this)}>
-                       {Table.renderedValue(row)}</td>))}
+              {_.map(row,
+                     ((cell) => <td draggable={false}
+                                    ondragstart={Table.disableEvent.bind(this)}
+                                    ondragend={Table.disableEvent.bind(this)}
+                                    ondragover={Table.disableEvent.bind(this)}>
+                       {Table.renderedValue(cell)}</td>))}
             </tr>
           );
         }))

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/modals.tsx
@@ -34,8 +34,8 @@ import {
   TextAreaField,
   TextField
 } from "views/components/forms/input_fields";
-import { Size } from "views/components/modal";
-import { EntityModal } from "views/components/modal/entity_modal";
+import {ModalState, Size} from "views/components/modal";
+import {EntityModal} from "views/components/modal/entity_modal";
 import styles from "views/pages/secret_configs/index.scss";
 import { RulesWidget } from "views/pages/secret_configs/rules_widget";
 
@@ -77,6 +77,9 @@ export abstract class SecretConfigModal extends EntityModal<SecretConfig> {
   }
 
   protected modalBody(): m.Children {
+    if (this.isLoading()) {
+       return;
+    }
     const pluginList = _.map(this.pluginInfos, (pluginInfo: PluginInfo) => {
       return { id: pluginInfo.id, text: pluginInfo.about.name };
     });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/rules_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/rules_widget.tsx
@@ -105,9 +105,10 @@ export class RulesWidget extends MithrilViewComponent<AutoCompleteAttrs> {
     </div>;
   }
 
-  private reArrange(rule: Stream<Rules>, oldIndex: number, newIndex: number) {
-    const splicedRule = rule().splice(oldIndex, 1);
-    rule().splice(newIndex, 0, splicedRule[0]);
+  private reArrange(rules: Stream<Rules>, oldIndex: number, newIndex: number) {
+    const originalRules = rules();
+    originalRules.splice(newIndex, 0, originalRules.splice(oldIndex, 1)[0]);
+    rules(originalRules);
     m.redraw();
   }
 }


### PR DESCRIPTION
The reordering of the rules on secretConfig Modal was not working because it was rendering a stale copy. Fixed it by rendering a spinner before the fetch completes.


