### PR TITLE
Ignore unknown properties while upgrading plugin profile configuration.

### DIFF
--- a/server/webapp/WEB-INF/rails/spec/webpack/views/shared/angular_plugin_new_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/shared/angular_plugin_new_spec.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import {AngularPluginNew} from "views/shared/angular_plugin_new.js.msx";
+import {TestHelper} from "views/pages/spec/test_helper";
+import Stream from "mithril/stream";
+import {Configurations, Configuration} from "models/shared/configuration";
+import {PlainTextValue} from "models/shared/config_value";
+import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
+import {AuthorizationPluginInfo} from "models/shared/plugin_infos_new/spec/test_data";
+import m from "mithril";
+
+describe("Angular Plugin View", () => {
+  const helper = new TestHelper();
+
+  afterEach(helper.unmount.bind(helper));
+
+  it("should ignore unknown properties", () => {
+    const pluginInfo     = PluginInfo.fromJSON(AuthorizationPluginInfo.file());
+    const configurations = new Configurations([
+      new Configuration("PasswordFilePath", new PlainTextValue("/var/lib/pass.prop")),
+      new Configuration("UnknownField", new PlainTextValue("random-value"))
+    ]);
+
+    expect(configurations.findConfiguration("PasswordFilePath")).not.toBeNull();
+    expect(configurations.findConfiguration("UnknownField")).not.toBeNull();
+    expect(configurations.findConfiguration("UnknownField")).not.toBeUndefined();
+
+    mount(pluginInfo.extensions[0].authConfigSettings, configurations);
+
+    expect(configurations.findConfiguration("UnknownField")).toBeUndefined();
+    expect(configurations.findConfiguration("PasswordFilePath")).not.toBeUndefined();
+  });
+
+  it("should not ignore appropriate properties", () => {
+    const pluginInfo     = PluginInfo.fromJSON(AuthorizationPluginInfo.file());
+    const configurations = new Configurations([
+      new Configuration("PasswordFilePath", new PlainTextValue("/var/lib/pass.prop")),
+      new Configuration("AnotherProperty", new PlainTextValue("some_value"))
+    ]);
+
+    expect(configurations.findConfiguration("PasswordFilePath")).not.toBeNull();
+    expect(configurations.findConfiguration("PasswordFilePath")).not.toBeNull();
+    expect(configurations.findConfiguration("AnotherProperty")).not.toBeNull();
+    expect(configurations.findConfiguration("AnotherProperty")).not.toBeUndefined();
+
+    mount(pluginInfo.extensions[0].authConfigSettings, configurations);
+
+    expect(configurations.findConfiguration("AnotherProperty")).not.toBeUndefined();
+    expect(configurations.findConfiguration("PasswordFilePath")).not.toBeUndefined();
+  });
+
+  function mount(pluginSettings, configurations) {
+    helper.mount(() => <AngularPluginNew pluginInfoSettings={Stream(pluginSettings)}
+                                         configuration={configurations}/>);
+  }
+});

--- a/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/spec/test_data.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/spec/test_data.ts
@@ -30,6 +30,34 @@ export function pluginImageLink() {
   } as LinksJSON;
 }
 
+class BasePluginInfo {
+  protected static withExtension(extension: AnalyticsExtensionJSON | AuthorizationExtensionJSON,
+                                 pluginId: string = "gocd.analytics.plugin",
+                                 name: string     = "Analytics plugin") {
+    return {
+      _links: pluginImageLink(),
+      id: pluginId,
+      status: {
+        state: "active"
+      },
+      plugin_file_location: "/foo/bar.jar",
+      bundled_plugin: false,
+      about: {
+        name,
+        version: "0.0.1",
+        target_go_version: "19.10.0",
+        description: "Some description about the plugin",
+        target_operating_systems: [],
+        vendor: {
+          name: "GoCD Contributors",
+          url: "https://foo/bar"
+        }
+      },
+      extensions: [extension],
+    } as PluginInfoJSON;
+  }
+}
+
 export class ArtifactPluginInfo {
   static docker() {
     return {
@@ -122,7 +150,43 @@ export class ArtifactPluginInfo {
   }
 }
 
-export class AuthorizationPluginInfo {
+export class AuthorizationPluginInfo extends BasePluginInfo {
+  static file() {
+    const extension = {
+      type: "authorization",
+      auth_config_settings: {
+        configurations: [
+          {
+            key: "PasswordFilePath",
+            metadata: {
+              secure: true,
+              required: true
+            }
+          },
+          {
+            key: "AnotherProperty",
+            metadata: {
+              secure: true,
+              required: true
+            }
+          }
+        ],
+        view: {
+          template: "<div class=\"form_item_block\">This is ldap auth config view.</div>"
+        }
+      },
+      capabilities: {
+        can_authorize: false,
+        can_search: false,
+        supported_auth_type: "Password"
+      }
+    } as AuthorizationExtensionJSON;
+
+    return this.withExtension(extension,
+                              "cd.go.authorization.file",
+                              "File based authorization plugin");
+  }
+
   static ldap() {
     return {
       _links: pluginImageLink(),
@@ -353,7 +417,7 @@ export class SecretPluginInfo {
   }
 }
 
-export class AnalyticsPluginInfo {
+export class AnalyticsPluginInfo extends BasePluginInfo {
   static with(pluginId: string, name: string) {
     return this.withExtension(this.analyticsExtension(), pluginId, name);
   }
@@ -393,31 +457,5 @@ export class AnalyticsPluginInfo {
         ]
       }
     } as AnalyticsExtensionJSON;
-  }
-
-  private static withExtension(extension: AnalyticsExtensionJSON,
-                               pluginId: string = "gocd.analytics.plugin",
-                               name: string     = "Analytics plugin") {
-    return {
-      _links: pluginImageLink(),
-      id: pluginId,
-      status: {
-        state: "active"
-      },
-      plugin_file_location: "/foo/bar.jar",
-      bundled_plugin: false,
-      about: {
-        name,
-        version: "0.0.1",
-        target_go_version: "19.10.0",
-        description: "Some description about the plugin",
-        target_operating_systems: [],
-        vendor: {
-          name: "GoCD Contributors",
-          url: "https://foo/bar"
-        }
-      },
-      extensions: [extension],
-    } as PluginInfoJSON;
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/shared/angular_plugin_new.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/shared/angular_plugin_new.js.msx
@@ -88,7 +88,7 @@ function onCreate(scope, args) {
 
         const supportedConfigKeys = pluginInfoSettings.configurations.map((configuration) => configuration.key);
 
-        _.remove(configurations, (configuration) => {
+        _.remove(configurations.configurations, (configuration) => {
           return !_.includes(supportedConfigKeys, configuration.key);
         });
       };
@@ -101,7 +101,7 @@ function onCreate(scope, args) {
 }
 
 function onUpdate(scope, args) {
-  return function (_vnode) {
+  return function () {
     scope().initialize(args.pluginInfoSettings(), args.configuration);
     scope().$apply();
   };


### PR DESCRIPTION
Issue: #6966 

Description:
- When plugin upgrades to newer and no longer supports some of the previous properties from previous version.
 - Plugin responds with `422 - Unprocessable Entity` while upgrading respective plugin profile configuration, as it doesn't understand unsupported properties.

Fix:
  - Ignoring(removing) the unknown/unsupported properties before sending it to plugin while
  creating angular template view.




