### PR TITLE
Introduce environments page feature toggle

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/SparkOrRailsEnvironmentsPageToggle.java
+++ b/server/src/main/java/com/thoughtworks/go/server/SparkOrRailsEnvironmentsPageToggle.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.server;
+
+import com.thoughtworks.go.server.service.support.toggle.Toggles;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class SparkOrRailsEnvironmentsPageToggle {
+
+    public void environmentsPage(HttpServletRequest request, HttpServletResponse response) {
+        basedOnToggle(Toggles.SHOW_NEW_ENVIRONMENTS_SPA, request);
+    }
+
+    @SuppressWarnings({"PMD.UnusedPrivateMethod", "unused"})
+    private void basedOnToggle(String toggle, HttpServletRequest request) {
+        if (Toggles.isToggleOn(toggle)) {
+            request.setAttribute("url", "/spark/admin/new-environments");
+        } else {
+            request.setAttribute("url", "/rails/admin/environments");
+        }
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -21,6 +21,7 @@ public class Toggles {
     public static String ALLOW_EMPTY_PIPELINE_GROUPS_DASHBOARD = "allow_empty_pipeline_groups_dashboard";
     public static String TEST_DRIVE = "test_drive";
     public static String NEW_PIPELINE_DROPDOWN = "new_pipeline_dropdown";
+    public static String SHOW_NEW_ENVIRONMENTS_SPA = "show_new_environments_spa";
 
     private static FeatureToggleService service;
 

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -25,6 +25,11 @@
       "key": "allow_empty_pipeline_groups_dashboard",
       "description": "Coupled with queryParam allowEmpty=true will show empty pipeline groups on the dashboard.",
       "value": false
+    },
+    {
+      "key": "show_new_environments_spa",
+      "description": "Switch to the new environments SPA. Default is false.",
+      "value": false
     }
   ]
 }

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -24,9 +24,10 @@
 
 <urlrewrite>
   <rule>
-    <name>new-environments UI</name>
-    <from>^/admin/new-environments(/?)$</from>
-    <to last="true">/spark/admin/new-environments</to>
+    <name>environments UI</name>
+    <from>^/admin/environments(/?)$</from>
+    <run class="com.thoughtworks.go.server.SparkOrRailsEnvironmentsPageToggle" method="environmentsPage"/>
+    <to last="true">%{attribute:url}</to>
   </rule>
 
   <rule>


### PR DESCRIPTION
###### Description:
	- Add a toggle to switch between old and new environments pages.
	- Defaults to old rails based environments page.



