### PR TITLE
Optional upstream dependencies

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
@@ -53,7 +53,7 @@ public class GoConstants {
 
     public static final String PRODUCT_NAME = "go";
 
-    public static final int CONFIG_SCHEMA_VERSION = 128;
+    public static final int CONFIG_SCHEMA_VERSION = 129;
 
     public static final String APPROVAL_SUCCESS = "success";
     public static final String APPROVAL_MANUAL = "manual";

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/AbstractMaterialTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/AbstractMaterialTest.java
@@ -28,9 +28,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.sameInstance;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AbstractMaterialTest {
 
@@ -164,15 +162,15 @@ public class AbstractMaterialTest {
         TestMaterial testMaterial = new TestMaterial("foo");
 
         Map<String, Object> sqlCriteria = testMaterial.getSqlCriteria();
-        assertThat(testMaterial.getSqlCriteria(), sameInstance(sqlCriteria));
-        assertThat(testMaterial.getSqlCriteria().get("foo"), is("bar"));
-        assertThat(testMaterial.getSqlCriteria().getClass().getCanonicalName(), is("java.util.Collections.UnmodifiableMap"));
+        assertThat(testMaterial.getSqlCriteria()).isSameAs(sqlCriteria);
+        assertThat(testMaterial.getSqlCriteria().get("foo")).isEqualTo("bar");
+        assertThat(testMaterial.getSqlCriteria().getClass().getCanonicalName()).isEqualTo("java.util.Collections.UnmodifiableMap");
 
-        Map < String, Object > attributesForXml = testMaterial.getAttributesForXml();
-        assertThat(testMaterial.getAttributesForXml(), sameInstance(attributesForXml));
-        assertThat(testMaterial.getAttributesForXml().get("baz"), is("quux"));
+        Map<String, Object> attributesForXml = testMaterial.getAttributesForXml();
+        assertThat(testMaterial.getAttributesForXml()).isSameAs(attributesForXml);
+        assertThat(testMaterial.getAttributesForXml().get("baz")).isEqualTo("quux");
 
-        assertThat(testMaterial.getAttributesForXml().getClass().getCanonicalName(), is("java.util.Collections.UnmodifiableMap"));
+        assertThat(testMaterial.getAttributesForXml().getClass().getCanonicalName()).isEqualTo("java.util.Collections.UnmodifiableMap");
     }
 
     @Test
@@ -181,19 +179,25 @@ public class AbstractMaterialTest {
 
         String pipelineUniqueFingerprint = testMaterial.getPipelineUniqueFingerprint();
         int appendPipelineUniqueAttrsCallCount = TestMaterial.PIPELINE_UNIQUE_ATTRIBUTE_ADDED;
-        assertThat(testMaterial.getPipelineUniqueFingerprint(), sameInstance(pipelineUniqueFingerprint));
-        assertThat(appendPipelineUniqueAttrsCallCount, is(TestMaterial.PIPELINE_UNIQUE_ATTRIBUTE_ADDED));
+        assertThat(testMaterial.getPipelineUniqueFingerprint()).isSameAs(pipelineUniqueFingerprint);
+        assertThat(appendPipelineUniqueAttrsCallCount).isEqualTo(TestMaterial.PIPELINE_UNIQUE_ATTRIBUTE_ADDED);
     }
 
     @Test
     public void shouldReturnFullNameIfTheLengthIsLessThanGivenThreshold() throws Exception {
         AbstractMaterial material = new TestMaterial("foo_bar_baz_quuz_ban");
-        assertThat(material.getTruncatedDisplayName(), is("foo_bar_baz_quuz_ban"));
+        assertThat(material.getTruncatedDisplayName()).isEqualTo("foo_bar_baz_quuz_ban");
     }
 
     @Test
     public void shouldReturnTruncatedNameIfTheLengthIsGreaterThanGivenThreshold() throws Exception {
         AbstractMaterial material = new TestMaterial("foo_bar_baz_quuz_ban_pavan");
-        assertThat(material.getTruncatedDisplayName(), is("foo_bar_ba..._ban_pavan"));
+        assertThat(material.getTruncatedDisplayName()).isEqualTo("foo_bar_ba..._ban_pavan");
+    }
+
+    @Test
+    public void shouldNotIgnoreForSchedulingByDefault_sinceItOnlyAppliesToDependencyMaterial() {
+        AbstractMaterial material = new TestMaterial("salty_sumatran_rhinoceros");
+        assertThat(material.ignoreForScheduling()).isFalse();
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/dependency/DependencyMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/dependency/DependencyMaterialConfig.java
@@ -44,8 +44,8 @@ public class DependencyMaterialConfig extends AbstractMaterialConfig implements 
     @ConfigAttribute(value = "stageName")
     private CaseInsensitiveString stageName = new CaseInsensitiveString("Unknown");
 
-    @ConfigAttribute(value = "skipScheduling")
-    private boolean skipSchedulingOnChange = false;
+    @ConfigAttribute(value = "ignoreForScheduling")
+    private boolean ignoreForScheduling = false;
 
     private String pipelineStageName;
 
@@ -58,8 +58,8 @@ public class DependencyMaterialConfig extends AbstractMaterialConfig implements 
         this(null, pipelineName, stageName, false);
     }
 
-    public DependencyMaterialConfig(final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName, boolean skipSchedulingOnChange) {
-        this(null, pipelineName, stageName, skipSchedulingOnChange);
+    public DependencyMaterialConfig(final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName, boolean ignoreForScheduling) {
+        this(null, pipelineName, stageName, ignoreForScheduling);
     }
 
     public DependencyMaterialConfig(final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName, final String serverAlias) {
@@ -70,13 +70,13 @@ public class DependencyMaterialConfig extends AbstractMaterialConfig implements 
         this(name, pipelineName, stageName, false);
     }
 
-    public DependencyMaterialConfig(final CaseInsensitiveString name, final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName, final boolean skipSchedulingOnChange) {
+    public DependencyMaterialConfig(final CaseInsensitiveString name, final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName, final boolean ignoreForScheduling) {
         super(TYPE, name, new ConfigErrors());
         bombIfNull(pipelineName, "null pipelineName");
         bombIfNull(stageName, "null stageName");
         this.pipelineName = pipelineName;
         this.stageName = stageName;
-        this.skipSchedulingOnChange = skipSchedulingOnChange;
+        this.ignoreForScheduling = ignoreForScheduling;
     }
 
     @Override
@@ -154,12 +154,12 @@ public class DependencyMaterialConfig extends AbstractMaterialConfig implements 
         this.stageName = stageName;
     }
 
-    public boolean skipSchedulingOnChange() {
-        return skipSchedulingOnChange;
+    public boolean ignoreForScheduling() {
+        return ignoreForScheduling;
     }
 
-    public void skipSchedulingOnChange(boolean skipSchedulingOnChange) {
-        this.skipSchedulingOnChange = skipSchedulingOnChange;
+    public void ignoreForScheduling(boolean ignoreForScheduling) {
+        this.ignoreForScheduling = ignoreForScheduling;
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/dependency/DependencyMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/dependency/DependencyMaterialConfig.java
@@ -44,6 +44,9 @@ public class DependencyMaterialConfig extends AbstractMaterialConfig implements 
     @ConfigAttribute(value = "stageName")
     private CaseInsensitiveString stageName = new CaseInsensitiveString("Unknown");
 
+    @ConfigAttribute(value = "skipScheduling")
+    private boolean skipSchedulingOnChange = false;
+
     private String pipelineStageName;
 
 
@@ -52,19 +55,28 @@ public class DependencyMaterialConfig extends AbstractMaterialConfig implements 
     }
 
     public DependencyMaterialConfig(final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName) {
-        this(null, pipelineName, stageName);
+        this(null, pipelineName, stageName, false);
+    }
+
+    public DependencyMaterialConfig(final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName, boolean skipSchedulingOnChange) {
+        this(null, pipelineName, stageName, skipSchedulingOnChange);
     }
 
     public DependencyMaterialConfig(final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName, final String serverAlias) {
-        this(null, pipelineName, stageName);
+        this(null, pipelineName, stageName, false);
     }
 
     public DependencyMaterialConfig(final CaseInsensitiveString name, final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName) {
+        this(name, pipelineName, stageName, false);
+    }
+
+    public DependencyMaterialConfig(final CaseInsensitiveString name, final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName, final boolean skipSchedulingOnChange) {
         super(TYPE, name, new ConfigErrors());
         bombIfNull(pipelineName, "null pipelineName");
         bombIfNull(stageName, "null stageName");
         this.pipelineName = pipelineName;
         this.stageName = stageName;
+        this.skipSchedulingOnChange = skipSchedulingOnChange;
     }
 
     @Override
@@ -140,6 +152,14 @@ public class DependencyMaterialConfig extends AbstractMaterialConfig implements 
 
     public void setStageName(CaseInsensitiveString stageName) {
         this.stageName = stageName;
+    }
+
+    public boolean skipSchedulingOnChange() {
+        return skipSchedulingOnChange;
+    }
+
+    public void skipSchedulingOnChange(boolean skipSchedulingOnChange) {
+        this.skipSchedulingOnChange = skipSchedulingOnChange;
     }
 
     @Override

--- a/config/config-server/src/main/resources/cruise-config.xsd
+++ b/config/config-server/src/main/resources/cruise-config.xsd
@@ -528,7 +528,7 @@
     <xsd:attribute name="pipelineName" type="xsd:string" use="required"/>
     <xsd:attribute name="stageName" type="xsd:string" use="required"/>
     <xsd:attribute name="materialName" type="nameType" use="optional"/>
-    <xsd:attribute type="xsd:boolean" name="skipScheduling"/>
+    <xsd:attribute type="xsd:boolean" name="ignoreForScheduling"/>
   </xsd:complexType>
   <xsd:complexType name="svnType">
     <xsd:sequence>

--- a/config/config-server/src/main/resources/schemas/128_cruise-config.xsd
+++ b/config/config-server/src/main/resources/schemas/128_cruise-config.xsd
@@ -84,7 +84,7 @@
           </xsd:unique>
         </xsd:element>
       </xsd:sequence>
-      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="129"/>
+      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="128"/>
     </xsd:complexType>
     <xsd:unique name="uniquePipelines">
       <xsd:selector xpath="pipelines"/>
@@ -528,7 +528,6 @@
     <xsd:attribute name="pipelineName" type="xsd:string" use="required"/>
     <xsd:attribute name="stageName" type="xsd:string" use="required"/>
     <xsd:attribute name="materialName" type="nameType" use="optional"/>
-    <xsd:attribute type="xsd:boolean" name="skipScheduling"/>
   </xsd:complexType>
   <xsd:complexType name="svnType">
     <xsd:sequence>

--- a/config/config-server/src/main/resources/upgrades/129.xsl
+++ b/config/config-server/src/main/resources/upgrades/129.xsl
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2019 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:template match="/cruise/@schemaVersion">
+        <xsl:attribute name="schemaVersion">129</xsl:attribute>
+    </xsl:template>
+    <!-- Copy everything -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/AbstractMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/AbstractMaterial.java
@@ -231,7 +231,8 @@ public abstract class AbstractMaterial extends PersistentObject implements Mater
     }
 
     @Override
-    public boolean skipSchedulingOnChange() {
+    public boolean ignoreForScheduling() {
+        //overridden in DependencyMaterial. Other materials don't support this flag
         return false;
     }
 }

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/AbstractMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/AbstractMaterial.java
@@ -229,4 +229,9 @@ public abstract class AbstractMaterial extends PersistentObject implements Mater
     @Override
     public void populateAgentSideEnvironmentContext(EnvironmentVariableContext context, File workingDir) {
     }
+
+    @Override
+    public boolean skipSchedulingOnChange() {
+        return false;
+    }
 }

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/dependency/DependencyMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/dependency/DependencyMaterial.java
@@ -45,6 +45,7 @@ public class DependencyMaterial extends AbstractMaterial {
 
     private CaseInsensitiveString pipelineName = new CaseInsensitiveString("Unknown");
     private CaseInsensitiveString stageName = new CaseInsensitiveString("Unknown");
+    private boolean skipSchedulingOnChange = false;
 
     public DependencyMaterial() {
         super("DependencyMaterial");
@@ -67,17 +68,22 @@ public class DependencyMaterial extends AbstractMaterial {
         this.name = name;
     }
 
+    public DependencyMaterial(final CaseInsensitiveString name, final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName, boolean skipSchedulingOnChange) {
+        this(name, pipelineName, stageName);
+        this.skipSchedulingOnChange = skipSchedulingOnChange;
+    }
+
     public DependencyMaterial(final CaseInsensitiveString name, final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName, String serverAlias) {
         this(name, pipelineName, stageName);
     }
 
     public DependencyMaterial(DependencyMaterialConfig config) {
-        this(config.getName(), config.getPipelineName(), config.getStageName());
+        this(config.getName(), config.getPipelineName(), config.getStageName(), config.skipSchedulingOnChange());
     }
 
     @Override
     public MaterialConfig config() {
-        return new DependencyMaterialConfig(name, pipelineName, stageName);
+        return new DependencyMaterialConfig(name, pipelineName, stageName, skipSchedulingOnChange);
     }
 
     @Override
@@ -205,6 +211,10 @@ public class DependencyMaterial extends AbstractMaterial {
     @Override
     public String getFolder() {
         return null;
+    }
+
+    public boolean skipSchedulingOnChange() {
+        return skipSchedulingOnChange;
     }
 
     @Override

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/dependency/DependencyMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/dependency/DependencyMaterial.java
@@ -45,7 +45,7 @@ public class DependencyMaterial extends AbstractMaterial {
 
     private CaseInsensitiveString pipelineName = new CaseInsensitiveString("Unknown");
     private CaseInsensitiveString stageName = new CaseInsensitiveString("Unknown");
-    private boolean skipSchedulingOnChange = false;
+    private boolean ignoreForScheduling = false;
 
     public DependencyMaterial() {
         super("DependencyMaterial");
@@ -68,9 +68,9 @@ public class DependencyMaterial extends AbstractMaterial {
         this.name = name;
     }
 
-    public DependencyMaterial(final CaseInsensitiveString name, final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName, boolean skipSchedulingOnChange) {
+    public DependencyMaterial(final CaseInsensitiveString name, final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName, boolean ignoreForScheduling) {
         this(name, pipelineName, stageName);
-        this.skipSchedulingOnChange = skipSchedulingOnChange;
+        this.ignoreForScheduling = ignoreForScheduling;
     }
 
     public DependencyMaterial(final CaseInsensitiveString name, final CaseInsensitiveString pipelineName, final CaseInsensitiveString stageName, String serverAlias) {
@@ -78,12 +78,12 @@ public class DependencyMaterial extends AbstractMaterial {
     }
 
     public DependencyMaterial(DependencyMaterialConfig config) {
-        this(config.getName(), config.getPipelineName(), config.getStageName(), config.skipSchedulingOnChange());
+        this(config.getName(), config.getPipelineName(), config.getStageName(), config.ignoreForScheduling());
     }
 
     @Override
     public MaterialConfig config() {
-        return new DependencyMaterialConfig(name, pipelineName, stageName, skipSchedulingOnChange);
+        return new DependencyMaterialConfig(name, pipelineName, stageName, ignoreForScheduling);
     }
 
     @Override
@@ -213,8 +213,8 @@ public class DependencyMaterial extends AbstractMaterial {
         return null;
     }
 
-    public boolean skipSchedulingOnChange() {
-        return skipSchedulingOnChange;
+    public boolean ignoreForScheduling() {
+        return ignoreForScheduling;
     }
 
     @Override

--- a/domain/src/main/java/com/thoughtworks/go/domain/MaterialRevision.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/MaterialRevision.java
@@ -324,7 +324,7 @@ public class MaterialRevision implements Serializable {
         return cardNumbers;
     }
 
-    public boolean isSetToSkipScheduling() {
-        return material.skipSchedulingOnChange();
+    public boolean shouldIgnoreForScheduling() {
+        return material.ignoreForScheduling();
     }
 }

--- a/domain/src/main/java/com/thoughtworks/go/domain/MaterialRevision.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/MaterialRevision.java
@@ -323,4 +323,8 @@ public class MaterialRevision implements Serializable {
         }
         return cardNumbers;
     }
+
+    public boolean isSetToSkipScheduling() {
+        return material.skipSchedulingOnChange();
+    }
 }

--- a/domain/src/main/java/com/thoughtworks/go/domain/MaterialRevisions.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/MaterialRevisions.java
@@ -361,12 +361,6 @@ public class MaterialRevisions implements Serializable, Iterable<MaterialRevisio
 
     }
 
-    public void updateRevisionChangedStatus(MaterialRevisions original) {
-        for (MaterialRevision materialRevision : this) {
-            materialRevision.updateRevisionChangedStatus(original.findRevisionFor(materialRevision.getMaterial()));
-        }
-    }
-
     public boolean hasDependencyMaterials() {
         for (MaterialRevision materialRevision : this) {
             if (materialRevision.getMaterial() instanceof DependencyMaterial) {

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/Material.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/Material.java
@@ -111,4 +111,6 @@ public interface Material extends Serializable {
     // Material implementations can safely assume correct MaterialConfig subtype is passed in. E.g For a SVNMaterial
     // materialConfig will be SVNMaterialConfig
     void updateFromConfig(MaterialConfig materialConfig);
+
+    boolean skipSchedulingOnChange();
 }

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/Material.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/Material.java
@@ -112,5 +112,5 @@ public interface Material extends Serializable {
     // materialConfig will be SVNMaterialConfig
     void updateFromConfig(MaterialConfig materialConfig);
 
-    boolean skipSchedulingOnChange();
+    boolean ignoreForScheduling();
 }

--- a/server/config/cruise-config.xml
+++ b/server/config/cruise-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="128">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="129">
   <server artifactsdir="artifacts" agentAutoRegisterKey="323040d4-f2e4-4b8a-8394-7a2d122054d1" webhookSecret="3d5cd2f5-7fe7-43c0-ba34-7e01678ba8b6" commandRepositoryLocation="default" serverId="60f5f682-5248-4ba9-bb35-72c92841bd75" tokenGenerationKey="8c3c8dc9-08bf-4cd7-ac80-cecb3e7ae86c">
     <siteUrls />
     <security>

--- a/server/src/main/java/com/thoughtworks/go/server/service/AutoBuild.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AutoBuild.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.server.service;
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
 import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.MaterialRevisions;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
@@ -87,7 +88,7 @@ public class AutoBuild implements BuildType {
     @Override
     public boolean isValidBuildCause(PipelineConfig pipelineConfig, BuildCause buildCause) {
         for (MaterialRevision materialRevision : buildCause.getMaterialRevisions()) {
-            if (materialRevision.isChanged()) {
+            if (materialRevision.isChanged() && !materialRevision.isSetToSkipScheduling()) {
                 return true;
             }
         }

--- a/server/src/main/java/com/thoughtworks/go/server/service/AutoBuild.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AutoBuild.java
@@ -18,7 +18,6 @@ package com.thoughtworks.go.server.service;
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.PipelineConfig;
-import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
 import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.MaterialRevisions;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
@@ -88,7 +87,7 @@ public class AutoBuild implements BuildType {
     @Override
     public boolean isValidBuildCause(PipelineConfig pipelineConfig, BuildCause buildCause) {
         for (MaterialRevision materialRevision : buildCause.getMaterialRevisions()) {
-            if (materialRevision.isChanged() && !materialRevision.isSetToSkipScheduling()) {
+            if (materialRevision.isChanged() && !materialRevision.shouldIgnoreForScheduling()) {
                 return true;
             }
         }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/AutoBuildCauseTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/AutoBuildCauseTest.java
@@ -351,9 +351,9 @@ public class AutoBuildCauseTest {
     }
 
     @Test
-    public void isValidBuildCause_shouldReturnFalseIfDependencyMaterialIsSetToSkipScheduling() {
+    public void isValidBuildCause_shouldReturnFalseIfDependencyMaterialIsSetToIgnoreForScheduling() {
         DependencyMaterialConfig dependencyMaterialConfig = new DependencyMaterialConfig(str("upstream-pipeline"), str("stage1"));
-        dependencyMaterialConfig.skipSchedulingOnChange(true);
+        dependencyMaterialConfig.ignoreForScheduling(true);
         PipelineConfig pipelineToBeScheduled = GoConfigMother.createPipelineConfigWithMaterialConfig("my-pipeline",
                 dependencyMaterialConfig);
 
@@ -369,7 +369,7 @@ public class AutoBuildCauseTest {
     }
 
     @Test
-    public void isValidBuildCause_shouldReturnTrueIfDependencyMaterialIsNotSetToSkipScheduling() {
+    public void isValidBuildCause_shouldReturnTrueIfDependencyMaterialIsNotSetToIgnoreForScheduling() {
         DependencyMaterialConfig dependencyMaterialConfig = new DependencyMaterialConfig(str("upstream-pipeline"), str("stage1"));
         PipelineConfig pipelineToBeScheduled = GoConfigMother.createPipelineConfigWithMaterialConfig("my-pipeline",
                 dependencyMaterialConfig);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/AutoBuildCauseTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/AutoBuildCauseTest.java
@@ -18,19 +18,18 @@ package com.thoughtworks.go.server.service;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.IgnoredFiles;
+import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterial;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig;
+import static com.thoughtworks.go.domain.config.CaseInsensitiveStringMother.str;
 import com.thoughtworks.go.config.materials.svn.SvnMaterial;
 import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.MaterialRevisions;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.domain.materials.Modification;
-import com.thoughtworks.go.helper.GoConfigMother;
-import com.thoughtworks.go.helper.MaterialConfigsMother;
-import com.thoughtworks.go.helper.MaterialsMother;
-import com.thoughtworks.go.helper.PipelineConfigMother;
+import com.thoughtworks.go.helper.*;
 import com.thoughtworks.go.server.domain.PipelineConfigDependencyGraph;
 import com.thoughtworks.go.server.materials.MaterialChecker;
 import com.thoughtworks.go.util.GoConstants;
@@ -43,8 +42,7 @@ import org.mockito.Mock;
 import java.util.Date;
 
 import static com.thoughtworks.go.helper.ModificationsMother.*;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.*;
@@ -91,7 +89,7 @@ public class AutoBuildCauseTest {
 
         BuildCause buildCause = new AutoBuild(goConfigService, pipelineService, "foo", new SystemEnvironment(), materialChecker).onModifications(materialRevisions, false,
                 null);
-        assertThat(buildCause.getApprover(), is(GoConstants.DEFAULT_APPROVED_BY));
+        assertThat(buildCause.getApprover()).isEqualTo(GoConstants.DEFAULT_APPROVED_BY);
     }
 
     @Test
@@ -109,7 +107,7 @@ public class AutoBuildCauseTest {
         AutoBuild autoBuild = new AutoBuild(goConfigService, pipelineService, "current", systemEnvironment, materialChecker);
 
         BuildCause current = autoBuild.onModifications(revisions, false, null);
-        assertThat(current, is(nullValue()));
+        assertThat(current).isNull();
     }
 
     @Test
@@ -132,7 +130,7 @@ public class AutoBuildCauseTest {
         AutoBuild build = new AutoBuild(goConfigService, pipelineService, "downstream", systemEnvironment, materialChecker);
 
         BuildCause cause = build.onModifications(revisions, false, null);
-        assertThat(cause, is(nullValue()));
+        assertThat(cause).isNull();
     }
 
     @Test
@@ -156,7 +154,9 @@ public class AutoBuildCauseTest {
         when(goConfigService.upstreamDependencyGraphOf(targetPipeline, cruiseConfig)).thenReturn(dependencyGraph);
         when(pipelineService.getRevisionsBasedOnDependencies(eq(revisions), eq(cruiseConfig), eq(dependencyGraph.getCurrent().name()))).thenReturn(expectedRevisions);
 
-        assertThat(new AutoBuild(goConfigService, pipelineService, targetPipeline, new SystemEnvironment(), materialChecker).onModifications(revisions, false, null).getMaterialRevisions(), is(expectedRevisions));
+        assertThat(new AutoBuild(goConfigService, pipelineService, targetPipeline, new SystemEnvironment(), materialChecker)
+                .onModifications(revisions, false, null).getMaterialRevisions())
+                .isEqualTo(expectedRevisions);
     }
 
     @Test
@@ -181,7 +181,10 @@ public class AutoBuildCauseTest {
         when(goConfigService.upstreamDependencyGraphOf(targetPipeline, cruiseConfig)).thenReturn(dependencyGraph);
         when(pipelineService.getRevisionsBasedOnDependencies(eq(revisions), eq(cruiseConfig), eq(dependencyGraph.getCurrent().name()))).thenReturn(expectedRevisions);
 
-        assertThat(new AutoBuild(goConfigService, pipelineService, targetPipeline, new SystemEnvironment(), materialChecker).onModifications(revisions, false, null).getMaterialRevisions(), is(expectedRevisions));
+        assertThat(new AutoBuild(goConfigService, pipelineService, targetPipeline, new SystemEnvironment(), materialChecker)
+                .onModifications(revisions, false, null)
+                .getMaterialRevisions())
+                .isEqualTo(expectedRevisions);
     }
 
     @Test
@@ -208,7 +211,7 @@ public class AutoBuildCauseTest {
         when(systemEnvironment.enforceRevisionCompatibilityWithUpstream()).thenReturn(false);
         AutoBuild build = new AutoBuild(goConfigService, pipelineService, "third", systemEnvironment, materialChecker);
         BuildCause cause = build.onModifications(revisions, false, null);
-        assertThat(cause, is(nullValue()));
+        assertThat(cause).isNull();
     }
 
     @Test
@@ -236,8 +239,10 @@ public class AutoBuildCauseTest {
 
         when(pipelineService.getRevisionsBasedOnDependencies(eq(revisions), eq(cruiseConfig), eq(dependencyGraph.getCurrent().name()))).thenReturn(expectedRevisions);
 
-        assertThat(new AutoBuild(goConfigService, pipelineService, "third", new SystemEnvironment(), materialChecker).onModifications(revisions, false, null).getMaterialRevisions(),
-                sameInstance(expectedRevisions));
+        assertThat(new AutoBuild(goConfigService, pipelineService, "third", new SystemEnvironment(), materialChecker)
+                        .onModifications(revisions, false, null)
+                        .getMaterialRevisions())
+                .isSameAs(expectedRevisions);
     }
 
     @Test
@@ -260,7 +265,7 @@ public class AutoBuildCauseTest {
         BuildCause buildCause = new AutoBuild(goConfigService, pipelineService, targetPipeline, new SystemEnvironment(), materialChecker).onModifications(revisions, false, null);
 
         MaterialRevision expected = expectedRevisions.getMaterialRevision(0);
-        assertThat(buildCause.getMaterialRevisions().getMaterialRevision(0), is(expected));
+        assertThat(buildCause.getMaterialRevisions().getMaterialRevision(0)).isEqualTo(expected);
     }
 
     @Test
@@ -290,13 +295,13 @@ public class AutoBuildCauseTest {
         BuildCause buildCause = new AutoBuild(goConfigService, pipelineService, targetPipeline, new SystemEnvironment(), materialChecker).onModifications(revisions, false, null);
         MaterialRevisions finalRevisions = buildCause.getMaterialRevisions();
 
-        assertThat(finalRevisions.numberOfRevisions(), is(expectedRevisions.numberOfRevisions()));
+        assertThat(finalRevisions.numberOfRevisions()).isEqualTo(expectedRevisions.numberOfRevisions());
 
         for (int i = 0; i < expectedRevisions.numberOfRevisions(); i++) {
             MaterialRevision finalRev = finalRevisions.getMaterialRevision(i);
             MaterialRevision expectedRev = expectedRevisions.getMaterialRevision(i);
-            assertThat(finalRev, is(expectedRev));
-            assertThat(finalRev.isChanged(), is(expectedRev.isChanged()));
+            assertThat(finalRev).isEqualTo(expectedRev);
+            assertThat(finalRev.isChanged()).isEqualTo(expectedRev.isChanged());
         }
     }
 
@@ -319,7 +324,7 @@ public class AutoBuildCauseTest {
             new AutoBuild(goConfigService, pipelineService, targetPipeline, systemEnvironment, materialChecker).onModifications(revisions, false, null);
             fail("should have thrown exception");
         } catch (NoCompatibleUpstreamRevisionsException e) {
-            assertThat(e, is(expectedException));
+            assertThat(e).isEqualTo(expectedException);
         }
     }
 
@@ -341,8 +346,43 @@ public class AutoBuildCauseTest {
             new AutoBuild(goConfigService, pipelineService, targetPipeline, systemEnvironment, materialChecker).onModifications(revisions, false, null);
             fail("should have thrown exception");
         } catch (RuntimeException e) {
-            assertThat(e, is(expectedException));
+            assertThat(e).isEqualTo(expectedException);
         }
+    }
+
+    @Test
+    public void isValidBuildCause_shouldReturnFalseIfDependencyMaterialIsSetToSkipScheduling() {
+        DependencyMaterialConfig dependencyMaterialConfig = new DependencyMaterialConfig(str("upstream-pipeline"), str("stage1"));
+        dependencyMaterialConfig.skipSchedulingOnChange(true);
+        PipelineConfig pipelineToBeScheduled = GoConfigMother.createPipelineConfigWithMaterialConfig("my-pipeline",
+                dependencyMaterialConfig);
+
+        MaterialRevision materialRevision = ModificationsMother.dependencyMaterialRevision(2, "2", 1,
+                new DependencyMaterial(dependencyMaterialConfig), new Date());
+        materialRevision.markAsChanged();
+        MaterialRevisions materialRevisions = new MaterialRevisions(materialRevision);
+
+        AutoBuild autoBuild = new AutoBuild(goConfigService, pipelineService, "my-pipeline", systemEnvironment, materialChecker);
+        boolean isValidBuildCause = autoBuild.isValidBuildCause(pipelineToBeScheduled, BuildCause.createWithModifications(materialRevisions, "changes"));
+
+        assertThat(isValidBuildCause).isFalse();
+    }
+
+    @Test
+    public void isValidBuildCause_shouldReturnTrueIfDependencyMaterialIsNotSetToSkipScheduling() {
+        DependencyMaterialConfig dependencyMaterialConfig = new DependencyMaterialConfig(str("upstream-pipeline"), str("stage1"));
+        PipelineConfig pipelineToBeScheduled = GoConfigMother.createPipelineConfigWithMaterialConfig("my-pipeline",
+                dependencyMaterialConfig);
+
+        MaterialRevision materialRevision = ModificationsMother.dependencyMaterialRevision(2, "2", 1,
+                new DependencyMaterial(dependencyMaterialConfig), new Date());
+        materialRevision.markAsChanged();
+        MaterialRevisions materialRevisions = new MaterialRevisions(materialRevision);
+
+        AutoBuild autoBuild = new AutoBuild(goConfigService, pipelineService, "my-pipeline", systemEnvironment, materialChecker);
+        boolean isValidBuildCause = autoBuild.isValidBuildCause(pipelineToBeScheduled, BuildCause.createWithModifications(materialRevisions, "changes"));
+
+        assertThat(isValidBuildCause).isTrue();
     }
 
     private PipelineConfigDependencyGraph dependencyGraphOfDepthOne(MaterialConfig sharedMaterial, MaterialConfig firstOrderMaterial) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceDependencyIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceDependencyIntegrationTest.java
@@ -1,0 +1,410 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.GoConfigDao;
+import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.config.materials.Filter;
+import com.thoughtworks.go.config.materials.IgnoredFiles;
+import com.thoughtworks.go.config.materials.MaterialConfigs;
+import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
+import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
+import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
+import com.thoughtworks.go.config.materials.git.GitMaterial;
+import com.thoughtworks.go.config.materials.svn.SvnMaterial;
+import com.thoughtworks.go.domain.MaterialRevision;
+import com.thoughtworks.go.domain.MaterialRevisions;
+import com.thoughtworks.go.domain.Pipeline;
+import com.thoughtworks.go.domain.buildcause.BuildCause;
+import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.domain.materials.git.GitTestRepo;
+import com.thoughtworks.go.domain.materials.svn.Subversion;
+import com.thoughtworks.go.domain.materials.svn.SvnCommand;
+import com.thoughtworks.go.helper.PipelineMother;
+import com.thoughtworks.go.helper.SvnTestRepo;
+import com.thoughtworks.go.helper.TestRepo;
+import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
+import com.thoughtworks.go.server.dao.PipelineDao;
+import com.thoughtworks.go.server.domain.PipelineTimeline;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.materials.DependencyMaterialUpdateNotifier;
+import com.thoughtworks.go.server.materials.MaterialDatabaseUpdater;
+import com.thoughtworks.go.server.persistence.MaterialRepository;
+import com.thoughtworks.go.server.scheduling.ScheduleHelper;
+import com.thoughtworks.go.server.service.result.HttpOperationResult;
+import com.thoughtworks.go.server.transaction.TransactionTemplate;
+import com.thoughtworks.go.util.GoConfigFileHelper;
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+        "classpath:WEB-INF/applicationContext-global.xml",
+        "classpath:WEB-INF/applicationContext-dataLocalAccess.xml",
+        "classpath:testPropertyConfigurer.xml",
+        "classpath:WEB-INF/spring-all-servlet.xml",
+})
+public class BuildCauseProducerServiceDependencyIntegrationTest {
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String STAGE_NAME = "dev";
+
+    @Autowired
+    private GoConfigDao goConfigDao;
+    @Autowired
+    private GoConfigService goConfigService;
+    @Autowired
+    private PipelineDao pipelineDao;
+    @Autowired
+    private PipelineScheduleQueue pipelineScheduleQueue;
+    @Autowired
+    private ScheduleHelper scheduleHelper;
+    @Autowired
+    private DatabaseAccessHelper dbHelper;
+    @Autowired
+    private MaterialDatabaseUpdater materialDatabaseUpdater;
+    @Autowired
+    private MaterialRepository materialRepository;
+    @Autowired
+    private SubprocessExecutionContext subprocessExecutionContext;
+    @Autowired
+    private PipelineTimeline pipelineTimeline;
+    @Autowired
+    private DependencyMaterialUpdateNotifier dependencyMaterialUpdateNotifier;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private static GoConfigFileHelper configHelper = new GoConfigFileHelper();
+    public Subversion repository;
+    public GitTestRepo gitTestRepo;
+    public static SvnTestRepo svnRepository;
+
+    private MinglePipeline minglePipeline;
+    private GoPipeline goPipeline;
+
+    private static final String MINGLE_PIPELINE_NAME = "mingle";
+    private static final String GO_PIPELINE_NAME = "go";
+    private MaterialRevisions svnMaterialRevs;
+    private HttpOperationResult result;
+    private SvnMaterial svnMaterial;
+    private GitMaterial gitMaterial;
+
+    //contains stuff related to the "Mingle" pipeline
+    class MinglePipeline {
+        PipelineConfig config;
+        Pipeline latest;
+
+        void setup(BuildCause buildCause) throws Exception {
+            config = configHelper.addPipeline(MINGLE_PIPELINE_NAME, STAGE_NAME, repository, new Filter(new IgnoredFiles("**/*.doc")), "unit", "functional");
+            latest = PipelineMother.schedule(this.config, buildCause);
+            latest = pipelineDao.saveWithStages(latest);
+            dbHelper.passStage(latest.getStages().first());
+            pipelineScheduleQueue.clear();
+        }
+
+        MaterialRevisions runAndPassWith(MaterialRevisions newRevs) throws Exception {
+            return runAndPassWith(newRevs, null);
+        }
+
+        MaterialRevisions runAndPassWith(MaterialRevisions newRevs, MaterialRevisions revsAfterFoo) throws Exception {
+            if (revsAfterFoo != null) {
+                for (MaterialRevision newRev : newRevs) {
+                    newRev.addModifications(revsAfterFoo.getModifications(newRev.getMaterial()));
+                }
+            }
+            runAndPass(newRevs);
+            return newRevs;
+        }
+
+        void runAndPass(MaterialRevisions mingleRev) {
+            BuildCause buildCause = BuildCause.createWithModifications(mingleRev, "boozer");
+            latest = PipelineMother.schedule(config, buildCause);
+            latest = pipelineDao.saveWithStages(latest);
+            dbHelper.passStage(latest.getStages().first());
+        }
+    }
+
+    //contains stuff related to the "Go" pipeline
+    class GoPipeline {
+        PipelineConfig config;
+        Pipeline latest;
+
+        void setup(BuildCause buildCause) throws Exception {
+            config = configHelper.addPipeline(GO_PIPELINE_NAME, STAGE_NAME, repository, "unit");
+            latest = PipelineMother.schedule(this.config, buildCause);
+            latest = pipelineDao.saveWithStages(latest);
+            dbHelper.passStage(latest.getStages().first());
+            pipelineScheduleQueue.clear();
+        }
+
+        MaterialRevisions runAndPassWith(MaterialRevisions newRevs) throws Exception {
+            return runAndPassWith(newRevs, null);
+        }
+
+        MaterialRevisions runAndPassWith(MaterialRevisions newRevs, MaterialRevisions revsAfterFoo) throws Exception {
+            if (revsAfterFoo != null) {
+                for (MaterialRevision newRev : newRevs) {
+                    newRev.addModifications(revsAfterFoo.getModifications(newRev.getMaterial()));
+                }
+            }
+            runAndPass(newRevs);
+            return newRevs;
+        }
+
+        void runAndPass(MaterialRevisions rev) {
+            BuildCause buildCause = BuildCause.createWithModifications(rev, "boozer");
+            latest = PipelineMother.schedule(config, buildCause);
+            latest = pipelineDao.saveWithStages(latest);
+            dbHelper.passStage(latest.getStages().first());
+        }
+    }
+
+    @Before
+    public void setup() throws Exception {
+        dbHelper.onSetUp();
+        configHelper.onSetUp();
+        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        dependencyMaterialUpdateNotifier.disableUpdates();
+
+        minglePipeline = new MinglePipeline();
+        goPipeline = new GoPipeline();
+
+        svnRepository = new SvnTestRepo(temporaryFolder);
+        repository = new SvnCommand(null, svnRepository.projectRepositoryUrl());
+
+        svnMaterialRevs = new MaterialRevisions();
+        svnMaterial = SvnMaterial.createSvnMaterialWithMock(repository);
+        svnMaterialRevs.addRevision(svnMaterial, svnMaterial.latestModification(null, new ServerSubprocessExecutionContext(goConfigService, new SystemEnvironment())));
+
+        final MaterialRevisions materialRevisions = new MaterialRevisions();
+        SvnMaterial anotherSvnMaterial = SvnMaterial.createSvnMaterialWithMock(repository);
+        materialRevisions.addRevision(anotherSvnMaterial, anotherSvnMaterial.latestModification(null, subprocessExecutionContext));
+
+        gitTestRepo = new GitTestRepo(temporaryFolder);
+        MaterialRevisions gitMaterialRevs = new MaterialRevisions();
+        gitMaterial = gitTestRepo.createMaterial();
+        gitMaterialRevs.addRevision(gitMaterial, gitTestRepo.latestModifications());
+
+        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
+                materialRepository.save(svnMaterialRevs);
+                materialRepository.save(gitMaterialRevs);
+            }
+        });
+
+        BuildCause buildCause = BuildCause.createWithModifications(svnMaterialRevs, "");
+
+        minglePipeline.setup(buildCause);
+        goPipeline.setup(buildCause);
+        result = new HttpOperationResult();
+    }
+
+    @After
+    public void teardown() throws Exception {
+        TestRepo.internalTearDown();
+        dbHelper.onTearDown();
+        pipelineScheduleQueue.clear();
+        configHelper.onTearDown();
+        dependencyMaterialUpdateNotifier.enableUpdates();
+    }
+
+    @Test
+    public void shouldNotScheduleDownstreamPipeline_whenSkipSchedulingIsTrue() throws Exception {
+        //set up a pipeline downstream to "mingle", run and save once instance of the pipelines.
+        String mingleDownstreamPipelineName = "down_of_mingle";
+        DependencyMaterialConfig mingleMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString(MINGLE_PIPELINE_NAME), new CaseInsensitiveString(STAGE_NAME));
+        mingleMaterialConfig.skipSchedulingOnChange(true);
+
+        PipelineConfig downstreamPipelineConfig = configHelper.addPipeline(mingleDownstreamPipelineName, STAGE_NAME, new MaterialConfigs(mingleMaterialConfig), "unit");
+
+        Pipeline latestMinglePipeline = minglePipeline.latest;
+        String revision = String.format("%s/%s/%s/%s", latestMinglePipeline.getName(), latestMinglePipeline.getCounter(), STAGE_NAME, latestMinglePipeline.getStages().last().getCounter());
+        MaterialRevision dependencyMaterialRevision = new MaterialRevision(new DependencyMaterial(mingleMaterialConfig), true, new Modification(latestMinglePipeline.getModifiedDate(), revision, latestMinglePipeline.getLabel(), latestMinglePipeline.getId()));
+        MaterialRevisions dependencyMaterialRevisions = new MaterialRevisions(dependencyMaterialRevision);
+        dbHelper.saveRevs(dependencyMaterialRevisions);
+
+        Pipeline latestDownstreamInstance = PipelineMother.schedule(downstreamPipelineConfig, BuildCause.createManualForced(dependencyMaterialRevisions, new Username(new CaseInsensitiveString("loser"))));
+        latestDownstreamInstance = pipelineDao.saveWithStages(latestDownstreamInstance);
+        dbHelper.passStage(latestDownstreamInstance.getStages().first());
+
+        //trigger pipeline
+        MaterialRevisions newRevs = checkinFile(svnMaterial, "bar.c", svnRepository);
+        minglePipeline.runAndPassWith(newRevs);
+        pipelineTimeline.update();
+        scheduleHelper.autoSchedulePipelinesWithRealMaterials(mingleDownstreamPipelineName);
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet()).doesNotContain(new CaseInsensitiveString(mingleDownstreamPipelineName));
+    }
+
+    @Test
+    public void shouldNotScheduleDownStreamPipeline_withTwoUpstreamMaterials_bothSkippedForScheduling() throws Exception {
+        String downstreamPipelineName = "downstream_pipeline";
+        //first upstream pipeline - "mingle"
+        DependencyMaterialConfig mingleMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString(MINGLE_PIPELINE_NAME), new CaseInsensitiveString(STAGE_NAME));
+        mingleMaterialConfig.skipSchedulingOnChange(true);
+
+        //second upstream pipeline - "go"
+        DependencyMaterialConfig goMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString(GO_PIPELINE_NAME), new CaseInsensitiveString(STAGE_NAME));
+        goMaterialConfig.skipSchedulingOnChange(true);
+
+        PipelineConfig downstreamPipelineConfig = configHelper.addPipeline(downstreamPipelineName, STAGE_NAME, new MaterialConfigs(mingleMaterialConfig, goMaterialConfig), "unit");
+
+        Pipeline latestMinglePipeline = minglePipeline.latest;
+        String revision = String.format("%s/%s/%s/%s", latestMinglePipeline.getName(), latestMinglePipeline.getCounter(), STAGE_NAME, latestMinglePipeline.getStages().last().getCounter());
+        MaterialRevision mingleMaterialRevision = new MaterialRevision(new DependencyMaterial(mingleMaterialConfig), true, new Modification(latestMinglePipeline.getModifiedDate(), revision, latestMinglePipeline.getLabel(), latestMinglePipeline.getId()));
+
+        Pipeline latestGoPipeline = goPipeline.latest;
+        revision = String.format("%s/%s/%s/%s", latestGoPipeline.getName(), latestGoPipeline.getCounter(), STAGE_NAME, latestGoPipeline.getStages().last().getCounter());
+        MaterialRevision goMaterialRevision = new MaterialRevision(new DependencyMaterial(goMaterialConfig), true, new Modification(latestGoPipeline.getModifiedDate(), revision, latestGoPipeline.getLabel(), latestGoPipeline.getId()));
+
+        MaterialRevisions dependencyMaterialRevisions = new MaterialRevisions(mingleMaterialRevision, goMaterialRevision);
+        dbHelper.saveRevs(dependencyMaterialRevisions);
+
+        Pipeline latestDownstreamInstance = PipelineMother.schedule(downstreamPipelineConfig, BuildCause.createManualForced(dependencyMaterialRevisions, new Username(new CaseInsensitiveString("loser"))));
+        latestDownstreamInstance = pipelineDao.saveWithStages(latestDownstreamInstance);
+        dbHelper.passStage(latestDownstreamInstance.getStages().first());
+
+        //trigger upstream pipelines
+        MaterialRevisions newRevs = checkinFile(svnMaterial, "bar.c", svnRepository);
+        minglePipeline.runAndPassWith(newRevs);
+        goPipeline.runAndPassWith(newRevs);
+        pipelineTimeline.update();
+        scheduleHelper.autoSchedulePipelinesWithRealMaterials(downstreamPipelineName);
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet()).doesNotContain(new CaseInsensitiveString(downstreamPipelineName));
+    }
+
+    @Test
+    public void shouldScheduleDownStreamPipeline_withTwoUpstreamMaterials_oneOneIsSkippedForScheduling() throws Exception {
+        String downstreamPipelineName = "downstream_pipeline";
+        //first upstream pipeline - "mingle"
+        DependencyMaterialConfig mingleMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString(MINGLE_PIPELINE_NAME), new CaseInsensitiveString(STAGE_NAME));
+        mingleMaterialConfig.skipSchedulingOnChange(true);
+
+        //second upstream pipeline - "go"
+        DependencyMaterialConfig goMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString(GO_PIPELINE_NAME), new CaseInsensitiveString(STAGE_NAME));
+        goMaterialConfig.skipSchedulingOnChange(false);
+
+        PipelineConfig downstreamPipelineConfig = configHelper.addPipeline(downstreamPipelineName, STAGE_NAME, new MaterialConfigs(mingleMaterialConfig, goMaterialConfig), "unit");
+
+        Pipeline latestMinglePipeline = minglePipeline.latest;
+        String revision = String.format("%s/%s/%s/%s", latestMinglePipeline.getName(), latestMinglePipeline.getCounter(), STAGE_NAME, latestMinglePipeline.getStages().last().getCounter());
+        MaterialRevision mingleMaterialRevision = new MaterialRevision(new DependencyMaterial(mingleMaterialConfig), true, new Modification(latestMinglePipeline.getModifiedDate(), revision, latestMinglePipeline.getLabel(), latestMinglePipeline.getId()));
+
+        Pipeline latestGoPipeline = goPipeline.latest;
+        revision = String.format("%s/%s/%s/%s", latestGoPipeline.getName(), latestGoPipeline.getCounter(), STAGE_NAME, latestGoPipeline.getStages().last().getCounter());
+        MaterialRevision goMaterialRevision = new MaterialRevision(new DependencyMaterial(goMaterialConfig), true, new Modification(latestGoPipeline.getModifiedDate(), revision, latestGoPipeline.getLabel(), latestGoPipeline.getId()));
+
+        MaterialRevisions dependencyMaterialRevisions = new MaterialRevisions(mingleMaterialRevision, goMaterialRevision);
+        dbHelper.saveRevs(dependencyMaterialRevisions);
+
+        Pipeline latestDownstreamInstance = PipelineMother.schedule(downstreamPipelineConfig, BuildCause.createManualForced(dependencyMaterialRevisions, new Username(new CaseInsensitiveString("loser"))));
+        latestDownstreamInstance = pipelineDao.saveWithStages(latestDownstreamInstance);
+        dbHelper.passStage(latestDownstreamInstance.getStages().first());
+
+        //trigger upstream pipelines
+        MaterialRevisions newRevs = checkinFile(svnMaterial, "bar.c", svnRepository);
+        minglePipeline.runAndPassWith(newRevs);
+        goPipeline.runAndPassWith(newRevs);
+        pipelineTimeline.update();
+        scheduleHelper.autoSchedulePipelinesWithRealMaterials(downstreamPipelineName);
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet()).contains(new CaseInsensitiveString(downstreamPipelineName));
+    }
+
+    @Test
+    public void shouldScheduleDownStreamPipeline_withSCMAndDependencyMaterials_whenSCMMaterialHasChanges() throws Exception {
+        String downstreamPipelineName = "downstream_pipeline";
+        //first upstream pipeline - "mingle"
+        DependencyMaterialConfig mingleMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString(MINGLE_PIPELINE_NAME), new CaseInsensitiveString(STAGE_NAME));
+        mingleMaterialConfig.skipSchedulingOnChange(true);
+
+        //setup the pipeline
+        PipelineConfig downstreamPipelineConfig = configHelper.addPipeline(downstreamPipelineName, STAGE_NAME, new MaterialConfigs(mingleMaterialConfig, gitMaterial.config()), "unit");
+        Pipeline latestMinglePipeline = minglePipeline.latest;
+        String revision = String.format("%s/%s/%s/%s", latestMinglePipeline.getName(), latestMinglePipeline.getCounter(), STAGE_NAME, latestMinglePipeline.getStages().last().getCounter());
+        MaterialRevision mingleMaterialRevision = new MaterialRevision(new DependencyMaterial(mingleMaterialConfig), true, new Modification(latestMinglePipeline.getModifiedDate(), revision, latestMinglePipeline.getLabel(), latestMinglePipeline.getId()));
+
+        MaterialRevision gitMaterialRevision = new MaterialRevision(gitMaterial, gitTestRepo.checkInOneFile("new_file.c", "Adding a new file"));
+        MaterialRevisions initialMaterialRevisions = new MaterialRevisions(mingleMaterialRevision, gitMaterialRevision);
+        dbHelper.saveRevs(initialMaterialRevisions);
+        Pipeline latestDownstreamInstance = PipelineMother.schedule(downstreamPipelineConfig, BuildCause.createManualForced(initialMaterialRevisions, new Username(new CaseInsensitiveString("loser"))));
+        latestDownstreamInstance = pipelineDao.saveWithStages(latestDownstreamInstance);
+        dbHelper.passStage(latestDownstreamInstance.getStages().first());
+
+        //make a commit on the git repo
+        List<Modification> newGitModifications = gitTestRepo.checkInOneFile("another_file.c", "Adding a new file");
+        MaterialRevision materialRevision = new MaterialRevision(gitMaterial, newGitModifications);
+        MaterialRevisions gitMaterialRevisions = new MaterialRevisions(materialRevision);
+        dbHelper.saveRevs(gitMaterialRevisions);
+
+        //schedule the pipeline
+        pipelineTimeline.update();
+        scheduleHelper.autoSchedulePipelinesWithRealMaterials(downstreamPipelineName);
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet()).contains(new CaseInsensitiveString(downstreamPipelineName));
+    }
+
+    @Test
+    public void shouldNotScheduleDownStreamPipeline_withSCMAndDependencyMaterials_whenDependencyMaterialHasChanges() throws Exception {
+        String downstreamPipelineName = "downstream_pipeline";
+        //first upstream pipeline - "mingle"
+        DependencyMaterialConfig mingleMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString(MINGLE_PIPELINE_NAME), new CaseInsensitiveString(STAGE_NAME));
+        mingleMaterialConfig.skipSchedulingOnChange(true);
+
+        //setup the pipeline
+        PipelineConfig downstreamPipelineConfig = configHelper.addPipeline(downstreamPipelineName, STAGE_NAME, new MaterialConfigs(mingleMaterialConfig, gitMaterial.config()), "unit");
+        Pipeline latestMinglePipeline = minglePipeline.latest;
+        String revision = String.format("%s/%s/%s/%s", latestMinglePipeline.getName(), latestMinglePipeline.getCounter(), STAGE_NAME, latestMinglePipeline.getStages().last().getCounter());
+        MaterialRevision mingleMaterialRevision = new MaterialRevision(new DependencyMaterial(mingleMaterialConfig), true, new Modification(latestMinglePipeline.getModifiedDate(), revision, latestMinglePipeline.getLabel(), latestMinglePipeline.getId()));
+
+        MaterialRevision gitMaterialRevision = new MaterialRevision(gitMaterial, gitTestRepo.checkInOneFile("new_file.c", "Adding a new file"));
+        MaterialRevisions initialMaterialRevisions = new MaterialRevisions(mingleMaterialRevision, gitMaterialRevision);
+        dbHelper.saveRevs(initialMaterialRevisions);
+        Pipeline latestDownstreamInstance = PipelineMother.schedule(downstreamPipelineConfig, BuildCause.createManualForced(initialMaterialRevisions, new Username(new CaseInsensitiveString("loser"))));
+        latestDownstreamInstance = pipelineDao.saveWithStages(latestDownstreamInstance);
+        dbHelper.passStage(latestDownstreamInstance.getStages().first());
+
+        //trigger upstream pipelines
+        MaterialRevisions newRevs = checkinFile(svnMaterial, "bar.c", svnRepository);
+        minglePipeline.runAndPassWith(newRevs);
+        pipelineTimeline.update();
+        scheduleHelper.autoSchedulePipelinesWithRealMaterials(downstreamPipelineName);
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet()).doesNotContain(new CaseInsensitiveString(downstreamPipelineName));
+    }
+
+    private MaterialRevisions checkinFile(SvnMaterial svn, String checkinFile, final SvnTestRepo svnRepository) throws Exception {
+        svnRepository.checkInOneFile(checkinFile);
+        materialDatabaseUpdater.updateMaterial(svn);
+        return materialRepository.findLatestModification(svn);
+    }
+
+}

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceDependencyIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceDependencyIntegrationTest.java
@@ -241,11 +241,11 @@ public class BuildCauseProducerServiceDependencyIntegrationTest {
     }
 
     @Test
-    public void shouldNotScheduleDownstreamPipeline_whenSkipSchedulingIsTrue() throws Exception {
+    public void shouldNotScheduleDownstreamPipeline_whenIgnoreForSchedulingIsTrue() throws Exception {
         //set up a pipeline downstream to "mingle", run and save once instance of the pipelines.
         String mingleDownstreamPipelineName = "down_of_mingle";
         DependencyMaterialConfig mingleMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString(MINGLE_PIPELINE_NAME), new CaseInsensitiveString(STAGE_NAME));
-        mingleMaterialConfig.skipSchedulingOnChange(true);
+        mingleMaterialConfig.ignoreForScheduling(true);
 
         PipelineConfig downstreamPipelineConfig = configHelper.addPipeline(mingleDownstreamPipelineName, STAGE_NAME, new MaterialConfigs(mingleMaterialConfig), "unit");
 
@@ -272,11 +272,11 @@ public class BuildCauseProducerServiceDependencyIntegrationTest {
         String downstreamPipelineName = "downstream_pipeline";
         //first upstream pipeline - "mingle"
         DependencyMaterialConfig mingleMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString(MINGLE_PIPELINE_NAME), new CaseInsensitiveString(STAGE_NAME));
-        mingleMaterialConfig.skipSchedulingOnChange(true);
+        mingleMaterialConfig.ignoreForScheduling(true);
 
         //second upstream pipeline - "go"
         DependencyMaterialConfig goMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString(GO_PIPELINE_NAME), new CaseInsensitiveString(STAGE_NAME));
-        goMaterialConfig.skipSchedulingOnChange(true);
+        goMaterialConfig.ignoreForScheduling(true);
 
         PipelineConfig downstreamPipelineConfig = configHelper.addPipeline(downstreamPipelineName, STAGE_NAME, new MaterialConfigs(mingleMaterialConfig, goMaterialConfig), "unit");
 
@@ -309,11 +309,11 @@ public class BuildCauseProducerServiceDependencyIntegrationTest {
         String downstreamPipelineName = "downstream_pipeline";
         //first upstream pipeline - "mingle"
         DependencyMaterialConfig mingleMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString(MINGLE_PIPELINE_NAME), new CaseInsensitiveString(STAGE_NAME));
-        mingleMaterialConfig.skipSchedulingOnChange(true);
+        mingleMaterialConfig.ignoreForScheduling(true);
 
         //second upstream pipeline - "go"
         DependencyMaterialConfig goMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString(GO_PIPELINE_NAME), new CaseInsensitiveString(STAGE_NAME));
-        goMaterialConfig.skipSchedulingOnChange(false);
+        goMaterialConfig.ignoreForScheduling(false);
 
         PipelineConfig downstreamPipelineConfig = configHelper.addPipeline(downstreamPipelineName, STAGE_NAME, new MaterialConfigs(mingleMaterialConfig, goMaterialConfig), "unit");
 
@@ -346,7 +346,7 @@ public class BuildCauseProducerServiceDependencyIntegrationTest {
         String downstreamPipelineName = "downstream_pipeline";
         //first upstream pipeline - "mingle"
         DependencyMaterialConfig mingleMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString(MINGLE_PIPELINE_NAME), new CaseInsensitiveString(STAGE_NAME));
-        mingleMaterialConfig.skipSchedulingOnChange(true);
+        mingleMaterialConfig.ignoreForScheduling(true);
 
         //setup the pipeline
         PipelineConfig downstreamPipelineConfig = configHelper.addPipeline(downstreamPipelineName, STAGE_NAME, new MaterialConfigs(mingleMaterialConfig, gitMaterial.config()), "unit");
@@ -378,7 +378,7 @@ public class BuildCauseProducerServiceDependencyIntegrationTest {
         String downstreamPipelineName = "downstream_pipeline";
         //first upstream pipeline - "mingle"
         DependencyMaterialConfig mingleMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString(MINGLE_PIPELINE_NAME), new CaseInsensitiveString(STAGE_NAME));
-        mingleMaterialConfig.skipSchedulingOnChange(true);
+        mingleMaterialConfig.ignoreForScheduling(true);
 
         //setup the pipeline
         PipelineConfig downstreamPipelineConfig = configHelper.addPipeline(downstreamPipelineName, STAGE_NAME, new MaterialConfigs(mingleMaterialConfig, gitMaterial.config()), "unit");


### PR DESCRIPTION
Issue #4931 - Optional upstream dependencies

Description:
Add a `skipScheduling` attribute to a dependency material. This can be used to prevent a Pipeline from triggering a downstream build.

