### PR TITLE
Remove jQuery from JS tests

### DIFF
--- a/server/webapp/WEB-INF/rails/spec/webpack/lib/form_helper_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/lib/form_helper_spec.js
@@ -17,7 +17,6 @@ import {TestHelper} from "views/pages/spec/test_helper";
 import {f} from "helpers/form_helper";
 import Stream from "mithril/stream";
 import m from "mithril";
-import $ from "jquery";
 import * as simulateEvent from "simulate-event";
 
 describe("Form Helper", () => {
@@ -37,19 +36,24 @@ describe("Form Helper", () => {
         'tooltipText': "show me on hover",
       }, "Fancy button with tooltip")
     );
-    const buttonWithTooltip = helper.find('button');
+    const buttonWithTooltip = helper.q('button');
     expect(buttonWithTooltip).toExist();
-    const tooltipId = $(buttonWithTooltip).attr("data-tooltip-id");
-    const tooltip   = helper.find(`#${tooltipId}`);
+
+    const tooltipId = buttonWithTooltip.getAttribute("data-tooltip-id");
+    const tooltip   = document.getElementById(tooltipId);
+
     expect(tooltip).toExist();
     expect(tooltip).toHaveText("show me on hover");
     expect(tooltip).not.toBeVisible();
-    simulateEvent.simulate(buttonWithTooltip[0], 'mouseover');
-    m.redraw.sync();
+
+    simulateEvent.simulate(buttonWithTooltip, 'mouseover');
+    helper.redraw();
+
     expect(tooltip).toBeVisible();
 
-    simulateEvent.simulate(buttonWithTooltip[0], 'mouseout');
-    m.redraw.sync();
+    simulateEvent.simulate(buttonWithTooltip, 'mouseout');
+    helper.redraw();
+
     expect(tooltip).not.toBeVisible();
   });
 
@@ -59,18 +63,25 @@ describe("Form Helper", () => {
       model,
       'tooltipText': "show me on hover",
     }, "Fancy link with tooltip"));
-    const linkWithTooltip = helper.find('a');
+
+    const linkWithTooltip = helper.q('a');
     expect(linkWithTooltip).toExist();
-    const tooltipId = $(linkWithTooltip).attr("data-tooltip-id");
-    const tooltip   = helper.find(`#${tooltipId}`);
+
+    const tooltipId = linkWithTooltip.getAttribute("data-tooltip-id");
+    const tooltip   = document.getElementById(tooltipId);
+
     expect(tooltip).toExist();
     expect(tooltip).toHaveText("show me on hover");
     expect(tooltip).not.toBeVisible();
-    simulateEvent.simulate(linkWithTooltip[0], 'mouseover');
-    m.redraw.sync();
+
+    simulateEvent.simulate(linkWithTooltip, 'mouseover');
+    helper.redraw();
+
     expect(tooltip).toBeVisible();
-    simulateEvent.simulate(linkWithTooltip[0], 'mouseout');
-    m.redraw.sync();
+
+    simulateEvent.simulate(linkWithTooltip, 'mouseout');
+    helper.redraw();
+
     expect(tooltip).not.toBeVisible();
   });
 });

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/agents/agent_row_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/agents/agent_row_widget_spec.js
@@ -21,13 +21,12 @@ import {PluginInfos} from "models/shared/plugin_infos";
 import {Modal} from "views/shared/new_modal";
 import Stream from "mithril/stream";
 import m from "mithril";
-import $ from "jquery";
-import  "jasmine-jquery";
-import * as simulateEvent from "simulate-event";
+import "jasmine-jquery";
 
 describe("Agent Row Widget", () => {
-  const agents          = Stream();
-  const agentsVM        = new AgentsVM();
+  const agents   = Stream();
+  const agentsVM = new AgentsVM();
+  const body     = document.body;
 
   let shouldShowAnalyticsIcon = true;
   let elasticAgentPluginInfo;
@@ -55,19 +54,19 @@ describe("Agent Row Widget", () => {
     const model = Stream(true);
     mount(agents().firstAgent(), model, true);
 
-    const row         = helper.find('tr:first');
-    const checkbox    = $(row).find('input');
-    const information = $(row).find('td');
+    const row         = helper.q('tr');
+    const checkbox    = helper.q("input", row);
+    const information = helper.qa("td", row);
     expect(information[1]).toExist();
-    expect($(information[2]).find('.content')).toHaveText('in-john.local');
-    expect($(information[2]).find('.content')).toContainElement('a');
-    expect($(information[3]).find('.content')).toHaveText('/var/lib/go-agent');
-    expect($(information[4]).find('.content')).toHaveText('Linux');
-    expect($(information[5]).find('.content')).toHaveText('10.12.2.200');
-    expect($(information[6]).find('.content')).toHaveText('Missing');
-    expect($(information[7]).find('.content')).toHaveText('Unknown');
-    expect($(information[8]).find('.content')).toHaveText('firefox');
-    expect($(information[9]).find('.content')).toHaveText('Dev');
+    expect(helper.text('.content', information[2])).toBe('in-john.local');
+    expect(helper.q('.content', information[2])).toContainElement('a');
+    expect(helper.text('.content', information[3])).toBe('/var/lib/go-agent');
+    expect(helper.text('.content', information[4])).toBe('Linux');
+    expect(helper.text('.content', information[5])).toBe('10.12.2.200');
+    expect(helper.text('.content', information[6])).toBe('Missing');
+    expect(helper.text('.content', information[7])).toBe('Unknown');
+    expect(helper.text('.content', information[8])).toBe('firefox');
+    expect(helper.text('.content', information[9])).toBe('Dev');
     expect(checkbox).toBeChecked();
   });
 
@@ -76,10 +75,10 @@ describe("Agent Row Widget", () => {
     const model = Stream(true);
     mount(agents().firstAgent(), model, false);
 
-    const row         = helper.find('tr')[0];
-    const information = $(row).find('td');
-    expect($(information[2]).find('.content')).toHaveText('in-john.local');
-    expect($(information[2]).find('.content')).not.toContainElement('a');
+    const row         = helper.q('tr');
+    const information = helper.qa("td", row);
+    expect(helper.text('.content', information[2])).toBe('in-john.local');
+    expect(helper.q('.content', information[2])).not.toContainElement('a');
   });
 
   it('should contain link to job run history for normal agents', () => {
@@ -87,12 +86,12 @@ describe("Agent Row Widget", () => {
     const model = Stream(true);
     mount(agents().firstAgent(), model, true);
 
-    const row         = helper.find('tr')[0];
-    const information = $(row).find('td');
-    const hostname    = $(information[2]).find('.content');
+    const row         = helper.q('tr');
+    const information = helper.qa("td", row);
+    const hostname    = helper.q(".content", information[2]);
 
     expect(hostname).toHaveText('in-john.local');
-    expect(hostname.find('a')[0].href).toContain(`/go/agents/${allAgents.firstAgent().uuid()}/job_run_history`);
+    expect(hostname.querySelector("a").href).toContain(`/go/agents/${allAgents.firstAgent().uuid()}/job_run_history`);
   });
 
   it('should contain link to job run history page for elastic agents', () => {
@@ -100,12 +99,13 @@ describe("Agent Row Widget", () => {
     const model = Stream(true);
     mount(agents().lastAgent(), model, true, true);
 
-    const row         = helper.find('tr')[0];
-    const information = $(row).find('td');
-    const hostname    = $(information[2]).find('.content');
+    const row         = helper.q('tr');
+    const information = helper.qa("td", row);
+    const hostname    = helper.q(".content", information[2]);
+
 
     expect(hostname).toHaveText('elastic-agent-hostname');
-    expect(hostname.find('a')[0].href).toContain(`/go/agents/${allAgents.lastAgent().uuid()}/job_run_history`);
+    expect(hostname.querySelector("a").href).toContain(`/go/agents/${allAgents.lastAgent().uuid()}/job_run_history`);
   });
 
   it('should contain link to job run history page for elastic agents when elastic agent plugin is missing', () => {
@@ -113,12 +113,12 @@ describe("Agent Row Widget", () => {
     const model = Stream(true);
     mount(agents().lastAgent(), model, true, null);
 
-    const row         = helper.find('tr')[0];
-    const information = $(row).find('td');
-    const hostname    = $(information[2]).find('.content');
+    const row         = helper.q('tr');
+    const information = helper.qa("td", row);
+    const hostname    = helper.q(".content", information[2]);
 
     expect(hostname).toHaveText('elastic-agent-hostname');
-    expect(hostname.find('a')[0].href).toContain(`/go/agents/${allAgents.lastAgent().uuid()}/job_run_history`);
+    expect(hostname.querySelector("a").href).toContain(`/go/agents/${allAgents.lastAgent().uuid()}/job_run_history`);
   });
 
 
@@ -127,12 +127,12 @@ describe("Agent Row Widget", () => {
     const model = Stream(true);
     mount(agents().lastAgent(), model, true);
 
-    const row         = helper.find('tr')[0];
-    const information = $(row).find('td');
-    const hostname    = $(information[2]).find('.content');
+    const row         = helper.q('tr');
+    const information = helper.qa("td", row);
+    const hostname    = helper.q(".content", information[2]);
 
     expect(hostname).toHaveText('elastic-agent-hostname');
-    expect(hostname.find('a')[0].href).toContain(`/go/agents/${allAgents.lastAgent().uuid()}/job_run_history`);
+    expect(hostname.querySelector("a").href).toContain(`/go/agents/${allAgents.lastAgent().uuid()}/job_run_history`);
   });
 
   it('should check the value based on the checkbox model', () => {
@@ -140,36 +140,38 @@ describe("Agent Row Widget", () => {
     const model = Stream(true);
     mount(agents().firstAgent(), model, true);
 
-    const checkbox = helper.find('input')[0];
+    const checkbox = helper.q('input');
     expect(checkbox.checked).toBe(model());
   });
 
   it('should not display checkbox for non-admin user', () => {
     agents(allAgents);
     mount(agents().firstAgent(), model, false);
-    expect('tr input').not.toBeInDOM();
+    expect(helper.q('tr input')).toBeFalsy();
   });
 
   it('should show none specified if agent has no resource', () => {
     agents(allAgents.toJSON()[1]);
     mount(agents(), model, true);
-    const row         = helper.find('tr')[0];
-    const information = $(row).find('td');
-    expect($(information[8]).find('.content')).toHaveText('none specified');
+
+    const row         = helper.q('tr');
+    const information = helper.qa("td", row);
+    expect(helper.text(".content", information[8])).toBe('none specified');
   });
 
   it('should show none specified if agent has no environment', () => {
     agents(allAgents.toJSON()[1]);
     mount(agents(), model, true);
-    const row         = helper.find('tr')[0];
-    const information = $(row).find('td');
-    expect($(information[9]).find('.content')).toHaveText('none specified');
+
+    const row         = helper.q('tr');
+    const information = helper.qa("td", row);
+    expect(helper.text(".content", information[9])).toBe('none specified');
   });
 
   it('should set the class based on the status of the agent', () => {
     agents(allAgents);
     mount(agents().firstAgent(), model, true);
-    const row = helper.find('tr')[0];
+    const row = helper.q('tr');
     expect(row.classList).toContain(agents().firstAgent().status().toLowerCase());
   });
 
@@ -177,18 +179,20 @@ describe("Agent Row Widget", () => {
     agents(allAgents);
     const model = Stream(false);
     mount(agents().firstAgent(), model, true);
-    const row      = helper.find('tr')[0];
-    const checkbox = $(row).find('input');
+    const row      = helper.q('tr');
+    const checkbox = helper.q('input', row);
+
     expect(model()).toBe(false);
-    $(checkbox).click();
-    m.redraw.sync();
+
+    helper.click(checkbox);
+
     expect(model()).toBe(true);
   });
 
   it('should have links to pipeline, stage and job as a part of build details dropdown', () => {
     agents(allAgents.toJSON()[2]);
     mount(agents(), model, true);
-    const buildDetailsLinks = helper.find('.build-details a').map((_i, el) => $(el).attr('href'));
+    const buildDetailsLinks = Array.from(helper.qa('.build-details a')).map((el) => el.href);
     const buildDetails      = agents().buildDetails();
     expect(buildDetailsLinks).toEqual([buildDetails.pipelineUrl(), buildDetails.stageUrl(), buildDetails.jobUrl()]);
   });
@@ -196,14 +200,14 @@ describe("Agent Row Widget", () => {
   it('should not render analytics plugin icon if no analytics plugin supports agent metric', () => {
     agents(allAgents);
     mount(agents().firstAgent(), model, true, false);
-    expect(helper.find('.agent-analytics')).not.toBeInDOM();
+    expect(helper.q(helper.q('.agent-analytics'))).toBeFalsy();
   });
 
   it('should render analytics plugin icon if any analytics plugin supports agent metric', () => {
     agents(allAgents);
     elasticAgentPluginInfo.extensions.push(getAnalyticsExtension());
     mount(agents().firstAgent(), model, true, true);
-    expect(helper.find('.agent-analytics')).toBeInDOM();
+    expect(helper.q('.agent-analytics')).toBeInDOM();
   });
 
   it('should render analytics for given agent on clicking analytics icon', () => {
@@ -212,13 +216,12 @@ describe("Agent Row Widget", () => {
     elasticAgentPluginInfo.extensions.push(getAnalyticsExtension());
 
     mount(agents(), model, true, false);
-    expect(helper.find('.agent-analytics')).toBeInDOM();
+    expect(helper.q('.agent-analytics')).toBeInDOM();
 
-    simulateEvent.simulate($('.agent-analytics').get(0), 'click');
-    m.redraw.sync();
+    helper.click('.agent-analytics', body);
 
-    expect($('.new-modal-container')).toBeInDOM();
-    expect($('.modal-title')).toContainText(`Analytics for agent: host-3`);
+    expect(helper.q('.new-modal-container', body)).toBeInDOM();
+    expect(helper.text('.modal-title', body)).toContain(`Analytics for agent: host-3`);
   });
 
 
@@ -229,7 +232,7 @@ describe("Agent Row Widget", () => {
     shouldShowAnalyticsIcon = false;
 
     mount(agents().firstAgent(), model, true);
-    expect(helper.find('.agent-analytics')).not.toBeInDOM();
+    expect(helper.q('.agent-analytics')).toBeFalsy();
   });
 
   const mount = (agent, model, isUserAdmin, supportsAgentStatusReportPage = false) => {

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/agents/agent_state_count_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/agents/agent_state_count_widget_spec.js
@@ -33,28 +33,28 @@ describe("Agent State Count Widget", () => {
   afterEach(helper.unmount.bind(helper));
 
   it('should contain the agents state count information', () => {
-    const children = helper.find('.search-summary').children();
-    expect(children).toHaveLength(4);
-    expect(children[0]).toContainText('Total');
-    expect(children[0]).toContainText('1');
+    const childText = helper.textAll('.search-summary > *');
+    expect(childText).toHaveLength(4);
+    expect(childText[0]).toContain('Total');
+    expect(childText[0]).toContain('1');
   });
 
   it('should contain the agents Pending count information', () => {
-    const children = helper.find('.search-summary').children();
-    expect(children[1]).toContainText('Pending');
-    expect(children[1]).toContainText('0');
+    const childText = helper.textAll('.search-summary > *');
+    expect(childText[1]).toContain('Pending');
+    expect(childText[1]).toContain('0');
   });
 
   it('should contain the agents Enabled count information', () => {
-    const children = helper.find('.search-summary').children();
-    expect(children[2]).toContainText('Enabled');
-    expect(children[2]).toContainText('1');
+    const childText = helper.textAll('.search-summary > *');
+    expect(childText[2]).toContain('Enabled');
+    expect(childText[2]).toContain('1');
   });
 
   it('should contain the agents Disabled count information', () => {
-    const children = helper.find('.search-summary').children();
-    expect(children[3]).toContainText('Disabled');
-    expect(children[3]).toContainText('0');
+    const childText = helper.textAll('.search-summary > *');
+    expect(childText[3]).toContain('Disabled');
+    expect(childText[3]).toContain('0');
   });
 
   const mount = (agents) => {

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/agents/agent_table_header_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/agents/agent_table_header_widget_spec.js
@@ -21,11 +21,11 @@ import {AgentsTableHeader} from "views/agents/agent_table_header";
 import Stream from "mithril/stream";
 import m from "mithril";
 import _ from "lodash";
-import $ from "jquery";
 import "jasmine-jquery";
 
 describe("Agent Table Header Widget", () => {
-  const helper            = new TestHelper();
+  const helper = new TestHelper();
+  const body   = document.body;
 
   let routeHandler;
 
@@ -65,29 +65,31 @@ describe("Agent Table Header Widget", () => {
 
 
   it('should select the checkbox depending upon the "checkboxValue" ', () => {
-    const checkbox = helper.find('thead input')[0];
+    const checkbox = helper.q('thead input');
     expect(checkbox.checked).toBe(checkboxValue());
   });
 
   it('should not display checkbox for non-admin user', () => {
     unmount();
     route(false);
-    expect($('thead input')).not.toBeInDOM();
+    expect(helper.q('thead input', body)).not.toExist();
   });
 
 
   it('should add the ascending css class to table header cell attribute when table is sorted ascending on the corresponding attribute', () => {
     routeHandler().toggleSortingOrder('hostname');
-    m.redraw.sync();
-    const headerAttribute = helper.find("th:contains('Agent Name') .sort");
+    helper.redraw();
+
+    const headerAttribute = helper.q(".sort", withText("th", "Agent Name"));
     expect(headerAttribute).toHaveClass('asc');
   });
 
   it('should add the descending css class to table header cell attribute when table is sorted descending on the corresponding attribute', () => {
     routeHandler().toggleSortingOrder('hostname');
     routeHandler().toggleSortingOrder('hostname');
-    m.redraw.sync();
-    const headerAttribute = helper.find("th:contains('Agent Name') .sort");
+    helper.redraw();
+
+    const headerAttribute = helper.q(".sort", withText("th", "Agent Name"));
     expect(headerAttribute).toHaveClass('desc');
   });
 
@@ -99,4 +101,8 @@ describe("Agent Table Header Widget", () => {
   });
 
   const checkboxValue = () => false;
+
+  function withText(selector, text) {
+    return Array.from(helper.qa(selector)).find((el) => el.textContent === text);
+  }
 });

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/agents/agents_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/agents/agents_widget_spec.js
@@ -18,12 +18,10 @@ import {TestHelper} from "views/pages/spec/test_helper";
 import {VM as AgentsVM} from "views/agents/models/agents_widget_view_model";
 import {AgentsWidget} from "views/agents/agents_widget";
 import {Agents} from "models/agents/agents";
-import simulateEvent from "simulate-event";
 import {SortOrder} from "views/agents/models/route_handler";
 import _ from "lodash";
 import Stream from "mithril/stream";
 import m from "mithril";
-import $ from "jquery";
 import "jasmine-ajax";
 import "jasmine-jquery";
 
@@ -80,7 +78,7 @@ describe("Agents Widget", () => {
       };
     });
     m.route.set('/');
-    m.redraw.sync();
+    helper.redraw();
   };
 
   const unmount = () => {
@@ -100,60 +98,58 @@ describe("Agents Widget", () => {
   });
 
   it('should contain the agent rows equal to the number of agents', () => {
-    const agentRows = helper.find('table tbody tr');
+    const agentRows = helper.qa('table tbody tr');
     expect(agentRows).toHaveLength(2);
   });
 
   it('should contain the agent row information', () => {
-    const agentInfo      = helper.find('table tbody tr')[0];
-    const firstAgentInfo = $(agentInfo).find('td');
+    const agentInfo      = helper.q('table tbody tr');
+    const firstAgentInfo = helper.qa("td", agentInfo);
     expect(firstAgentInfo).toHaveLength(10);
-    expect($(firstAgentInfo[0]).find(':checkbox')).toExist();
-    expect($(firstAgentInfo[2]).find('.content')).toHaveText('host-1');
-    expect($(firstAgentInfo[3]).find('.content')).toHaveText('usr/local/foo');
-    expect($(firstAgentInfo[4]).find('.content')).toHaveText('Linux');
-    expect($(firstAgentInfo[5]).find('.content')).toHaveText('10.12.2.200');
-    expect($(firstAgentInfo[6]).find('.content')).toContainText('Disabled (Building)');
-    expect($(firstAgentInfo[7]).find('.content')).toHaveText('Unknown');
-    expect($(firstAgentInfo[8]).find('.content')).toHaveText('Firefox');
-    expect($(firstAgentInfo[9]).find('.content')).toHaveText('Dev, Test');
+    expect(helper.q('input[type="checkbox"]', firstAgentInfo[0])).toExist();
+    expect(helper.text('.content', firstAgentInfo[2])).toBe('host-1');
+    expect(helper.text('.content', firstAgentInfo[3])).toBe('usr/local/foo');
+    expect(helper.text('.content', firstAgentInfo[4])).toBe('Linux');
+    expect(helper.text('.content', firstAgentInfo[5])).toBe('10.12.2.200');
+    expect(helper.text('.content', firstAgentInfo[6])).toContain('Disabled (Building)');
+    expect(helper.text('.content', firstAgentInfo[7])).toBe('Unknown');
+    expect(helper.text('.content', firstAgentInfo[8])).toBe('Firefox');
+    expect(helper.text('.content', firstAgentInfo[9])).toBe('Dev, Test');
   });
 
   it('should contain the analytics icon row when analytics icon should be shown', () => {
     shouldShowAnalyticsIcon = true;
-    m.redraw.sync();
+    helper.redraw();
 
-    expect(helper.find('th')).toHaveLength(11);
+    expect(helper.qa('th')).toHaveLength(11);
   });
 
   it('should select all the agents when selectAll checkbox is checked', () => {
-    const allBoxes          = helper.find('tbody :checkbox');
-    const selectAllCheckbox = helper.find('thead :checkbox');
+    const allBoxes          = helper.qa('tbody input[type="checkbox"]');
+    const selectAllCheckbox = helper.q('thead input[type="checkbox"]');
 
-    expect(selectAllCheckbox[0]).not.toBeChecked();
+    expect(selectAllCheckbox).not.toBeChecked();
     expect(allBoxes[0]).not.toBeChecked();
     expect(allBoxes[1]).not.toBeChecked();
 
-    $(selectAllCheckbox).click();
-    m.redraw.sync();
+    helper.click(selectAllCheckbox);
 
     expect(allBoxes[0]).toBeChecked();
     expect(allBoxes[1]).toBeChecked();
-
   });
 
   it('should check select all checkbox on selecting all the checkboxes', () => {
-    const allBoxes          = helper.find('tbody :checkbox');
-    const selectAllCheckbox = helper.find('thead :checkbox');
+    const allBoxes          = helper.qa('tbody input[type="checkbox"]');
+    const selectAllCheckbox = helper.q('thead input[type="checkbox"]');
 
-    expect(selectAllCheckbox[0]).not.toBeChecked();
+    expect(selectAllCheckbox).not.toBeChecked();
     expect(allBoxes[0]).not.toBeChecked();
 
-    $(allBoxes[0]).click();
-    $(allBoxes[1]).click();
-    m.redraw.sync();
+    allBoxes[0].click();
+    allBoxes[1].click();
+    helper.redraw();
 
-    expect(selectAllCheckbox[0]).toBeChecked();
+    expect(selectAllCheckbox).toBeChecked();
   });
 
   it('should hide all dropdown on click of the body', () => {
@@ -161,17 +157,15 @@ describe("Agents Widget", () => {
 
     jasmine.Ajax.withMock(() => {
       stubResourcesList();
-      const resourceButton = helper.find("button:contains('Resources')");
-      resourceButton.click();
-      m.redraw.sync();
 
-      expect($(resourceButton).parent().attr('class')).toContain('is-open');
+      const resourceButton = buttonLabeled("Resources");
+      helper.click(resourceButton);
 
-      const body = helper.find('.agents-search-panel');
-      $(body).click();
-      m.redraw.sync();
+      expect(resourceButton.parentElement).toHaveClass("is-open");
 
-      expect($(resourceButton).parent().attr('class')).not.toContain('is-open');
+      helper.click('.agents-search-panel');
+
+      expect(resourceButton.parentElement).not.toHaveClass("is-open");
     });
   });
 
@@ -181,13 +175,12 @@ describe("Agents Widget", () => {
     jasmine.Ajax.withMock(() => {
       stubResourcesList();
 
-      const resourceButton = helper.find("button:contains('Resources')");
-      simulateEvent.simulate(resourceButton.get(0), 'click');
-      m.redraw.sync();
-      expect(resourceButton.parent()).toHaveClass('is-open');
-      simulateEvent.simulate(helper.find('.resource-dropdown').get(0), 'click');
-      m.redraw.sync();
-      expect(resourceButton.parent()).toHaveClass('is-open');
+      const resourceButton = buttonLabeled("Resources");
+      helper.click(resourceButton);
+
+      expect(resourceButton.parentElement).toHaveClass("is-open");
+      helper.click('.resource-dropdown');
+      expect(resourceButton.parentElement).toHaveClass("is-open");
     });
   });
 
@@ -195,7 +188,7 @@ describe("Agents Widget", () => {
     unmount();
     route(false);
     clickAllAgents();
-    const sampleButton = helper.find("button:contains('Resources')");
+    const sampleButton = buttonLabeled("Resources");
     expect(sampleButton).toBeDisabled();
   });
 
@@ -204,12 +197,11 @@ describe("Agents Widget", () => {
       clickAllAgents();
 
       allowBulkUpdate('PATCH');
-      let message = helper.find('.callout');
-      expect(message).toHaveLength(0);
-      simulateEvent.simulate(helper.find("button:contains('Disable')").get(0), 'click');
-      m.redraw.sync();
-      message = helper.find('.callout');
-      expect(message).toHaveText('Disabled 2 agents');
+      expect(helper.q('.callout')).not.toExist();
+
+      helper.click(buttonLabeled("Disable"));
+
+      expect(helper.text('.callout')).toBe('Disabled 2 agents');
     });
   });
 
@@ -219,12 +211,11 @@ describe("Agents Widget", () => {
       clickAllAgents();
       allowBulkUpdate('PATCH');
 
-      let message = helper.find('.callout');
-      expect(message).toHaveLength(0);
-      simulateEvent.simulate(helper.find("button:contains('Enable')").get(0), 'click');
-      m.redraw.sync();
-      message = helper.find('.callout');
-      expect(message).toHaveText('Enabled 2 agents');
+      expect(helper.q('.callout')).not.toExist();
+
+      helper.click(buttonLabeled("Enable"));
+
+      expect(helper.text('.callout')).toBe('Enabled 2 agents');
     });
   });
 
@@ -236,12 +227,11 @@ describe("Agents Widget", () => {
       clickAllAgents();
       allowBulkUpdate('DELETE');
 
-      let message = helper.find('.callout');
-      expect(message).toHaveLength(0);
-      simulateEvent.simulate(helper.find("button:contains('Delete')").get(0), 'click');
-      m.redraw.sync();
-      message = helper.find('.callout');
-      expect(message).toHaveText('Deleted 2 agents');
+      expect(helper.q('.callout')).not.toExist();
+
+      helper.click(buttonLabeled("Delete"));
+
+      expect(helper.text('.callout')).toBe('Deleted 2 agents');
     });
   });
 
@@ -251,17 +241,12 @@ describe("Agents Widget", () => {
       allowBulkUpdate('PATCH');
       stubResourcesList();
 
-      let message = helper.find('.callout');
-      expect(message).toHaveLength(0);
+      expect(helper.q('.callout')).not.toExist();
 
-      simulateEvent.simulate(helper.find("button:contains('Resources')").get(0), 'click');
-      m.redraw.sync();
+      helper.click(buttonLabeled("Resources"));
+      helper.click(buttonLabeled("Apply"));
 
-      simulateEvent.simulate(helper.find(".add-resource button:contains('Apply')").get(0), 'click');
-      m.redraw.sync();
-
-      message = helper.find('.callout');
-      expect(message).toHaveText('Resources modified on 2 agents');
+      expect(helper.text('.callout')).toBe('Resources modified on 2 agents');
     });
   });
 
@@ -271,57 +256,42 @@ describe("Agents Widget", () => {
       allowBulkUpdate('PATCH');
       stubEnvironmentsList();
 
-      let message = helper.find('.callout');
-      expect(message).toHaveLength(0);
+      expect(helper.q('.callout')).not.toExist();
 
-      simulateEvent.simulate(helper.find("button:contains('Environments')").get(0), 'click');
-      m.redraw.sync();
+      helper.click(buttonLabeled("Environments"));
+      helper.click(buttonLabeled("Apply"));
 
-      simulateEvent.simulate(helper.find(".env-dropdown button:contains('Apply')").get(0), 'click');
-      m.redraw.sync();
-
-      message = helper.find('.callout');
-      expect(message).toHaveText('Environments modified on 2 agents');
+      expect(helper.text('.callout')).toBe('Environments modified on 2 agents');
     });
   });
 
   it('should show only filtered agents after inserting filter text', () => {
-    const searchField     = helper.find('#filter-agent').get(0);
-    let agentsCountOnPage = helper.find('.agents-table-body .agents-table tbody tr');
+    const searchField     = helper.q('#filter-agent');
+    let agentsCountOnPage = helper.qa('.agents-table-body .agents-table tbody tr');
     expect(agentsCountOnPage).toHaveLength(2);
 
-    $(searchField).val('host-2');
-    simulateEvent.simulate(searchField, 'input');
-    m.redraw.sync();
+    helper.oninput(searchField, 'host-2');
 
-    agentsCountOnPage = helper.find('.agents-table-body .agents-table tbody tr');
+    agentsCountOnPage = helper.qa('.agents-table-body .agents-table tbody tr');
     expect(agentsCountOnPage).toHaveLength(1);
 
-    $(searchField).val('host-');
-    simulateEvent.simulate(searchField, 'input');
-    m.redraw.sync();
+    helper.oninput(searchField, 'host-');
 
-    agentsCountOnPage = helper.find('.agents-table-body .agents-table tbody tr');
+    agentsCountOnPage = helper.qa('.agents-table-body .agents-table tbody tr');
     expect(agentsCountOnPage).toHaveLength(2);
   });
 
   it('should preserve the selection of agents during filter', () => {
-    const searchField = helper.find('#filter-agent').get(0);
+    const searchField = helper.q('#filter-agent');
 
-    $(searchField).val('host-1');
-    simulateEvent.simulate(searchField, 'input');
-    m.redraw.sync();
+    helper.oninput(searchField, 'host-1');
 
-    let allBoxes = helper.find('.agents-table-body .agents-table tbody tr input[type="checkbox"]');
-    allBoxes.each((_i, checkbox) => {
-      simulateEvent.simulate(checkbox, 'click');
-    });
+    let allBoxes = helper.qa('.agents-table-body .agents-table tbody tr input[type="checkbox"]');
+    allBoxes.forEach((cb) => helper.click(cb));
 
-    $(searchField).val('');
-    simulateEvent.simulate(searchField, 'input');
-    m.redraw.sync();
+    helper.oninput(searchField, '');
 
-    allBoxes = helper.find('.agents-table tbody tr input[type="checkbox"]');
+    allBoxes = helper.qa('.agents-table tbody tr input[type="checkbox"]');
     expect(allBoxes).toHaveLength(2);
     expect(allBoxes[0]).toBeChecked();
     expect(allBoxes[1]).not.toBeChecked();
@@ -329,26 +299,17 @@ describe("Agents Widget", () => {
 
   it('should allow sorting', () => {
     const getHostnamesInTable = () => {
-      const hostnameCells = helper.find(".agents-table tbody td:nth-child(3)");
-
-      return hostnameCells.map((_i, cell) => $(cell).find('.content').text()).toArray();
+      return helper.textAll(".agents-table tbody td:nth-child(3) .content");
     };
 
-    let agentNameHeader = helper.find("label:contains('Agent Name')");
-    simulateEvent.simulate(agentNameHeader.get(0), 'click');
-    m.redraw.sync();
+    const agentNameHeader = labelCalled("Agent Name");
+    helper.click(agentNameHeader);
 
     expect(getHostnamesInTable()).toEqual(['host-1', 'host-2']);
-
-    agentNameHeader = helper.find("label:contains('Agent Name')");
-    simulateEvent.simulate(agentNameHeader.get(0), 'click');
-    m.redraw.sync();
+    helper.click(agentNameHeader);
 
     expect(getHostnamesInTable()).toEqual(['host-2', 'host-1']);
-
-    agentNameHeader = helper.find("label:contains('Agent Name')");
-    simulateEvent.simulate(agentNameHeader.get(0), 'click');
-    m.redraw.sync();
+    helper.click(agentNameHeader);
 
     expect(getHostnamesInTable()).toEqual(['host-1', 'host-2']);
   });
@@ -360,19 +321,17 @@ describe("Agents Widget", () => {
     jasmine.Ajax.withMock(() => {
       clickAllAgents();
       stubResourcesList();
-      const resourceButton = helper.find("button:contains('Resources')");
-      let resourcesList    = helper.find('.has-dropdown')[0];
-      expect(resourcesList.classList).not.toContain('is-open');
+      const resourceButton = buttonLabeled("Resources");
+      const resourcesList    = helper.q('.has-dropdown');
+      expect(resourcesList).not.toHaveClass('is-open');
 
-      $(resourceButton).click();
-      m.redraw.sync();
+      helper.click(resourceButton);
 
-      resourcesList = helper.find('.has-dropdown')[0];
-      expect(resourcesList.classList).toContain('is-open');
+      expect(resourcesList).toHaveClass('is-open');
 
-      resourceButton.click();
-      m.redraw.sync();
-      expect(resourcesList.classList).not.toContain('is-open');
+      helper.click(resourceButton);
+
+      expect(resourcesList).not.toHaveClass('is-open');
     });
   });
 
@@ -381,18 +340,17 @@ describe("Agents Widget", () => {
       clickAllAgents();
       stubEnvironmentsList();
 
-      const environmentButton = helper.find("button:contains('Environments')");
-      let environmentsList    = helper.find('.has-dropdown')[1];
-      expect(environmentsList.classList).not.toContain('is-open');
+      const environmentButton = buttonLabeled("Environments");
+      const environmentsList  = helper.qa('.has-dropdown')[1];
+      expect(environmentsList).not.toHaveClass('is-open');
 
-      $(environmentButton).click();
-      m.redraw.sync();
-      environmentsList = helper.find('.has-dropdown')[1];
-      expect(environmentsList.classList).toContain('is-open');
+      helper.click(environmentButton);
 
-      environmentButton.click();
-      m.redraw.sync();
-      expect(environmentsList.classList).not.toContain('is-open');
+      expect(environmentsList).toHaveClass('is-open');
+
+      helper.click(environmentButton);
+
+      expect(environmentsList).not.toHaveClass('is-open');
     });
   });
 
@@ -401,19 +359,17 @@ describe("Agents Widget", () => {
       clickAllAgents();
       stubResourcesList();
       stubEnvironmentsList();
-      const environmentButton = helper.find("button:contains('Environments')");
-      const resourcesButton   = helper.find("button:contains('Resources')");
-      const resourcesDropdown = helper.find("button:contains('Resources')").parent()[0];
+      const environmentButton = buttonLabeled("Environments");
+      const resourcesButton   = buttonLabeled("Resources");
+      const resourcesDropdown = resourcesButton.parentElement;
 
-      resourcesButton.click();
-      m.redraw.sync();
+      helper.click(resourcesButton);
 
-      expect(resourcesDropdown.classList).toContain('is-open');
+      expect(resourcesDropdown).toHaveClass('is-open');
 
-      environmentButton.click();
-      m.redraw.sync();
+      helper.click(environmentButton);
 
-      expect(resourcesDropdown.classList).not.toContain('is-open');
+      expect(resourcesDropdown).not.toHaveClass('is-open');
 
       hideAllDropDowns();
     });
@@ -425,33 +381,28 @@ describe("Agents Widget", () => {
       stubResourcesList();
       stubEnvironmentsList();
 
-      const environmentButton    = helper.find("button:contains('Environments')");
-      const resourcesButton      = helper.find("button:contains('Resources')");
-      const environmentsDropdown = helper.find("button:contains('Environments')").parent()[0];
+      const environmentButton    = buttonLabeled("Environments");
+      const resourcesButton      = buttonLabeled("Resources");
+      const environmentsDropdown = environmentButton.parentElement;
 
-      environmentButton.click();
-      m.redraw.sync();
+      helper.click(environmentButton);
 
-      expect(environmentsDropdown.classList).toContain('is-open');
+      expect(environmentsDropdown).toHaveClass('is-open');
 
-      resourcesButton.click();
-      m.redraw.sync();
+      helper.click(resourcesButton);
 
-      expect(environmentsDropdown.classList).not.toContain('is-open');
+      expect(environmentsDropdown).not.toHaveClass('is-open');
 
       hideAllDropDowns();
     });
   });
 
   it('should show build details dropdown for building agent', () => {
-    let buildingAgentStatus = helper.find(".agents-table tbody td:nth-child(7)")[0];
+    const buildingAgentStatus = helper.q(".agents-table tbody td:nth-child(7)");
     expect(buildingAgentStatus).not.toHaveClass('is-open');
-    const buildingDetailsLink = $(buildingAgentStatus).find('.has-build-details-drop-down')[0];
 
-    simulateEvent.simulate(buildingDetailsLink, "click");
-    m.redraw.sync();
+    helper.click('.has-build-details-drop-down', buildingAgentStatus);
 
-    buildingAgentStatus = helper.find(".agents-table tbody td:nth-child(7)")[0];
     expect(buildingAgentStatus).toHaveClass('is-open');
   });
 
@@ -460,12 +411,12 @@ describe("Agents Widget", () => {
     _.forEach(uuids, (uuid) => {
       agentsVM.agents.checkboxFor(uuid)(true);
     });
-    m.redraw.sync();
+    helper.redraw();
   };
 
   const hideAllDropDowns = () => {
     agentsVM.dropdown.hideAllDropDowns();
-    m.redraw.sync();
+    helper.redraw();
   };
 
   const allowBulkUpdate = (method) => {
@@ -614,4 +565,12 @@ describe("Agents Widget", () => {
     }
   ];
   /* eslint-enable camelcase */
+
+  function buttonLabeled(name) {
+    return Array.from(helper.qa("button")).find((b) => b.textContent === name);
+  }
+
+  function labelCalled(name) {
+    return Array.from(helper.qa("label")).find((b) => b.textContent === name);
+  }
 });

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/agents/button_row_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/agents/button_row_widget_spec.js
@@ -57,24 +57,24 @@ describe("Button Row Widget", () => {
 
   describe('Heading Row', () => {
     it('should contain the agents page heading text', () => {
-      const headingText = helper.find('.page-header h1');
-      expect(headingText).toHaveText('Agents');
+      const headingText = helper.text('.page-header h1');
+      expect(headingText).toBe('Agents');
     });
   });
 
   describe('Button Group', () => {
     it('should contain the row elements', () => {
-      const rowElementButtons = helper.find('.header-panel-button-group button');
-      expect(rowElementButtons).toHaveLength(5);
-      expect(rowElementButtons[0]).toHaveText("Delete");
-      expect(rowElementButtons[1]).toHaveText("Disable");
-      expect(rowElementButtons[2]).toHaveText("Enable");
-      expect(rowElementButtons[3]).toHaveText("Resources");
-      expect(rowElementButtons[4]).toHaveText("Environments");
+      const rowButtonText = helper.textAll('.header-panel-button-group button');
+      expect(rowButtonText).toHaveLength(5);
+      expect(rowButtonText[0]).toBe("Delete");
+      expect(rowButtonText[1]).toBe("Disable");
+      expect(rowButtonText[2]).toBe("Enable");
+      expect(rowButtonText[3]).toBe("Resources");
+      expect(rowButtonText[4]).toBe("Environments");
     });
 
     it('should disable the buttons if agents are not selected', () => {
-      const rowElements = helper.find('.header-panel-button-group button');
+      const rowElements = helper.qa('.header-panel-button-group button');
       expect(rowElements[0]).toBeDisabled();
       expect(rowElements[1]).toBeDisabled();
       expect(rowElements[2]).toBeDisabled();
@@ -86,7 +86,7 @@ describe("Button Row Widget", () => {
       const areOperationsAllowed = Stream(true);
       helper.unmount();
       mount(areOperationsAllowed);
-      const rowElements = helper.find('.header-panel-button-group button');
+      const rowElements = helper.qa('.header-panel-button-group button');
 
       expect(rowElements[0]).not.toBeDisabled();
       expect(rowElements[1]).not.toBeDisabled();

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/agents/environments_list_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/agents/environments_list_widget_spec.js
@@ -18,15 +18,14 @@ import {EnvironmentsListWidget} from "views/agents/environments_list_widget";
 import {TriStateCheckbox} from "models/agents/tri_state_checkbox";
 import Stream from "mithril/stream";
 import m from "mithril";
-import $ from "jquery";
 import _ from "lodash";
 import "jasmine-ajax";
 import "jasmine-jquery";
 import "foundation-sites";
 
 describe("Environments List Widget", () => {
-
   const helper = new TestHelper();
+  const body = document.body;
 
   let  environments;
 
@@ -70,7 +69,7 @@ describe("Environments List Widget", () => {
   });
 
   it('should contain all the environments checkbox', () => {
-    const allEnvironments = $.find('.resources-items :checkbox');
+    const allEnvironments = helper.qa('.resources-items input[type="checkbox"]', body);
     expect(allEnvironments).toHaveLength(4);
     expect(allEnvironments[0]).toHaveValue('Build');
     expect(allEnvironments[1]).toHaveValue('Deploy');
@@ -79,13 +78,13 @@ describe("Environments List Widget", () => {
   });
 
   it('should check environments that are present on all the agents', () => {
-    const allEnvironments = $.find('.resources-items :checkbox');
+    const allEnvironments = helper.qa('.resources-items input[type="checkbox"]', body);
     expect(allEnvironments[3]).toHaveValue('Testing');
     expect(allEnvironments[3]).toBeChecked();
   });
 
   it('should select environments as indeterminate that are present on some of the agents', () => {
-    const allEnvironments = $.find('.resources-items :checkbox');
+    const allEnvironments = helper.qa('.resources-items input[type="checkbox"]', body);
     expect(allEnvironments[2]).toHaveValue('Dev');
     expect(allEnvironments[2].indeterminate).toBe(true);
 
@@ -94,7 +93,7 @@ describe("Environments List Widget", () => {
   });
 
   it('should uncheck environments that are not present on any the agents', () => {
-    const allEnvironments = $.find('.resources-items :checkbox');
+    const allEnvironments = helper.qa('.resources-items input[type="checkbox"]', body);
     expect(allEnvironments[1]).toHaveValue('Deploy');
     expect(allEnvironments[1]).not.toBeChecked();
     expect(allEnvironments[1].indeterminate).toBe(false);
@@ -104,10 +103,10 @@ describe("Environments List Widget", () => {
     it('should show page spinner until environments are fetched', () => {
       helper.unmount();
       mount();
-      expect($('.page-spinner')).toBeInDOM();
+      expect(helper.q('.page-spinner', body)).toBeInDOM();
       helper.unmount();
       mount(environments);
-      expect($('.page-spinner')).not.toBeInDOM();
+      expect(helper.q('.page-spinner', body)).not.toExist();
     });
   });
 
@@ -117,7 +116,7 @@ describe("Environments List Widget", () => {
       const environmentsFetchError = () => err;
       helper.unmount();
       mount(environments, environmentsFetchError);
-      expect($('.alert')).toContainText(err);
+      expect(helper.text('.alert', body)).toContain(err);
     });
   });
 

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/agents/resources_list_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/agents/resources_list_widget_spec.js
@@ -17,14 +17,12 @@ import {TestHelper} from "views/pages/spec/test_helper";
 import {TriStateCheckbox} from "models/agents/tri_state_checkbox";
 import Stream from "mithril/stream";
 import m from "mithril";
-import simulateEvent from "simulate-event";
-import $ from "jquery";
 import "foundation-sites";
 import {ResourcesListWidget} from "views/agents/resources_list_widget";
 
 describe("ResourcesListWidget", () => {
-
-  const helper              = new TestHelper();
+  const helper = new TestHelper();
+  const body = document.body;
 
   let resources;
 
@@ -65,7 +63,7 @@ describe("ResourcesListWidget", () => {
   });
 
   it('should contain all the resources checkbox', () => {
-    const allResources = $.find('.resources-items :checkbox');
+    const allResources = helper.qa('.resources-items input[type="checkbox"]', body);
     expect(allResources).toHaveLength(4);
     expect(allResources[0]).toHaveValue('Gauge');
     expect(allResources[1]).toHaveValue('Java');
@@ -74,13 +72,13 @@ describe("ResourcesListWidget", () => {
   });
 
   it('should check resources that are present on all the agents', () => {
-    const allResources = $.find('.resources-items :checkbox');
+    const allResources = helper.qa('.resources-items input[type="checkbox"]', body);
     expect(allResources[1]).toHaveValue('Java');
     expect(allResources[1]).toBeChecked();
   });
 
   it('should select resources as indeterminate that are present on some of the agents', () => {
-    const allResources = $.find('.resources-items :checkbox');
+    const allResources = helper.qa('.resources-items input[type="checkbox"]', body);
     expect(allResources[2]).toHaveValue('Linux');
     expect(allResources[2].indeterminate).toBe(true);
 
@@ -89,66 +87,51 @@ describe("ResourcesListWidget", () => {
   });
 
   it('should uncheck resources that are not present on any the agents', () => {
-    const allResources = $.find('.resources-items :checkbox');
+    const allResources = helper.qa('.resources-items input[type="checkbox"]', body);
     expect(allResources[3]).toHaveValue('Windows');
     expect(allResources[3]).not.toBeChecked();
     expect(allResources[3].indeterminate).toBe(false);
   });
 
   it('should have button to add resources', () => {
-    const addButton = helper.find('.add-resource :button')[0];
-    expect(addButton).toHaveText("Add");
+    expect(helper.text('.add-resource button')).toBe("Add");
   });
 
   it('should have button to apply resources', () => {
-    const applyButton = helper.find('.add-resource :button')[1];
+    const applyButton = helper.qa('.add-resource button')[1];
     expect(applyButton).toHaveText("Apply");
   });
 
   it('should add resource after invoking add button', () => {
-    let allResources = helper.find('.resources-items :checkbox');
+    let allResources = helper.qa('.resources-items input[type="checkbox"]');
     expect(allResources).toHaveLength(4);
 
-    const inputBox = helper.find('.add-resource-input').get(0);
-    $(inputBox).val('Chrome');
-    simulateEvent.simulate(inputBox, 'input');
+    helper.oninput('.add-resource-input', 'Chrome');
+    helper.click('.add-resource .add-resource-btn');
 
-    expect(inputBox).toHaveValue('Chrome');
-    const addButton = helper.find('.add-resource .add-resource-btn')[0];
-    simulateEvent.simulate(addButton, 'click');
-    m.redraw.sync();
-
-    allResources = helper.find('.resources-items :checkbox');
+    allResources = helper.qa('.resources-items input[type="checkbox"]');
     expect(allResources).toHaveLength(5);
   });
 
 
   it('should clear input-text box after adding resource', () => {
-    let inputBox = helper.find('.add-resource input');
-    $(inputBox).val('Chrome').trigger('change');
+    const inputBox = helper.q('.add-resource input');
+    helper.onchange(inputBox, "Chrome");
+    helper.click('.add-resource button');
 
-    expect(inputBox).toHaveValue('Chrome');
-    const addButton = helper.find('.add-resource button')[0];
-    addButton.click();
-    m.redraw.sync();
-
-    inputBox = helper.find('.add-resource input');
     expect(inputBox).toHaveValue('');
   });
 
   it('should not add duplicate resources', () => {
-    let allResources = helper.find('.resources-items input[type="Checkbox"]');
+    let allResources = helper.qa('.resources-items input[type="checkbox"]');
     expect(allResources).toHaveLength(4);
     expect(allResources[2]).toHaveValue('Linux');
 
-    const inputBox = helper.find('.add-resource :input')[0];
-    $(inputBox).val('Linux').trigger('change');
+    helper.onchange('.add-resource input', "Linux");
 
-    const addButton = helper.find('.add-resource :button')[1];
-    addButton.click();
-    m.redraw.sync();
+    helper.click(helper.qa('.add-resource button')[1]);
 
-    allResources = helper.find('.resources-items input[type="Checkbox"]');
+    allResources = helper.qa('.resources-items input[type="checkbox"]');
     expect(allResources).toHaveLength(4);
   });
 
@@ -156,10 +139,10 @@ describe("ResourcesListWidget", () => {
     it('should show page spinner until resources are fetched', () => {
       helper.unmount();
       mount(undefined);
-      expect($('.page-spinner')).toBeInDOM();
+      expect(helper.q('.page-spinner', body)).toBeInDOM();
       helper.unmount();
       mount(resources);
-      expect($('.page-spinner')).not.toBeInDOM();
+      expect(helper.q('.page-spinner', body)).not.toExist();
     });
   });
 
@@ -168,7 +151,7 @@ describe("ResourcesListWidget", () => {
       const err = 'BOOM!';
       helper.unmount();
       mount(resources, () => err);
-      expect($('.alert')).toContainText(err);
+      expect(helper.text('.alert', body)).toContain(err);
     });
   });
 

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/agents/tri_state_checkbox_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/agents/tri_state_checkbox_widget_spec.js
@@ -29,37 +29,37 @@ describe("TriStateCheckboxWidget", () => {
 
   it('should have checkbox with value', () => {
     mount(new TriStateCheckbox('Firefox', resources));
-    const checkbox = helper.find('input')[0];
+    const checkbox = helper.q('input');
     expect(checkbox).toHaveValue('Firefox');
   });
 
   it('should select the box as checked depending upon check field', () => {
     mount(new TriStateCheckbox('Firefox', resources));
-    const checkbox = helper.find('input')[0];
+    const checkbox = helper.q('input');
     expect(checkbox).toBeChecked();
   });
 
   it('should select the box as unchecked depending upon check field', () => {
     mount(new TriStateCheckbox('Linux', resources));
-    const checkbox = helper.find('input')[0];
+    const checkbox = helper.q('input');
     expect(checkbox).not.toBeChecked();
   });
 
   it('should select the box as indeterminate depending upon the isIndeterminate field', () => {
     mount(new TriStateCheckbox('Chrome', resources));
-    const checkbox = helper.find('input')[0];
+    const checkbox = helper.q('input');
     expect(checkbox.indeterminate).toBe(true);
   });
 
   it('should disable the checkbox when disabled flag is set', () => {
     mount(new TriStateCheckbox('Chrome', resources, true));
-    const checkbox = helper.find('input')[0];
+    const checkbox = helper.q('input');
     expect(checkbox).toHaveAttr('disabled');
   });
 
   it('should not disable the checkbox when disabled flag is not set', () => {
     mount(new TriStateCheckbox('Chrome', resources));
-    const checkbox = helper.find('input')[0];
+    const checkbox = helper.q('input');
     expect(checkbox).not.toHaveAttr('disabled');
   });
 

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/analytics/analytics_widget_spec.js.msx
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/analytics/analytics_widget_spec.js.msx
@@ -33,38 +33,37 @@ describe("Analytics Widget", () => {
   });
 
   it('should render analytics header', () => {
-    expect(helper.find('.header-panel')).toBeInDOM();
-    expect(helper.find('.header-panel')).toContainText("Analytics");
+    expect(helper.q('.header-panel')).toBeInDOM();
+    expect(helper.q('.header-panel')).toContainText("Analytics");
   });
 
   it('should render global tab', () => {
-    expect(helper.find('.dashboard-tabs li').get(0)).toContainText("Global");
+    expect(helper.q('.dashboard-tabs li')).toContainText("Global");
   });
 
   it('should render pipelines tab', () => {
-    expect(helper.find('.dashboard-tabs li').get(1)).toContainText("Pipeline");
+    expect(helper.qa('.dashboard-tabs li').item(1)).toContainText("Pipeline");
   });
 
   it('should render global chart contents when global tab is selected', () => {
-    expect(helper.find('.dashboard-tabs li').get(0)).toContainText("Global");
-    expect(helper.find('.dashboard-tabs li').get(0)).toHaveClass("current");
-    expect(helper.find('.global')).toBeInDOM();
+    expect(helper.q('.dashboard-tabs li')).toContainText("Global");
+    expect(helper.q('.dashboard-tabs li')).toHaveClass("current");
+    expect(helper.q('.global')).toBeInDOM();
   });
 
   it('should render global chart contents when global tab is selected', () => {
-    helper.find('.dashboard-tabs li').get(1).click();
-    m.redraw.sync();
+    helper.click(helper.qa('.dashboard-tabs li')[1]);
 
-    expect(helper.find('.dashboard-tabs li').get(1)).toContainText("Pipeline");
-    expect(helper.find('.dashboard-tabs li').get(1)).toHaveClass("current");
-    expect(helper.find('.pipeline')).toBeInDOM();
+    expect(helper.qa('.dashboard-tabs li')[1]).toContainText("Pipeline");
+    expect(helper.qa('.dashboard-tabs li')[1]).toHaveClass("current");
+    expect(helper.q('.pipeline')).toBeInDOM();
   });
 
   it('should render no analytics plugin installed message when no analytics plugin is installed', () => {
     helper.unmount();
     mount(0);
 
-    expect(helper.find('.info')).toContainText('No analytics plugin installed.');
+    expect(helper.text('.info')).toContain('No analytics plugin installed.');
   });
 
 

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/analytics/global_metrics_spec.js.msx
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/analytics/global_metrics_spec.js.msx
@@ -41,7 +41,7 @@ describe("Global Dashboard Metrics", () => {
     jasmine.Ajax.stubRequest("/analytics/plugin-id-y/z/three", undefined, 'GET').andReturn({status: 200});
 
     helper.mount(() => <GlobalMetrics metrics={supportedMetrics}/>);
-    expect(helper.find("iframe").length).toBe(3);
+    expect(helper.qa("iframe").length).toBe(3);
   });
 
 });

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/analytics/pipeline_metrics_spec.js.msx
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/analytics/pipeline_metrics_spec.js.msx
@@ -15,10 +15,8 @@
  */
 import {TestHelper} from "views/pages/spec/test_helper";
 import {PipelineMetrics} from "views/analytics/pipeline_metrics";
-import $ from "jquery";
 import "jasmine-jquery";
 import m from "mithril";
-import * as simulateEvent from "simulate-event";
 
 describe("Pipeline Dashboard Metrics", () => {
 
@@ -41,20 +39,20 @@ describe("Pipeline Dashboard Metrics", () => {
   });
 
   it('should have a dropdown with each pipeline', () => {
-    const list = helper.find("select option");
+    const list = helper.qa("select option");
     expect(list.length).toBe(3);
-    expect($(list[0]).val()).toBe("p1");
-    expect($(list[1]).val()).toBe("p2");
-    expect($(list[2]).val()).toBe("p3");
+    expect(list[0].value).toBe("p1");
+    expect(list[1].value).toBe("p2");
+    expect(list[2].value).toBe("p3");
   });
 
   it('Add a frame for each plugin', () => {
-    expect(helper.find("iframe").length).toBe(2);
+    expect(helper.qa("iframe").length).toBe(2);
   });
 
   it('should change displayed graphs when new pipeline is selected', () => {
-    simulateEvent.simulate(helper.find("select").val("p2")[0], "change");
-    m.redraw.sync();
+    helper.onchange(helper.q("select"), "p2");
+
     const requests = jasmine.Ajax.requests;
     expect(requests.count()).toBe(4);
     expect(requests.at(2).url).toBe('/go/analytics/plugin-id-x/pipeline/metric-1?pipeline_name=p2&context=dashboard');

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/comment_render_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/comment_render_widget_spec.js
@@ -36,7 +36,7 @@ describe("Comment Render Widget", () => {
       const trackingTool = {"link": "http://example.com/${ID}", "regex": "#(\\d+)"};
       const text         = "Fix issues #8076 and #8077";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
 
       expect(commentRenderWidget).toHaveHtml("<p>Fix issues <a target='story_tracker' href='http://example.com/8076'>#8076</a> and <a target='story_tracker' href='http://example.com/8077'>#8077</a></p>");
     });
@@ -45,7 +45,7 @@ describe("Comment Render Widget", () => {
       const trackingTool = {"link": "http://example.com/${ID}", "regex": "(\\d+)"};
       const text         = "Fix issues 8076";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
 
       expect(commentRenderWidget).toHaveHtml("<p>Fix issues <a target='story_tracker' href='http://example.com/8076'>8076</a></p>");
     });
@@ -54,7 +54,7 @@ describe("Comment Render Widget", () => {
       const trackingTool = {"link": "http://example.com/${ID}", "regex": "(\\d+)"};
       const text         = "";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
 
       expect(commentRenderWidget).toHaveHtml("<p/>");
     });
@@ -66,7 +66,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "evo-abc: checkin message";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
 
       expect(commentRenderWidget).toHaveHtml("<p>evo-abc: checkin message</p>");
     });
@@ -78,7 +78,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "evo-abc: checkin message";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
       expect(commentRenderWidget).toHaveHtml("<p><a target='story_tracker' href='http://mingle05/projects/cce/cards/ab'>evo-ab</a>c: checkin message</p>");
     });
 
@@ -89,7 +89,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "evo-111: checkin message";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
       expect(commentRenderWidget).toHaveHtml("<p><a target='story_tracker' href='http://mingle05/projects/cce/cards/111'>evo-111</a>: checkin message</p>");
     });
 
@@ -100,7 +100,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "evo-1020: checkin message";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
       expect(commentRenderWidget).toHaveHtml("<p>evo-<a target='story_tracker' href='http://mingle05/projects/cce/cards/1020'>1020</a>: checkin message</p>");
     });
 
@@ -111,7 +111,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "1020-evo1: checkin message";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
       expect(commentRenderWidget).toHaveHtml("<p><a target='story_tracker' href='http://mingle05/projects/cce/cards/1020'>1020-evo1</a>: checkin message</p>");
     });
 
@@ -122,7 +122,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "evo-abc: checkin message";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
       expect(commentRenderWidget).toHaveHtml("<p>evo-abc: checkin message</p>");
     });
 
@@ -133,7 +133,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "evo-abc: checkin message";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
       expect(commentRenderWidget).toHaveHtml("<p>evo-abc: checkin message</p>");
     });
 
@@ -144,7 +144,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "evo-111: checkin message";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
       expect(commentRenderWidget).toHaveHtml("<p><a target='story_tracker' href='http://mingle05/projects/cce/cards/wall-E'>evo-111</a>: checkin message</p>");
     });
 
@@ -155,7 +155,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "111: checkin message";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
       expect(commentRenderWidget).toHaveHtml("<p><a target='story_tracker' href='aaa111'>111</a>: checkin message</p>");
     });
 
@@ -166,7 +166,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "Replace evo-1994.  Don't replace 1994";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
       expect(commentRenderWidget).toHaveHtml("<p>Replace <a target='story_tracker' href='http://mingle05/projects/cce/cards/1994'>evo-1994</a>.  Don't replace 1994</p>");
     });
 
@@ -177,7 +177,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "The story #111 is fixed by 德里克. #122 is also related to this";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
       expect(commentRenderWidget).toHaveHtml("<p>The story <a target='story_tracker' href='http://mingle05/projects/cce/cards/111'>#111</a> is fixed by 德里克. <a target='story_tracker' href='http://mingle05/projects/cce/cards/122'>#122</a> is also related to this");
     });
 
@@ -188,7 +188,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "some <string>";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
       expect(commentRenderWidget).toHaveHtml("<p>some &lt;string&gt;</p>");
     });
 
@@ -199,7 +199,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "ABC-\"><svg/onload=\"alert(1)";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
       expect(commentRenderWidget).toHaveHtml("<p><a target='story_tracker' href='http://jira.example.com/ABC-&quot;&gt;&lt;svg/onload=&quot;alert(1)'>ABC-&quot;&gt;&lt;svg/onload=&quot;alert(1)</a></p>");
     });
 
@@ -210,7 +210,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "Don't render the apostrophe as a link";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
       expect(commentRenderWidget).toHaveHtml("<p>Don't render the apostrophe as a link</p>");
     });
 
@@ -221,7 +221,7 @@ describe("Comment Render Widget", () => {
       };
       const text         = "<b>This should not be bold</b>";
       mountView(text, trackingTool);
-      const commentRenderWidget = helper.find('.comment');
+      const commentRenderWidget = helper.q('.comment');
       expect(commentRenderWidget).toHaveHtml("<p>&lt;b&gt;This should not be bold&lt;/b&gt;</p>");
     });
 
@@ -237,21 +237,21 @@ describe("Comment Render Widget", () => {
       it('should render comment with task', () => {
         const text = "Task 111: checkin message";
         mountView(text, trackingTool);
-        const commentRenderWidget = helper.find('.comment');
+        const commentRenderWidget = helper.q('.comment');
         expect(commentRenderWidget).toHaveHtml("<p><a target='story_tracker' href='http://mingle05/projects/cce/cards/111'>Task 111</a>: checkin message</p>");
       });
 
       it('should render comment with bug', () => { //no pun intended
         const text = "Bug 111: checkin message";
         mountView(text, trackingTool);
-        const commentRenderWidget = helper.find('.comment');
+        const commentRenderWidget = helper.q('.comment');
         expect(commentRenderWidget).toHaveHtml("<p><a target='story_tracker' href='http://mingle05/projects/cce/cards/111'>Bug 111</a>: checkin message</p>");
       });
 
       it('should render comment with #', () => {
         const text = "#111: checkin message";
         mountView(text, trackingTool);
-        const commentRenderWidget = helper.find('.comment');
+        const commentRenderWidget = helper.q('.comment');
         expect(commentRenderWidget).toHaveHtml("<p><a target='story_tracker' href='http://mingle05/projects/cce/cards/111'>#111</a>: checkin message</p>");
       });
     });

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
@@ -22,7 +22,6 @@ import {PipelineInstanceWidget} from "views/dashboard/pipeline_instance_widget";
 import {timeFormatter} from "helpers/time_formatter";
 import _ from "lodash";
 import m from "mithril";
-import * as simulateEvent from "simulate-event";
 
 describe("Dashboard Pipeline Instance Widget", () => {
 
@@ -108,39 +107,35 @@ describe("Dashboard Pipeline Instance Widget", () => {
   afterEach(helper.unmount.bind(helper));
 
   it("should render instance label", () => {
-    expect(helper.find('.pipeline_instance-label')).toContainText('Instance: 1');
+    expect(helper.text('.pipeline_instance-label')).toContain('Instance: 1');
   });
 
   it("should render triggered by information", () => {
-    expect(helper.find('.pipeline_instance-details div:nth-child(1)').text()).toEqual(`${pipelineInstanceJson.triggered_by}`);
+    expect(helper.text('.pipeline_instance-details div:nth-child(1)')).toBe(`${pipelineInstanceJson.triggered_by}`);
     const expectedTime = `on ${timeFormatter.format(pipelineInstanceJson.scheduled_at)}`;
-    expect(helper.find('.pipeline_instance-details div:nth-child(2)').text()).toEqual(expectedTime);
+    expect(helper.text('.pipeline_instance-details div:nth-child(2)')).toBe(expectedTime);
   });
 
   it("should show server triggered by information on hover", () => {
     const expectedTime = timeFormatter.formatInServerTime(pipelineInstanceJson.scheduled_at);
-    expect(helper.find('.pipeline_instance-details div:nth-child(2)').get(0).title).toEqual(expectedTime);
+    expect(helper.q('.pipeline_instance-details div:nth-child(2)').title).toBe(expectedTime);
   });
 
   it("should render compare link", () => {
-    const links       = helper.find('.info a');
-    const compareLink = links.get(0);
+    const compareLink = helper.q('.info a');
 
     expect(compareLink).toContainText('Compare');
-
-    const hasCompareLink = compareLink.href.indexOf("/go/compare/up42/0/with/1") >= 0;
-    expect(hasCompareLink).toBe(true);
+    expect(compareLink.href).toContain("/go/compare/up42/0/with/1");
   });
 
   it("should render changes link", () => {
-    const links       = helper.find('.info a');
-    const changesLink = links.get(1);
+    const changesLink = helper.qa('.info a')[1];
 
     expect(changesLink).toContainText('Changes');
   });
 
   it("should show changes once changes link is clicked", () => {
-    expect(helper.find('.material_changes')).not.toBeInDOM();
+    expect(helper.q('.material_changes')).not.toExist();
 
     jasmine.Ajax.withMock(() => {
       jasmine.Ajax.stubRequest(SparkRoutes.buildCausePath(pipelineName, instance.counter), undefined, 'GET').andReturn({
@@ -149,27 +144,23 @@ describe("Dashboard Pipeline Instance Widget", () => {
         status:          200
       });
 
-      simulateEvent.simulate(helper.find('.info a').get(1), 'click');
-      m.redraw.sync();
+      helper.click(helper.qa('.info a')[1]);
     });
 
-    expect(helper.find('.material_changes')).toBeInDOM();
-    expect(helper.find('.comment')).toHaveHtml('<p>Initial commit <a target="story_tracker" href="http://example.com/1234">#1234</a></p>');
+    expect(helper.q('.material_changes')).toBeInDOM();
+    expect(helper.q('.comment')).toHaveHtml('<p>Initial commit <a target="story_tracker" href="http://example.com/1234">#1234</a></p>');
   });
 
   it("should render vsm link", () => {
-    const links   = helper.find('.info a');
-    const vsmLink = links.get(2);
+    const vsmLink = helper.qa('.info a')[2];
 
     expect(vsmLink).toContainText('VSM');
-
-    const hasVSMLink = vsmLink.href.indexOf("/go/pipelines/value_stream_map/up42/1") >= 0;
-    expect(hasVSMLink).toBe(true);
+    expect(vsmLink.href).toContain("/go/pipelines/value_stream_map/up42/1");
   });
 
   it("should render stages instance", () => {
-    expect(helper.find('.pipeline_stages')).toBeInDOM();
-    expect(helper.find('.pipeline_stage')).toBeInDOM();
+    expect(helper.q('.pipeline_stages')).toBeInDOM();
+    expect(helper.q('.pipeline_stage')).toBeInDOM();
   });
 
   const dashboardJsonForPipelines = (pipelines) => {

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -20,14 +20,13 @@ import {Dashboard} from "models/dashboard/dashboard";
 import {Pipelines} from "models/dashboard/pipelines";
 import {PipelineWidget} from "views/dashboard/pipeline_widget";
 import {timeFormatter} from "helpers/time_formatter";
-import $ from "jquery";
 import _ from "lodash";
 import m from "mithril";
 import "jasmine-ajax";
 import * as simulateEvent from "simulate-event";
 
 describe("Dashboard Pipeline Widget", () => {
-
+  const body = document.body;
   const pipelineName   = 'up42';
 
   let dashboardViewModel, dashboard, pipelinesJson, dashboardJSON, pipeline, doCancelPolling,
@@ -83,18 +82,18 @@ describe("Dashboard Pipeline Widget", () => {
     afterEach(helper.unmount.bind(helper));
 
     it("should render pipeline name", () => {
-      expect(helper.find('.pipeline_name')).toContainText('up42');
+      expect(helper.text('.pipeline_name')).toContain('up42');
     });
 
     it("should link history to pipeline history page", () => {
-      expect(helper.find('.pipeline_header>div>a')).toContainText('History');
+      expect(helper.text('.pipeline_header>div>a')).toContain('History');
       const expectedPath = `/go/tab/pipeline/history/${pipelinesJson[0].name}`;
-      expect(helper.find('.pipeline_header .pipeline_history').get(0).href.indexOf(expectedPath)).not.toEqual(-1);
+      expect(helper.q('.pipeline_header .pipeline_history').href.indexOf(expectedPath)).not.toEqual(-1);
     });
 
     it("should link to pipeline settings path", () => {
       const expectedPath = pipeline.settingsPath;
-      expect(helper.find('.edit_config').get(0).href.indexOf(expectedPath)).not.toEqual(-1);
+      expect(helper.q('.edit_config').href.indexOf(expectedPath)).not.toEqual(-1);
     });
 
     it('should disable pipeline settings showing tooltip information for non admin users', () => {
@@ -102,8 +101,8 @@ describe("Dashboard Pipeline Widget", () => {
       mount(false, {}, {}, true, true);
 
       expect(pipeline.canAdminister).toBe(false);
-      expect(helper.find('.edit_config')).toHaveClass('disabled');
-      expect(helper.find('.edit_config')).toHaveAttr('data-tooltip-id');
+      expect(helper.q('.edit_config')).toHaveClass('disabled');
+      expect(helper.q('.edit_config')).toHaveAttr('data-tooltip-id');
     });
 
     it('should disable pipeline settings for config repo pipelines', () => {
@@ -111,7 +110,7 @@ describe("Dashboard Pipeline Widget", () => {
       mount(true, {}, {}, true, true, true);
 
       expect(pipeline.isDefinedInConfigRepo()).toBe(true);
-      expect(helper.find('.edit_config')).toHaveClass('disabled');
+      expect(helper.q('.edit_config')).toHaveClass('disabled');
     });
   });
 
@@ -127,21 +126,20 @@ describe("Dashboard Pipeline Widget", () => {
     });
 
     it("should link to pipeline analytics if there are any", () => {
-      expect(helper.find('.pipeline-analytics')).toBeInDOM();
+      expect(helper.q('.pipeline-analytics')).toBeInDOM();
     });
 
     it("should open up a modal when the analytics icon is clicked", () => {
       helper.click('.pipeline-analytics');
-      expect($('.reveal:visible')).toBeInDOM();
-      expect($(".frame-container")).toBeInDOM();
-      const modalTitle = $('.modal-title:visible');
-      expect(modalTitle).toHaveText("Analytics for pipeline: up42");
+      expect(helper.q(".reveal", body)).toBeInDOM();
+      expect(helper.q(".frame-container", body)).toBeInDOM();
+      expect(helper.text('.modal-title', body)).toBe("Analytics for pipeline: up42");
     });
 
     it("should not display the analytics icon if the user is not an admin", () => {
       helper.unmount();
       mount(false, {}, {}, true, true, false, {"plugin-x": "pipeline_duration"}, false);
-      expect(helper.find('.pipeline-analytics')).not.toBeInDOM();
+      expect(helper.q('.pipeline-analytics')).toBeFalsy();
     });
   });
 
@@ -153,17 +151,17 @@ describe("Dashboard Pipeline Widget", () => {
       });
 
       it("should not disable pipeline settings button for admin users", () => {
-        expect(helper.find('.edit_config')).not.toHaveClass("disabled");
+        expect(helper.q('.edit_config')).not.toHaveClass("disabled");
       });
 
       it("should disable pipeline settings button for non admin users", () => {
         helper.unmount();
         mount(false);
-        expect(helper.find('.edit_config')).toHaveClass("disabled");
+        expect(helper.q('.edit_config')).toHaveClass("disabled");
       });
 
       it("should render pipeline settings icon", () => {
-        expect(helper.find('.edit_config')).toBeInDOM();
+        expect(helper.q('.edit_config')).toBeInDOM();
       });
     });
 
@@ -184,27 +182,27 @@ describe("Dashboard Pipeline Widget", () => {
       });
 
       it("should render unpause pipeline button", () => {
-        const pauseButton = helper.find('.unpause');
+        const pauseButton = helper.q('.unpause');
         expect(pauseButton).toBeInDOM();
-        expect($(pauseButton).attr('title')).toBe("Pipeline Paused");
+        expect(pauseButton.getAttribute('title')).toBe("Pipeline Paused");
       });
 
       it('should disable pause button for non admin users', () => {
         helper.unmount();
         mount(true, pauseInfo, undefined, false);
 
-        expect(helper.find('.unpause')).toHaveClass('disabled');
+        expect(helper.q('.unpause')).toHaveClass('disabled');
       });
 
       it('should not add onclick handler for non admin users', () => {
         helper.unmount();
         mount(true, pauseInfo, undefined, false);
 
-        expect(_.isFunction(helper.find('.unpause').get(0).onclick)).toBe(false);
+        expect(_.isFunction(helper.q('.unpause').onclick)).toBe(false);
       });
 
       it("should render the pipeline pause message", () => {
-        expect(helper.find('.pipeline_pause-message')).toContainText('Paused by admin (under construction)');
+        expect(helper.text('.pipeline_pause-message')).toContain('Paused by admin (under construction)');
       });
 
       it("should not render null in case of no pipeline pause message", () => {
@@ -216,13 +214,13 @@ describe("Dashboard Pipeline Widget", () => {
         };
 
         mount(true, pauseInfo, undefined, false);
-        expect(helper.find('.pipeline_pause-message')).toContainText('Paused by admin ()');
+        expect(helper.text('.pipeline_pause-message')).toContain('Paused by admin ()');
       });
 
       it("should not render the pipeline flash message", () => {
-        expect(helper.find('.pipeline_message')).not.toBeInDOM();
-        expect(helper.find('.pipeline_message .success')).not.toBeInDOM();
-        expect(helper.find('.pipeline_message .error')).not.toBeInDOM();
+        expect(helper.q('.pipeline_message')).toBeFalsy();
+        expect(helper.q('.pipeline_message .success')).toBeFalsy();
+        expect(helper.q('.pipeline_message .error')).toBeFalsy();
       });
 
       it("should unpause a pipeline", () => {
@@ -244,9 +242,9 @@ describe("Dashboard Pipeline Widget", () => {
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
 
-        expect(helper.find('.pipeline_pause-message')).not.toBeInDOM();
-        expect(helper.find('.pipeline_message')).toContainText(responseMessage);
-        expect(helper.find('.pipeline_message')).toHaveClass("success");
+        expect(helper.q('.pipeline_pause-message')).toBeFalsy();
+        expect(helper.text('.pipeline_message')).toContain(responseMessage);
+        expect(helper.q('.pipeline_message')).toHaveClass("success");
       });
 
       it("should show error when unpause a pipeline fails", () => {
@@ -267,8 +265,8 @@ describe("Dashboard Pipeline Widget", () => {
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
 
-        expect(helper.find('.pipeline_message')).toContainText(responseMessage);
-        expect(helper.find('.pipeline_message')).toHaveClass("error");
+        expect(helper.text('.pipeline_message')).toContain(responseMessage);
+        expect(helper.q('.pipeline_message')).toHaveClass("error");
       });
     });
 
@@ -294,14 +292,14 @@ describe("Dashboard Pipeline Widget", () => {
       });
 
       it("should render pause pipeline button", () => {
-        expect(helper.find('.pause')).toBeInDOM();
+        expect(helper.q('.pause')).toBeInDOM();
       });
 
       it('should disable pause button for non admin users', () => {
         helper.unmount();
         mount(true, pauseInfo, dashboard, false);
 
-        expect(helper.find('.pause')).toHaveClass('disabled');
+        expect(helper.q('.pause')).toHaveClass('disabled');
       });
 
 
@@ -309,22 +307,21 @@ describe("Dashboard Pipeline Widget", () => {
         helper.unmount();
         mount(true, pauseInfo, dashboard, false);
 
-        expect(_.isFunction(helper.find('.pause').get(0).onclick)).toBe(false);
+        expect(_.isFunction(helper.q('.pause').onclick)).toBe(false);
       });
 
       it("should show modal to specify pause reason upon pausing a pipeline", () => {
-        expect($('.reveal:visible')).not.toBeInDOM();
+        expect(helper.q(".reveal", body)).toBeFalsy();
 
         helper.click('.pause');
 
-        expect($('.reveal:visible')).toBeInDOM();
+        expect(helper.q(".reveal", body)).toBeInDOM();
       });
 
       it("should show appropriate header for popup modal upon pause button click", () => {
         helper.click('.pause');
 
-        const modalTitle = $('.modal-title:visible');
-        expect(modalTitle).toHaveText(`Pause pipeline ${pipeline.name}`);
+        expect(helper.text('.modal-title', body)).toBe(`Pause pipeline ${pipeline.name}`);
       });
 
       it("should pause a pipeline", () => {
@@ -342,20 +339,19 @@ describe("Dashboard Pipeline Widget", () => {
 
         helper.click('.pause');
 
-        $('.reveal input').val("test");
+        helper.q('.reveal input', body).value = "test";
 
         doRefreshImmediately.and.callFake(() => pipeline.isPaused = true);
-        simulateEvent.simulate($('.reveal .primary').get(0), 'click');
-        m.redraw.sync();
+        helper.click('.reveal .primary', body);
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
 
-        expect(helper.find('.pipeline_pause-message')).toBeInDOM();
-        expect(helper.find('.pipeline_pause-message')).toContainText(`on ${timeFormatter.format(pauseInfo.paused_at)}`);
-        expect(helper.find('.pipeline_pause-message div').get(0).title).toEqual(timeFormatter.formatInServerTime(pauseInfo.paused_at));
-        expect(helper.find('.pipeline_message')).toContainText(responseMessage);
-        expect(helper.find('.pipeline_message')).toHaveClass("success");
+        expect(helper.q('.pipeline_pause-message')).toBeInDOM();
+        expect(helper.text('.pipeline_pause-message')).toContain(`on ${timeFormatter.format(pauseInfo.paused_at)}`);
+        expect(helper.q('.pipeline_pause-message div').title).toEqual(timeFormatter.formatInServerTime(pauseInfo.paused_at));
+        expect(helper.text('.pipeline_message')).toContain(responseMessage);
+        expect(helper.q('.pipeline_message')).toHaveClass("success");
       });
 
       it("should not pause a pipeline", () => {
@@ -373,15 +369,14 @@ describe("Dashboard Pipeline Widget", () => {
 
         helper.click('.pause');
 
-        $('.reveal input').val("test");
-        simulateEvent.simulate($('.reveal .primary').get(0), 'click');
-        m.redraw.sync();
+        helper.q('.reveal input', body).value = "test";
+        helper.click('.reveal .primary', body);
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
 
-        expect(helper.find('.pipeline_message')).toContainText(responseMessage);
-        expect(helper.find('.pipeline_message')).toHaveClass("error");
+        expect(helper.text('.pipeline_message')).toContain(responseMessage);
+        expect(helper.q('.pipeline_message')).toHaveClass("error");
       });
 
       it("should pause pipeline and close popup when enter is pressed inside the pause popup", () => {
@@ -395,36 +390,38 @@ describe("Dashboard Pipeline Widget", () => {
         });
 
         helper.click('.pause');
-        expect($('.reveal:visible')).toBeInDOM();
-        const pausePopupTextBox = $('.reveal input');
-        pausePopupTextBox.val("test");
+        expect(helper.q(".reveal", body)).toBeInDOM();
+        const pausePopupTextBox = helper.q('.reveal input', body);
+        pausePopupTextBox.value = "test";
 
-        simulateEvent.simulate(pausePopupTextBox.get(0), 'keydown', { key: 'Enter' });
+        simulateEvent.simulate(pausePopupTextBox, 'keydown', { key: 'Enter' });
         m.redraw.sync();
 
-        expect($('.reveal:visible')).not.toBeInDOM();
-        expect(helper.find('.pipeline_message')).toContainText(responseMessage);
-        expect(helper.find('.pipeline_message')).toHaveClass("success");
+        expect(helper.q(".reveal", body)).toBeFalsy();
+        expect(helper.text('.pipeline_message')).toContain(responseMessage);
+        expect(helper.q('.pipeline_message')).toHaveClass("success");
       });
 
       it("should close pause popup when escape is pressed", () => {
         helper.click('.pause');
-        expect($('.reveal:visible')).toBeInDOM();
+        expect(helper.q(".reveal", body)).toBeInDOM();
 
-        simulateEvent.simulate($('body').get(0), 'keydown', { key: 'Escape' });
+        simulateEvent.simulate(body, 'keydown', { key: 'Escape' });
         m.redraw.sync();
 
-        expect($('.reveal:visible')).not.toBeInDOM();
+        expect(helper.q(".reveal", body)).toBeFalsy();
       });
 
       it("should not retain text entered when the pause popup is closed", () => {
         helper.click('.pause');
-        expect($('.reveal:visible')).toBeInDOM();
-        let pausePopupTextBox = $('.reveal input');
-        pausePopupTextBox.val("test");
-        $('.reveal .secondary').trigger('click');
+        expect(helper.q(".reveal", body)).toBeInDOM();
+        let pausePopupTextBox = helper.q('.reveal input', body);
+        pausePopupTextBox.value = "test";
+
+        helper.click('.reveal .secondary', body);
         helper.click('.pause');
-        pausePopupTextBox = $('.reveal input');
+
+        pausePopupTextBox = helper.q('.reveal input', body);
 
         expect(pausePopupTextBox).toHaveValue("");
       });
@@ -432,10 +429,10 @@ describe("Dashboard Pipeline Widget", () => {
       it("should have tooltip for pause button when it is disabled", () => {
         helper.unmount();
         mount(true, pauseInfo, {}, false);
-        const pauseButton = helper.find('.pause');
+        const pauseButton = helper.q('.pause');
         expect(pauseButton).toHaveAttr('data-tooltip-id');
-        const tooltipId = $(pauseButton).attr('data-tooltip-id');
-        expect($(`#${tooltipId}`)).toHaveText("You do not have permission to pause the pipeline.");
+        const tooltipId = pauseButton.getAttribute('data-tooltip-id');
+        expect(helper.text(document.getElementById(tooltipId))).toBe("You do not have permission to pause the pipeline.");
       });
 
       it('should not show the paused time if it is null', () => {
@@ -465,20 +462,19 @@ describe("Dashboard Pipeline Widget", () => {
         expect(doRefreshImmediately).not.toHaveBeenCalled();
 
         helper.click('.pause');
-        $('.reveal input').val("test");
+        helper.q('.reveal input', body).value = "test";
 
         doRefreshImmediately.and.callFake(() => pipeline.isPaused = true);
-        simulateEvent.simulate($('.reveal .primary').get(0), 'click');
-        m.redraw.sync();
+        helper.click('.reveal .primary', body);
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
 
-        expect(helper.find('.pipeline_pause-message')).toBeInDOM();
-        expect(helper.find('.pipeline_pause-message').text()).toBe('Paused by admin (under construction)');
-        expect(helper.find('.pipeline_pause-message div')).not.toBeInDOM();
-        expect(helper.find('.pipeline_message')).toContainText(responseMessage);
-        expect(helper.find('.pipeline_message')).toHaveClass("success");
+        expect(helper.q('.pipeline_pause-message')).toBeInDOM();
+        expect(helper.text('.pipeline_pause-message')).toBe('Paused by admin (under construction)');
+        expect(helper.q('.pipeline_pause-message div')).toBeFalsy();
+        expect(helper.text('.pipeline_message')).toContain(responseMessage);
+        expect(helper.q('.pipeline_message')).toHaveClass("success");
       });
     });
 
@@ -496,11 +492,11 @@ describe("Dashboard Pipeline Widget", () => {
       });
 
       it("should render unlock pipeline button", () => {
-        expect(helper.find('.pipeline_locked')).toBeInDOM();
+        expect(helper.q('.pipeline_locked')).toBeInDOM();
       });
 
       it("should enable unlock pipeline button when user can unlock a pipeline", () => {
-        expect(helper.find('.pipeline_locked')).not.toHaveClass('disabled');
+        expect(helper.q('.pipeline_locked')).not.toHaveClass('disabled');
       });
 
       it("should disable unlock pipeline button when user can not unlock a pipeline", () => {
@@ -511,13 +507,13 @@ describe("Dashboard Pipeline Widget", () => {
         };
 
         mount(true, undefined, lockInfo);
-        expect(helper.find('.pipeline_locked')).toHaveClass('disabled');
+        expect(helper.q('.pipeline_locked')).toHaveClass('disabled');
       });
 
       it("should not render the pipeline flash message", () => {
-        expect(helper.find('.pipeline_message')).not.toBeInDOM();
-        expect(helper.find('.pipeline_message .success')).not.toBeInDOM();
-        expect(helper.find('.pipeline_message .error')).not.toBeInDOM();
+        expect(helper.q('.pipeline_message')).toBeFalsy();
+        expect(helper.q('.pipeline_message .success')).toBeFalsy();
+        expect(helper.q('.pipeline_message .error')).toBeFalsy();
       });
 
       it("should unlock a pipeline", () => {
@@ -538,8 +534,8 @@ describe("Dashboard Pipeline Widget", () => {
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
 
-        expect(helper.find('.pipeline_message')).toContainText(responseMessage);
-        expect(helper.find('.pipeline_message')).toHaveClass("success");
+        expect(helper.text('.pipeline_message')).toContain(responseMessage);
+        expect(helper.q('.pipeline_message')).toHaveClass("success");
       });
 
       it("should show error when unlocking a pipeline fails", () => {
@@ -560,8 +556,8 @@ describe("Dashboard Pipeline Widget", () => {
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
 
-        expect(helper.find('.pipeline_message')).toContainText(responseMessage);
-        expect(helper.find('.pipeline_message')).toHaveClass("error");
+        expect(helper.text('.pipeline_message')).toContain(responseMessage);
+        expect(helper.q('.pipeline_message')).toHaveClass("error");
       });
     });
 
@@ -574,14 +570,14 @@ describe("Dashboard Pipeline Widget", () => {
       });
 
       it("should render trigger pipeline button", () => {
-        expect(helper.find('.play')).toBeInDOM();
+        expect(helper.q('.play')).toBeInDOM();
       });
 
       it('should disable trigger button for non admin users', () => {
         helper.unmount();
         mount(true, {}, {}, false, false);
 
-        expect(helper.find('.play')).toHaveClass('disabled');
+        expect(helper.q('.play')).toHaveClass('disabled');
       });
 
       it('should disable trigger button when first stage is in progress', () => {
@@ -589,7 +585,7 @@ describe("Dashboard Pipeline Widget", () => {
         pipelineInstances[0]._embedded.stages[0].status = 'Building';
         mount();
 
-        expect(helper.find('.play')).toHaveClass('disabled');
+        expect(helper.q('.play')).toHaveClass('disabled');
       });
 
       it('should not add onclick handler when first stage is in progess', () => {
@@ -597,14 +593,14 @@ describe("Dashboard Pipeline Widget", () => {
         pipelineInstances[0]._embedded.stages[0].status = 'Building';
         mount();
 
-        expect(_.isFunction(helper.find('.play').get(0).onclick)).toBe(false);
+        expect(_.isFunction(helper.q('.play').onclick)).toBe(false);
       });
 
       it('should disable trigger button when pipeline is locked', () => {
         helper.unmount();
         mount(true, undefined, {"locked": true});
 
-        expect(helper.find('.play')).toHaveClass('disabled');
+        expect(helper.q('.play')).toHaveClass('disabled');
       });
 
       it('should disable trigger button when pipeline is paused', () => {
@@ -615,21 +611,21 @@ describe("Dashboard Pipeline Widget", () => {
           "pause_reason": "under construction"
         });
 
-        expect(helper.find('.play')).toHaveClass('disabled');
+        expect(helper.q('.play')).toHaveClass('disabled');
       });
 
       it('should not add onclick handler pipeline is locked', () => {
         helper.unmount();
         mount(true, undefined, {"locked": true});
 
-        expect(_.isFunction(helper.find('.play').get(0).onclick)).toBe(false);
+        expect(_.isFunction(helper.q('.play').onclick)).toBe(false);
       });
 
       it('should not add onclick handler for non admin users', () => {
         helper.unmount();
         mount(true, {}, {}, false, false);
 
-        expect(_.isFunction(helper.find('.play').get(0).onclick)).toBe(false);
+        expect(_.isFunction(helper.q('.play').onclick)).toBe(false);
       });
 
       it("should trigger a pipeline", () => {
@@ -648,8 +644,8 @@ describe("Dashboard Pipeline Widget", () => {
 
         expect(pipeline.triggerDisabled()).toBe(true);
 
-        expect(helper.find('.pipeline_message')).toContainText(responseMessage);
-        expect(helper.find('.pipeline_message')).toHaveClass("success");
+        expect(helper.text('.pipeline_message')).toContain(responseMessage);
+        expect(helper.q('.pipeline_message')).toHaveClass("success");
       });
 
       it("should show error when triggering a pipeline fails", () => {
@@ -668,17 +664,17 @@ describe("Dashboard Pipeline Widget", () => {
 
         expect(pipeline.triggerDisabled()).toBe(false);
 
-        expect(helper.find('.pipeline_message')).toContainText(responseMessage);
-        expect(helper.find('.pipeline_message')).toHaveClass("error");
+        expect(helper.text('.pipeline_message')).toContain(responseMessage);
+        expect(helper.q('.pipeline_message')).toHaveClass("error");
       });
 
       it("should have tooltips for trigger buttons when it is disabled", () => {
         helper.unmount();
         mount(true, {}, {}, true, false);
-        const playButton = helper.find('.pipeline_operations .play');
+        const playButton = helper.q('.pipeline_operations .play');
         expect(playButton).toHaveAttr('data-tooltip-id');
-        const tooltipId = $(playButton).attr('data-tooltip-id');
-        expect($(`#${tooltipId}`)).toHaveText("You do not have permission to trigger the pipeline");
+        const tooltipId = playButton.getAttribute('data-tooltip-id');
+        expect(helper.text(document.getElementById(tooltipId))).toBe("You do not have permission to trigger the pipeline");
       });
     });
 
@@ -691,14 +687,14 @@ describe("Dashboard Pipeline Widget", () => {
       });
 
       it("should render trigger with options pipeline button", () => {
-        expect(helper.find('.play_with_options')).toBeInDOM();
+        expect(helper.q('.play_with_options')).toBeInDOM();
       });
 
       it('should disable trigger with options button for non admin users', () => {
         helper.unmount();
         mount(true, {}, {}, false, false);
 
-        expect(helper.find('.play_with_options')).toHaveClass('disabled');
+        expect(helper.q('.play_with_options')).toHaveClass('disabled');
       });
 
       it('should disable trigger with options button when first stage is in progress', () => {
@@ -706,7 +702,7 @@ describe("Dashboard Pipeline Widget", () => {
         pipelineInstances[0]._embedded.stages[0].status = 'Building';
         mount();
 
-        expect(helper.find('.play_with_options')).toHaveClass('disabled');
+        expect(helper.q('.play_with_options')).toHaveClass('disabled');
       });
 
       it('should not add onclick handler when first stage is in progess', () => {
@@ -714,13 +710,13 @@ describe("Dashboard Pipeline Widget", () => {
         pipelineInstances[0]._embedded.stages[0].status = 'Building';
         mount();
 
-        expect(_.isFunction(helper.find('.play_with_options').get(0).onclick)).toBe(false);
+        expect(_.isFunction(helper.q('.play_with_options').onclick)).toBe(false);
       });
 
       it('should disable trigger with options button when pipeline is locked', () => {
         helper.unmount();
         mount(true, undefined, {"locked": true});
-        expect(helper.find('.play_with_options')).toHaveClass('disabled');
+        expect(helper.q('.play_with_options')).toHaveClass('disabled');
       });
 
       it('should disable trigger with options button when pipeline is paused', () => {
@@ -730,17 +726,17 @@ describe("Dashboard Pipeline Widget", () => {
           "paused_by":    "admin",
           "pause_reason": "under construction"
         });
-        const triggerWithOptsButton = helper.find('.play_with_options');
+        const triggerWithOptsButton = helper.q('.play_with_options');
         expect(triggerWithOptsButton).toHaveClass('disabled');
         expect(triggerWithOptsButton).toHaveAttr('title');
-        expect($(triggerWithOptsButton).attr('title')).toBe("Trigger with Options Disabled");
+        expect(triggerWithOptsButton.getAttribute('title')).toBe("Trigger with Options Disabled");
       });
 
       it('should not add onclick handler pipeline is locked', () => {
         helper.unmount();
         mount(true, undefined, {"locked": true});
 
-        expect(_.isFunction(helper.find('.play_with_options').get(0).onclick)).toBe(false);
+        expect(_.isFunction(helper.q('.play_with_options').onclick)).toBe(false);
       });
 
 
@@ -748,63 +744,61 @@ describe("Dashboard Pipeline Widget", () => {
         helper.unmount();
         mount(true, {}, {}, false, false);
 
-        expect(_.isFunction(helper.find('.play_with_options').get(0).onclick)).toBe(false);
+        expect(_.isFunction(helper.q('.play_with_options').onclick)).toBe(false);
       });
 
       it("should show modal to specify trigger options for a pipeline", () => {
         stubTriggerOptions(pipelineName);
 
-        expect($('.reveal:visible')).not.toBeInDOM();
+        expect(helper.q(".reveal", body)).toBeFalsy();
 
         helper.click('.play_with_options');
 
-        expect($('.reveal:visible')).toBeInDOM();
+        expect(helper.q(".reveal", body)).toBeInDOM();
       });
 
       it('should render error message in modal when api response parsing fails', () => {
         stubTriggerOptionsWithInvalidData(pipelineName);
 
-        expect($('.reveal:visible')).not.toBeInDOM();
+        expect(helper.q(".reveal", body)).toBeFalsy();
 
         helper.click('.play_with_options');
         m.redraw.sync();
 
-        expect($('.reveal:visible')).toBeInDOM();
-        expect($('.callout.alert')).toBeInDOM();
+        expect(helper.q(".reveal", body)).toBeInDOM();
+        expect(helper.q('.callout.alert', body)).toBeInDOM();
       });
 
       it("should show appropriate header for trigger with options popup modal", () => {
 
         helper.click('.play_with_options');
 
-        const modalTitle = $('.modal-title:visible');
-        expect(modalTitle).toHaveText(`${pipeline.name} - Trigger`);
+        expect(helper.text('.modal-title', body)).toBe(`${pipeline.name} - Trigger`);
       });
 
       it('should show modal appropriately when opened and closed multiple times', () => {
         stubTriggerOptions(pipelineName);
 
         //open trigger with options modal
-        expect($('.reveal:visible')).not.toBeInDOM();
-        expect($('.pipeline_options-heading')).not.toContainText('Materials');
+        expect(helper.q(".reveal", body)).toBeFalsy();
+        expect(helper.q('.pipeline_options-heading', body)).toBeFalsy();
 
         helper.click('.play_with_options');
 
-        expect($('.reveal:visible')).toBeInDOM();
-        expect($('.pipeline_options-heading')).toContainText('Materials');
+        expect(helper.q(".reveal", body)).toBeInDOM();
+        expect(helper.text('.pipeline_options-heading', body)).toContain('Materials');
 
         //close trigger with options modal
-        simulateEvent.simulate($('.modal-buttons .button.save.secondary').get(0), 'click');
-        m.redraw.sync();
+        helper.click('.modal-buttons .button.save.secondary', body);
 
         //open again trigger with options modal
-        expect($('.reveal:visible')).not.toBeInDOM();
-        expect($('.pipeline_options-heading')).not.toContainText('Materials');
+        expect(helper.q(".reveal", body)).toBeFalsy();
+        expect(helper.q('.pipeline_options-heading', body)).toBeFalsy();
 
         helper.click('.play_with_options');
 
-        expect($('.reveal:visible')).toBeInDOM();
-        expect($('.pipeline_options-heading')).toContainText('Materials');
+        expect(helper.q(".reveal", body)).toBeInDOM();
+        expect(helper.text('.pipeline_options-heading', body)).toContain('Materials');
       });
 
       it("should trigger a pipeline", () => {
@@ -822,13 +816,12 @@ describe("Dashboard Pipeline Widget", () => {
 
         helper.click('.play_with_options');
 
-        simulateEvent.simulate($('.modal-buttons .button.save.primary').get(0), 'click');
-        m.redraw.sync();
+        helper.click('.modal-buttons .button.save.primary', body);
 
         expect(pipeline.triggerDisabled()).toBe(true);
 
-        expect(helper.find('.pipeline_message')).toContainText(responseMessage);
-        expect(helper.find('.pipeline_message')).toHaveClass("success");
+        expect(helper.text('.pipeline_message')).toContain(responseMessage);
+        expect(helper.q('.pipeline_message')).toHaveClass("success");
       });
 
       it("should show error when triggering a pipeline fails", () => {
@@ -850,17 +843,17 @@ describe("Dashboard Pipeline Widget", () => {
 
         expect(pipeline.triggerDisabled()).toBe(false);
 
-        expect(helper.find('.pipeline_message')).toContainText(responseMessage);
-        expect(helper.find('.pipeline_message')).toHaveClass("error");
+        expect(helper.text('.pipeline_message')).toContain(responseMessage);
+        expect(helper.q('.pipeline_message')).toHaveClass("error");
       });
 
       it("should have tooltips when it is disabled", () => {
         helper.unmount();
         mount(true, {}, {}, true, false);
-        const playButton = helper.find('.pipeline_operations .play_with_options');
+        const playButton = helper.q('.pipeline_operations .play_with_options');
         expect(playButton).toHaveAttr('data-tooltip-id');
-        const tooltipId = $(playButton).attr('data-tooltip-id');
-        expect($(`#${tooltipId}`)).toHaveText("You do not have permission to trigger the pipeline");
+        const tooltipId = playButton.getAttribute('data-tooltip-id');
+        expect(helper.text(document.getElementById(tooltipId))).toBe("You do not have permission to trigger the pipeline");
       });
     });
   });
@@ -869,8 +862,8 @@ describe("Dashboard Pipeline Widget", () => {
     it("should render pipeline instances", () => {
       mount();
 
-      expect(helper.find('.pipeline_instances')).toBeInDOM();
-      expect(helper.find('.pipeline_instance')).toBeInDOM();
+      expect(helper.q('.pipeline_instances')).toBeInDOM();
+      expect(helper.q('.pipeline_instance')).toBeInDOM();
 
       helper.unmount();
     });
@@ -879,11 +872,11 @@ describe("Dashboard Pipeline Widget", () => {
       pipelineInstances = [];
       mount();
 
-      expect(helper.find('.pipeline_instances')).toBeInDOM();
+      expect(helper.q('.pipeline_instances')).toBeInDOM();
 
-      expect(helper.find('.no_instance')).toBeInDOM();
+      expect(helper.q('.no_instance')).toBeInDOM();
       const pipelineNeverRunMessage = 'You haven\'t run this pipeline yet. Click the play button to run pipeline.';
-      expect(helper.find('.no_instance')).toContainText(pipelineNeverRunMessage);
+      expect(helper.text('.no_instance')).toContain(pipelineNeverRunMessage);
 
       helper.unmount();
     });

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/stages_instance_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/stages_instance_widget_spec.js
@@ -98,21 +98,19 @@ describe("Dashboard Stages Instance Widget", () => {
   });
 
   it("should render each stage instance", () => {
-    const stagesInstance = helper.find('.pipeline_stage');
+    const stagesInstance = helper.qa('.pipeline_stage');
 
-    expect(stagesInstance.get(0)).toHaveClass('failed');
-    expect(stagesInstance.get(1)).toHaveClass('unknown');
+    expect(stagesInstance[0]).toHaveClass('failed');
+    expect(stagesInstance[1]).toHaveClass('unknown');
   });
 
   it("should link to stage details page", () => {
-    const stagesInstance = helper.find('.pipeline_stage');
-
-    expect(stagesInstance.get(0).href.indexOf(`/go/pipelines/up42/1/up42_stage/1`)).not.toEqual(-1);
+    expect(helper.q('.pipeline_stage').href).toContain("/go/pipelines/up42/1/up42_stage/1");
   });
 
   it("should not link to stage details page for stages with no run", () => {
-    expect(helper.find('span.pipeline_stage')).toBeInDOM();
-    expect(helper.find('span.pipeline_stage')).toHaveClass('unknown');
+    expect(helper.q('span.pipeline_stage')).toBeInDOM();
+    expect(helper.q('span.pipeline_stage')).toHaveClass('unknown');
   });
 
   it("should show stage status on hover", () => {
@@ -121,8 +119,8 @@ describe("Dashboard Stages Instance Widget", () => {
     const stage2Status = `${stages[1].name} (${stages[1].status})`;
     const stage3Status = `${stages[2].name} (cancelled by: ${stages[2].cancelled_by})`;
 
-    expect(helper.find('.pipeline_stage').get(0).title).toEqual(stage1Status);
-    expect(helper.find('.pipeline_stage').get(1).title).toEqual(stage2Status);
-    expect(helper.find('.pipeline_stage').get(2).title).toEqual(stage3Status);
+    expect(helper.qa('.pipeline_stage')[0].title).toEqual(stage1Status);
+    expect(helper.qa('.pipeline_stage')[1].title).toEqual(stage2Status);
+    expect(helper.qa('.pipeline_stage')[2].title).toEqual(stage3Status);
   });
 });

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/environment_variables_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/environment_variables_widget_spec.js
@@ -16,8 +16,6 @@
 import {TestHelper} from "views/pages/spec/test_helper";
 import {EnvironmentVariables} from "models/dashboard/environment_variables";
 import * as EnvironmentVariablesWidget from "views/dashboard/trigger_with_options/environment_variables_widget";
-import simulateEvent from "simulate-event";
-import $ from "jquery";
 import m from "mithril";
 
 describe("Dashboard Environment Variables Trigger Widget", () => {
@@ -51,30 +49,28 @@ describe("Dashboard Environment Variables Trigger Widget", () => {
     afterEach(helper.unmount.bind(helper));
 
     it("should render plain text variables", () => {
-      expect(helper.find('.environment-variables .name')).toHaveLength(2);
-      expect(helper.find('.environment-variables input')).toHaveLength(2);
+      expect(helper.qa('.environment-variables .name')).toHaveLength(2);
+      expect(helper.qa('.environment-variables input')).toHaveLength(2);
 
-      expect(helper.find('.environment-variables .name').get(0)).toContainText(json[0].name);
-      expect(helper.find('.environment-variables .name').get(1)).toContainText(json[1].name);
+      expect(helper.qa('.environment-variables .name')[0]).toContainText(json[0].name);
+      expect(helper.qa('.environment-variables .name')[1]).toContainText(json[1].name);
 
-      expect(helper.find('.environment-variables input').get(0)).toHaveValue(json[0].value);
-      expect(helper.find('.environment-variables input').get(1)).toHaveValue(json[1].value);
+      expect(helper.qa('.environment-variables input')[0]).toHaveValue(json[0].value);
+      expect(helper.qa('.environment-variables input')[1]).toHaveValue(json[1].value);
     });
 
     it("it should display variable overriden message", () => {
-      const valueInputField = helper.find('.environment-variables input').get(0);
+      const valueInputField = helper.q('.environment-variables input');
 
       expect(valueInputField).toHaveValue(json[0].value);
-      expect(helper.find('.overridden-message')).not.toBeInDOM();
+      expect(helper.q('.overridden-message')).not.toExist();
 
       const newValue = "ldap";
-      $(valueInputField).val(newValue);
-      simulateEvent.simulate(valueInputField, 'input');
-      m.redraw.sync();
+      helper.oninput(valueInputField, newValue);
 
       expect(variables[0].value()).toBe(newValue);
       expect(valueInputField).toHaveValue(newValue);
-      expect(helper.find('.overridden-message')).toContainText(`The value is overridden. Default value :${json[0].value}`);
+      expect(helper.text('.overridden-message')).toContain(`The value is overridden. Default value :${json[0].value}`);
     });
   });
 
@@ -101,40 +97,38 @@ describe("Dashboard Environment Variables Trigger Widget", () => {
     afterEach(helper.unmount.bind(helper));
 
     it("should render Secure text variables", () => {
-      expect(helper.find('.environment-variables .name')).toHaveLength(2);
-      expect(helper.find('.environment-variables input')).toHaveLength(2);
+      expect(helper.qa('.environment-variables .name')).toHaveLength(2);
+      expect(helper.qa('.environment-variables input')).toHaveLength(2);
 
-      expect(helper.find('.environment-variables .name').get(0)).toContainText(json[0].name);
-      expect(helper.find('.environment-variables .name').get(1)).toContainText(json[1].name);
+      expect(helper.qa('.environment-variables .name')[0]).toContainText(json[0].name);
+      expect(helper.qa('.environment-variables .name')[1]).toContainText(json[1].name);
 
-      expect(helper.find('.environment-variables input').get(0)).toHaveValue('*****');
-      expect(helper.find('.environment-variables input').get(1)).toHaveValue('*****');
+      expect(helper.qa('.environment-variables input')[0]).toHaveValue('*****');
+      expect(helper.qa('.environment-variables input')[1]).toHaveValue('*****');
     });
 
     it("it should display variable overriden message", () => {
-      const valueInputField = helper.find('.environment-variables input').get(0);
+      const valueInputField = helper.q('.environment-variables input');
       expect(valueInputField).toBeDisabled();
 
       expect(valueInputField).toHaveValue('*****');
-      expect(helper.find('.reset')).not.toBeInDOM();
+      expect(helper.q('.reset')).not.toExist();
 
-      simulateEvent.simulate(helper.find('.override').get(0), 'click');
-      m.redraw.sync();
+      helper.click('.override');
+
       expect(valueInputField).not.toBeDisabled();
-      expect(helper.find('.reset')).toBeInDOM();
+      expect(helper.q('.reset')).toBeInDOM();
 
       const newValue = "ldap";
-      $(valueInputField).val(newValue);
-      simulateEvent.simulate(valueInputField, 'input');
-      m.redraw.sync();
+      helper.oninput(valueInputField, newValue);
 
       expect(variables[0].value()).toBe(newValue);
       expect(valueInputField).toHaveValue(newValue);
 
-      simulateEvent.simulate(helper.find('.reset').get(0), 'click');
-      m.redraw.sync();
+      helper.click('.reset');
+
       expect(valueInputField).toBeDisabled();
-      expect(helper.find('.reset')).not.toBeInDOM();
+      expect(helper.q('.reset')).not.toExist();
     });
   });
 });

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/material_info_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/material_info_widget_spec.js
@@ -47,42 +47,42 @@ describe("Dashboard Trigger With Options Material Info Widget", () => {
     mount(triggerWithOptionsInfo.materials[0]);
     const material = json.materials[0];
 
-    expect(helper.find('.name-value .meta')).toContainText(material.type);
+    expect(helper.q('.name-value .meta')).toContainText(material.type);
 
-    expect(helper.find('.name-value .meta')).toContainText(material.name);
+    expect(helper.q('.name-value .meta')).toContainText(material.name);
 
-    expect(helper.find('.name-value .destination')).toContainText(material.folder);
+    expect(helper.q('.name-value .destination')).toContainText(material.folder);
 
-    expect(helper.find('.name-value .date')).toContainText(timeFormatter.format(material.revision.date));
+    expect(helper.q('.name-value .date')).toContainText(timeFormatter.format(material.revision.date));
 
-    expect(helper.find('.name-value .user')).toContainText(material.revision.user);
+    expect(helper.q('.name-value .user')).toContainText(material.revision.user);
 
-    expect(helper.find('.name-value .comment')).toContainText(material.revision.comment);
+    expect(helper.q('.name-value .comment')).toContainText(material.revision.comment);
 
-    expect(helper.find('.name-value .last-run-revision')).toContainText(material.revision.last_run_revision);
+    expect(helper.q('.name-value .last-run-revision')).toContainText(material.revision.last_run_revision);
   });
 
   it("it should render material info when revision is not present", () => {
     mount(triggerWithOptionsInfo.materials[1]);
     const material = json.materials[1];
 
-    expect(helper.find('.name-value .meta')).toContainText(material.type);
-    expect(helper.find('.name-value .meta')).toContainText(material.name);
+    expect(helper.q('.name-value .meta')).toContainText(material.type);
+    expect(helper.q('.name-value .meta')).toContainText(material.name);
 
-    expect(helper.find('.name-value .destination')).toContainText('not specified');
+    expect(helper.q('.name-value .destination')).toContainText('not specified');
 
-    expect(helper.find('.name-value .date')).toContainText('never ran');
+    expect(helper.q('.name-value .date')).toContainText('never ran');
 
-    expect(helper.find('.name-value .user')).toContainText('never ran');
+    expect(helper.q('.name-value .user')).toContainText('never ran');
 
-    expect(helper.find('.name-value .comment')).toContainText('never ran');
+    expect(helper.q('.name-value .comment')).toContainText('never ran');
 
-    expect(helper.find('.name-value .last-run-revision')).toContainText('never ran');
+    expect(helper.q('.name-value .last-run-revision')).toContainText('never ran');
   });
 
   it('should render searched material revision spinner', () => {
     mount(triggerWithOptionsInfo.materials[0]);
-    expect(helper.find('.commits')).toBeInDOM();
+    expect(helper.q('.commits')).toBeInDOM();
   });
 
   const json = {

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/material_revision_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/material_revision_widget_spec.js
@@ -53,24 +53,23 @@ describe("Dashboard Material Revision Widget", () => {
     afterEach(helper.unmount.bind(helper));
 
     it('should render material type and material name', () => {
-      const widgetHeader = helper.find('.rev-head');
+      const widgetHeader = helper.q('.rev-head');
       expect(widgetHeader).toContainText(gitRevisionJson.material_type);
       expect(widgetHeader).toContainText(gitRevisionJson.material_name);
     });
 
     it('should render changes information related to the git material', () => {
-      const modificationWidget = helper.find('.modifications');
+      const modificationWidgetTxt = helper.text('.modifications');
       const modification       = gitRevisionJson.modifications[0];
-      expect(modificationWidget).toContainText(modification.user_name);
-      expect(modificationWidget).toContainText(modification.revision);
-      expect(modificationWidget).toContainText(timeFormatter.format(modification.modified_time));
-      expect(modificationWidget).toContainText(modification.comment);
-      expect(modificationWidget).toContainText("VSM");
+      expect(modificationWidgetTxt).toContain(modification.user_name);
+      expect(modificationWidgetTxt).toContain(modification.revision);
+      expect(modificationWidgetTxt).toContain(timeFormatter.format(modification.modified_time));
+      expect(modificationWidgetTxt).toContain(modification.comment);
+      expect(modificationWidgetTxt).toContain("VSM");
 
-      const vsmLink = helper.find('a');
+      const vsmLink = helper.q('a');
       expect(vsmLink).toHaveAttr("href", modification._links.vsm.href);
     });
-
   });
 
   describe("Pipeline Material Revision View", () => {
@@ -103,13 +102,13 @@ describe("Dashboard Material Revision Widget", () => {
     afterEach(helper.unmount.bind(helper));
 
     it('should render material type and pipeline material name', () => {
-      const widgetHeader = helper.find('.rev-head');
+      const widgetHeader = helper.q('.rev-head');
       expect(widgetHeader).toContainText(pipelineRevisionJson.material_type);
       expect(widgetHeader).toContainText(pipelineRevisionJson.material_name);
     });
 
     it('should render changes information related to the pipeline material', () => {
-      const modificationWidget = helper.find('.modifications');
+      const modificationWidget = helper.q('.modifications');
       const modification       = pipelineRevisionJson.modifications[0];
 
       expect(modificationWidget).toContainText(modification.revision);
@@ -118,12 +117,12 @@ describe("Dashboard Material Revision Widget", () => {
     });
 
     it('should contain a link to overview of stage details page of the stage that triggered the pipeline', () => {
-      const pipelineDependencyLink = helper.find('.modified_by a').get(0);
-      expect(pipelineDependencyLink.href).toEqual(pipelineRevisionJson.modifications[0]._links.stage_details_url.href);
+      const pipelineDependencyLink = helper.q('.modified_by a');
+      expect(pipelineDependencyLink.href).toBe(pipelineRevisionJson.modifications[0]._links.stage_details_url.href);
     });
 
     it('should contain a link to stage details page showing pipeline dependencies of the run of the upstream pipeline run', () => {
-      const pipelineDependencyLink = helper.find('.comment a').get(0);
+      const pipelineDependencyLink = helper.q('.comment a');
       expect(pipelineDependencyLink.href.indexOf(`/go/pipelines/value_stream_map/up42/2`)).not.toBe(-1);
     });
 
@@ -160,13 +159,13 @@ describe("Dashboard Material Revision Widget", () => {
 
 
     it("should render material type as Package and the correct package name", () => {
-      const widgetHeader = helper.find('.rev-head');
+      const widgetHeader = helper.q('.rev-head');
       expect(widgetHeader).toContainText(packageRevisionJson.material_type);
       expect(widgetHeader).toContainText(packageRevisionJson.material_name);
     });
 
     it("should render changes information related to the package material", () => {
-      const modificationWidget = helper.find('.modifications');
+      const modificationWidget = helper.q('.modifications');
       const modification       = packageRevisionJson.modifications[0];
 
       expect(modificationWidget).toContainText(modification.user_name);
@@ -177,10 +176,10 @@ describe("Dashboard Material Revision Widget", () => {
     });
 
     it("should contain link to vsm of the package material", () => {
-      const modificationWidget = helper.find('.modifications');
+      const modificationWidget = helper.q('.modifications');
       const modification       = packageRevisionJson.modifications[0];
 
-      const vsmLink = modificationWidget.find('a');
+      const vsmLink = modificationWidget.querySelector('a');
       expect(vsmLink).toHaveAttr("href", modification._links.vsm.href);
     });
   });
@@ -215,7 +214,7 @@ describe("Dashboard Material Revision Widget", () => {
     afterEach(helper.unmount.bind(helper));
 
     it("should highlight the revision that triggered the pipeline with yellow color", () => {
-      const revisionWidget = helper.find('.changed');
+      const revisionWidget = helper.q('.changed');
 
       expect(revisionWidget).toExist();
     });
@@ -252,7 +251,7 @@ describe("Dashboard Material Revision Widget", () => {
     afterEach(helper.unmount.bind(helper));
 
     it("should not highlight revisions which aren't modified", () => {
-      const revision = helper.find('.changed');
+      const revision = helper.q('.changed');
 
       expect(revision).not.toExist();
     });

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/material_search_results_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/material_search_results_widget_spec.js
@@ -36,25 +36,25 @@ describe("Dashboard Material Search Results Widget", () => {
     material.searchResults(json);
     helper.redraw();
     const expectedMessage = 'Last 4 commits listed in chronological order';
-    expect(helper.find('.commits .helper')).toContainText(expectedMessage);
+    expect(helper.text('.commits .helper')).toContain(expectedMessage);
   });
 
   it("should render all matched material search revisions and no message", () => {
     material.searchText('some search text');
     material.searchResults(json);
     helper.redraw();
-    expect(helper.find('.commit_info li')).toHaveLength(4);
-    expect(helper.find('.commits .helper')).toContainText('');
+    expect(helper.qa('.commit_info li')).toHaveLength(4);
+    expect(helper.q('.commits .helper')).toBeFalsy();
   });
 
   it("should render commit information", () => {
     material.searchResults(json);
     helper.redraw();
 
-    expect(helper.find('.commit_info .rev').get(0)).toContainText(json[0].revision);
-    expect(helper.find('.commit_info .committer').get(0)).toContainText(json[0].user);
-    expect(helper.find('.commit_info .time').get(0)).toContainText(timeFormatter.format(json[0].date));
-    expect(helper.find('.commit_info .commit_message').get(0)).toContainText(json[0].comment);
+    expect(helper.text('.commit_info .rev')).toContain(json[0].revision);
+    expect(helper.text('.commit_info .committer')).toContain(json[0].user);
+    expect(helper.text('.commit_info .time')).toContain(timeFormatter.format(json[0].date));
+    expect(helper.text('.commit_info .commit_message')).toContain(json[0].comment);
   });
 
   it("should render no revisions found message", () => {
@@ -62,13 +62,13 @@ describe("Dashboard Material Search Results Widget", () => {
     material.searchResults([]);
     helper.redraw();
     const expectedMessage = `No revisions found matching 'foo'`;
-    expect(helper.find('.commits .helper')).toContainText(expectedMessage);
+    expect(helper.text('.commits .helper')).toContain(expectedMessage);
   });
 
   it("should not render view when search is in progress", () => {
     material.searchInProgress(true);
     helper.redraw();
-    expect(helper.find('.commits')).not.toBeInDOM();
+    expect(helper.q('.commits')).toBeFalsy();
   });
 
   it("should select searched revision onclick", (done) => {
@@ -79,8 +79,8 @@ describe("Dashboard Material Search Results Widget", () => {
 
     helper.click('.commit_info li:nth-child(2)');
 
-    expect(material.selection()).toEqual(json[1].revision);
-    expect(material.searchText()).toEqual(json[1].revision);
+    expect(material.selection()).toBe(json[1].revision);
+    expect(material.searchText()).toBe(json[1].revision);
 
     //timeout is required to wait for the debounced search
     setTimeout(done, 250);

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/materials_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/materials_widget_spec.js
@@ -20,7 +20,6 @@ import {TriggerWithOptionsVM} from "views/dashboard/models/trigger_with_options_
 import Stream from "mithril/stream";
 import m from "mithril";
 import _ from "lodash";
-import * as simulateEvent from "simulate-event";
 
 describe("Dashboard Trigger With Options Material Widget", () => {
 
@@ -49,45 +48,44 @@ describe("Dashboard Trigger With Options Material Widget", () => {
   });
 
   it("should show latest if material revision is not present", () => {
-    const headings = helper.find('.v-tab_tab-head li');
+    const headings = helper.qa('.v-tab_tab-head li')[1];
 
-    expect(headings.get(1)).toContainText("latest");
+    expect(headings).toContainText("latest");
   });
 
   it("it should render material select tabs", () => {
-    const headings = helper.find('.v-tab_tab-head li');
+    const headings = helper.textAll('.v-tab_tab-head li');
 
     expect(headings).toHaveLength(json.materials.length);
 
-    expect(headings.get(0)).toContainText(json.materials[0].revision.last_run_revision);
-    expect(headings.get(0)).toContainText(json.materials[0].name);
+    expect(headings[0]).toContain(json.materials[0].revision.last_run_revision);
+    expect(headings[0]).toContain(json.materials[0].name);
 
-    expect(headings.get(1)).toContainText("latest");
-    expect(headings.get(1)).toContainText(json.materials[1].name);
+    expect(headings[1]).toContain("latest");
+    expect(headings[1]).toContain(json.materials[1].name);
   });
 
   it("it should render the first material info content", () => {
-    const contents = helper.find('.v-tab_container .v-tab_content');
+    const contents = helper.qa('.v-tab_container .v-tab_content');
 
     expect(contents).toHaveLength(1);
 
-    expect(contents.get(0)).toContainText(json.materials[0].name);
+    expect(contents[0]).toContainText(json.materials[0].name);
   });
 
   it("should show first material by default", () => {
-    expect(helper.find('.v-tab_tab-head li').get(0)).toHaveClass('active');
-    expect(helper.find('#material1').get(0)).not.toHaveClass('hidden');
+    expect(helper.q('.v-tab_tab-head li')).toHaveClass('active');
+    expect(helper.q('#material1')).not.toHaveClass('hidden');
   });
 
   it("should show appropriate material content material heading selection", () => {
-    expect(helper.find('.v-tab_tab-head li').get(0)).toHaveClass('active');
-    expect(helper.find('#material1').get(0)).not.toHaveClass('hidden');
+    expect(helper.q('.v-tab_tab-head li')).toHaveClass('active');
+    expect(helper.q('#material1')).not.toHaveClass('hidden');
 
-    simulateEvent.simulate(helper.find('.v-tab_tab-head li').get(1), "click");
-    helper.redraw();
+    helper.click(helper.qa('.v-tab_tab-head li')[1]);
 
-    expect(helper.find('.v-tab_tab-head li').get(1)).toHaveClass('active');
-    expect(helper.find('#material1').get(1)).not.toHaveClass('hidden');
+    expect(helper.qa('.v-tab_tab-head li').item(1)).toHaveClass('active');
+    expect(helper.qa('#material1').item(1)).not.toHaveClass('hidden');
   });
 
   const json = {

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/modal_body_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/modal_body_spec.js
@@ -22,7 +22,6 @@ import {ModalBody} from "views/dashboard/trigger_with_options/modal_body";
 import {Modal} from "views/shared/new_modal";
 import Stream from "mithril/stream";
 import m from "mithril";
-import * as simulateEvent from "simulate-event";
 
 describe("Dashboard Pipeline Trigger With Options Modal Body", () => {
 
@@ -74,36 +73,36 @@ describe("Dashboard Pipeline Trigger With Options Modal Body", () => {
   });
 
   it("should render pipeline trigger with options information", () => {
-    expect(helper.find('.pipeline-trigger-with-options')).toBeInDOM();
+    expect(helper.q('.pipeline-trigger-with-options')).toBeInDOM();
   });
 
   it("shoould render tab headings", () => {
-    const headings = helper.find('.pipeline_options-heading li');
+    const headings = helper.qa('.pipeline_options-heading li');
 
     expect(headings.length).toBe(3);
-    expect(headings.get(0)).toContainText('Materials');
-    expect(headings.get(1)).toContainText('Environment variables');
-    expect(headings.get(2)).toContainText('Secure Environment variables');
+    expect(headings[0]).toContainText('Materials');
+    expect(headings[1]).toContainText('Environment variables');
+    expect(headings[2]).toContainText('Secure Environment variables');
   });
 
   it("should render materials section", () => {
-    expect(helper.find('.material-for-trigger')).toBeInDOM();
+    expect(helper.q('.material-for-trigger')).toBeInDOM();
   });
 
   it("should render environment variables section", () => {
-    expect(helper.find('.environment-variables.plain')).toBeInDOM();
+    expect(helper.q('.environment-variables.plain')).toBeInDOM();
   });
 
   it("should render secure environment variables section", () => {
-    expect(helper.find('.environment-variables.secure')).toBeInDOM();
+    expect(helper.q('.environment-variables.secure')).toBeInDOM();
   });
 
   it("should show select materials tab by default", () => {
-    expect(helper.find('.pipeline_options-heading li').get(0)).toHaveClass('active');
+    expect(helper.q('.pipeline_options-heading li')).toHaveClass('active');
 
-    const materialsContent = helper.find('.pipeline_options-body .h-tab_content:first');
-    const envContent       = helper.find('.pipeline_options-body .h-tab_content:nth-child(2)');
-    const secureEnvContent = helper.find('.pipeline_options-body .h-tab_content:nth-child(3)');
+    const materialsContent = helper.q('.pipeline_options-body .h-tab_content');
+    const envContent       = helper.q('.pipeline_options-body .h-tab_content:nth-child(2)');
+    const secureEnvContent = helper.q('.pipeline_options-body .h-tab_content:nth-child(3)');
 
     expect(materialsContent).not.toHaveClass('hidden');
     expect(envContent).toHaveClass('hidden');
@@ -111,20 +110,19 @@ describe("Dashboard Pipeline Trigger With Options Modal Body", () => {
   });
 
   it("should show appropriate content based on tab selected", () => {
-    const materialsContent = helper.find('.pipeline_options-body .h-tab_content:first');
-    const envContent       = helper.find('.pipeline_options-body .h-tab_content:nth-child(2)');
-    const secureEnvContent = helper.find('.pipeline_options-body .h-tab_content:nth-child(3)');
+    const materialsContent = helper.q('.pipeline_options-body .h-tab_content');
+    const envContent       = helper.q('.pipeline_options-body .h-tab_content:nth-child(2)');
+    const secureEnvContent = helper.q('.pipeline_options-body .h-tab_content:nth-child(3)');
 
-    expect(helper.find('.pipeline_options-heading li').get(0)).toHaveClass('active');
+    expect(helper.q('.pipeline_options-heading li')).toHaveClass('active');
 
     expect(materialsContent).not.toHaveClass('hidden');
     expect(envContent).toHaveClass('hidden');
     expect(secureEnvContent).toHaveClass('hidden');
 
-    simulateEvent.simulate(helper.find('.pipeline_options-heading li').get(1), 'click');
-    m.redraw.sync();
+    helper.click(helper.qa('.pipeline_options-heading li').item(1));
 
-    expect(helper.find('.pipeline_options-heading li').get(1)).toHaveClass('active');
+    expect(helper.qa('.pipeline_options-heading li').item(1)).toHaveClass('active');
 
     expect(materialsContent).toHaveClass('hidden');
     expect(envContent).not.toHaveClass('hidden');
@@ -135,17 +133,17 @@ describe("Dashboard Pipeline Trigger With Options Modal Body", () => {
     triggerWithOptionsInfo(TriggerWithOptionsInfo.fromJSON({variables: [], materials: json.materials}));
     vm.initialize(triggerWithOptionsInfo());
     m.redraw.sync();
-    const headings = helper.find('.pipeline_options-heading li');
+    const headings = helper.qa('.pipeline_options-heading li');
 
     expect(headings.length).toBe(1);
-    expect(headings.get(0)).toContainText('Materials');
+    expect(headings.item(0)).toContainText('Materials');
   });
 
   it("should show error if API call failed", () => {
     const errorMessage = Stream("Error occurred while parsing the data.");
     unmount();
     mount(Stream(), new TriggerWithOptionsVM(), errorMessage);
-    expect(helper.find('.callout.alert')).toBeInDOM();
+    expect(helper.q('.callout.alert')).toBeInDOM();
   });
 
   function mount(triggerWithOptionsInfo, vm, errorMessage) {

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/data_sharing_settings/data_sharing_settings_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/data_sharing_settings/data_sharing_settings_widget_spec.js
@@ -17,9 +17,7 @@ import {UsageData} from "models/shared/data_sharing/usage_data";
 import {DataSharingSettings} from "models/shared/data_sharing/data_sharing_settings";
 import {TestHelper} from "views/pages/spec/test_helper";
 import {DataSharingSettingsWidget} from "views/data_sharing_settings/data_sharing_settings_widget";
-import simulateEvent from "simulate-event";
 import m from "mithril";
-import $ from "jquery";
 
 describe("Data Sharing Settings Widget", () => {
   const helper        = new TestHelper();
@@ -51,7 +49,7 @@ describe("Data Sharing Settings Widget", () => {
   });
 
   it("should show metrics collection title", () => {
-    expect(helper.find('.page-header')).toContainText('Help improve GoCD by sharing technical data');
+    expect(helper.text('.page-header')).toContain('Help improve GoCD by sharing technical data');
   });
 
   it('should render the consent description', () => {
@@ -60,59 +58,58 @@ describe("Data Sharing Settings Widget", () => {
       'Choose your settings below. You can change these settings at any time.'
     ];
 
-    const consentDescription = helper.find('.consent-description p');
+    const consentDescription = helper.qa('.consent-description p');
 
     expect(consentDescription).toHaveLength(description.length);
-    expect($(consentDescription.get(0))).toContainText(description[0]);
-    expect($(consentDescription.get(1))).toContainText(description[1]);
+    expect(consentDescription.item(0)).toContainText(description[0]);
+    expect(consentDescription.item(1)).toContainText(description[1]);
   });
 
   it('should not show the last updated by when settings hasn\'t been changed by any admin', () => {
-    expect(helper.find('.updated-by')).not.toBeInDOM();
+    expect(helper.q('.updated-by')).toBeFalsy();
   });
 
   it('should not show the last updated by time and username', () => {
     settings.updatedBy('Bob');
-    m.redraw.sync();
+    helper.redraw();
 
     const updatedByMessage = `${settings.updatedBy()} changed the data sharing permission on ${settings.updatedOn()}.`;
 
-    expect(helper.find('.updated-by')).toBeInDOM();
-    expect(helper.find('.updated-by')).toContainText(updatedByMessage);
+    expect(helper.q('.updated-by')).toBeInDOM();
+    expect(helper.text('.updated-by')).toContain(updatedByMessage);
   });
 
   it('should show the consent toggle button', () => {
-    expect(helper.find('.consent-toggle p')).toContainText('Allow GoCD to collect the following data:');
-    expect(helper.find('.switch')).toBeInDOM();
+    expect(helper.text('.consent-toggle p')).toContain('Allow GoCD to collect the following data:');
+    expect(helper.q('.switch')).toBeInDOM();
   });
 
   it('should show the consent toggle value same as of metrics settings consent value', () => {
-    expect(helper.find('.switch')).toBeInDOM();
+    expect(helper.q('.switch')).toBeInDOM();
 
     expect(settings.allowed()).toBe(true);
-    expect(helper.find('.switch input')).toBeChecked();
+    expect(helper.q('.switch input')).toBeChecked();
 
-    simulateEvent.simulate(helper.find('.switch input').get(0), 'click');
-    m.redraw.sync();
+    helper.click('.switch input');
 
     expect(settings.allowed()).toBe(false);
-    expect(helper.find('.switch input')).not.toBeChecked();
+    expect(helper.q('.switch input')).not.toBeChecked();
   });
 
   it('should show human readable consent text', () => {
     expect(settings.allowed()).toBe(true);
-    expect(helper.find('.human-readable-consent')).toContainText('Yes');
+    expect(helper.text('.human-readable-consent')).toContain('Yes');
 
     settings.toggleConsent();
-    m.redraw.sync();
+    helper.redraw();
 
     expect(settings.allowed()).toBe(false);
-    expect(helper.find('.human-readable-consent')).toContainText('No');
+    expect(helper.text('.human-readable-consent')).toContain('No');
   });
 
   it('should show the consent for collected metrics list', () => {
-    expect(helper.find('.consent-for-wrapper .consent-for')).toHaveLength(10);
-    const consentFor = helper.find('.consent-for-wrapper .consent-for');
+    expect(helper.qa('.consent-for-wrapper .consent-for')).toHaveLength(10);
+    const consentFor = helper.qa('.consent-for-wrapper .consent-for');
 
     const pipelineConsentKey         = 'Number of pipelines (pipeline_count)';
     const pipelineConsentDescription = 'This allows the calculation of the average number of pipelines a GoCD instance has. Knowing the average number of pipelines helps us optimize the GoCD experience.';
@@ -144,62 +141,62 @@ describe("Data Sharing Settings Widget", () => {
     const messageVersionConsentKey         = "Message version (message_version)";
     const messageVersionConsentDescription = "Schema version number for this message.";
 
-    expect($(consentFor.get(0))).toContainText(pipelineConsentKey);
-    expect($(consentFor.get(0))).toContainText(pipelineConsentDescription);
+    expect(consentFor.item(0)).toContainText(pipelineConsentKey);
+    expect(consentFor.item(0)).toContainText(pipelineConsentDescription);
 
-    expect($(consentFor.get(1))).toContainText(configRepoPipelineConsentKey);
-    expect($(consentFor.get(1))).toContainText(configRepoPipelineConsentDescription);
+    expect(consentFor.item(1)).toContainText(configRepoPipelineConsentKey);
+    expect(consentFor.item(1)).toContainText(configRepoPipelineConsentDescription);
 
-    expect($(consentFor.get(2))).toContainText(agentConsentKey);
-    expect($(consentFor.get(2))).toContainText(agentsConsentDescription);
+    expect(consentFor.item(2)).toContainText(agentConsentKey);
+    expect(consentFor.item(2)).toContainText(agentsConsentDescription);
 
-    expect($(consentFor.get(3))).toContainText(oldestPipelineRuntimeKey);
-    expect($(consentFor.get(3))).toContainText(oldestPipelineRuntimeDescription);
+    expect(consentFor.item(3)).toContainText(oldestPipelineRuntimeKey);
+    expect(consentFor.item(3)).toContainText(oldestPipelineRuntimeDescription);
 
-    expect($(consentFor.get(4))).toContainText(elasticAgentJobConsentKey);
-    expect($(consentFor.get(4))).toContainText(elasticAgentJobConsentDescription);
+    expect(consentFor.item(4)).toContainText(elasticAgentJobConsentKey);
+    expect(consentFor.item(4)).toContainText(elasticAgentJobConsentDescription);
 
-    expect($(consentFor.get(5))).toContainText(testDriveConsentKey);
-    expect($(consentFor.get(5))).toContainText(testDriveConsentDescription);
+    expect(consentFor.item(5)).toContainText(testDriveConsentKey);
+    expect(consentFor.item(5)).toContainText(testDriveConsentDescription);
 
-    expect($(consentFor.get(6))).toContainText(testDriveMetricsConsentKey);
-    expect($(consentFor.get(6))).toContainText(testDriveMetricsConsentDescription);
+    expect(consentFor.item(6)).toContainText(testDriveMetricsConsentKey);
+    expect(consentFor.item(6)).toContainText(testDriveMetricsConsentDescription);
 
-    expect($(consentFor.get(7))).toContainText(gocdVersionConsentKey);
-    expect($(consentFor.get(7))).toContainText(gocdVersionConsentDescription);
+    expect(consentFor.item(7)).toContainText(gocdVersionConsentKey);
+    expect(consentFor.item(7)).toContainText(gocdVersionConsentDescription);
 
-    expect($(consentFor.get(8))).toContainText(serverIdConsentKey);
-    expect($(consentFor.get(8))).toContainText(serverIdConsentDescription);
+    expect(consentFor.item(8)).toContainText(serverIdConsentKey);
+    expect(consentFor.item(8)).toContainText(serverIdConsentDescription);
 
-    expect($(consentFor.get(9))).toContainText(messageVersionConsentKey);
-    expect($(consentFor.get(9))).toContainText(messageVersionConsentDescription);
+    expect(consentFor.item(9)).toContainText(messageVersionConsentKey);
+    expect(consentFor.item(9)).toContainText(messageVersionConsentDescription);
   });
 
   it('should show what data will be sent when GoCD data sharing is allowed', () => {
     expect(settings.allowed()).toBe(true);
 
-    expect(helper.find('.data-share-message')).toContainText('Data that will be sent:');
-    expect(helper.find('.shared-data')).toContainText(usageData.represent());
+    expect(helper.text('.data-share-message')).toContain('Data that will be sent:');
+    expect(helper.text('.shared-data')).toContain(usageData.represent());
   });
 
   it('should show what data would have been sent when GoCD data sharing is not allowed', () => {
     settings.allowed(false);
 
-    m.redraw.sync();
+    helper.redraw();
 
     expect(settings.allowed()).toBe(false);
 
-    expect(helper.find('.data-share-message')).toContainText('Data that would have been sent, if allowed:');
-    expect(helper.find('.shared-data')).toContainText(usageData.represent());
+    expect(helper.text('.data-share-message')).toContain('Data that would have been sent, if allowed:');
+    expect(helper.text('.shared-data')).toContain(usageData.represent());
   });
 
   describe('Buttons', () => {
     it('should render save button', () => {
-      expect(helper.find('.update-consent')).toBeInDOM();
+      expect(helper.q('.update-consent')).toBeInDOM();
     });
 
     it('should render reset button', () => {
-      expect(helper.find('.reset-consent')).toBeInDOM();
+      expect(helper.q('.reset-consent')).toBeInDOM();
     });
 
     it('should reset the settings consent value on clicking reset button', () => {
@@ -207,8 +204,7 @@ describe("Data Sharing Settings Widget", () => {
       settings.toggleConsent();
       expect(settings.allowed()).toBe(false);
 
-      simulateEvent.simulate(helper.find('.reset-consent').get(0), 'click');
-      m.redraw.sync();
+      helper.click('.reset-consent');
 
       expect(settings.allowed()).toBe(true);
     });
@@ -218,8 +214,7 @@ describe("Data Sharing Settings Widget", () => {
       settings.toggleConsent();
       expect(settings.allowed()).toBe(false);
 
-      simulateEvent.simulate(helper.find('.reset-consent').get(0), 'click');
-      m.redraw.sync();
+      helper.click('.reset-consent');
 
       expect(settings.allowed()).toBe(true);
 
@@ -241,8 +236,7 @@ describe("Data Sharing Settings Widget", () => {
         settings.toggleConsent();
         expect(settings.allowed()).toBe(false);
 
-        simulateEvent.simulate(helper.find('.update-consent').get(0), 'click');
-        m.redraw.sync();
+        helper.click('.update-consent');
 
         expect(settings.allowed()).toBe(false);
       });
@@ -254,7 +248,7 @@ describe("Data Sharing Settings Widget", () => {
     afterEach(jasmine.clock().uninstall);
 
     it('should not render flash message container if no flash message present', () => {
-      expect(helper.find('.callout')).not.toBeInDOM();
+      expect(helper.q('.callout')).toBeFalsy();
     });
 
     it('should show the success flash message when updating consent value is successful', () => {
@@ -272,14 +266,13 @@ describe("Data Sharing Settings Widget", () => {
           }
         });
 
-        expect(helper.find('.callout')).not.toBeInDOM();
+        expect(helper.q('.callout')).toBeFalsy();
 
-        simulateEvent.simulate(helper.find('.update-consent').get(0), 'click');
-        m.redraw.sync();
+        helper.click('.update-consent');
 
-        expect(helper.find('.callout')).toBeInDOM();
-        expect(helper.find('.callout')).toHaveClass('success');
-        expect(helper.find('.callout')).toContainText('Data Sharing Settings updated Successfully!');
+        expect(helper.q('.callout')).toBeInDOM();
+        expect(helper.q('.callout')).toHaveClass('success');
+        expect(helper.q('.callout')).toContainText('Data Sharing Settings updated Successfully!');
       });
     });
 
@@ -298,14 +291,13 @@ describe("Data Sharing Settings Widget", () => {
           }
         });
 
-        expect(helper.find('.callout')).not.toBeInDOM();
+        expect(helper.q('.callout')).toBeFalsy();
 
-        simulateEvent.simulate(helper.find('.update-consent').get(0), 'click');
-        m.redraw.sync();
+        helper.click('.update-consent');
 
-        expect(helper.find('.callout')).toBeInDOM();
-        expect(helper.find('.callout')).toHaveClass('alert');
-        expect(helper.find('.callout')).toContainText(response.message);
+        expect(helper.q('.callout')).toBeInDOM();
+        expect(helper.q('.callout')).toHaveClass('alert');
+        expect(helper.q('.callout')).toContainText(response.message);
       });
     });
 
@@ -323,19 +315,18 @@ describe("Data Sharing Settings Widget", () => {
           }
         });
 
-        expect(helper.find('.callout')).not.toBeInDOM();
+        expect(helper.q('.callout')).toBeFalsy();
 
-        simulateEvent.simulate(helper.find('.update-consent').get(0), 'click');
-        m.redraw.sync();
+        helper.click('.update-consent');
 
-        expect(helper.find('.callout')).toBeInDOM();
-        expect(helper.find('.callout')).toHaveClass('alert');
-        expect(helper.find('.callout')).toContainText(response.message);
+        expect(helper.q('.callout')).toBeInDOM();
+        expect(helper.q('.callout')).toHaveClass('alert');
+        expect(helper.q('.callout')).toContainText(response.message);
 
         jasmine.clock().tick(5001);
-        m.redraw.sync();
+        helper.redraw();
 
-        expect(helper.find('.callout')).not.toBeInDOM();
+        expect(helper.q('.callout')).toBeFalsy();
       });
     });
   });

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/shared/analytics_iframe_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/shared/analytics_iframe_widget_spec.js
@@ -54,10 +54,10 @@ describe("Analytics iFrame Widget", () => {
 
   it('should load view path from model and create an iframe with sandbox', () => {
     mount(newModel({a: 1}, "/some/path"), noop);
-    const iframe = helper.find('iframe');
+    const iframe = helper.q('iframe');
 
-    expect(iframe.attr('sandbox')).toEqual('allow-scripts');
-    expect(iframe.attr('src')).toEqual('/some/path');
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts');
+    expect(iframe.getAttribute('src')).toBe('/some/path');
   });
 
   it('should show errors if any', () => {
@@ -67,7 +67,7 @@ describe("Analytics iFrame Widget", () => {
       responseText:      "here is an error"
     });
     mount(model, noop);
-    expect(helper.find(".frame-container")[0].getAttribute("data-error-text")).toBe("here is an error");
+    expect(helper.q(".frame-container").getAttribute("data-error-text")).toBe("here is an error");
   });
 
   it('should render html error if any', () => {
@@ -78,7 +78,7 @@ describe("Analytics iFrame Widget", () => {
       responseText:      htmlErrorString
     });
     mount(model, noop);
-    expect(helper.find("iframe")[0].getAttribute("src")).toBe(`data:text/html;charset=utf-8,${htmlErrorString}`);
+    expect(helper.q("iframe").getAttribute("src")).toBe(`data:text/html;charset=utf-8,${htmlErrorString}`);
   });
 
   it('should initialize iframe oncreate', () => {
@@ -88,7 +88,7 @@ describe("Analytics iFrame Widget", () => {
       actualMessage = JSON.stringify(data);
     });
 
-    const iframe = helper.find('iframe')[0];
+    const iframe = helper.q('iframe');
     iframe.onload();
 
     const expectedMessage = JSON.stringify({

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/shared/dropdown_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/shared/dropdown_spec.js
@@ -56,22 +56,22 @@ describe('Dropdown widget', () => {
   });
 
   it('should open dropdown on click', () => {
-    expect(helper.find('.c-dropdown')).not.toHaveClass('open');
+    expect(helper.q('.c-dropdown')).not.toHaveClass('open');
     helper.click('.c-dropdown_head');
-    expect(helper.find('.c-dropdown')).toHaveClass('open');
+    expect(helper.q('.c-dropdown')).toHaveClass('open');
   });
 
   it('should close dropdown when an item is selected', () => {
     helper.click('.c-dropdown_head');
-    expect(helper.find('.c-dropdown')).toHaveClass('open');
+    expect(helper.q('.c-dropdown')).toHaveClass('open');
     helper.click('.c-dropdown_item');
-    expect(helper.find('.c-dropdown')).not.toHaveClass('open');
+    expect(helper.q('.c-dropdown')).not.toHaveClass('open');
   });
 
   it('should open drowndown when down-arrow is clicked', () => {
-    expect(helper.find('.c-dropdown')).not.toHaveClass('open');
+    expect(helper.q('.c-dropdown')).not.toHaveClass('open');
     helper.click('.c-down-arrow');
-    expect(helper.find('.c-dropdown')).toHaveClass('open');
+    expect(helper.q('.c-dropdown')).toHaveClass('open');
   });
 
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/components/collapsible_panel/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/collapsible_panel/spec/index_spec.tsx
@@ -18,8 +18,6 @@ import {TestHelper} from "views/pages/spec/test_helper";
 import {CollapsiblePanel} from "../index";
 import styles from "../index.scss";
 
-import * as simulateEvent from "simulate-event";
-
 describe("Collapsible Panel Component", () => {
 
   const pageTitle = "Test Header";
@@ -30,37 +28,35 @@ describe("Collapsible Panel Component", () => {
 
   it("should render expand collapsible component", () => {
     mount();
-    expect(helper.findByDataTestId("collapse-header")).toContainText(pageTitle);
-    expect(helper.find(".collapse-content")).toBeInDOM();
+    expect(helper.byTestId("collapse-header")).toContainText(pageTitle);
+    expect(helper.q(".collapse-content")).toBeInDOM();
   });
 
   it("should render component, collapsed by default", () => {
     mount();
-    expect(helper.findByDataTestId("collapse-header")).not.toHaveClass(styles.expanded);
-    expect(helper.findByDataTestId("collapse-body")).toHaveClass(styles.hide);
+    expect(helper.byTestId("collapse-header")).not.toHaveClass(styles.expanded);
+    expect(helper.byTestId("collapse-body")).toHaveClass(styles.hide);
   });
 
   it("should toggle component state on click", () => {
     mount();
-    expect(helper.findByDataTestId("collapse-header")).not.toHaveClass(styles.expanded);
-    expect(helper.findByDataTestId("collapse-body")).toHaveClass(styles.hide);
+    expect(helper.byTestId("collapse-header")).not.toHaveClass(styles.expanded);
+    expect(helper.byTestId("collapse-body")).toHaveClass(styles.hide);
 
-    simulateEvent.simulate(helper.findByDataTestId("collapse-header").get(0), "click");
-    helper.redraw();
+    helper.clickByTestId("collapse-header");
 
-    expect(helper.findByDataTestId("collapse-header")).toHaveClass(styles.expanded);
-    expect(helper.findByDataTestId("collapse-body")).not.toHaveClass(styles.hide);
+    expect(helper.byTestId("collapse-header")).toHaveClass(styles.expanded);
+    expect(helper.byTestId("collapse-body")).not.toHaveClass(styles.hide);
 
-    simulateEvent.simulate(helper.findByDataTestId("collapse-header").get(0), "click");
-    helper.redraw();
+    helper.clickByTestId("collapse-header");
 
-    expect(helper.findByDataTestId("collapse-header")).not.toHaveClass(styles.expanded);
-    expect(helper.findByDataTestId("collapse-body")).toHaveClass(styles.hide);
+    expect(helper.byTestId("collapse-header")).not.toHaveClass(styles.expanded);
+    expect(helper.byTestId("collapse-body")).toHaveClass(styles.hide);
   });
 
   it("should apply error state", () => {
     mount(true);
-    expect(helper.findByDataTestId("collapsible-panel-wrapper")).toHaveClass(styles.error);
+    expect(helper.byTestId("collapsible-panel-wrapper")).toHaveClass(styles.error);
   });
 
   function mount(error?: boolean) {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/config_repos/spec/material_check_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/config_repos/spec/material_check_spec.tsx
@@ -62,7 +62,7 @@ describe("ConfigRepos: MaterialCheck", () => {
       }}/>);
 
       expect(helper.byTestId('material-check-button')).toBeVisible();
-      helper.clickByDataTestId("material-check-button");
+      helper.clickByTestId("material-check-button");
       expect(jasmine.Ajax.requests.count()).toEqual(1);
     });
   });
@@ -100,7 +100,7 @@ describe("ConfigRepos: MaterialCheck", () => {
       }}/>);
 
       expect(helper.byTestId('material-check-button')).toBeVisible();
-      helper.clickByDataTestId("material-check-button");
+      helper.clickByTestId("material-check-button");
       expect(jasmine.Ajax.requests.count()).toEqual(1);
     });
   });
@@ -137,7 +137,7 @@ describe("ConfigRepos: MaterialCheck", () => {
       }}/>);
 
       expect(helper.byTestId('material-check-button')).toBeVisible();
-      helper.clickByDataTestId("material-check-button");
+      helper.clickByTestId("material-check-button");
       expect(jasmine.Ajax.requests.count()).toEqual(1);
     });
   });
@@ -167,7 +167,7 @@ describe("ConfigRepos: MaterialCheck", () => {
       }}/>);
 
       expect(helper.byTestId('material-check-button')).toBeVisible();
-      helper.clickByDataTestId("material-check-button");
+      helper.clickByTestId("material-check-button");
       expect(jasmine.Ajax.requests.count()).toEqual(1);
     });
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/components/ellipsize/spec/ellipsize_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/ellipsize/spec/ellipsize_spec.tsx
@@ -50,7 +50,7 @@ describe("EllipsizeComponent", () => {
 
       expect(helper.findByClass(styles.wrapper)).toBeInDOM();
       expect(helper.findByClass(styles.wrapper)).not.toHaveClass(styles.fixEllipsized);
-      expect(helper.findByDataTestId("ellipsized-content")).toHaveText("This ...");
+      expect(helper.byTestId("ellipsized-content")).toHaveText("This ...");
       expect(helper.findByClass(styles.ellipsisActionButton)).toBeInDOM();
     });
   });
@@ -61,13 +61,13 @@ describe("EllipsizeComponent", () => {
 
       expect(helper.findByClass(styles.wrapper)).toBeInDOM();
       expect(helper.findByClass(styles.wrapper)).not.toHaveClass(styles.fixEllipsized);
-      expect(helper.findByDataTestId("ellipsized-content")).toHaveText("This ...");
+      expect(helper.byTestId("ellipsized-content")).toHaveText("This ...");
       expect(helper.findByClass(styles.ellipsisActionButton)).toHaveText("more");
 
       simulateEvent.simulate(helper.findByClass(styles.ellipsisActionButton)[0], "click");
       m.redraw.sync();
 
-      expect(helper.findByDataTestId("ellipsized-content")).toHaveText("This is small");
+      expect(helper.byTestId("ellipsized-content")).toHaveText("This is small");
       expect(helper.findByClass(styles.ellipsisActionButton)).toBeInDOM();
       expect(helper.findByClass(styles.ellipsisActionButton)).toHaveText("less");
     });
@@ -77,20 +77,20 @@ describe("EllipsizeComponent", () => {
 
       expect(helper.findByClass(styles.wrapper)).toBeInDOM();
       expect(helper.findByClass(styles.wrapper)).not.toHaveClass(styles.fixEllipsized);
-      expect(helper.findByDataTestId("ellipsized-content")).toHaveText("This ...");
+      expect(helper.byTestId("ellipsized-content")).toHaveText("This ...");
       expect(helper.findByClass(styles.ellipsisActionButton)).toHaveText("more");
 
       simulateEvent.simulate(helper.findByClass(styles.ellipsisActionButton)[0], "click");
       m.redraw.sync();
 
-      expect(helper.findByDataTestId("ellipsized-content")).toHaveText("This is small");
+      expect(helper.byTestId("ellipsized-content")).toHaveText("This is small");
       expect(helper.findByClass(styles.ellipsisActionButton)).toBeInDOM();
       expect(helper.findByClass(styles.ellipsisActionButton)).toHaveText("less");
 
       simulateEvent.simulate(helper.findByClass(styles.ellipsisActionButton)[0], "click");
       m.redraw.sync();
 
-      expect(helper.findByDataTestId("ellipsized-content")).toHaveText("This ...");
+      expect(helper.byTestId("ellipsized-content")).toHaveText("This ...");
     });
   });
 

--- a/server/webapp/WEB-INF/rails/webpack/views/components/environment_variables/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/environment_variables/spec/index_spec.tsx
@@ -33,45 +33,45 @@ describe("Environment Variables Widget", () => {
 
   describe("Plain Text Variables", () => {
     it("should have a title", () => {
-      expect(helper.findByDataTestId("plain-text-variables-title")).toBeInDOM();
+      expect(helper.byTestId("plain-text-variables-title")).toBeInDOM();
     });
 
     it("should have an add button", () => {
-      expect(helper.findByDataTestId("add-plain-text-variables-btn")).toBeInDOM();
+      expect(helper.byTestId("add-plain-text-variables-btn")).toBeInDOM();
     });
 
     it("should have plain text environment variable fields", () => {
       const plainTextValue = plainTextEnvVar.value();
-      expect(helper.findByDataTestId("env-var-name")[0]).toHaveValue(plainTextEnvVar.name());
-      expect(helper.findByDataTestId("env-var-value")[0]).toHaveValue(plainTextValue ? plainTextValue : "");
-      expect(helper.findByDataTestId("remove-env-var-btn")[0]).toBeInDOM();
+      expect(helper.byTestId("env-var-name")).toHaveValue(plainTextEnvVar.name());
+      expect(helper.byTestId("env-var-value")).toHaveValue(plainTextValue ? plainTextValue : "");
+      expect(helper.byTestId("remove-env-var-btn")).toBeInDOM();
     });
 
     it("should have readonly fields if environment variable is non-editable", () => {
-      expect(helper.findByDataTestId("env-var-name")[0] as HTMLElement).not.toHaveAttr("readonly");
-      expect(helper.findByDataTestId("env-var-value")[0] as HTMLElement).not.toHaveAttr("readonly");
+      expect(helper.byTestId("env-var-name")).not.toHaveAttr("readonly");
+      expect(helper.byTestId("env-var-value")).not.toHaveAttr("readonly");
 
       plainTextEnvVar.editable = () => false;
       m.redraw.sync();
 
-      expect(helper.findByDataTestId("env-var-name")[0] as HTMLElement).toHaveAttr("readonly");
-      expect(helper.findByDataTestId("env-var-value")[0] as HTMLElement).toHaveAttr("readonly");
+      expect(helper.byTestId("env-var-name")).toHaveAttr("readonly");
+      expect(helper.byTestId("env-var-value")).toHaveAttr("readonly");
     });
   });
 
   describe("Secure Variables", () => {
     it("should have a title", () => {
-      expect(helper.findByDataTestId("plain-text-variables-title")).toBeInDOM();
+      expect(helper.byTestId("plain-text-variables-title")).toBeInDOM();
     });
 
     it("should have an add button", () => {
-      expect(helper.findByDataTestId("add-secure-variables-btn")).toBeInDOM();
+      expect(helper.byTestId("add-secure-variables-btn")).toBeInDOM();
     });
 
     it("should have secure environment variable fields", () => {
-      expect(helper.findByDataTestId("env-var-name")[1]).toHaveValue(secureEnvVar.name());
-      expect(helper.findByDataTestId("env-var-value")[1]).toBeInDOM();
-      expect(helper.findByDataTestId("remove-env-var-btn")[1]).toBeInDOM();
+      expect(helper.allByTestId("env-var-name")[1]).toHaveValue(secureEnvVar.name());
+      expect(helper.allByTestId("env-var-value")[1]).toBeInDOM();
+      expect(helper.allByTestId("remove-env-var-btn")[1]).toBeInDOM();
     });
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/components/header_panel/spec/index_spec.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/header_panel/spec/index_spec.js
@@ -26,7 +26,7 @@ describe("Header Panel Component", () => {
   it("should render header panel component", () => {
     const pageTitle = "Test Header";
     mount(pageTitle, []);
-    expect(helper.findByDataTestId('title')).toContainText(pageTitle);
+    expect(helper.textByTestId('title')).toContain(pageTitle);
   });
 
   it("should render header panel along with buttons", () => {
@@ -34,21 +34,21 @@ describe("Header Panel Component", () => {
     const buttons   = [m("button", "Do something"), m("button", "Do something more")];
     mount(pageTitle, buttons);
 
-    expect(helper.findByDataTestId('title')).toContainText(pageTitle);
+    expect(helper.textByTestId('title')).toContain(pageTitle);
 
-    const pageActionButtons = helper.findByDataTestId('pageActions').children();
+    const pageActionButtons = helper.byTestId('pageActions').children;
 
     expect(pageActionButtons).toHaveLength(buttons.length);
-    expect(pageActionButtons.get(0)).toContainText("Do something");
-    expect(pageActionButtons.get(1)).toContainText("Do something more");
+    expect(pageActionButtons.item(0)).toContainText("Do something");
+    expect(pageActionButtons.item(1)).toContainText("Do something more");
   });
 
   it("should not render buttons when no buttons are provided for header panel", () => {
     const pageTitle = "Test Header";
     mount(pageTitle);
 
-    expect(helper.findByDataTestId('title')).toContainText(pageTitle);
-    expect(helper.findByDataTestId('pageActions')).not.toBeInDOM();
+    expect(helper.textByTestId('title')).toContain(pageTitle);
+    expect(helper.byTestId('pageActions')).toBeFalsy();
   });
 
   function mount(pageTitle, buttons) {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/spec/index_spec.tsx
@@ -25,32 +25,32 @@ describe("KeyValuePair", () => {
   it("should render key value pairs", () => {
     helper.mount(() => <KeyValuePair data={data()}/>);
 
-    expect(helper.find(`.${styles.keyValuePair}`).children()).toHaveLength(data().size);
+    expect(helper.q(`.${styles.keyValuePair}`).children).toHaveLength(data().size);
 
-    expect(helper.find(`.${styles.keyValuePair} .${styles.key}`).get(0)).toHaveText("First Name");
-    expect(helper.find(`.${styles.keyValuePair} .${styles.value}`).get(0)).toHaveText("Jon");
+    expect(helper.q(`.${styles.keyValuePair} .${styles.key}`)).toHaveText("First Name");
+    expect(helper.q(`.${styles.keyValuePair} .${styles.value}`)).toHaveText("Jon");
 
-    expect(helper.find(`.${styles.keyValuePair} .${styles.key}`).get(1)).toHaveText("Last Name");
-    expect(helper.find(`.${styles.keyValuePair} .${styles.value}`).get(1)).toHaveText("Doe");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.key}`).item(1)).toHaveText("Last Name");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.value}`).item(1)).toHaveText("Doe");
 
-    expect(helper.find(`.${styles.keyValuePair} .${styles.key}`).get(2)).toHaveText("email");
-    expect(helper.find(`.${styles.keyValuePair} .${styles.value}`).get(2)).toHaveText("jdoe@example.com");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.key}`).item(2)).toHaveText("email");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.value}`).item(2)).toHaveText("jdoe@example.com");
 
-    expect(helper.find(`.${styles.keyValuePair} .${styles.value}`).get(3)).toHaveText("true");
-    expect(helper.find(`.${styles.keyValuePair} .${styles.value}`).get(4)).toHaveText("false");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.value}`).item(3)).toHaveText("true");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.value}`).item(4)).toHaveText("false");
 
-    expect(helper.find(`.${styles.keyValuePair} .${styles.value}`).get(5)).toHaveHtml("<em>(Not specified)</em>");
-    expect(helper.find(`.${styles.keyValuePair} .${styles.value}`).get(6)).toHaveHtml("<em>(Not specified)</em>");
-    expect(helper.find(`.${styles.keyValuePair} .${styles.value}`).get(7)).toHaveHtml("<em>(Not specified)</em>");
-    expect(helper.find(`.${styles.keyValuePair} .${styles.value}`).get(8)).toHaveHtml("<em>(Not specified)</em>");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.value}`).item(5)).toHaveHtml("<em>(Not specified)</em>");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.value}`).item(6)).toHaveHtml("<em>(Not specified)</em>");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.value}`).item(7)).toHaveHtml("<em>(Not specified)</em>");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.value}`).item(8)).toHaveHtml("<em>(Not specified)</em>");
 
-    expect(helper.find(`.${styles.keyValuePair} .${styles.value}`).get(9)).toHaveHtml("<strong>grrr!</strong>");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.value}`).item(9)).toHaveHtml("<strong>grrr!</strong>");
 
-    expect(helper.find(`.${styles.keyValuePair} .${styles.key}`).get(10)).toHaveText("Integer");
-    expect(helper.find(`.${styles.keyValuePair} .${styles.value}`).get(10)).toHaveText("1");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.key}`).item(10)).toHaveText("Integer");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.value}`).item(10)).toHaveText("1");
 
-    expect(helper.find(`.${styles.keyValuePair} .${styles.key}`).get(11)).toHaveText("Float");
-    expect(helper.find(`.${styles.keyValuePair} .${styles.value}`).get(11)).toHaveText("3.14");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.key}`).item(11)).toHaveText("Float");
+    expect(helper.qa(`.${styles.keyValuePair} .${styles.value}`).item(11)).toHaveText("3.14");
   });
 
   function data() {
@@ -84,17 +84,17 @@ describe("KeyValueTitle", () => {
   it("should render key value title", () => {
     helper.mount(() => <KeyValueTitle {...data()} inline={false}/>);
 
-    expect(helper.find(`.${styles.title}`)).toContainText("A Long Descriptive Title");
-    expect(helper.find(`.${styles.title}`)).not.toHaveClass(styles.titleInline);
-    expect(helper.findByDataTestId("data-test-icon-span")).toContainText("Icon Goes Here");
+    expect(helper.q(`.${styles.title}`)).toContainText("A Long Descriptive Title");
+    expect(helper.q(`.${styles.title}`)).not.toHaveClass(styles.titleInline);
+    expect(helper.byTestId("data-test-icon-span")).toContainText("Icon Goes Here");
   });
 
   it("should render key value title inline", () => {
     helper.mount(() => <KeyValueTitle {...data()} inline={true}/>);
 
-    expect(helper.find(`.${styles.title}`)).toContainText("A Long Descriptive Title");
-    expect(helper.find(`.${styles.title}`)).toHaveClass(styles.titleInline);
-    expect(helper.findByDataTestId("data-test-icon-span")).toContainText("Icon Goes Here");
+    expect(helper.q(`.${styles.title}`)).toContainText("A Long Descriptive Title");
+    expect(helper.q(`.${styles.title}`)).toHaveClass(styles.titleInline);
+    expect(helper.byTestId("data-test-icon-span")).toContainText("Icon Goes Here");
   });
 
   function data() {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/materials/spec/test_connection_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/materials/spec/test_connection_spec.tsx
@@ -56,7 +56,7 @@ describe("Materials: TestConnection", () => {
       }}/>);
 
       expect(helper.byTestId('test-connection-button')).toBeVisible();
-      helper.clickByDataTestId("test-connection-button");
+      helper.clickByTestId("test-connection-button");
       expect(jasmine.Ajax.requests.count()).toEqual(1);
     });
   });
@@ -88,7 +88,7 @@ describe("Materials: TestConnection", () => {
       }}/>);
 
       expect(helper.byTestId('test-connection-button')).toBeVisible();
-      helper.clickByDataTestId("test-connection-button");
+      helper.clickByTestId("test-connection-button");
       expect(jasmine.Ajax.requests.count()).toEqual(1);
     });
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/components/notification_center/spec/system_notifications_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/notification_center/spec/system_notifications_widget_spec.tsx
@@ -18,7 +18,6 @@ import "jasmine-jquery";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {Notification, SystemNotifications} from "models/notifications/system_notifications";
-import * as simulateEvent from "simulate-event";
 import {SystemNotificationsWidget} from "views/components/notification_center/system_notifications_widget";
 import {TestHelper} from "views/pages/spec/test_helper";
 
@@ -38,7 +37,7 @@ describe("SystemNotificationsWidget", () => {
   it("should not display notification bell when there are no notifications to display", () => {
     systemNotifications(SystemNotifications.fromJSON([]));
     helper.redraw();
-    expect(helper.find(".notifications").get(0)).not.toBeInDOM();
+    expect(helper.q(".notifications")).toBeFalsy();
   });
 
   it("should display notification bell and the notifications", () => {
@@ -63,15 +62,15 @@ describe("SystemNotificationsWidget", () => {
 
     systemNotifications(SystemNotifications.fromJSON(notifications));
     helper.redraw();
-    const allNotifications = helper.findByDataTestId("notification-item");
-    expect(allNotifications.get(0)).toBeInDOM();
+    const allNotifications = helper.allByTestId("notification-item");
+    expect(allNotifications.item(0)).toBeInDOM();
     expect(allNotifications.length).toBe(2);
-    expect(allNotifications.eq(0)).toContainText("message 1. read more");
-    expect(allNotifications.eq(0).find("a")).toContainText("read more");
-    expect(allNotifications.eq(0).find(`[data-test-id='notification-item_close']`)).toContainText("X");
-    expect(allNotifications.eq(1)).toContainText("message 2. read more");
-    expect(allNotifications.eq(1).find("a")).toContainText("read more");
-    expect(allNotifications.eq(1).find(`[data-test-id='notification-item_close']`)).toContainText("X");
+    expect(allNotifications.item(0)).toContainText("message 1. read more");
+    expect(helper.q("a", allNotifications.item(0))).toContainText("read more");
+    expect(helper.byTestId("notification-item_close", allNotifications.item(0))).toContainText("X");
+    expect(allNotifications.item(1)).toContainText("message 2. read more");
+    expect(helper.q("a", allNotifications.item(1))).toContainText("read more");
+    expect(helper.allByTestId("notification-item_close", allNotifications.item(1))).toContainText("X");
   });
 
   it("should mark a notification as read and stop displaying it when user marks a notification as read", () => {
@@ -96,14 +95,14 @@ describe("SystemNotificationsWidget", () => {
 
     systemNotifications(SystemNotifications.fromJSON(notifications));
     helper.redraw();
-    let allNotifications = helper.findByDataTestId("notification-item");
+    let allNotifications = helper.allByTestId("notification-item");
     expect(allNotifications.length).toBe(2);
-    simulateEvent.simulate(allNotifications.eq(0).find(`[data-test-id='notification-item_close']`).get(0), "click");
-    helper.redraw();
 
-    allNotifications = helper.findByDataTestId("notification-item");
+    helper.clickByTestId("notification-item_close", allNotifications.item(0));
+
+    allNotifications = helper.allByTestId("notification-item");
     expect(allNotifications.length).toBe(1);
-    expect(allNotifications.eq(0)).toContainText("message 2. read more");
+    expect(allNotifications.item(0)).toContainText("message 2. read more");
 
     expect(systemNotifications().find((m: Notification) => {
       return m.id === "id1";

--- a/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/spec/server_health_messages_count_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/spec/server_health_messages_count_widget_spec.tsx
@@ -15,7 +15,6 @@
  */
 
 import {timeFormatter} from "helpers/time_formatter";
-import $ from "jquery";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {ServerHealthMessages} from "models/shared/server_health_messages/server_health_messages";
@@ -52,20 +51,20 @@ describe("ServerHealthMessagesCountWidget", () => {
   it("should render the count of errors and warnings", () => {
     helper.mount(() => <ServerHealthMessagesCountWidget serverHealthMessages={Stream(serverHealthMessages)}/>);
 
-    expect(helper.find("a")).toContainText("1 error and 1 warning");
+    expect(helper.byTestId("server-health-messages-count")).toContainText("1 error and 1 warning");
   });
 
   it("should render the list of messages in modal on click", () => {
     helper.mount(() => <ServerHealthMessagesCountWidget serverHealthMessages={Stream(serverHealthMessages)}/>);
 
-    helper.click('a');
+    helper.clickByTestId("server-health-messages-count");
 
-    expect($(`.component-modal-container [data-test-id='server-health-message-for-${s.slugify(jsonData[0].message)}'] [data-test-class='server-health-message_message']:first`))
-      .toContainText(jsonData[0].message);
-    expect($(`.component-modal-container [data-test-id='server-health-message-for-${s.slugify(jsonData[0].message)}'] [data-test-class='server-health-message_detail']:first`))
-      .toContainText(jsonData[0].detail);
-    expect($(`.component-modal-container [data-test-id='server-health-message-for-${s.slugify(jsonData[0].message)}'] [data-test-class='server-health-message_timestamp']:first`))
-      .toContainText(timeFormatter.format(jsonData[0].time));
+    const container = document.querySelector(".component-modal-container")!;
+    const msgEl = helper.byTestId(`server-health-message-for-${s.slugify(jsonData[0].message)}`, container);
+
+    expect(helper.q("[data-test-class='server-health-message_message']", msgEl)).toContainText(jsonData[0].message);
+    expect(helper.q("[data-test-class='server-health-message_detail']", msgEl)).toContainText(jsonData[0].detail);
+    expect(helper.q("[data-test-class='server-health-message_timestamp']", msgEl)).toContainText(timeFormatter.format(jsonData[0].time));
   });
 
   it("should trust html messages in modal", () => {
@@ -77,14 +76,14 @@ describe("ServerHealthMessagesCountWidget", () => {
     }]))}
     />);
 
-    helper.click('a');
+    helper.clickByTestId("server-health-messages-count");
 
-    expect($(".component-modal-container [data-test-id='server-health-message-for-test-message'] [data-test-class='server-health-message_message']"))
-      .toContainText("Test Message");
-    expect($(".component-modal-container [data-test-id='server-health-message-for-test-message'] [data-test-class='server-health-message_detail']"))
-      .toContainHtml(`This is a <a href="http://example.com">link</a>`);
-    expect($($(".component-modal-container [data-test-id='server-health-message-for-test-message'] [data-test-class='server-health-message_timestamp']")))
-      .toContainText(timeFormatter.format("2018-01-30T07:34:43Z"));
+    const container = document.querySelector(".component-modal-container")!;
+    const msgEl = helper.byTestId("server-health-message-for-test-message", container);
+
+    expect(helper.q("[data-test-class='server-health-message_message']", msgEl)).toContainText("Test Message");
+    expect(helper.q("[data-test-class='server-health-message_detail']", msgEl)).toContainHtml(`This is a <a href="http://example.com">link</a>`);
+    expect(helper.q("[data-test-class='server-health-message_timestamp']", msgEl)).toContainText(timeFormatter.format("2018-01-30T07:34:43Z"));
   });
 
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/components/site_menu/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/site_menu/spec/index_spec.tsx
@@ -31,10 +31,10 @@ describe("Site Menu", () => {
             canViewAdminPage: true,
             showAnalytics: true
           } as Attrs);
-    const dashboard = helper.find("a").get(0);
-    const agents    = helper.find("a").get(1);
-    const analytics = helper.find("a").get(2);
-    const admin     = helper.find("a").get(3);
+    const dashboard = helper.qa("a").item(0);
+    const agents    = helper.qa("a").item(1);
+    const analytics = helper.qa("a").item(2);
+    const admin     = helper.qa("a").item(3);
     expect(dashboard).toHaveText("Dashboard");
     expect(dashboard).toHaveAttr("href", "/go/pipelines");
     expect(agents).toHaveText("Agents");
@@ -60,8 +60,8 @@ describe("Site Menu", () => {
     expect(findMenuItem("/go/admin/security/auth_configs")).toHaveText("Authorization Configuration");
     expect(findMenuItem("/go/admin/security/roles")).toHaveText("Role configuration");
     expect(findMenuItem("/go/admin/admin_access_tokens")).toHaveText("Access Tokens Management");
-    expect(helper.find(`a.${styles.siteNavLink}`)).toHaveLength(4);
-    expect(helper.find(`a.${styles.siteSubNavLink}`)).toHaveLength(19);
+    expect(helper.qa(`a.${styles.siteNavLink}`)).toHaveLength(4);
+    expect(helper.qa(`a.${styles.siteSubNavLink}`)).toHaveLength(19);
   });
 
   it("should display the menus for users who can view templates", () => {
@@ -72,10 +72,10 @@ describe("Site Menu", () => {
             canViewAdminPage: true,
             showAnalytics: true
           } as Attrs);
-    const dashboard = helper.find("a").get(0);
-    const agents    = helper.find("a").get(1);
-    const analytics = helper.find("a").get(2);
-    const admin     = helper.find("a").get(3);
+    const dashboard = helper.qa("a").item(0);
+    const agents    = helper.qa("a").item(1);
+    const analytics = helper.qa("a").item(2);
+    const admin     = helper.qa("a").item(3);
     expect(dashboard).toHaveText("Dashboard");
     expect(dashboard).toHaveAttr("href", "/go/pipelines");
     expect(agents).toHaveText("Agents");
@@ -83,20 +83,20 @@ describe("Site Menu", () => {
     expect(analytics).toHaveText("Analytics");
     expect(analytics).toHaveAttr("href", "/go/analytics");
     expect(admin).toHaveText("Admin");
-    expect(findMenuItem("/go/admin/pipelines")).not.toBeInDOM();
-    expect(findMenuItem("/go/admin/config_repos")).not.toBeInDOM();
+    expect(findMenuItem("/go/admin/pipelines")).toBeFalsy();
+    expect(findMenuItem("/go/admin/config_repos")).toBeFalsy();
     expect(findMenuItem("/go/admin/templates")).toHaveText("Templates");
-    expect(findMenuItem("/go/admin/elastic_agent_configurations")).not.toBeInDOM();
-    expect(findMenuItem("/go/admin/config_xml")).not.toBeInDOM();
-    expect(findMenuItem("/go/admin/config/server")).not.toBeInDOM();
-    expect(findMenuItem("/go/admin/users")).not.toBeInDOM();
-    expect(findMenuItem("/go/admin/backup")).not.toBeInDOM();
-    expect(findMenuItem("/go/admin/plugins")).not.toBeInDOM();
-    expect(findMenuItem("/go/admin/package_repositories/new")).not.toBeInDOM();
-    expect(findMenuItem("/go/admin/security/auth_configs")).not.toBeInDOM();
-    expect(findMenuItem("/go/admin/security/roles")).not.toBeInDOM();
-    expect(helper.find(`a.${styles.siteNavLink}`)).toHaveLength(4);
-    expect(helper.find(`a.${styles.siteSubNavLink}`)).toHaveLength(1);
+    expect(findMenuItem("/go/admin/elastic_agent_configurations")).toBeFalsy();
+    expect(findMenuItem("/go/admin/config_xml")).toBeFalsy();
+    expect(findMenuItem("/go/admin/config/server")).toBeFalsy();
+    expect(findMenuItem("/go/admin/users")).toBeFalsy();
+    expect(findMenuItem("/go/admin/backup")).toBeFalsy();
+    expect(findMenuItem("/go/admin/plugins")).toBeFalsy();
+    expect(findMenuItem("/go/admin/package_repositories/new")).toBeFalsy();
+    expect(findMenuItem("/go/admin/security/auth_configs")).toBeFalsy();
+    expect(findMenuItem("/go/admin/security/roles")).toBeFalsy();
+    expect(helper.qa(`a.${styles.siteNavLink}`)).toHaveLength(4);
+    expect(helper.qa(`a.${styles.siteSubNavLink}`)).toHaveLength(1);
   });
 
   it("should display the menus for Group Admins", () => {
@@ -107,10 +107,10 @@ describe("Site Menu", () => {
             canViewAdminPage: true,
             showAnalytics: true
           } as Attrs);
-    const dashboard = helper.find("a").get(0);
-    const agents    = helper.find("a").get(1);
-    const analytics = helper.find("a").get(2);
-    const admin     = helper.find("a").get(3);
+    const dashboard = helper.qa("a").item(0);
+    const agents    = helper.qa("a").item(1);
+    const analytics = helper.qa("a").item(2);
+    const admin     = helper.qa("a").item(3);
     expect(dashboard).toHaveText("Dashboard");
     expect(dashboard).toHaveAttr("href", "/go/pipelines");
     expect(agents).toHaveText("Agents");
@@ -119,19 +119,19 @@ describe("Site Menu", () => {
     expect(analytics).toHaveAttr("href", "/go/analytics");
     expect(admin).toHaveText("Admin");
     expect(findMenuItem("/go/admin/pipelines")).toHaveText("Pipelines");
-    expect(findMenuItem("/go/admin/config_repos")).not.toBeInDOM();
+    expect(findMenuItem("/go/admin/config_repos")).toBeFalsy();
     expect(findMenuItem("/go/admin/templates")).toHaveText("Templates");
     expect(findMenuItem("/go/admin/elastic_agent_configurations")).toHaveText("Elastic Agent Configurations");
     expect(findMenuItem("/go/admin/pipelines/snippet")).toHaveText("Config XML");
-    expect(findMenuItem("/go/admin/config/server")).not.toBeInDOM();
-    expect(findMenuItem("/go/admin/users")).not.toBeInDOM();
-    expect(findMenuItem("/go/admin/backup")).not.toBeInDOM();
+    expect(findMenuItem("/go/admin/config/server")).toBeFalsy();
+    expect(findMenuItem("/go/admin/users")).toBeFalsy();
+    expect(findMenuItem("/go/admin/backup")).toBeFalsy();
     expect(findMenuItem("/go/admin/plugins")).toHaveText("Plugins");
     expect(findMenuItem("/go/admin/package_repositories/new")).toHaveText("Package Repositories");
-    expect(findMenuItem("/go/admin/security/auth_configs")).not.toBeInDOM();
-    expect(findMenuItem("/go/admin/security/roles")).not.toBeInDOM();
-    expect(helper.find(`a.${styles.siteNavLink}`)).toHaveLength(4);
-    expect(helper.find(`a.${styles.siteSubNavLink}`)).toHaveLength(6);
+    expect(findMenuItem("/go/admin/security/auth_configs")).toBeFalsy();
+    expect(findMenuItem("/go/admin/security/roles")).toBeFalsy();
+    expect(helper.qa(`a.${styles.siteNavLink}`)).toHaveLength(4);
+    expect(helper.qa(`a.${styles.siteSubNavLink}`)).toHaveLength(6);
   });
 
   it("should not show analytics when the attribute is passed as false", () => {
@@ -142,15 +142,15 @@ describe("Site Menu", () => {
             canViewAdminPage: true,
             showAnalytics: false
           } as Attrs);
-    const dashboard = helper.find("a").get(0);
-    const agents    = helper.find("a").get(1);
-    const admin     = helper.find("a").get(2);
+    const dashboard = helper.qa("a").item(0);
+    const agents    = helper.qa("a").item(1);
+    const admin     = helper.qa("a").item(2);
     expect(dashboard).toHaveText("Dashboard");
     expect(dashboard).toHaveAttr("href", "/go/pipelines");
     expect(agents).toHaveText("Agents");
     expect(agents).toHaveAttr("href", "/go/agents");
     expect(admin).toHaveText("Admin");
-    expect(findMenuItem("/go/analytics")).not.toBeInDOM();
+    expect(findMenuItem("/go/analytics")).toBeFalsy();
   });
 
   it("should not show Admin link for non-admins", () => {
@@ -161,9 +161,9 @@ describe("Site Menu", () => {
             canViewAdminPage: false,
             showAnalytics: false
           } as Attrs);
-    const dashboard = helper.find("a").get(0);
-    const agents    = helper.find("a").get(1);
-    const admin     = helper.find("a").get(2);
+    const dashboard = helper.qa("a").item(0);
+    const agents    = helper.qa("a").item(1);
+    const admin     = helper.qa("a").item(2);
     expect(dashboard).toHaveText("Dashboard");
     expect(dashboard).toHaveAttr("href", "/go/pipelines");
     expect(agents).toHaveText("Agents");
@@ -176,7 +176,7 @@ describe("Site Menu", () => {
   }
 
   function findMenuItem(href: string) {
-    return helper.find(`a[href='${href}']`);
+    return helper.q(`a[href='${href}']`);
   }
 
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/components/switch/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/switch/spec/index_spec.tsx
@@ -33,22 +33,22 @@ describe("SwitchBtn component", () => {
   it("should render switch", () => {
     mount();
 
-    expect(helper.findByDataTestId("switch-wrapper")).toBeInDOM();
-    expect(helper.findByDataTestId("switch-wrapper")).toHaveClass(styles.switchBtn);
+    expect(helper.byTestId("switch-wrapper")).toBeInDOM();
+    expect(helper.byTestId("switch-wrapper")).toHaveClass(styles.switchBtn);
 
-    expect(helper.findByDataTestId("switch-label")).toContainText("This is switch");
-    expect(helper.findByDataTestId("switch-label")).toHaveClass(styles.switchLabel);
+    expect(helper.byTestId("switch-label")).toContainText("This is switch");
+    expect(helper.byTestId("switch-label")).toHaveClass(styles.switchLabel);
 
-    expect(helper.findByDataTestId("switch-checkbox")).toHaveClass(styles.switchInput);
-    expect(helper.findByDataTestId("switch-paddle")).toHaveClass(styles.switchPaddle);
+    expect(helper.byTestId("switch-checkbox")).toHaveClass(styles.switchInput);
+    expect(helper.byTestId("switch-paddle")).toHaveClass(styles.switchPaddle);
   });
 
   it("should render small switch", () => {
     mount(true);
 
-    expect(helper.findByDataTestId("switch-wrapper")).toBeInDOM();
-    expect(helper.findByDataTestId("switch-wrapper")).toHaveClass(styles.switchBtn);
-    expect(helper.findByDataTestId("switch-wrapper")).toHaveClass(styles.switchSmall);
+    expect(helper.byTestId("switch-wrapper")).toBeInDOM();
+    expect(helper.byTestId("switch-wrapper")).toHaveClass(styles.switchBtn);
+    expect(helper.byTestId("switch-wrapper")).toHaveClass(styles.switchSmall);
   });
 
   it("should toggle a state of field", () => {
@@ -56,10 +56,10 @@ describe("SwitchBtn component", () => {
 
     expect(switchStream()).toBe(false);
 
-    helper.clickByDataTestId("switch-paddle");
+    helper.clickByTestId("switch-paddle");
     expect(switchStream()).toBe(true);
 
-    helper.clickByDataTestId("switch-paddle");
+    helper.clickByTestId("switch-paddle");
     expect(switchStream()).toBe(false);
   });
 
@@ -68,10 +68,10 @@ describe("SwitchBtn component", () => {
 
     expect(switchStream()).toBe(false);
 
-    helper.clickByDataTestId("switch-paddle");
+    helper.clickByTestId("switch-paddle");
     expect(switchStream()).toBe(true);
 
-    helper.clickByDataTestId("switch-paddle");
+    helper.clickByTestId("switch-paddle");
     expect(switchStream()).toBe(false);
   });
 

--- a/server/webapp/WEB-INF/rails/webpack/views/components/tab/spec/tab_conponent_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/tab/spec/tab_conponent_spec.tsx
@@ -15,7 +15,6 @@
  */
 
 import m from "mithril";
-import * as simulateEvent from "simulate-event";
 import {Tabs} from "views/components/tab/index";
 import {TestHelper} from "views/pages/spec/test_helper";
 import styles from "../index.scss";
@@ -28,36 +27,35 @@ describe("TabComponent", () => {
   it("should render tab with first tab selected", () => {
     mount();
 
-    expect(helper.findByDataTestId("tab-header-0")).toBeInDOM();
-    expect(helper.findByDataTestId("tab-header-0")).toHaveText("One");
-    expect(helper.findByDataTestId("tab-header-0")).toHaveClass(styles.active);
-    expect(helper.findByDataTestId("tab-content-0")).toBeInDOM();
-    expect(helper.findByDataTestId("tab-content-0")).toBeVisible();
-    expect(helper.findByDataTestId("tab-content-0")).toHaveText("Content for one");
+    expect(helper.byTestId("tab-header-0")).toBeInDOM();
+    expect(helper.byTestId("tab-header-0")).toHaveText("One");
+    expect(helper.byTestId("tab-header-0")).toHaveClass(styles.active);
+    expect(helper.byTestId("tab-content-0")).toBeInDOM();
+    expect(helper.byTestId("tab-content-0")).toBeVisible();
+    expect(helper.byTestId("tab-content-0")).toHaveText("Content for one");
 
-    expect(helper.findByDataTestId("tab-header-1")).toBeInDOM();
-    expect(helper.findByDataTestId("tab-header-1")).toHaveText("Two");
-    expect(helper.findByDataTestId("tab-header-1")).not.toHaveClass(styles.active);
-    expect(helper.findByDataTestId("tab-content-1")).toBeInDOM();
-    expect(helper.findByDataTestId("tab-content-1")).toBeHidden();
-    expect(helper.findByDataTestId("tab-content-1")).toHaveText("Content for two");
+    expect(helper.byTestId("tab-header-1")).toBeInDOM();
+    expect(helper.byTestId("tab-header-1")).toHaveText("Two");
+    expect(helper.byTestId("tab-header-1")).not.toHaveClass(styles.active);
+    expect(helper.byTestId("tab-content-1")).toBeInDOM();
+    expect(helper.byTestId("tab-content-1")).toBeHidden();
+    expect(helper.byTestId("tab-content-1")).toHaveText("Content for two");
   });
 
   it("should change tab on click of tab name", () => {
     mount();
 
-    expect(helper.findByDataTestId("tab-header-0")).toHaveClass(styles.active);
-    expect(helper.findByDataTestId("tab-content-0")).toBeVisible();
-    expect(helper.findByDataTestId("tab-header-1")).not.toHaveClass(styles.active);
-    expect(helper.findByDataTestId("tab-content-1")).toBeHidden();
+    expect(helper.byTestId("tab-header-0")).toHaveClass(styles.active);
+    expect(helper.byTestId("tab-content-0")).toBeVisible();
+    expect(helper.byTestId("tab-header-1")).not.toHaveClass(styles.active);
+    expect(helper.byTestId("tab-content-1")).toBeHidden();
 
-    simulateEvent.simulate(helper.findByDataTestId("tab-header-1").get(0), "click");
-    m.redraw.sync();
+    helper.clickByTestId("tab-header-1");
 
-    expect(helper.findByDataTestId("tab-header-0")).not.toHaveClass(styles.active);
-    expect(helper.findByDataTestId("tab-content-0")).toBeHidden();
-    expect(helper.findByDataTestId("tab-header-1")).toHaveClass(styles.active);
-    expect(helper.findByDataTestId("tab-content-1")).toBeVisible();
+    expect(helper.byTestId("tab-header-0")).not.toHaveClass(styles.active);
+    expect(helper.byTestId("tab-content-0")).toBeHidden();
+    expect(helper.byTestId("tab-header-1")).toHaveClass(styles.active);
+    expect(helper.byTestId("tab-content-1")).toBeVisible();
   });
 
   function mount() {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/spec/index_spec.tsx
@@ -15,7 +15,6 @@
  */
 import m from "mithril";
 import Stream from "mithril/stream";
-import * as simulateEvent from "simulate-event";
 import {TestHelper} from "views/pages/spec/test_helper";
 import {Table, TableSortHandler} from "../index";
 import styles from "../index.scss";
@@ -29,84 +28,79 @@ describe("TableComponent", () => {
 
   it("should render table component", () => {
     mount(headers, data);
-    expect(helper.find(`[data-test-id='${"table"}']`)).toBeVisible();
-    expect(helper.find(`[data-test-id='${"table-header-row"}']`).length).toEqual(1);
-    expect(helper.find(`[data-test-id='${"table-row"}']`).length).toEqual(2);
+    expect(helper.byTestId("table")).toBeVisible();
+    expect(helper.allByTestId("table-header-row").length).toBe(1);
+    expect(helper.allByTestId("table-row").length).toBe(2);
   });
 
   it("should render headers and data", () => {
     mount(headers, data);
-    expect(helper.find(`[data-test-id='${"table-header-row"}']`)).toContainText("Col1");
-    expect(helper.find(`[data-test-id='${"table-header-row"}']`)).toContainText("Col2");
-    expect(helper.find(`[data-test-id='${"table-header-row"}']`)).toContainText("Col3");
+    expect(helper.byTestId("table-header-row")).toContainText("Col1");
+    expect(helper.byTestId("table-header-row")).toContainText("Col2");
+    expect(helper.byTestId("table-header-row")).toContainText("Col3");
 
-    expect(helper.find(`[data-test-id='${"table-row"}']`).get(0)).toContainText("1");
-    expect(helper.find(`[data-test-id='${"table-row"}']`).get(0)).toContainText("2");
-    expect(helper.find(`[data-test-id='${"table-row"}']`).get(0)).toContainText("");
+    expect(helper.allByTestId("table-row").item(0)).toContainText("1");
+    expect(helper.allByTestId("table-row").item(0)).toContainText("2");
+    expect(helper.allByTestId("table-row").item(0)).toContainText("");
 
-    expect(helper.find(`[data-test-id='${"table-row"}']`).get(1)).toContainText("true");
-    expect(helper.find(`[data-test-id='${"table-row"}']`).get(1)).toContainText("two");
-    expect(helper.find(`[data-test-id='${"table-row"}']`).get(1)).toContainText("");
+    expect(helper.allByTestId("table-row").item(1)).toContainText("true");
+    expect(helper.allByTestId("table-row").item(1)).toContainText("two");
+    expect(helper.allByTestId("table-row").item(1)).toContainText("");
   });
 
   describe("Sort", () => {
-    const initialOrderOfData = "AZMCXNBYL";
-    const ascendingOrder     = "AZMBYLCXN";
-    const descendingOrder    = "CXNBYLAZM";
+    const initialOrderOfData = ["AZM", "CXN", "BYL"];
+    const ascendingOrder     = ["AZM", "BYL", "CXN"];
+    const descendingOrder    = ["CXN", "BYL", "AZM"];
 
     it("should have sort button for first column", () => {
       const testData = getTestData();
       mount(["Col-1", "Col-2", "Col-3"], testData(), new TestTableSortHandler(testData, [0]));
 
-      expect(helper.find(`.${styles.sortButton}`)).toHaveLength(1);
-      expect(helper.find(`.${styles.sortButton}`).parent()).toHaveText("Col-1");
+      expect(helper.qa(`.${styles.sortButton}`)).toHaveLength(1);
+      expect(helper.q(`.${styles.sortButton}`).parentElement).toHaveText("Col-1");
     });
 
     it("should call handler to sort data", () => {
       const testData = getTestData();
       mount(["Col-1", "Col-2", "Col-3"], testData(), new TestTableSortHandler(testData, [0]));
 
-      expect(helper.find(`[data-test-id='${"table-row"}']`)).toHaveText(initialOrderOfData);
+      expect(helper.textAllByTestId("table-row")).toEqual(initialOrderOfData);
 
-      simulateEvent.simulate(helper.find(`.${styles.sortableColumn}`).get(0), "click");
-      m.redraw.sync();
+      helper.click(`.${styles.sortableColumn}`);
 
-      expect(helper.find(`[data-test-id='${"table-row"}']`)).toHaveText(ascendingOrder);
+      expect(helper.textAllByTestId("table-row")).toEqual(ascendingOrder);
     });
 
     it("should reverse the sorted data if user click's twice on the sort button", () => {
       const testData = getTestData();
       mount(["Col-1", "Col-2", "Col-3"], testData(), new TestTableSortHandler(testData, [0]));
 
-      expect(helper.find(`[data-test-id='${"table-row"}']`)).toHaveText(initialOrderOfData);
+      expect(helper.textAllByTestId("table-row")).toEqual(initialOrderOfData);
 
-      simulateEvent.simulate(helper.find(`.${styles.sortableColumn}`).get(0), "click");
-      m.redraw.sync();
+      helper.click(`.${styles.sortableColumn}`);
 
-      expect(helper.find(`[data-test-id='${"table-row"}']`)).toHaveText(ascendingOrder);
+      expect(helper.textAllByTestId("table-row")).toEqual(ascendingOrder);
 
-      simulateEvent.simulate(helper.find(`.${styles.sortableColumn}`).get(0), "click");
-      m.redraw.sync();
+      helper.click(`.${styles.sortableColumn}`);
 
-      expect(helper.find(`[data-test-id='${"table-row"}']`)).toHaveText(descendingOrder);
+      expect(helper.textAllByTestId("table-row")).toEqual(descendingOrder);
     });
 
     it("should highlight current sorted column", () => {
       const testData = getTestData();
       mount(["Col-1", "Col-2", "Col-3"], testData(), new TestTableSortHandler(testData, [0, 1]));
-      expect(helper.find(`.${styles.sortButton}`)).toHaveClass(styles.inActive);
+      expect(helper.q(`.${styles.sortButton}`)).toHaveClass(styles.inActive);
 
-      simulateEvent.simulate(helper.find(`.${styles.sortableColumn}`).get(0), "click");
-      m.redraw.sync();
+      helper.click(`.${styles.sortableColumn}`);
 
-      expect(helper.find(`.${styles.sortButton}`).eq(0)).not.toHaveClass(styles.inActive);
-      expect(helper.find(`.${styles.sortButton}`).eq(1)).toHaveClass(styles.inActive);
+      expect(helper.qa(`.${styles.sortButton}`).item(0)).not.toHaveClass(styles.inActive);
+      expect(helper.qa(`.${styles.sortButton}`).item(1)).toHaveClass(styles.inActive);
 
-      simulateEvent.simulate(helper.find(`.${styles.sortableColumn}`).get(1), "click");
-      m.redraw.sync();
+      helper.click(helper.qa(`.${styles.sortableColumn}`).item(1));
 
-      expect(helper.find(`.${styles.sortButton}`).eq(0)).toHaveClass(styles.inActive);
-      expect(helper.find(`.${styles.sortButton}`).eq(1)).not.toHaveClass(styles.inActive);
+      expect(helper.qa(`.${styles.sortButton}`).item(0)).toHaveClass(styles.inActive);
+      expect(helper.qa(`.${styles.sortButton}`).item(1)).not.toHaveClass(styles.inActive);
     });
   });
 
@@ -114,17 +108,17 @@ describe("TableComponent", () => {
     it("should have a drag icon for each row if draggable to set to true", () => {
       mount(headers, getTestData()(), undefined, true);
 
-      expect(helper.find(`.${styles.draggable}`)).toBeInDOM();
+      expect(helper.q(`.${styles.draggable}`)).toBeInDOM();
 
-      expect(helper.find(`.${styles.dragIcon}`)).toBeInDOM();
-      expect(helper.find(`.${styles.dragIcon}`).length).toBe(3);
+      expect(helper.q(`.${styles.dragIcon}`)).toBeInDOM();
+      expect(helper.qa(`.${styles.dragIcon}`).length).toBe(3);
     });
 
     it("should not have a drag icon for each row if draggable is set to false", () => {
       mount(headers, getTestData()(), undefined, false);
 
-      expect(helper.find(`.${styles.draggable}`)).not.toBeInDOM();
-      expect(helper.find(`.${styles.dragIcon}`)).not.toBeInDOM();
+      expect(helper.q(`.${styles.draggable}`)).toBeFalsy();
+      expect(helper.q(`.${styles.dragIcon}`)).toBeFalsy();
     });
 
     it("should give a callback on dragover", () => {
@@ -135,8 +129,8 @@ describe("TableComponent", () => {
         return;
       }
 
-      const rowFirst  = helper.find("tr[data-id=\"0\"]").get(0);
-      const rowSecond = helper.find("tr[data-id=\"1\"]").get(0);
+      const rowFirst  = helper.q("tr[data-id=\"0\"]");
+      const rowSecond = helper.q("tr[data-id=\"1\"]");
 
       expect(rowFirst.textContent).toBe("AZM");
       expect(rowSecond.textContent).toBe("CXN");
@@ -152,7 +146,7 @@ describe("TableComponent", () => {
 
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(0, 1);
-      expect(helper.find(`.${styles.draggableOver}`)).toBeInDOM();
+      expect(helper.q(`.${styles.draggableOver}`)).toBeInDOM();
 
       rowFirst.dispatchEvent(new DragEvent("dragend"));
       m.redraw.sync();

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/access_tokens/spec/access_tokens_widget_for_admin_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/access_tokens/spec/access_tokens_widget_for_admin_spec.tsx
@@ -54,67 +54,65 @@ describe("AccessTokensWidgetForAdminSpec", () => {
     helper.mount(() => <AccessTokensWidgetForAdmin accessTokens={Stream(new AccessTokens())} onRevoke={onRevoke}
                                                    searchText={Stream("")}/>);
 
-    expect(helper.findByDataTestId("access_token_info")).toBeInDOM();
-    expect(helper.findByDataTestId("access_token_info").text())
-      .toContain(
-        "Navigate to Personal Access TokensClick on \"Generate Token\" to create new personal access token.The generated token can be used to access the GoCD API.");
+    expect(helper.byTestId("access_token_info")).toBeInDOM();
+    expect(helper.textByTestId("access_token_info")).
+      toContain("Navigate to Personal Access TokensClick on \"Generate Token\" to create new personal access token.The generated token can be used to access the GoCD API.");
 
-    expect(helper.findByDataTestId("tab-header-0")).not.toBeInDOM();
-    expect(helper.findByDataTestId("tab-header-1")).not.toBeInDOM();
+    expect(helper.byTestId("tab-header-0")).toBeFalsy();
+    expect(helper.byTestId("tab-header-1")).toBeFalsy();
   });
 
   it("should be able to render two tabs when access tokens are present", () => {
     mount();
 
-    expect(helper.findByDataTestId("access-token-info")).not.toBeInDOM();
-    expect(helper.findByDataTestId("tab-header-0")).toBeInDOM();
-    expect(helper.findByDataTestId("tab-header-0")).toHaveText("Active Tokens");
-    expect(helper.findByDataTestId("tab-header-1")).toBeInDOM();
-    expect(helper.findByDataTestId("tab-header-0").text()).toContain("Active Token");
+    expect(helper.byTestId("access-token-info")).toBeFalsy();
+    expect(helper.byTestId("tab-header-0")).toBeInDOM();
+    expect(helper.byTestId("tab-header-0")).toHaveText("Active Tokens");
+    expect(helper.byTestId("tab-header-1")).toBeInDOM();
+    expect(helper.textByTestId("tab-header-0")).toContain("Active Token");
   });
 
   it("should be able to render active access tokens data", () => {
     const allActiveAccessTokens = allAccessTokens.activeTokens();
     mount(allActiveAccessTokens);
 
-    const activeTokensTab = helper.findByDataTestId("tab-header-0");
+    const activeTokensTab = helper.byTestId("tab-header-0");
     expect(activeTokensTab).toBeInDOM();
     expect(activeTokensTab).toHaveText("Active Tokens");
-    const activeTokenTableHeaders = helper.findIn(helper.findByDataTestId("tab-content-0"), "table-header-row")
-                                          .find("th");
-    expect(activeTokenTableHeaders.eq(0)).toHaveText("Created By");
-    expect(activeTokenTableHeaders.eq(1)).toHaveText("Description");
-    expect(activeTokenTableHeaders.eq(2)).toHaveText("Created At");
-    expect(activeTokenTableHeaders.eq(3)).toHaveText("Last Used");
-    expect(activeTokenTableHeaders.eq(4)).toHaveText("Revoke");
 
-    const activeTokenTableRows = helper.findIn(helper.findByDataTestId("tab-content-0"), "table-row");
-    expect(activeTokenTableRows.length).toEqual(3);
-    assertActiveTokenRow(activeTokenTableRows.eq(0), allActiveAccessTokens[0]());
-    assertActiveTokenRow(activeTokenTableRows.eq(1), allActiveAccessTokens[1]());
-    assertActiveTokenRow(activeTokenTableRows.eq(2), allActiveAccessTokens[2]());
+    const activeTokenTableHeaders = helper.qa("th", helper.byTestId("table-header-row", helper.byTestId("tab-content-0")));
+    expect(activeTokenTableHeaders.item(0)).toHaveText("Created By");
+    expect(activeTokenTableHeaders.item(1)).toHaveText("Description");
+    expect(activeTokenTableHeaders.item(2)).toHaveText("Created At");
+    expect(activeTokenTableHeaders.item(3)).toHaveText("Last Used");
+    expect(activeTokenTableHeaders.item(4)).toHaveText("Revoke");
 
-    const revokedTokensTab = helper.findByDataTestId("tab-header-1");
+    const activeTokenTableRows = helper.allByTestId("table-row", helper.byTestId("tab-content-0"));
+    expect(activeTokenTableRows.length).toBe(3);
+    assertActiveTokenRow(activeTokenTableRows.item(0), allActiveAccessTokens[0]());
+    assertActiveTokenRow(activeTokenTableRows.item(1), allActiveAccessTokens[1]());
+    assertActiveTokenRow(activeTokenTableRows.item(2), allActiveAccessTokens[2]());
+
+    const revokedTokensTab = helper.byTestId("tab-header-1");
     expect(revokedTokensTab).toHaveText("Revoked Tokens");
-    expect(helper.findIn(helper.findByDataTestId("tab-content-1"), "table-header-row")).not.toBeInDOM();
-    expect(helper.findByDataTestId("tab-content-1")).toHaveText("There are no revoked tokens.");
+    expect(helper.allByTestId("table-header-row", helper.byTestId("tab-content-1"))).toHaveLength(0);
+    expect(helper.byTestId("tab-content-1")).toHaveText("There are no revoked tokens.");
   });
 
   it("should be able to render revoked access tokens data", () => {
     const revokedTokens = allAccessTokens.revokedTokens();
     mount(revokedTokens);
 
-    const revokedTokenTableRows = helper.findIn(helper.findByDataTestId("tab-content-1"), "table-row");
-    expect(revokedTokenTableRows.length).toEqual(3);
-    assertRevokedTokenRow(revokedTokenTableRows.eq(0), revokedTokens[0]());
-    assertRevokedTokenRow(revokedTokenTableRows.eq(1), revokedTokens[1]());
-    assertRevokedTokenRow(revokedTokenTableRows.eq(2), revokedTokens[2]());
+    const revokedTokenTableRows = helper.allByTestId("table-row", helper.byTestId("tab-content-1"));
+    expect(revokedTokenTableRows.length).toBe(3);
+    assertRevokedTokenRow(revokedTokenTableRows.item(0), revokedTokens[0]());
+    assertRevokedTokenRow(revokedTokenTableRows.item(1), revokedTokens[1]());
+    assertRevokedTokenRow(revokedTokenTableRows.item(2), revokedTokens[2]());
 
-    const activeTokensTab = helper.findByDataTestId("tab-header-0");
+    const activeTokensTab = helper.byTestId("tab-header-0");
     expect(activeTokensTab).toHaveText("Active Tokens");
-    expect(helper.findIn(helper.findByDataTestId("tab-content-0"), "table-header-row")).not.toBeInDOM();
-    expect(helper.findByDataTestId("tab-content-0"))
-      .toHaveText("There are no active tokens.");
+    expect(helper.allByTestId("table-header-row", helper.byTestId("tab-content-0"))).toHaveLength(0);
+    expect(helper.byTestId("tab-content-0")).toHaveText("There are no active tokens.");
   });
 
   describe("Search By Description", () => {
@@ -122,46 +120,46 @@ describe("AccessTokensWidgetForAdminSpec", () => {
       const searchText = Stream("");
       mount(allAccessTokens, searchText);
 
-      let activeTokenTableRows = helper.findIn(helper.findByDataTestId("tab-content-0"), "table-row");
-      expect(activeTokenTableRows.length).toEqual(3);
+      let activeTokenTableRows = helper.allByTestId("table-row", helper.byTestId("tab-content-0"));
+      expect(activeTokenTableRows).toHaveLength(3);
 
       searchText("token 1");
       helper.redraw();
 
       const filteredActiveAccessTokens = allAccessTokens.activeTokens().filterBySearchText("token 1");
-      activeTokenTableRows             = helper.findIn(helper.findByDataTestId("tab-content-0"), "table-row");
-      expect(activeTokenTableRows.length).toEqual(2);
-      assertActiveTokenRow(activeTokenTableRows.eq(0), filteredActiveAccessTokens[0]());
-      assertActiveTokenRow(activeTokenTableRows.eq(1), filteredActiveAccessTokens[1]());
+      activeTokenTableRows             = helper.allByTestId("table-row", helper.byTestId("tab-content-0"));
+      expect(activeTokenTableRows).toHaveLength(2);
+      assertActiveTokenRow(activeTokenTableRows.item(0), filteredActiveAccessTokens[0]());
+      assertActiveTokenRow(activeTokenTableRows.item(1), filteredActiveAccessTokens[1]());
     });
 
     it("should filter revoked tokens", () => {
       const searchText = Stream("");
       mount(allAccessTokens, searchText);
 
-      let activeTokenTableRows = helper.findIn(helper.findByDataTestId("tab-content-1"), "table-row");
+      let activeTokenTableRows = helper.allByTestId("table-row", helper.byTestId("tab-content-1"));
       expect(activeTokenTableRows.length).toEqual(3);
 
       searchText("token 2");
       helper.redraw();
 
       const filteredRevokedAccessTokens = allAccessTokens.revokedTokens().filterBySearchText("token 2");
-      activeTokenTableRows              = helper.findIn(helper.findByDataTestId("tab-content-1"), "table-row");
+      activeTokenTableRows              = helper.allByTestId("table-row", helper.byTestId("tab-content-1"));
       expect(activeTokenTableRows.length).toEqual(1);
-      assertRevokedTokenRow(activeTokenTableRows.eq(0), filteredRevokedAccessTokens[0]());
+      assertRevokedTokenRow(activeTokenTableRows.item(0), filteredRevokedAccessTokens[0]());
     });
 
     it("should show message if the search query results in empty array for active tokens", () => {
       const searchText = Stream("");
       mount(allAccessTokens, searchText);
 
-      const activeTokenTableRows = helper.findIn(helper.findByDataTestId("tab-content-0"), "table-row");
+      const activeTokenTableRows = helper.allByTestId("table-row", helper.byTestId("tab-content-0"));
       expect(activeTokenTableRows.length).toEqual(3);
 
       searchText("token 14");
       helper.redraw();
 
-      const tabContent = helper.findByDataTestId("tab-content-0");
+      const tabContent = helper.byTestId("tab-content-0");
       expect(tabContent).toHaveText("There are no active tokens matching your search query.");
     });
 
@@ -169,13 +167,13 @@ describe("AccessTokensWidgetForAdminSpec", () => {
       const searchText = Stream("");
       mount(allAccessTokens, searchText);
 
-      const activeTokenTableRows = helper.findIn(helper.findByDataTestId("tab-content-1"), "table-row");
+      const activeTokenTableRows = helper.allByTestId("table-row", helper.byTestId("tab-content-1"));
       expect(activeTokenTableRows.length).toEqual(3);
 
       searchText("token 14");
       helper.redraw();
 
-      const tabContent = helper.findByDataTestId("tab-content-1");
+      const tabContent = helper.byTestId("tab-content-1");
       expect(tabContent).toHaveText("There are no revoked tokens matching your search query.");
     });
   });
@@ -185,54 +183,54 @@ describe("AccessTokensWidgetForAdminSpec", () => {
       const searchText = Stream("");
       mount(allAccessTokens, searchText);
 
-      let activeTokenTableRows = helper.findIn(helper.findByDataTestId("tab-content-0"), "table-row");
+      let activeTokenTableRows = helper.allByTestId("table-row", helper.byTestId("tab-content-0"));
       expect(activeTokenTableRows.length).toEqual(3);
 
       searchText("John");
       helper.redraw();
 
       const filteredActiveTokens = allAccessTokens.activeTokens().filterBySearchText("John");
-      activeTokenTableRows       = helper.findIn(helper.findByDataTestId("tab-content-0"), "table-row");
+      activeTokenTableRows       = helper.allByTestId("table-row", helper.byTestId("tab-content-0"));
       expect(activeTokenTableRows.length).toEqual(1);
-      assertActiveTokenRow(activeTokenTableRows.eq(0), filteredActiveTokens[0]());
+      assertActiveTokenRow(activeTokenTableRows.item(0), filteredActiveTokens[0]());
     });
 
     it("should filter revoked tokens", () => {
       const searchText = Stream("");
       mount(allAccessTokens, searchText);
 
-      let activeTokenTableRows = helper.findIn(helper.findByDataTestId("tab-content-1"), "table-row");
+      let activeTokenTableRows = helper.allByTestId("table-row", helper.byTestId("tab-content-1"));
       expect(activeTokenTableRows.length).toEqual(3);
 
       searchText("John");
       helper.redraw();
 
       const filteredRevokedTokens = allAccessTokens.revokedTokens().filterBySearchText("John");
-      activeTokenTableRows        = helper.findIn(helper.findByDataTestId("tab-content-1"), "table-row");
+      activeTokenTableRows        = helper.allByTestId("table-row", helper.byTestId("tab-content-1"));
       expect(activeTokenTableRows.length).toEqual(2);
-      assertRevokedTokenRow(activeTokenTableRows.eq(0), filteredRevokedTokens[0]());
-      assertRevokedTokenRow(activeTokenTableRows.eq(1), filteredRevokedTokens[1]());
+      assertRevokedTokenRow(activeTokenTableRows.item(0), filteredRevokedTokens[0]());
+      assertRevokedTokenRow(activeTokenTableRows.item(1), filteredRevokedTokens[1]());
     });
   });
 
   afterEach(helper.unmount.bind(helper));
 
-  function assertActiveTokenRow(elem: any, accessToken: AccessToken) {
-    const columns = elem.find("td");
-    expect(columns.eq(0)).toContainText(accessToken.username());
-    expect(columns.eq(1)).toContainText(accessToken.description());
-    expect(columns.eq(2)).toContainText(formatTimeInformation(accessToken.createdAt()));
-    expect(columns.eq(3)).toContainText(getLastUsedInformation(accessToken));
+  function assertActiveTokenRow(elem: Element, accessToken: AccessToken) {
+    const columns = helper.qa("td", elem);
+    expect(columns.item(0)).toContainText(accessToken.username());
+    expect(columns.item(1)).toContainText(accessToken.description());
+    expect(columns.item(2)).toContainText(formatTimeInformation(accessToken.createdAt()));
+    expect(columns.item(3)).toContainText(getLastUsedInformation(accessToken));
   }
 
-  function assertRevokedTokenRow(elem: any, accessToken: AccessToken) {
-    const columns = elem.find("td");
-    expect(columns.eq(0)).toContainText(accessToken.username());
-    expect(columns.eq(1)).toContainText(accessToken.description());
-    expect(columns.eq(2)).toContainText(formatTimeInformation(accessToken.createdAt()));
-    expect(columns.eq(3)).toContainText(getLastUsedInformation(accessToken));
-    expect(columns.eq(4)).toContainText(getRevokedBy(accessToken.revokedBy()));
-    expect(columns.eq(5)).toContainText(formatTimeInformation(accessToken.revokedAt()!));
-    expect(columns.eq(6)).toContainText(accessToken.revokeCause()!);
+  function assertRevokedTokenRow(elem: Element, accessToken: AccessToken) {
+    const columns = helper.qa("td", elem);
+    expect(columns.item(0)).toContainText(accessToken.username());
+    expect(columns.item(1)).toContainText(accessToken.description());
+    expect(columns.item(2)).toContainText(formatTimeInformation(accessToken.createdAt()));
+    expect(columns.item(3)).toContainText(getLastUsedInformation(accessToken));
+    expect(columns.item(4)).toContainText(getRevokedBy(accessToken.revokedBy()));
+    expect(columns.item(5)).toContainText(formatTimeInformation(accessToken.revokedAt()!));
+    expect(columns.item(6)).toContainText(accessToken.revokeCause()!);
   }
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/access_tokens/spec/access_tokens_widget_for_current_user_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/access_tokens/spec/access_tokens_widget_for_current_user_spec.tsx
@@ -18,7 +18,6 @@ import m from "mithril";
 import Stream from "mithril/stream";
 import {AccessTokenTestData} from "models/access_tokens/spec/access_token_test_data";
 import {AccessToken, AccessTokens} from "models/access_tokens/types";
-import * as simulateEvent from "simulate-event";
 import {
   AccessTokensWidgetForCurrentUser,
   formatTimeInformation,
@@ -36,75 +35,74 @@ describe("AccessTokensWidgetForCurrentUserSpec", () => {
   it("should be able to render info when no access tokens have been created", () => {
     mount(Stream(new AccessTokens()));
 
-    expect(helper.findByDataTestId("access-token-info")).toBeInDOM();
-    expect(helper.findByDataTestId("access-token-info").text())
-      .toContain(
-        "Click on \"Generate Token\" to create new personal access token.A Generated token can be used to access the GoCD API.");
+    expect(helper.byTestId("access-token-info")).toBeInDOM();
+    expect(helper.textByTestId("access-token-info")).
+      toContain("Click on \"Generate Token\" to create new personal access token.A Generated token can be used to access the GoCD API.");
 
-    expect(helper.findByDataTestId("tab-header-0")).not.toBeInDOM();
-    expect(helper.findByDataTestId("tab-header-1")).not.toBeInDOM();
+    expect(helper.byTestId("tab-header-0")).toBeFalsy();
+    expect(helper.byTestId("tab-header-1")).toBeFalsy();
   });
 
   it("should render two tabs", () => {
     mount(Stream(allAccessTokens));
 
-    expect(helper.findByDataTestId("access-token-info")).not.toBeInDOM();
-    expect(helper.findByDataTestId("tab-header-0")).toBeInDOM();
-    expect(helper.findByDataTestId("tab-header-0")).toHaveText("Active Tokens");
-    expect(helper.findByDataTestId("tab-header-1")).toBeInDOM();
-    expect(helper.findByDataTestId("tab-header-1")).toHaveText("Revoked Tokens");
+    expect(helper.byTestId("access-token-info")).toBeFalsy();
+    expect(helper.byTestId("tab-header-0")).toBeInDOM();
+    expect(helper.byTestId("tab-header-0")).toHaveText("Active Tokens");
+    expect(helper.byTestId("tab-header-1")).toBeInDOM();
+    expect(helper.byTestId("tab-header-1")).toHaveText("Revoked Tokens");
   });
 
   it("should list all active tokens under active tokens tab", () => {
     mount(Stream(new AccessTokens(Stream(validToken))));
 
-    const activeTokensTab = helper.findByDataTestId("tab-header-0");
+    const activeTokensTab = helper.byTestId("tab-header-0");
     expect(activeTokensTab).toBeInDOM();
     expect(activeTokensTab).toHaveText("Active Tokens");
-    const activeTokenTableHeaders = helper.findIn(helper.findByDataTestId("tab-content-0"), "table-header-row")
-                                          .find("th");
-    expect(activeTokenTableHeaders.eq(0)).toHaveText("Description");
-    expect(activeTokenTableHeaders.eq(1)).toHaveText("Created At");
-    expect(activeTokenTableHeaders.eq(2)).toHaveText("Last Used");
-    expect(activeTokenTableHeaders.eq(3)).toHaveText("Revoke");
 
-    const activeTokenTableRows = helper.findIn(helper.findByDataTestId("tab-content-0"), "table-row");
-    expect(activeTokenTableRows.length).toEqual(1);
-    assertActiveTokenRow(activeTokenTableRows.eq(0), validToken);
+    const activeTokenTableHeaders = helper.qa("th", helper.byTestId("table-header-row", helper.byTestId("tab-content-0")));
 
-    const revokedTokensTab = helper.findByDataTestId("tab-header-1");
+    expect(activeTokenTableHeaders.item(0)).toHaveText("Description");
+    expect(activeTokenTableHeaders.item(1)).toHaveText("Created At");
+    expect(activeTokenTableHeaders.item(2)).toHaveText("Last Used");
+    expect(activeTokenTableHeaders.item(3)).toHaveText("Revoke");
+
+    const activeTokenTableRows = helper.allByTestId("table-row", helper.byTestId("tab-content-0"));
+    expect(activeTokenTableRows.length).toBe(1);
+    assertActiveTokenRow(activeTokenTableRows.item(0), validToken);
+
+    const revokedTokensTab = helper.byTestId("tab-header-1");
     expect(revokedTokensTab).toHaveText("Revoked Tokens");
-    expect(helper.findIn(helper.findByDataTestId("tab-content-1"), "table-header-row")).not.toBeInDOM();
-    expect(helper.findByDataTestId("tab-content-1")).toHaveText("You don't have any revoked tokens.");
+    expect(helper.byTestId("table-header-row", helper.byTestId("tab-content-1"))).toBeFalsy();
+    expect(helper.byTestId("tab-content-1")).toHaveText("You don't have any revoked tokens.");
   });
 
   it("should list all revoked tokens under revoked tokens tab", () => {
     mount(Stream(new AccessTokens(Stream(revokedToken))));
 
-    const activeTokensTab = helper.findByDataTestId("tab-header-0");
+    const activeTokensTab = helper.byTestId("tab-header-0");
     expect(activeTokensTab).toHaveText("Active Tokens");
-    expect(helper.findIn(helper.findByDataTestId("tab-content-0"), "table-header-row")).not.toBeInDOM();
-    expect(helper.findByDataTestId("tab-content-0"))
+    expect(helper.byTestId("table-header-row", helper.byTestId("tab-content-0"))).toBeFalsy();
+    expect(helper.byTestId("tab-content-0"))
       .toHaveText("You don't have any active tokens. Click on 'Generate Token' button to create a new token.");
 
-    const revokedTokensTab = helper.findByDataTestId("tab-header-1");
-    simulateEvent.simulate(revokedTokensTab.get(0), "click");
-    helper.redraw();
+    const revokedTokensTab = helper.byTestId("tab-header-1");
+    helper.click(revokedTokensTab);
 
     expect(revokedTokensTab).toBeInDOM();
     expect(revokedTokensTab).toHaveText("Revoked Tokens");
-    const revokedTokenTableHeaders = helper.findIn(helper.findByDataTestId("tab-content-1"), "table-header-row")
-                                           .find("th");
-    expect(revokedTokenTableHeaders.eq(0)).toHaveText("Description");
-    expect(revokedTokenTableHeaders.eq(1)).toHaveText("Created At");
-    expect(revokedTokenTableHeaders.eq(2)).toHaveText("Last Used");
-    expect(revokedTokenTableHeaders.eq(3)).toHaveText("Revoked By");
-    expect(revokedTokenTableHeaders.eq(4)).toHaveText("Revoked At");
-    expect(revokedTokenTableHeaders.eq(5)).toHaveText("Revoked Message");
 
-    const revokedTokensTableRows = helper.findIn(helper.findByDataTestId("tab-content-1"), "table-row");
+    const revokedTokenTableHeaders = helper.qa("th", helper.byTestId("table-header-row", helper.byTestId("tab-content-1")));
+    expect(revokedTokenTableHeaders.item(0)).toHaveText("Description");
+    expect(revokedTokenTableHeaders.item(1)).toHaveText("Created At");
+    expect(revokedTokenTableHeaders.item(2)).toHaveText("Last Used");
+    expect(revokedTokenTableHeaders.item(3)).toHaveText("Revoked By");
+    expect(revokedTokenTableHeaders.item(4)).toHaveText("Revoked At");
+    expect(revokedTokenTableHeaders.item(5)).toHaveText("Revoked Message");
+
+    const revokedTokensTableRows = helper.allByTestId("table-row", helper.byTestId("tab-content-1"));
     expect(revokedTokensTableRows.length).toEqual(1);
-    assertRevokedTokenRow(revokedTokensTableRows.eq(0), revokedToken);
+    assertRevokedTokenRow(revokedTokensTableRows.item(0), revokedToken);
   });
 
   function mount(accessTokens: Stream<AccessTokens>) {
@@ -113,20 +111,20 @@ describe("AccessTokensWidgetForCurrentUserSpec", () => {
 
   afterEach(helper.unmount.bind(helper));
 
-  function assertActiveTokenRow(elem: any, accessToken: AccessToken) {
-    const columns = elem.find("td");
-    expect(columns.eq(0)).toContainText(accessToken.description());
-    expect(columns.eq(1)).toContainText(formatTimeInformation(accessToken.createdAt()));
-    expect(columns.eq(2)).toContainText(getLastUsedInformation(accessToken));
+  function assertActiveTokenRow(elem: Element, accessToken: AccessToken) {
+    const columns = helper.qa("td", elem);
+    expect(columns.item(0)).toContainText(accessToken.description());
+    expect(columns.item(1)).toContainText(formatTimeInformation(accessToken.createdAt()));
+    expect(columns.item(2)).toContainText(getLastUsedInformation(accessToken));
   }
 
-  function assertRevokedTokenRow(elem: any, accessToken: AccessToken) {
-    const columns = elem.find("td");
-    expect(columns.eq(0)).toContainText(accessToken.description());
-    expect(columns.eq(1)).toContainText(formatTimeInformation(accessToken.createdAt()));
-    expect(columns.eq(2)).toContainText(getLastUsedInformation(accessToken));
-    expect(columns.eq(3)).toContainText(getRevokedBy(accessToken.revokedBy()));
-    expect(columns.eq(4)).toContainText(formatTimeInformation(accessToken.revokedAt()!));
-    expect(columns.eq(5)).toContainText(accessToken.revokeCause()!);
+  function assertRevokedTokenRow(elem: Element, accessToken: AccessToken) {
+    const columns = helper.qa("td", elem);
+    expect(columns.item(0)).toContainText(accessToken.description());
+    expect(columns.item(1)).toContainText(formatTimeInformation(accessToken.createdAt()));
+    expect(columns.item(2)).toContainText(getLastUsedInformation(accessToken));
+    expect(columns.item(3)).toContainText(getRevokedBy(accessToken.revokedBy()));
+    expect(columns.item(4)).toContainText(formatTimeInformation(accessToken.revokedAt()!));
+    expect(columns.item(5)).toContainText(accessToken.revokeCause()!);
   }
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/artifact_stores/spec/artifact_store_modal_body_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/artifact_stores/spec/artifact_store_modal_body_spec.tsx
@@ -33,13 +33,13 @@ describe("ArtifactModalBodyWidget", () => {
     const artifactStore = new ArtifactStore("", "cd.go.artifact.docker.registry", new Configurations([]));
     mount(artifactStore);
 
-    expect(helper.findByDataTestId("form-field-label-id")).toContainText("Id");
-    expect(helper.findByDataTestId("form-field-input-id")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-id").val()).toEqual("");
+    expect(helper.byTestId("form-field-label-id")).toContainText("Id");
+    expect(helper.byTestId("form-field-input-id")).toBeInDOM();
+    expect((helper.byTestId("form-field-input-id") as HTMLInputElement).value).toBe("");
 
-    expect(helper.findByDataTestId("form-field-label-plugin-id")).toContainText("Plugin Id");
+    expect(helper.byTestId("form-field-label-plugin-id")).toContainText("Plugin Id");
 
-    expect(helper.find(".plugin-view")).toContainText("This is store config view.");
+    expect(helper.q(".plugin-view")).toContainText("This is store config view.");
   });
 
   function mount(artifactStore: ArtifactStore, disableId = false) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/artifact_stores/spec/artifact_stores_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/artifact_stores/spec/artifact_stores_widget_spec.tsx
@@ -20,7 +20,6 @@ import {ArtifactStore, ArtifactStores} from "models/artifact_stores/artifact_sto
 import {ArtifactStoreTestData} from "models/artifact_stores/spec/test_data";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {ArtifactPluginInfo} from "models/shared/plugin_infos_new/spec/test_data";
-import * as simulateEvent from "simulate-event";
 import {ArtifactStoresWidget} from "views/pages/artifact_stores/artifact_stores_widget";
 import {TestHelper} from "views/pages/spec/test_helper";
 
@@ -36,56 +35,56 @@ describe("ArtifactStoresModal", () => {
   it("should show flash message when no artifact plugin installed", () => {
     mount(new ArtifactStores(), new PluginInfos());
 
-    expect(helper.findByDataTestId("flash-message-info")).toBeInDOM();
-    expect(helper.findByDataTestId("flash-message-info").text()).toEqual("No artifact plugin installed.");
+    expect(helper.byTestId("flash-message-info")).toBeInDOM();
+    expect(helper.textByTestId("flash-message-info")).toBe("No artifact plugin installed.");
   });
 
   it("should render action buttons", () => {
     const artifactStores = new ArtifactStores(dockerArtifactStore);
     mount(artifactStores, new PluginInfos(PluginInfo.fromJSON(ArtifactPluginInfo.docker())));
 
-    const groups = helper.findByDataTestId("artifact-stores-group");
+    const groups = helper.byTestId("artifact-stores-group");
 
-    expect(helper.findIn(groups.eq(0), "artifact-store-edit")).toBeInDOM();
-    expect(helper.findIn(groups.eq(0), "artifact-store-clone")).toBeInDOM();
-    expect(helper.findIn(groups.eq(0), "artifact-store-delete")).toBeInDOM();
-    expect(helper.findIn(groups.eq(0), "artifact-store-edit")).not.toBeDisabled();
-    expect(helper.findIn(groups.eq(0), "artifact-store-clone")).not.toBeDisabled();
-    expect(helper.findIn(groups.eq(0), "artifact-store-delete")).not.toBeDisabled();
+    expect(helper.byTestId("artifact-store-edit", groups)).toBeInDOM();
+    expect(helper.byTestId("artifact-store-clone", groups)).toBeInDOM();
+    expect(helper.byTestId("artifact-store-delete", groups)).toBeInDOM();
+    expect(helper.byTestId("artifact-store-edit", groups)).not.toBeDisabled();
+    expect(helper.byTestId("artifact-store-clone", groups)).not.toBeDisabled();
+    expect(helper.byTestId("artifact-store-delete", groups)).not.toBeDisabled();
   });
 
   it("should disable edit and clone button when plugin is not installed", () => {
     mount(new ArtifactStores(dockerArtifactStore), new PluginInfos());
 
-    const groups = helper.findByDataTestId("artifact-stores-group");
+    const groups = helper.byTestId("artifact-stores-group");
 
-    expect(helper.findIn(groups.eq(0), "artifact-store-edit")).toBeInDOM();
-    expect(helper.findIn(groups.eq(0), "artifact-store-clone")).toBeInDOM();
-    expect(helper.findIn(groups.eq(0), "artifact-store-delete")).toBeInDOM();
-    expect(helper.findIn(groups.eq(0), "artifact-store-edit")).toBeDisabled();
-    expect(helper.findIn(groups.eq(0), "artifact-store-clone")).toBeDisabled();
-    expect(helper.findIn(groups.eq(0), "artifact-store-delete")).not.toBeDisabled();
+    expect(helper.byTestId("artifact-store-edit", groups)).toBeInDOM();
+    expect(helper.byTestId("artifact-store-clone", groups)).toBeInDOM();
+    expect(helper.byTestId("artifact-store-delete", groups)).toBeInDOM();
+    expect(helper.byTestId("artifact-store-edit", groups)).toBeDisabled();
+    expect(helper.byTestId("artifact-store-clone", groups)).toBeDisabled();
+    expect(helper.byTestId("artifact-store-delete", groups)).not.toBeDisabled();
   });
 
   it("should render artifact store properties", () => {
     const artifactStores = new ArtifactStores(dockerArtifactStore);
     mount(artifactStores, new PluginInfos(PluginInfo.fromJSON(ArtifactPluginInfo.docker())));
 
-    const groups = helper.findByDataTestId("artifact-stores-group");
+    const groups = helper.byTestId("artifact-stores-group");
 
-    expect(helper.findIn(groups, "key-value-key-registryurl")).toContainText("RegistryURL");
-    expect(helper.findIn(groups, "key-value-key-username")).toContainText("Username");
-    expect(helper.findIn(groups, "key-value-key-password")).toContainText("Password");
-    expect(helper.findIn(groups, "key-value-value-registryurl")).toContainText("https://your_docker_registry_url");
-    expect(helper.findIn(groups, "key-value-value-username")).toContainText("admin");
-    expect(helper.findIn(groups, "key-value-value-password")).toContainText("************");
+    expect(helper.byTestId("key-value-key-registryurl", groups)).toContainText("RegistryURL");
+    expect(helper.byTestId("key-value-key-username", groups)).toContainText("Username");
+    expect(helper.byTestId("key-value-key-password", groups)).toContainText("Password");
+    expect(helper.byTestId("key-value-value-registryurl", groups)).toContainText("https://your_docker_registry_url");
+    expect(helper.byTestId("key-value-value-username", groups)).toContainText("admin");
+    expect(helper.byTestId("key-value-value-password", groups)).toContainText("************");
   });
 
   it("should callback the edit function when edit button is clicked", () => {
     const artifactStores = new ArtifactStores(dockerArtifactStore);
     mount(artifactStores, new PluginInfos(PluginInfo.fromJSON(ArtifactPluginInfo.docker())));
 
-    simulateEvent.simulate(helper.findByDataTestId("artifact-store-edit").get(0), "click");
+    helper.clickByTestId("artifact-store-edit");
 
     expect(onEdit).toHaveBeenCalledWith(dockerArtifactStore, jasmine.any(Event));
   });
@@ -94,7 +93,7 @@ describe("ArtifactStoresModal", () => {
     const artifactStores = new ArtifactStores(dockerArtifactStore);
     mount(artifactStores, new PluginInfos(PluginInfo.fromJSON(ArtifactPluginInfo.docker())));
 
-    simulateEvent.simulate(helper.findByDataTestId("artifact-store-clone").get(0), "click");
+    helper.clickByTestId("artifact-store-clone");
 
     expect(onClone).toHaveBeenCalledWith(dockerArtifactStore, jasmine.any(Event));
   });
@@ -103,7 +102,7 @@ describe("ArtifactStoresModal", () => {
     const artifactStores = new ArtifactStores(dockerArtifactStore);
     mount(artifactStores, new PluginInfos(PluginInfo.fromJSON(ArtifactPluginInfo.docker())));
 
-    simulateEvent.simulate(helper.findByDataTestId("artifact-store-delete").get(0), "click");
+    helper.clickByTestId("artifact-store-delete");
 
     expect(onDelete).toHaveBeenCalledWith(dockerArtifactStore, jasmine.any(Event));
   });
@@ -113,23 +112,17 @@ describe("ArtifactStoresModal", () => {
     const artifactStores     = new ArtifactStores(dockerArtifactStore, mavenArtifactStore);
     mount(artifactStores, new PluginInfos(PluginInfo.fromJSON(ArtifactPluginInfo.docker())));
 
-    const groups = helper.findByDataTestId("artifact-stores-group");
+    const groups = helper.allByTestId("artifact-stores-group");
 
     expect(groups.length).toEqual(2);
 
-    expect(helper.findIn(groups.eq(0), "plugin-name").text())
-      .toEqual("Artifact plugin for docker");
-    expect(helper.findIn(groups.eq(0), "key-value-value-plugin-id").text())
-      .toEqual("cd.go.artifact.docker.registry");
-    expect(helper.findIn(groups.eq(0), "key-value-value-id").text())
-      .toEqual("hub.docker");
+    expect(helper.textByTestId("plugin-name", groups.item(0))).toBe("Artifact plugin for docker");
+    expect(helper.textByTestId("key-value-value-plugin-id", groups.item(0))).toBe("cd.go.artifact.docker.registry");
+    expect(helper.textByTestId("key-value-value-id", groups.item(0))).toBe("hub.docker");
 
-    expect(helper.findIn(groups.eq(1), "plugin-name").text())
-      .toEqual("Plugin is not installed");
-    expect(helper.findIn(groups.eq(1), "key-value-value-plugin-id").text())
-      .toEqual("cd.go.artifact.maven.registry");
-    expect(helper.findIn(groups.eq(1), "key-value-value-id").text())
-      .toEqual("maven.central");
+    expect(helper.textByTestId("plugin-name", groups.item(1))).toBe("Plugin is not installed");
+    expect(helper.textByTestId("key-value-value-plugin-id", groups.item(1))).toBe("cd.go.artifact.maven.registry");
+    expect(helper.textByTestId("key-value-value-id", groups.item(1))).toBe("maven.central");
   });
 
   function mount(artifactStores: ArtifactStores, pluginInfos: PluginInfos) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/auth_configs/spec/auth_configs_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/auth_configs/spec/auth_configs_widget_spec.tsx
@@ -20,7 +20,6 @@ import {AuthConfigs} from "models/auth_configs/auth_configs";
 import {TestData} from "models/auth_configs/spec/test_data";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {AuthorizationPluginInfo} from "models/shared/plugin_infos_new/spec/test_data";
-import * as simulateEvent from "simulate-event";
 import {AuthConfigsWidget} from "views/pages/auth_configs/auth_configs_widget";
 import {TestHelper} from "views/pages/spec/test_helper";
 
@@ -37,58 +36,58 @@ describe("AuthorizationConfigurationWidget", () => {
 
   it("should render info message when authorization plugins are not installed on the server", () => {
     mount(new AuthConfigs(), new PluginInfos());
-    expect(helper.findByDataTestId("flash-message-info")).toContainText("No authorization plugin installed.");
+    expect(helper.textByTestId("flash-message-info")).toContain("No authorization plugin installed.");
   });
 
   it("should render id info and action buttons", () => {
     mount(authConfigs, pluginInfos);
-    expect(helper.findByDataTestId("key-value-key-id")).toContainText("Id");
-    expect(helper.findByDataTestId("key-value-value-id")).toContainText("ldap");
-    expect(helper.findByDataTestId("key-value-key-plugin-id")).toContainText("Plugin Id");
-    expect(helper.findByDataTestId("key-value-value-plugin-id")).toContainText("cd.go.authorization.ldap");
-    expect(helper.findByDataTestId("auth-config-edit")).toBeInDOM();
-    expect(helper.findByDataTestId("auth-config-clone")).toBeInDOM();
-    expect(helper.findByDataTestId("auth-config-delete")).toBeInDOM();
+    expect(helper.textByTestId("key-value-key-id")).toContain("Id");
+    expect(helper.textByTestId("key-value-value-id")).toContain("ldap");
+    expect(helper.textByTestId("key-value-key-plugin-id")).toContain("Plugin Id");
+    expect(helper.textByTestId("key-value-value-plugin-id")).toContain("cd.go.authorization.ldap");
+    expect(helper.byTestId("auth-config-edit")).toBeInDOM();
+    expect(helper.byTestId("auth-config-clone")).toBeInDOM();
+    expect(helper.byTestId("auth-config-delete")).toBeInDOM();
 
-    expect(helper.findByDataTestId("auth-config-edit")).not.toBeDisabled();
-    expect(helper.findByDataTestId("auth-config-clone")).not.toBeDisabled();
-    expect(helper.findByDataTestId("auth-config-delete")).not.toBeDisabled();
+    expect(helper.byTestId("auth-config-edit")).not.toBeDisabled();
+    expect(helper.byTestId("auth-config-clone")).not.toBeDisabled();
+    expect(helper.byTestId("auth-config-delete")).not.toBeDisabled();
   });
 
   it("should disable edit & clone button when plugin is not installed", () => {
     mount(authConfigs, new PluginInfos());
-    expect(helper.findByDataTestId("auth-config-edit")).toBeDisabled();
-    expect(helper.findByDataTestId("auth-config-clone")).toBeDisabled();
-    expect(helper.findByDataTestId("auth-config-delete")).not.toBeDisabled();
+    expect(helper.byTestId("auth-config-edit")).toBeDisabled();
+    expect(helper.byTestId("auth-config-clone")).toBeDisabled();
+    expect(helper.byTestId("auth-config-delete")).not.toBeDisabled();
   });
 
   it("should render auth config properties", () => {
     mount(authConfigs, pluginInfos);
-    expect(helper.findByDataTestId("key-value-key-url")).toContainText("Url");
-    expect(helper.findByDataTestId("key-value-key-managerdn")).toContainText("ManagerDN");
-    expect(helper.findByDataTestId("key-value-key-password")).toContainText("Password");
-    expect(helper.findByDataTestId("key-value-value-url")).toContainText("ldap://ldap.server.url");
-    expect(helper.findByDataTestId("key-value-value-managerdn")).toContainText("uid=admin,ou=system");
-    expect(helper.findByDataTestId("key-value-value-password")).toContainText("************");
+    expect(helper.textByTestId("key-value-key-url")).toContain("Url");
+    expect(helper.textByTestId("key-value-key-managerdn")).toContain("ManagerDN");
+    expect(helper.textByTestId("key-value-key-password")).toContain("Password");
+    expect(helper.textByTestId("key-value-value-url")).toContain("ldap://ldap.server.url");
+    expect(helper.textByTestId("key-value-value-managerdn")).toContain("uid=admin,ou=system");
+    expect(helper.textByTestId("key-value-value-password")).toContain("************");
   });
 
   it("should callback the edit function when edit button is clicked", () => {
     mount(authConfigs, pluginInfos);
-    simulateEvent.simulate(helper.findByDataTestId("auth-config-edit").get(0), "click");
+    helper.clickByTestId("auth-config-edit");
 
     expect(onEdit).toHaveBeenCalledWith(authConfigs[0], jasmine.any(Event));
   });
 
   it("should callback the clone function when clone button is clicked", () => {
     mount(authConfigs, pluginInfos);
-    simulateEvent.simulate(helper.findByDataTestId("auth-config-clone").get(0), "click");
+    helper.clickByTestId("auth-config-clone");
 
     expect(onClone).toHaveBeenCalledWith(authConfigs[0], jasmine.any(Event));
   });
 
   it("should callback the delete function when delete button is clicked", () => {
     mount(authConfigs, pluginInfos);
-    simulateEvent.simulate(helper.findByDataTestId("auth-config-delete").get(0), "click");
+    helper.clickByTestId("auth-config-delete");
 
     expect(onDelete).toHaveBeenCalledWith(authConfigs[0], jasmine.any(Event));
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/backup/spec/backup_config_modal_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/backup/spec/backup_config_modal_spec.tsx
@@ -41,10 +41,10 @@ describe("BackupConfigModal", () => {
   afterEach(helper.unmount.bind(helper));
 
   it("should render form", () => {
-    expect(modal.title()).toEqual("Configure backup settings");
-    expect(helper.findByDataTestId("form-field-input-backup-schedule")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-post-backup-script")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-send-email-on-backup-failure")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-send-email-on-backup-success")).toBeInDOM();
+    expect(modal.title()).toBe("Configure backup settings");
+    expect(helper.byTestId("form-field-input-backup-schedule")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-post-backup-script")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-send-email-on-backup-failure")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-send-email-on-backup-success")).toBeInDOM();
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/backup/spec/backup_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/backup/spec/backup_widget_spec.tsx
@@ -53,22 +53,22 @@ describe("Backup Widget", () => {
 
   it("should not disable button when backup not in progress", () => {
     mount("2000 GB", BackupStatus.NOT_STARTED, "");
-    expect(helper.findByDataTestId("perform-backup")).not.toBeDisabled();
+    expect(helper.byTestId("perform-backup")).not.toBeDisabled();
   });
 
   it("should disable the button only when backup in progress", () => {
     mount("200 GB", BackupStatus.IN_PROGRESS, "");
-    expect(helper.findByDataTestId("perform-backup")).toBeDisabled();
+    expect(helper.byTestId("perform-backup")).toBeDisabled();
   });
 
   it("should render top level error if backup fails to start", () => {
     mount("200 GB", BackupStatus.ERROR, "Something went wrong");
-    expect(helper.findByDataTestId(`top-level-error`)).toHaveText("Something went wrong");
+    expect(helper.byTestId(`top-level-error`)).toHaveText("Something went wrong");
   });
 
   it("should not render top level error if backup has already started", () => {
     mount("200 GB", BackupStatus.ERROR, "Something went wrong", BackupProgressStatus.BACKUP_VERSION_FILE);
-    expect(helper.findByDataTestId(`top-level-error`)).not.toBeInDOM();
+    expect(helper.byTestId(`top-level-error`)).toBeFalsy();
   });
 
   function mount(availableDiskSpace: string,

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/backup/spec/progress_indicator_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/backup/spec/progress_indicator_spec.tsx
@@ -40,8 +40,8 @@ describe("Backup Progress Indicator Widget", () => {
   it("should render status while backup is running", () => {
     mount(BackupStatus.IN_PROGRESS, "Backing up version file", BackupProgressStatus.BACKUP_VERSION_FILE);
 
-    expect(helper.findByDataTestId(`step-${BackupProgressStatus.BACKUP_VERSION_FILE}`)).toHaveClass(styles.backingUp);
-    expect(helper.findByDataTestId(`step-${BackupProgressStatus.CREATING_DIR}`)).toHaveClass(styles.backedUp);
+    expect(helper.byTestId(`step-${BackupProgressStatus.BACKUP_VERSION_FILE}`)).toHaveClass(styles.backingUp);
+    expect(helper.byTestId(`step-${BackupProgressStatus.CREATING_DIR}`)).toHaveClass(styles.backedUp);
     for (let key = BackupProgressStatus.BACKUP_CONFIG; key < BackupProgressStatus.POST_BACKUP_SCRIPT_COMPLETE; key++) {
       expectStatusNotRun(key);
     }
@@ -54,7 +54,7 @@ describe("Backup Progress Indicator Widget", () => {
     mount(BackupStatus.COMPLETED, "", BackupProgressStatus.POST_BACKUP_SCRIPT_COMPLETE);
 
     for (let key = BackupProgressStatus.CREATING_DIR; key < BackupProgressStatus.POST_BACKUP_SCRIPT_COMPLETE; key++) {
-      expect(helper.findByDataTestId(`step-${key}`)).toHaveClass(styles.backedUp);
+      expect(helper.byTestId(`step-${key}`)).toHaveClass(styles.backedUp);
     }
     expect(helper.findByClass(styles.stepsContainer)).not.toContainText("Backup in progress...");
     expect(helper.findByClass(styles.stepsContainer)).toContainText("Backup Completed");
@@ -64,9 +64,9 @@ describe("Backup Progress Indicator Widget", () => {
   it("should render failed status", () => {
     mount(BackupStatus.ERROR, "Backup failed for some reason", BackupProgressStatus.BACKUP_DATABASE);
     for (let key = BackupProgressStatus.CREATING_DIR; key < BackupProgressStatus.BACKUP_DATABASE; key++) {
-      expect(helper.findByDataTestId(`step-${key}`)).toHaveClass(styles.backedUp);
+      expect(helper.byTestId(`step-${key}`)).toHaveClass(styles.backedUp);
     }
-    expect(helper.findByDataTestId(`step-${BackupProgressStatus.BACKUP_DATABASE}`)).toHaveClass(styles.failed);
+    expect(helper.byTestId(`step-${BackupProgressStatus.BACKUP_DATABASE}`)).toHaveClass(styles.failed);
     expect(helper.findByClass(styles.errorContainer)).toHaveText("Backup failed for some reason");
     expectStatusNotRun(BackupProgressStatus.POST_BACKUP_SCRIPT_START);
   });
@@ -80,9 +80,9 @@ describe("Backup Progress Indicator Widget", () => {
   }
 
   function expectStatusNotRun(key: BackupProgressStatus) {
-    expect(helper.findByDataTestId(`step-${key}`)).not.toHaveClass(styles.backingUp);
-    expect(helper.findByDataTestId(`step-${key}`)).not.toHaveClass(styles.backedUp);
-    expect(helper.findByDataTestId(`step-${key}`)).not.toHaveClass(styles.failed);
+    expect(helper.byTestId(`step-${key}`)).not.toHaveClass(styles.backingUp);
+    expect(helper.byTestId(`step-${key}`)).not.toHaveClass(styles.backedUp);
+    expect(helper.byTestId(`step-${key}`)).not.toHaveClass(styles.failed);
   }
 
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_widget_spec.tsx
@@ -309,7 +309,7 @@ describe("ConfigReposWidget", () => {
     models([vm(repo)]);
     helper.redraw();
 
-    helper.clickByDataTestId("config-repo-delete");
+    helper.clickByTestId("config-repo-delete");
 
     expect(showDeleteModal).toHaveBeenCalledWith(jasmine.any(MouseEvent));
   });
@@ -319,7 +319,7 @@ describe("ConfigReposWidget", () => {
     models([vm(repo)]);
     helper.redraw();
 
-    helper.clickByDataTestId("config-repo-edit");
+    helper.clickByTestId("config-repo-edit");
 
     expect(showEditModal).toHaveBeenCalledWith(jasmine.any(MouseEvent));
   });
@@ -329,7 +329,7 @@ describe("ConfigReposWidget", () => {
     models([vm(repo)]);
     helper.redraw();
 
-    helper.clickByDataTestId("config-repo-refresh");
+    helper.clickByTestId("config-repo-refresh");
 
     expect(reparseRepo).toHaveBeenCalledWith(jasmine.any(MouseEvent));
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/modals_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/modals_spec.tsx
@@ -66,16 +66,14 @@ describe("ConfigRepoModal", () => {
     helper.mount(modal.body.bind(modal));
 
     expect(modal.title()).toEqual("Modal Title for Config Repo");
-    expect(helper.findByDataTestId("form-field-label-plugin-id")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-label-material-type")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-label-config-repository-name")).toBeInDOM();
+    expect(helper.byTestId("form-field-label-plugin-id")).toBeInDOM();
+    expect(helper.byTestId("form-field-label-material-type")).toBeInDOM();
+    expect(helper.byTestId("form-field-label-config-repository-name")).toBeInDOM();
 
-    expect(helper.findByDataTestId("form-field-input-plugin-id")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-plugin-id").get(0).children[0])
-      .toContainText("JSON Configuration Plugin");
-    expect(helper.findByDataTestId("form-field-input-material-type")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-material-type").get(0).children[0])
-      .toContainText("Git");
+    expect(helper.byTestId("form-field-input-plugin-id")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-plugin-id").firstElementChild!.textContent).toContain("JSON Configuration Plugin");
+    expect(helper.byTestId("form-field-input-material-type")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-material-type").firstElementChild!.textContent).toContain("Git");
   });
 
   it("should display error message", () => {
@@ -83,8 +81,8 @@ describe("ConfigRepoModal", () => {
     modal.setErrorMessageForTest("some error message");
     helper.mount(modal.body.bind(modal));
 
-    expect(helper.findByDataTestId("flash-message-alert")).toBeInDOM();
-    expect(helper.findByDataTestId("flash-message-alert")).toContainText("some error message");
+    expect(helper.byTestId("flash-message-alert")).toBeInDOM();
+    expect(helper.textByTestId("flash-message-alert")).toContain("some error message");
   });
 
   describe("CreateModal", () => {
@@ -92,8 +90,8 @@ describe("ConfigRepoModal", () => {
       const modal = new TestConfigRepoModal(onSuccessfulSave, onError, pluginInfos);
       helper.mount(modal.body.bind(modal));
 
-      expect(helper.findByDataTestId("form-field-input-config-repository-name")).toBeInDOM();
-      expect(helper.findByDataTestId("form-field-input-config-repository-name")).not.toBeDisabled();
+      expect(helper.byTestId("form-field-input-config-repository-name")).toBeInDOM();
+      expect(helper.byTestId("form-field-input-config-repository-name")).not.toBeDisabled();
     });
   });
 
@@ -102,7 +100,7 @@ describe("ConfigRepoModal", () => {
       const modal = new TestConfigRepoModal(onSuccessfulSave, onError, pluginInfos, false);
       helper.mount(modal.body.bind(modal));
 
-      expect(helper.findByDataTestId("form-field-input-config-repository-name")).toBeDisabled();
+      expect(helper.byTestId("form-field-input-config-repository-name")).toBeDisabled();
     });
   });
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/cluster_profiles_modals_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/cluster_profiles_modals_spec.tsx
@@ -48,10 +48,9 @@ describe("ClusterProfileModal", () => {
       const clusterProfile = new ClusterProfile("", "cd.go.contrib.elasticagent.kubernetes");
       modal                = new TestClusterProfile(pluginInfos, ModalType.edit, clusterProfile);
       helper.mount(modal.body.bind(modal));
-
-      expect(helper.findIn(find("cluster-profile-form-header"), "flash-message-warning")).toBeInDOM();
-      expect(helper.findIn(find("cluster-profile-form-header"), "flash-message-warning")).toHaveText("Can not edit Cluster profile for 'Kubernetes Elastic Agent Plugin' plugin as it does not support cluster profiles.");
-      expect(helper.findByDataTestId("cluster-profile-properties-form")).toBeEmpty();
+      expect(helper.byTestId("flash-message-warning", find("cluster-profile-form-header"))).toBeInDOM();
+      expect(helper.byTestId("flash-message-warning", find("cluster-profile-form-header"))).toHaveText("Can not edit Cluster profile for 'Kubernetes Elastic Agent Plugin' plugin as it does not support cluster profiles.");
+      expect(helper.byTestId("cluster-profile-properties-form")).toBeEmpty();
 
       helper.unmount();
     });
@@ -74,8 +73,8 @@ describe("ClusterProfileModal", () => {
       modal                = new TestClusterProfile(pluginInfos, ModalType.create, clusterProfile);
       helper.mount(modal.body.bind(modal));
 
-      expect(helper.findIn(find("cluster-profile-form-header"), "flash-message-alert")).not.toBeInDOM();
-      expect(helper.findByDataTestId("cluster-profile-properties-form")).not.toBeEmpty();
+      expect(helper.byTestId("flash-message-alert", find("cluster-profile-form-header"))).toBeFalsy();
+      expect(helper.byTestId("cluster-profile-properties-form")).toBeTruthy();
 
       helper.unmount();
     });
@@ -85,9 +84,9 @@ describe("ClusterProfileModal", () => {
       modal                = new TestClusterProfile(pluginInfos, ModalType.create, clusterProfile);
       helper.mount(modal.body.bind(modal));
 
-      expect(helper.findIn(find("cluster-profile-form-header"), "flash-message-alert")).toBeInDOM();
-      expect(helper.findIn(find("cluster-profile-form-header"), "flash-message-alert")).toHaveText("Can not define Cluster profiles for 'Kubernetes Elastic Agent Plugin' plugin as it does not support cluster profiles.");
-      expect(helper.findByDataTestId("cluster-profile-properties-form")).toBeEmpty();
+      expect(helper.byTestId("flash-message-alert", find("cluster-profile-form-header"))).toBeInDOM();
+      expect(helper.byTestId("flash-message-alert", find("cluster-profile-form-header"))).toHaveText("Can not define Cluster profiles for 'Kubernetes Elastic Agent Plugin' plugin as it does not support cluster profiles.");
+      expect(helper.byTestId("cluster-profile-properties-form")).toBeEmpty();
 
       helper.unmount();
     });
@@ -102,8 +101,8 @@ describe("ClusterProfileModal", () => {
     expect(find("form-field-label-plugin-id")).toBeInDOM();
 
     expect(find("form-field-input-plugin-id")).toBeInDOM();
-    expect(find("form-field-input-plugin-id").get(0).children[0]).toContainText("Docker Elastic Agent Plugin");
-    expect(find("form-field-input-plugin-id").get(0).children[1]).toContainText("Kubernetes Elastic Agent Plugin");
+    expect(find("form-field-input-plugin-id").children[0]).toContainText("Docker Elastic Agent Plugin");
+    expect(find("form-field-input-plugin-id").children[1]).toContainText("Kubernetes Elastic Agent Plugin");
 
     helper.unmount();
   });
@@ -114,7 +113,7 @@ describe("ClusterProfileModal", () => {
     modal = new TestClusterProfile(pluginInfos, ModalType.edit, clusterProfile);
     helper.mount(modal.body.bind(modal));
 
-    expect(find("form-field-input-id").parent()).toContainText("should be unique");
+    expect(find("form-field-input-id").parentElement).toContainText("should be unique");
 
     helper.unmount();
   });
@@ -135,12 +134,12 @@ describe("ClusterProfileModal", () => {
     modal = new TestClusterProfile(pluginInfos, ModalType.edit);
     helper.mount(modal.body.bind(modal));
 
-    expect(find("spinner-wrapper").parent()).toBeInDOM();
+    expect(find("spinner-wrapper").parentElement).toBeInDOM();
 
     helper.unmount();
   });
 
   function find(id: string) {
-    return helper.findByDataTestId(id);
+    return helper.byTestId(id);
   }
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/cluster_profiles_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/cluster_profiles_widget_spec.tsx
@@ -19,13 +19,11 @@ import m from "mithril";
 import Stream from "mithril/stream";
 import {ClusterProfile, ClusterProfiles, ElasticAgentProfile, ElasticAgentProfiles} from "models/elastic_profiles/types";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
-import * as collapsiblePanelStyles from "views/components/collapsible_panel/index.scss";
+import collapsiblePanelStyles from "views/components/collapsible_panel/index.scss";
 import {ClusterProfilesWidget} from "views/pages/elastic_agent_configurations/cluster_profiles_widget";
-import * as elasticProfilePageStyles from "views/pages/elastic_agent_configurations/index.scss";
+import elasticProfilePageStyles from "views/pages/elastic_agent_configurations/index.scss";
 import {TestData} from "views/pages/elastic_agent_configurations/spec/test_data";
 import {TestHelper} from "views/pages/spec/test_helper";
-
-import simulateEvent from "simulate-event";
 
 describe("ClusterProfilesWidget", () => {
   const helper                                                 = new TestHelper();
@@ -42,7 +40,7 @@ describe("ClusterProfilesWidget", () => {
     const clusterProfiles = new ClusterProfiles([ClusterProfile.fromJSON(TestData.dockerClusterProfile()), ClusterProfile.fromJSON(TestData.kubernetesClusterProfile())]);
     mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
 
-    expect(helper.findByDataTestId("cluster-profile-panel")).toHaveLength(2);
+    expect(helper.allByTestId("cluster-profile-panel")).toHaveLength(2);
 
     helper.unmount();
   });
@@ -50,7 +48,7 @@ describe("ClusterProfilesWidget", () => {
   it("should display the message in absence of elastic plugin", () => {
     mount(new PluginInfos(), new ClusterProfiles([]), new ElasticAgentProfiles([]));
 
-    expect(helper.findByDataTestId("flash-message-info").text()).toEqual("No elastic agent plugin installed.");
+    expect(helper.textByTestId("flash-message-info")).toBe("No elastic agent plugin installed.");
 
     helper.unmount();
   });
@@ -58,7 +56,7 @@ describe("ClusterProfilesWidget", () => {
   it("should display message to add cluster profiles if no cluster profiles defined", () => {
     mount(pluginInfos, new ClusterProfiles([]), new ElasticAgentProfiles([]));
 
-    expect(helper.findByDataTestId("flash-message-info").text()).toEqual("Click on 'Add' button to create new cluster profile.");
+    expect(helper.textByTestId("flash-message-info")).toBe("Click on 'Add' button to create new cluster profile.");
 
     helper.unmount();
   });
@@ -67,8 +65,8 @@ describe("ClusterProfilesWidget", () => {
     const clusterProfiles = new ClusterProfiles([ClusterProfile.fromJSON(TestData.dockerClusterProfile())]);
     mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
 
-    expect(helper.findByDataTestId("new-elastic-agent-profile-button")).toBeInDOM();
-    expect(helper.findByDataTestId("new-elastic-agent-profile-button")).toHaveText("Elastic Agent Profile");
+    expect(helper.byTestId("new-elastic-agent-profile-button")).toBeInDOM();
+    expect(helper.byTestId("new-elastic-agent-profile-button")).toHaveText("Elastic Agent Profile");
 
     helper.unmount();
   });
@@ -77,8 +75,8 @@ describe("ClusterProfilesWidget", () => {
     const clusterProfiles = new ClusterProfiles([ClusterProfile.fromJSON(TestData.dockerClusterProfile()), ClusterProfile.fromJSON(TestData.kubernetesClusterProfile())]);
     mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
 
-    expect(helper.findIn(helper.findByDataTestId("cluster-profile-panel")[0], "status-report-link")).toBeInDOM();
-    expect(helper.findIn(helper.findByDataTestId("cluster-profile-panel")[1], "status-report-link")).not.toBeInDOM();
+    expect(helper.byTestId( "status-report-link", helper.allByTestId("cluster-profile-panel").item(0))).toBeInDOM();
+    expect(helper.byTestId( "status-report-link", helper.allByTestId("cluster-profile-panel").item(1))).toBeFalsy();
 
     helper.unmount();
   });
@@ -87,7 +85,7 @@ describe("ClusterProfilesWidget", () => {
     const clusterProfiles = new ClusterProfiles([ClusterProfile.fromJSON(TestData.dockerClusterProfile())]);
     mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
 
-    expect(helper.findIn(helper.findByDataTestId("collapse-header")[0], "cluster-profile-name")).toHaveText("cluster_3");
+    expect(helper.byTestId("cluster-profile-name", helper.byTestId("collapse-header"))).toHaveText("cluster_3");
 
     helper.unmount();
   });
@@ -96,7 +94,7 @@ describe("ClusterProfilesWidget", () => {
     const clusterProfiles = new ClusterProfiles([ClusterProfile.fromJSON(TestData.dockerClusterProfile())]);
     mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
 
-    expect(helper.findIn(helper.findByDataTestId("collapse-header")[0], "plugin-icon")).toBeInDOM();
+    expect(helper.byTestId("plugin-icon", helper.byTestId("collapse-header"))).toBeInDOM();
 
     helper.unmount();
   });
@@ -108,7 +106,7 @@ describe("ClusterProfilesWidget", () => {
     const clusterProfiles = new ClusterProfiles([ClusterProfile.fromJSON(TestData.dockerClusterProfile())]);
     mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
 
-    expect(helper.findIn(helper.findByDataTestId("collapse-header")[0], "plugin-icon")).not.toBeInDOM();
+    expect(helper.byTestId("plugin-icon", helper.byTestId("collapse-header"))).not.toBeInDOM();
 
     helper.unmount();
   });
@@ -117,23 +115,23 @@ describe("ClusterProfilesWidget", () => {
     const clusterProfiles = new ClusterProfiles([ClusterProfile.fromJSON(TestData.dockerClusterProfile())]);
     mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
 
-    expect(helper.findIn(helper.findByDataTestId("collapse-body")[0], "key-value-key-id")).toHaveText("Id");
-    expect(helper.findIn(helper.findByDataTestId("collapse-body")[0], "key-value-value-id")).toHaveText("cluster_3");
+    expect(helper.byTestId("key-value-key-id", helper.byTestId("collapse-body"))).toHaveText("Id");
+    expect(helper.byTestId("key-value-value-id", helper.byTestId("collapse-body"))).toHaveText("cluster_3");
 
-    expect(helper.findIn(helper.findByDataTestId("collapse-body")[0], "key-value-key-pluginid")).toHaveText("PluginId");
-    expect(helper.findIn(helper.findByDataTestId("collapse-body")[0], "key-value-value-pluginid")).toHaveText("cd.go.contrib.elastic-agent.docker");
+    expect(helper.byTestId("key-value-key-pluginid", helper.byTestId("collapse-body"))).toHaveText("PluginId");
+    expect(helper.byTestId("key-value-value-pluginid", helper.byTestId("collapse-body"))).toHaveText("cd.go.contrib.elastic-agent.docker");
 
-    expect(helper.findIn(helper.findByDataTestId("collapse-body")[0], "key-value-key-go-server-url")).toHaveText("go_server_url");
-    expect(helper.findIn(helper.findByDataTestId("collapse-body")[0], "key-value-value-go-server-url")).toHaveText("https://localhost:8154/go");
+    expect(helper.byTestId("key-value-key-go-server-url", helper.byTestId("collapse-body"))).toHaveText("go_server_url");
+    expect(helper.byTestId("key-value-value-go-server-url", helper.byTestId("collapse-body"))).toHaveText("https://localhost:8154/go");
 
-    expect(helper.findIn(helper.findByDataTestId("collapse-body")[0], "key-value-key-max-docker-containers")).toHaveText("max_docker_containers");
-    expect(helper.findIn(helper.findByDataTestId("collapse-body")[0], "key-value-value-max-docker-containers")).toHaveText("30");
+    expect(helper.byTestId("key-value-key-max-docker-containers", helper.byTestId("collapse-body"))).toHaveText("max_docker_containers");
+    expect(helper.byTestId("key-value-value-max-docker-containers", helper.byTestId("collapse-body"))).toHaveText("30");
 
-    expect(helper.findIn(helper.findByDataTestId("collapse-body")[0], "key-value-key-auto-register-timeout")).toHaveText("auto_register_timeout");
-    expect(helper.findIn(helper.findByDataTestId("collapse-body")[0], "key-value-value-auto-register-timeout")).toHaveText("10");
+    expect(helper.byTestId("key-value-key-auto-register-timeout", helper.byTestId("collapse-body"))).toHaveText("auto_register_timeout");
+    expect(helper.byTestId("key-value-value-auto-register-timeout", helper.byTestId("collapse-body"))).toHaveText("10");
 
-    expect(helper.findIn(helper.findByDataTestId("collapse-body")[0], "key-value-key-docker-uri")).toHaveText("docker_uri");
-    expect(helper.findIn(helper.findByDataTestId("collapse-body")[0], "key-value-value-docker-uri")).toHaveText("unix:///var/docker.sock");
+    expect(helper.byTestId("key-value-key-docker-uri", helper.byTestId("collapse-body"))).toHaveText("docker_uri");
+    expect(helper.byTestId("key-value-value-docker-uri", helper.byTestId("collapse-body"))).toHaveText("unix:///var/docker.sock");
 
     helper.unmount();
   });
@@ -148,23 +146,23 @@ describe("ClusterProfilesWidget", () => {
     const clusterProfiles = new ClusterProfiles([ClusterProfile.fromJSON(TestData.dockerClusterProfile()), ClusterProfile.fromJSON(TestData.kubernetesClusterProfile())]);
     mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([dockerElasticProfile, kubernetesElasticProfile]));
 
-    const dockerElasticProfilePanel = helper.findByDataTestId("elastic-profile-header")[0];
-    expect(helper.findIn(dockerElasticProfilePanel, "elastic-profile-id")).toHaveText("Profile2");
-    expect(helper.findIn(dockerElasticProfilePanel, "key-value-value-image")).toHaveText("docker-image122345");
-    expect(helper.findIn(dockerElasticProfilePanel, "key-value-value-command")).toHaveText("ls\n-alh");
-    expect(helper.findIn(dockerElasticProfilePanel, "key-value-value-environment")).toHaveText("JAVA_HOME=/bin/java");
-    expect(helper.findIn(dockerElasticProfilePanel, "key-value-value-hosts")).toHaveText("(Not specified)");
+    const dockerElasticProfilePanel = helper.byTestId("elastic-profile-header");
+    expect(helper.byTestId("elastic-profile-id", dockerElasticProfilePanel)).toHaveText("Profile2");
+    expect(helper.byTestId("key-value-value-image", dockerElasticProfilePanel)).toHaveText("docker-image122345");
+    expect(helper.byTestId("key-value-value-command", dockerElasticProfilePanel)).toHaveText("ls\n-alh");
+    expect(helper.byTestId("key-value-value-environment", dockerElasticProfilePanel)).toHaveText("JAVA_HOME=/bin/java");
+    expect(helper.byTestId("key-value-value-hosts", dockerElasticProfilePanel)).toHaveText("(Not specified)");
 
-    const kubernetesElasticProfilePanel = helper.findByDataTestId("elastic-profile-header")[1];
-    expect(helper.findIn(kubernetesElasticProfilePanel, "elastic-profile-id")).toHaveText("Kuber1");
-    expect(helper.findIn(kubernetesElasticProfilePanel, "key-value-value-image")).toHaveText("Image1");
-    expect(helper.findIn(kubernetesElasticProfilePanel, "key-value-value-maxmemory")).toHaveText("(Not specified)");
-    expect(helper.findIn(kubernetesElasticProfilePanel, "key-value-value-maxcpu")).toHaveText("(Not specified)");
-    expect(helper.findIn(kubernetesElasticProfilePanel, "key-value-value-environment")).toHaveText("(Not specified)");
-    expect(helper.findIn(kubernetesElasticProfilePanel, "key-value-value-podconfiguration"))
+    const kubernetesElasticProfilePanel = helper.allByTestId("elastic-profile-header").item(1);
+    expect(helper.byTestId("elastic-profile-id", kubernetesElasticProfilePanel)).toHaveText("Kuber1");
+    expect(helper.byTestId("key-value-value-image", kubernetesElasticProfilePanel)).toHaveText("Image1");
+    expect(helper.byTestId("key-value-value-maxmemory", kubernetesElasticProfilePanel)).toHaveText("(Not specified)");
+    expect(helper.byTestId("key-value-value-maxcpu", kubernetesElasticProfilePanel)).toHaveText("(Not specified)");
+    expect(helper.byTestId("key-value-value-environment", kubernetesElasticProfilePanel)).toHaveText("(Not specified)");
+    expect(helper.byTestId("key-value-value-podconfiguration", kubernetesElasticProfilePanel))
       .toHaveText("apiVersion: v1\nkind: Pod\nmetadata:\n  name: pod-name-prefix-{{ POD_POSTFIX }}\n  labels:\n    app: web\nspec:\n  containers:\n    - name: gocd-agent-container-{{ CONTAINER_POSTFIX }}\n      image: {{ GOCD_AGENT_IMAGE }}:{{ LATEST_VERSION }}\n      securityContext:\n        privileged: true");
-    expect(helper.findIn(kubernetesElasticProfilePanel, "key-value-value-specifiedusingpodconfiguration")).toHaveText("false");
-    expect(helper.findIn(kubernetesElasticProfilePanel, "key-value-value-privileged")).toHaveText("(Not specified)");
+    expect(helper.byTestId("key-value-value-specifiedusingpodconfiguration", kubernetesElasticProfilePanel)).toHaveText("false");
+    expect(helper.byTestId("key-value-value-privileged", kubernetesElasticProfilePanel)).toHaveText("(Not specified)");
 
     helper.unmount();
   });
@@ -173,10 +171,10 @@ describe("ClusterProfilesWidget", () => {
     const clusterProfiles = new ClusterProfiles([ClusterProfile.fromJSON(TestData.dockerClusterProfile())]);
     mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
 
-    const dockerClusterProfilePanel = helper.findByDataTestId("cluster-profile-panel")[0];
-    expect(helper.findIn(dockerClusterProfilePanel, "edit-cluster-profile")).toBeInDOM();
-    expect(helper.findIn(dockerClusterProfilePanel, "delete-cluster-profile")).toBeInDOM();
-    expect(helper.findIn(dockerClusterProfilePanel, "clone-cluster-profile")).toBeInDOM();
+    const dockerClusterProfilePanel = helper.byTestId("cluster-profile-panel");
+    expect(helper.byTestId("edit-cluster-profile", dockerClusterProfilePanel)).toBeInDOM();
+    expect(helper.byTestId("delete-cluster-profile", dockerClusterProfilePanel)).toBeInDOM();
+    expect(helper.byTestId("clone-cluster-profile", dockerClusterProfilePanel)).toBeInDOM();
 
     helper.unmount();
   });
@@ -185,11 +183,11 @@ describe("ClusterProfilesWidget", () => {
     const clusterProfiles = new ClusterProfiles([ClusterProfile.fromJSON(TestData.dockerClusterProfile())]);
     mount(new PluginInfos(), clusterProfiles, new ElasticAgentProfiles([]));
 
-    const dockerClusterProfilePanel = helper.findByDataTestId("cluster-profile-panel")[0];
-    expect(helper.findIn(dockerClusterProfilePanel, "edit-cluster-profile")).toBeDisabled();
-    expect(helper.findIn(dockerClusterProfilePanel, "clone-cluster-profile")).toBeDisabled();
-    expect(helper.findIn(dockerClusterProfilePanel, "new-elastic-agent-profile-button")).toBeDisabled();
-    expect(helper.findIn(dockerClusterProfilePanel, "delete-cluster-profile")).not.toBeDisabled();
+    const dockerClusterProfilePanel = helper.byTestId("cluster-profile-panel");
+    expect(helper.byTestId("edit-cluster-profile", dockerClusterProfilePanel)).toBeDisabled();
+    expect(helper.byTestId("clone-cluster-profile", dockerClusterProfilePanel)).toBeDisabled();
+    expect(helper.byTestId("new-elastic-agent-profile-button", dockerClusterProfilePanel)).toBeDisabled();
+    expect(helper.byTestId("delete-cluster-profile", dockerClusterProfilePanel)).not.toBeDisabled();
 
     helper.unmount();
   });
@@ -202,7 +200,7 @@ describe("ClusterProfilesWidget", () => {
       const elasticAgentProfile = ElasticAgentProfile.fromJSON(TestData.dockerElasticProfile());
       elasticAgentProfile.clusterProfileId(clusterProfile.id());
       mount(pluginInfos, new ClusterProfiles([clusterProfile]), new ElasticAgentProfiles([elasticAgentProfile]));
-      clusterProfilePanelHeader = helper.findIn(helper.findByDataTestId("cluster-profile-panel"), "collapse-header")[0];
+      clusterProfilePanelHeader = helper.byTestId("collapse-header", helper.byTestId("cluster-profile-panel"));
     });
 
     afterEach(() => {
@@ -212,36 +210,31 @@ describe("ClusterProfilesWidget", () => {
     it("should toggle expanded state of cluster profile on click", () => {
       expect(clusterProfilePanelHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
 
-      simulateEvent.simulate(clusterProfilePanelHeader, "click");
-      m.redraw.sync();
+      helper.click(clusterProfilePanelHeader);
 
       expect(clusterProfilePanelHeader).toHaveClass(collapsiblePanelStyles.expanded);
     });
 
     it("should toggle expanded state of cluster profile show details on click", () => {
-      simulateEvent.simulate(clusterProfilePanelHeader, "click");
-      m.redraw.sync();
+      helper.click(clusterProfilePanelHeader);
 
-      const clusterProfileInfoHeader = helper.findIn(helper.findByDataTestId("cluster-profile-panel"), "cluster-profile-details-header")[0];
+      const clusterProfileInfoHeader = helper.byTestId("cluster-profile-details-header", helper.byTestId("cluster-profile-panel"));
 
       expect(clusterProfileInfoHeader).not.toHaveClass(elasticProfilePageStyles.expanded);
-      expect(helper.findIn(helper.findByDataTestId("cluster-profile-panel"), "cluster-profile-details")[0]).not.toHaveClass(elasticProfilePageStyles.expanded);
+      expect(helper.byTestId("cluster-profile-details", helper.byTestId("cluster-profile-panel"))).not.toHaveClass(elasticProfilePageStyles.expanded);
 
-      simulateEvent.simulate(clusterProfileInfoHeader, "click");
-      m.redraw.sync();
+      helper.click(clusterProfileInfoHeader);
 
       expect(clusterProfileInfoHeader).toHaveClass(elasticProfilePageStyles.expanded);
-      expect(helper.findIn(helper.findByDataTestId("cluster-profile-panel"), "cluster-profile-details")[0]).toHaveClass(elasticProfilePageStyles.expanded);
+      expect(helper.byTestId("cluster-profile-details", helper.byTestId("cluster-profile-panel"))).toHaveClass(elasticProfilePageStyles.expanded);
     });
 
     it("should toggle expanded state of elastic agent profile show details on click", () => {
-      simulateEvent.simulate(clusterProfilePanelHeader, "click");
-      m.redraw.sync();
+      helper.click(clusterProfilePanelHeader);
 
-      const elasticAgentProfileInfoHeader = helper.findIn(helper.findByDataTestId("elastic-profile-header")[0], "collapse-header")[0];
+      const elasticAgentProfileInfoHeader = helper.byTestId("collapse-header", helper.byTestId("elastic-profile-header"));
 
-      simulateEvent.simulate(elasticAgentProfileInfoHeader, "click");
-      m.redraw.sync();
+      helper.click(elasticAgentProfileInfoHeader);
 
       expect(elasticAgentProfileInfoHeader).toHaveClass(collapsiblePanelStyles.expanded);
     });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/elastic_agent_profiles_modals_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/elastic_agent_profiles_modals_spec.tsx
@@ -15,14 +15,14 @@
  */
 
 import _ from "lodash";
-import { ClusterProfile, ClusterProfiles, ElasticAgentProfile } from "models/elastic_profiles/types";
-import { Configurations } from "models/shared/configuration";
+import {ClusterProfile, ClusterProfiles, ElasticAgentProfile} from "models/elastic_profiles/types";
+import {Configurations} from "models/shared/configuration";
 import {ExtensionTypeString} from "models/shared/plugin_infos_new/extension_type";
-import { ElasticAgentExtension } from "models/shared/plugin_infos_new/extensions";
-import { PluginInfo, PluginInfos } from "models/shared/plugin_infos_new/plugin_info";
-import { NewElasticProfileModal } from "views/pages/elastic_agent_configurations/elastic_agent_profiles_modals";
-import { TestData } from "views/pages/elastic_agent_configurations/spec/test_data";
-import { TestHelper } from "views/pages/spec/test_helper";
+import {ElasticAgentExtension} from "models/shared/plugin_infos_new/extensions";
+import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {NewElasticProfileModal} from "views/pages/elastic_agent_configurations/elastic_agent_profiles_modals";
+import {TestData} from "views/pages/elastic_agent_configurations/spec/test_data";
+import {TestHelper} from "views/pages/spec/test_helper";
 
 describe("New Elastic Agent Profile Modals Spec", () => {
   let pluginInfo: PluginInfo, clusterProfiles: ClusterProfile[] = [], helper: TestHelper;
@@ -81,8 +81,8 @@ describe("New Elastic Agent Profile Modals Spec", () => {
     expect(find("form-field-label-cluster-profile-id")).toBeInDOM();
     expect(find("form-field-input-cluster-profile-id")).toBeInDOM();
 
-    expect(find("form-field-input-cluster-profile-id").get(0).children[0]).toContainText("cluster1");
-    expect(find("form-field-input-cluster-profile-id").get(0).children[1]).toContainText("cluster2");
+    expect(find("form-field-input-cluster-profile-id").children[0]).toContainText("cluster1");
+    expect(find("form-field-input-cluster-profile-id").children[1]).toContainText("cluster2");
 
     helper.unmount();
   });
@@ -103,10 +103,10 @@ describe("New Elastic Agent Profile Modals Spec", () => {
     expect(find("form-field-label-cluster-profile-id")).toBeInDOM();
     expect(find("form-field-input-cluster-profile-id")).toBeInDOM();
 
-    expect(find("form-field-input-cluster-profile-id").get(0).children).toHaveLength(2);
+    expect(find("form-field-input-cluster-profile-id").children).toHaveLength(2);
 
-    expect(find("form-field-input-cluster-profile-id").get(0).children[0]).toContainText("cluster1");
-    expect(find("form-field-input-cluster-profile-id").get(0).children[1]).toContainText("cluster2");
+    expect(find("form-field-input-cluster-profile-id").children[0]).toContainText("cluster1");
+    expect(find("form-field-input-cluster-profile-id").children[1]).toContainText("cluster2");
 
     helper.unmount();
   });
@@ -125,8 +125,8 @@ describe("New Elastic Agent Profile Modals Spec", () => {
 
     helper.mount(modal.body.bind(modal));
 
-    expect(find("form-field-input-cluster-profile-id").get(0)).toHaveValue("cluster2");
-    expect(find("form-field-input-cluster-profile-id").get(0)).toContainText(`cluster2 (${pluginInfos[1].about.name})`);
+    expect(find("form-field-input-cluster-profile-id")).toHaveValue("cluster2");
+    expect(find("form-field-input-cluster-profile-id")).toContainText(`cluster2 (${pluginInfos[1].about.name})`);
 
     helper.unmount();
   });
@@ -145,13 +145,13 @@ describe("New Elastic Agent Profile Modals Spec", () => {
 
     helper.mount(modal.body.bind(modal));
 
-    expect(find("form-field-input-cluster-profile-id").get(0)).toHaveValue("cluster1");
-    expect(find("form-field-input-cluster-profile-id").get(0)).toContainText(`cluster1 (${pluginInfos[0].about.name})`);
+    expect(find("form-field-input-cluster-profile-id")).toHaveValue("cluster1");
+    expect(find("form-field-input-cluster-profile-id")).toContainText(`cluster1 (${pluginInfos[0].about.name})`);
 
     helper.unmount();
   });
 
   function find(id: string) {
-    return helper.findByDataTestId(id);
+    return helper.byTestId(id);
   }
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/elastic_profile_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/elastic_profile_widget_spec.tsx
@@ -33,7 +33,7 @@ describe("New Elastic Agent Profile Widget", () => {
   it("should render elastic agent profile id", () => {
     mount(pluginInfo, elasticProfile);
 
-    expect(helper.findByDataTestId("elastic-profile-id").get(0)).toContainText(TestData.dockerElasticProfile().id);
+    expect(helper.textByTestId("elastic-profile-id")).toContain(TestData.dockerElasticProfile().id);
 
     helper.unmount();
   });
@@ -51,7 +51,7 @@ describe("New Elastic Agent Profile Widget", () => {
   it("should render properties of elastic agent profile", () => {
     mount(pluginInfo, elasticProfile);
 
-    const profileHeader = helper.find(`.${keyValuePairStyles.keyValuePair}`).get(0);
+    const profileHeader = helper.q(`.${keyValuePairStyles.keyValuePair}`);
 
     expect(profileHeader).toContainText("Image");
     expect(profileHeader).toContainText("docker-image122345");
@@ -70,7 +70,7 @@ describe("New Elastic Agent Profile Widget", () => {
 
   it("should toggle between expanded and collapsed state on click of header", () => {
     mount(pluginInfo, elasticProfile);
-    const elasticProfileHeader = find("collapse-header").get(0);
+    const elasticProfileHeader = find("collapse-header");
 
     expect(elasticProfileHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
 
@@ -92,9 +92,9 @@ describe("New Elastic Agent Profile Widget", () => {
   it("should disable action buttons if no elastic agent plugin installed", () => {
     mount(undefined, ElasticAgentProfile.fromJSON(TestData.dockerElasticProfile()));
 
-    expect(helper.findIn(helper.findByDataTestId("elastic-profile-header")[0], "edit-elastic-profile")).toBeDisabled();
-    expect(helper.findIn(helper.findByDataTestId("elastic-profile-header")[0], "clone-elastic-profile")).toBeDisabled();
-    expect(helper.findIn(helper.findByDataTestId("elastic-profile-header")[0], "delete-elastic-profile")).not.toBeDisabled();
+    expect(helper.byTestId("edit-elastic-profile", helper.byTestId("elastic-profile-header"))).toBeDisabled();
+    expect(helper.byTestId("clone-elastic-profile", helper.byTestId("elastic-profile-header"))).toBeDisabled();
+    expect(helper.byTestId("delete-elastic-profile", helper.byTestId("elastic-profile-header"))).not.toBeDisabled();
 
     helper.unmount();
   });
@@ -110,6 +110,6 @@ describe("New Elastic Agent Profile Widget", () => {
   }
 
   function find(id: string) {
-    return helper.findByDataTestId(id);
+    return helper.byTestId(id);
   }
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/elastic_profiles_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/elastic_profiles_widget_spec.tsx
@@ -42,11 +42,11 @@ describe("Elastic Agent Profiles Widget", () => {
     afterEach(helper.unmount.bind(helper));
 
     it("should render all elastic agent profile info panels", () => {
-      expect(helper.findByDataTestId("elastic-profile-list").get(0).children).toHaveLength(3);
+      expect(helper.byTestId("elastic-profile-list").children).toHaveLength(3);
     });
 
     it("should toggle between expanded and collapsed state on click of header", () => {
-      const elasticProfileListHeader = helper.findByDataTestId("collapse-header").get(1);
+      const elasticProfileListHeader = helper.allByTestId("collapse-header").item(1);
 
       expect(elasticProfileListHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
 
@@ -67,7 +67,7 @@ describe("Elastic Agent Profiles Widget", () => {
   it("should display message to add new elastic agent profiles if no elastic agent profiles defined", () => {
     mount(pluginInfo, new ElasticAgentProfiles([]));
 
-    expect(helper.findByDataTestId("flash-message-info")).toHaveText("Click on 'Add' button to create new elastic agent profile.");
+    expect(helper.textByTestId("flash-message-info")).toBe("Click on 'Add' button to create new elastic agent profile.");
 
     helper.unmount();
   });
@@ -75,7 +75,7 @@ describe("Elastic Agent Profiles Widget", () => {
   it("should not display message to add new elastic agent profiles if no elastic agent profiles defined", () => {
     mount(undefined, new ElasticAgentProfiles([]));
 
-    expect(helper.findByDataTestId("flash-message-info")).not.toBeInDOM();
+    expect(helper.byTestId("flash-message-info")).toBeFalsy();
 
     helper.unmount();
   });
@@ -83,12 +83,12 @@ describe("Elastic Agent Profiles Widget", () => {
   it("should disable action buttons if no elastic agent plugin installed", () => {
     mount(undefined, elasticProfiles, true);
 
-    const elasticAgentProfilePanel = helper.findByDataTestId("elastic-profile-header")[0];
+    const elasticAgentProfilePanel = helper.byTestId("elastic-profile-header");
 
-    expect(helper.findIn(elasticAgentProfilePanel, "edit-elastic-profile")).toBeDisabled();
-    expect(helper.findIn(elasticAgentProfilePanel, "clone-elastic-profile")).toBeDisabled();
-    expect(helper.findIn(elasticAgentProfilePanel, "delete-elastic-profile")).not.toBeDisabled();
-    expect(helper.findIn(elasticAgentProfilePanel, "show-usage-elastic-profile")).not.toBeDisabled();
+    expect(helper.byTestId("edit-elastic-profile", elasticAgentProfilePanel)).toBeDisabled();
+    expect(helper.byTestId("clone-elastic-profile", elasticAgentProfilePanel)).toBeDisabled();
+    expect(helper.byTestId("delete-elastic-profile", elasticAgentProfilePanel)).not.toBeDisabled();
+    expect(helper.byTestId("show-usage-elastic-profile", elasticAgentProfilePanel)).not.toBeDisabled();
 
     helper.unmount();
   });
@@ -96,12 +96,12 @@ describe("Elastic Agent Profiles Widget", () => {
   it("should not disable action buttons if elastic agent plugin installed", () => {
     mount(pluginInfo, elasticProfiles, true);
 
-    const elasticAgentProfilePanel = helper.findByDataTestId("elastic-profile")[0];
+    const elasticAgentProfilePanel = helper.byTestId("elastic-profile");
 
-    expect(helper.findIn(elasticAgentProfilePanel, "edit-elastic-profile")).not.toBeDisabled();
-    expect(helper.findIn(elasticAgentProfilePanel, "clone-elastic-profile")).not.toBeDisabled();
-    expect(helper.findIn(elasticAgentProfilePanel, "delete-elastic-profile")).not.toBeDisabled();
-    expect(helper.findIn(elasticAgentProfilePanel, "show-usage-elastic-profile")).not.toBeDisabled();
+    expect(helper.byTestId("edit-elastic-profile", elasticAgentProfilePanel)).not.toBeDisabled();
+    expect(helper.byTestId("clone-elastic-profile", elasticAgentProfilePanel)).not.toBeDisabled();
+    expect(helper.byTestId("delete-elastic-profile", elasticAgentProfilePanel)).not.toBeDisabled();
+    expect(helper.byTestId("show-usage-elastic-profile", elasticAgentProfilePanel)).not.toBeDisabled();
 
     helper.unmount();
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/login_page/spec/login_page_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/login_page/spec/login_page_widget_spec.tsx
@@ -36,14 +36,14 @@ describe("LoginPageWidget", () => {
             }]
           });
 
-    expect(helper.findByDataTestId("form-field-input-username")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-password")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-username")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-password")).toBeInDOM();
 
-    expect($(helper.root!)).toContainText("Or login using:");
-    expect(helper.findByDataTestId("link-to-login-using-my-plugin")).toBeInDOM();
-    expect(helper.findByDataTestId("link-to-login-using-my-plugin")).toHaveAttr("href", "/some-redirect-url");
-    expect(helper.findByDataTestId("image-for-my-plugin")).toBeInDOM();
-    expect(helper.findByDataTestId("image-for-my-plugin")).toHaveAttr("src", "https://example.com/image");
+    expect(helper.root!.textContent).toContain("Or login using:");
+    expect(helper.byTestId("link-to-login-using-my-plugin")).toBeInDOM();
+    expect(helper.byTestId("link-to-login-using-my-plugin")).toHaveAttr("href", "/some-redirect-url");
+    expect(helper.byTestId("image-for-my-plugin")).toBeInDOM();
+    expect(helper.byTestId("image-for-my-plugin")).toHaveAttr("src", "https://example.com/image");
   });
 
   it("should show login form only when no web based plugins are installed", () => {
@@ -53,13 +53,13 @@ describe("LoginPageWidget", () => {
             webBasedPlugins: []
           });
 
-    expect(helper.findByDataTestId("form-field-input-username")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-password")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-username")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-password")).toBeInDOM();
 
-    expect($(helper.root!)).not.toContainText("redirect");
+    expect(helper.root!.textContent).not.toContain("redirect");
 
-    expect(helper.find("a")).not.toBeInDOM();
-    expect(helper.find(`.${styles.loginOptions} img`)).not.toBeInDOM();
+    expect(helper.q("a")).toBeFalsy();
+    expect(helper.q(`.${styles.loginOptions} img`)).toBeFalsy();
   });
 
   it("should show web login buttons and no login form when only web based plugins are installed", () => {
@@ -77,12 +77,12 @@ describe("LoginPageWidget", () => {
             }]
           });
 
-    expect(helper.find("input")).not.toBeInDOM();
+    expect(helper.q("input")).toBeFalsy();
 
-    expect($(helper.root!)).not.toContainText("redirect");
+    expect(helper.root!.textContent).not.toContain("redirect");
 
-    expect(helper.find("a")).toBeInDOM();
-    expect(helper.find(`.${styles.loginOptions} img`)).toBeInDOM();
+    expect(helper.q("a")).toBeInDOM();
+    expect(helper.q(`.${styles.loginOptions} img`)).toBeInDOM();
   });
 
   it("should show redirect message if only 1 web based plugin is installed and no password plugins", () => {
@@ -97,12 +97,12 @@ describe("LoginPageWidget", () => {
             }]
           });
 
-    expect(helper.find("input")).not.toBeInDOM();
+    expect(helper.q("input")).toBeFalsy();
 
-    expect($(helper.root!)).toContainText("redirect");
+    expect(helper.root!.textContent).toContain("redirect");
 
-    expect(helper.find("a")).toBeInDOM();
-    expect(helper.find(`.${styles.redirect} img`)).toBeInDOM();
+    expect(helper.q("a")).toBeInDOM();
+    expect(helper.q(`.${styles.redirect} img`)).toBeInDOM();
   });
 
   it("should show login error", () => {
@@ -118,7 +118,7 @@ describe("LoginPageWidget", () => {
             }]
           });
 
-    expect(helper.findByDataTestId("flash-message-alert")).toContainText("Login error: wrong username or password.");
+    expect(helper.textByTestId("flash-message-alert")).toContain("Login error: wrong username or password.");
 
   });
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/logout_page/spec/logout_page_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/logout_page/spec/logout_page_widget_spec.tsx
@@ -37,9 +37,9 @@ describe("LogoutPageWidget", () => {
             }]
           });
 
-    expect($(helper.root!)).toContainText("You have been logged out.");
-    expect($(helper.root!)).toContainText("automatically redirected");
-    expect(helper.find("a")).toHaveAttr("href", "/go/auth/login");
+    expect(helper.root!.textContent).toContain("You have been logged out.");
+    expect(helper.root!.textContent).toContain("automatically redirected");
+    expect(helper.q("a")).toHaveAttr("href", "/go/auth/login");
   });
 
   it("should show logout message with auto redirect message when no web based plugins are installed", () => {
@@ -50,9 +50,9 @@ describe("LogoutPageWidget", () => {
             webBasedPlugins: []
           });
 
-    expect($(helper.root!)).toContainText("You have been logged out.");
-    expect($(helper.root!)).toContainText("automatically redirected");
-    expect(helper.find("a")).toHaveAttr("href", "/go/auth/login");
+    expect(helper.root!.textContent).toContain("You have been logged out.");
+    expect(helper.root!.textContent).toContain("automatically redirected");
+    expect(helper.q("a")).toHaveAttr("href", "/go/auth/login");
   });
 
   it("should show logout message with auto redirect message when when only web based plugins are installed", () => {
@@ -71,9 +71,9 @@ describe("LogoutPageWidget", () => {
             }]
           });
 
-    expect($(helper.root!)).toContainText("You have been logged out.");
-    expect($(helper.root!)).toContainText("automatically redirected");
-    expect(helper.find("a")).toHaveAttr("href", "/go/auth/login");
+    expect(helper.root!.textContent).toContain("You have been logged out.");
+    expect(helper.root!.textContent).toContain("automatically redirected");
+    expect(helper.q("a")).toHaveAttr("href", "/go/auth/login");
   });
 
   it("should not show redirect message if only 1 web based plugin is installed and no password plugins", () => {
@@ -88,10 +88,10 @@ describe("LogoutPageWidget", () => {
             }]
           });
 
-    expect($(helper.root!)).toContainText("You have been logged out.");
-    expect($(helper.root!)).not.toContainText("automatic");
-    expect($(helper.root!)).toContainText("Click here to login again.");
-    expect(helper.find("a")).toHaveAttr("href", "/go/auth/login");
+    expect(helper.root!.textContent).toContain("You have been logged out.");
+    expect(helper.root!.textContent).not.toContain("automatic");
+    expect(helper.root!.textContent).toContain("Click here to login again.");
+    expect(helper.q("a")).toHaveAttr("href", "/go/auth/login");
   });
 
   function mount(authPluginInfo: AuthPluginInfo) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/mail_server/spec/mail_server_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/mail_server/spec/mail_server_widget_spec.tsx
@@ -29,13 +29,13 @@ describe("MailServerWidget", () => {
   it("should show form", () => {
     mount(new MailServer());
 
-    expect(helper.findByDataTestId("form-field-input-smtp-hostname")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-smtp-port")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-use-smtps")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-smtp-username")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-smtp-password")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-send-email-using-address")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-administrator-email")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-smtp-hostname")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-smtp-port")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-use-smtps")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-smtp-username")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-smtp-password")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-send-email-using-address")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-administrator-email")).toBeInDOM();
   });
 
   function mount(mailServer: MailServer) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/spec/disabled_susbsystems_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/spec/disabled_susbsystems_widget_spec.tsx
@@ -155,13 +155,13 @@ describe("Maintenance Mode Disabled subsystem Widget", () => {
       const stopConfigChanges   = "Prevent users from modifying configurations.";
       const stopDBChanges       = "Prevent users from performing operations that modifies state in the database or filesystem.";
 
-      expect(find("stop-material").get(0)).toContainText(stopMaterials);
-      expect(find("stop-config-repo").get(0)).toContainText(stopConfigRepos);
-      expect(find("stop-pipeline-scheduling").get(0)).toContainText(stopPipelineTrigger);
-      expect(find("stop-work-assignment").get(0)).toContainText(stopAgentAssignment);
-      expect(find("stop-manual-trigger").get(0)).toContainText(stopManualTrigger);
-      expect(find("stop-config-changes").get(0)).toContainText(stopConfigChanges);
-      expect(find("stop-db-changes").get(0)).toContainText(stopDBChanges);
+      expect(find("stop-material")).toContainText(stopMaterials);
+      expect(find("stop-config-repo")).toContainText(stopConfigRepos);
+      expect(find("stop-pipeline-scheduling")).toContainText(stopPipelineTrigger);
+      expect(find("stop-work-assignment")).toContainText(stopAgentAssignment);
+      expect(find("stop-manual-trigger")).toContainText(stopManualTrigger);
+      expect(find("stop-config-changes")).toContainText(stopConfigChanges);
+      expect(find("stop-db-changes")).toContainText(stopDBChanges);
     });
   });
 
@@ -170,7 +170,7 @@ describe("Maintenance Mode Disabled subsystem Widget", () => {
   }
 
   function find(id: string) {
-    return helper.findByDataTestId(id);
+    return helper.byTestId(id);
   }
 
   function checkIcon() {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/spec/maintenance_mode_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/spec/maintenance_mode_widget_spec.tsx
@@ -35,21 +35,20 @@ describe("Maintenance Mode Widget", () => {
 
   it("should provide the description of the maintenance mode feature", () => {
     const expectedDescription = "When put into maintenance mode, it is safe to restart or upgrade the GoCD server without having any running jobs reschedule when the server is back up.";
-    expect(helper.findByDataTestId("maintenance-mode-description")).toContainText(expectedDescription);
+    expect(helper.textByTestId("maintenance-mode-description")).toContain(expectedDescription);
   });
 
   it("should add a link to the maintenance mode documentation", () => {
     const expectedLink = docsUrl("/advanced_usage/maintenance_mode.html");
     const expectedText = "Learn more..";
 
-    // @ts-ignore
-    expect(helper.find("a")[0].href).toBe(expectedLink);
-    expect(helper.find("a")[0].innerText).toBe(expectedText);
+    expect((helper.q("a") as HTMLAnchorElement).href).toBe(expectedLink);
+    expect(helper.q("a").innerText).toBe(expectedText);
   });
 
   it("should provide the maintenance mode updated information", () => {
     const updatedOn             = timeFormatter.format(TestData.UPDATED_ON);
     const expectedUpdatedByInfo = `${TestData.info().metdata.updatedBy} changed the maintenance mode state on ${updatedOn}.`;
-    expect(helper.findByDataTestId("maintenance-mode-updated-by-info")).toContainText(expectedUpdatedByInfo);
+    expect(helper.textByTestId("maintenance-mode-updated-by-info")).toContain(expectedUpdatedByInfo);
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_pipelines_modal_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_pipelines_modal_spec.tsx
@@ -61,61 +61,61 @@ describe("Edit Pipelines Modal", () => {
   });
 
   it("should render available pipelines", () => {
-    const availablePipelinesSection = helper.findByDataTestId(`available-pipelines`);
+    const availablePipelinesSection = helper.byTestId(`available-pipelines`);
     const pipeline1Selector         = `pipeline-checkbox-for-${pipelineGroupsJSON.groups[0].pipelines[0].name}`;
     const pipeline2Selector         = `pipeline-checkbox-for-${pipelineGroupsJSON.groups[1].pipelines[0].name}`;
 
     expect(availablePipelinesSection).toBeInDOM();
     expect(availablePipelinesSection).toContainText("Available Pipelines");
-    expect(helper.findIn(availablePipelinesSection, pipeline1Selector)).toBeInDOM();
-    expect(helper.findIn(availablePipelinesSection, pipeline2Selector)).toBeInDOM();
+    expect(helper.byTestId(pipeline1Selector, availablePipelinesSection)).toBeInDOM();
+    expect(helper.byTestId(pipeline2Selector, availablePipelinesSection)).toBeInDOM();
   });
 
   it("should render pipelines associated with current environment in config repository", () => {
-    const configRepoAssociated = helper.findByDataTestId(`pipelines-associated-with-this-environment-in-configuration-repository`);
+    const configRepoAssociated = helper.byTestId(`pipelines-associated-with-this-environment-in-configuration-repository`);
     const expectedMsg          = "Pipelines associated with this environment in configuration repository:";
     const pipeline1Selector    = `pipeline-checkbox-for-${pipelineGroupsJSON.groups[1].pipelines[1].name}`;
 
     expect(configRepoAssociated).toBeInDOM();
     expect(configRepoAssociated).toContainText(expectedMsg);
-    expect(helper.findIn(configRepoAssociated, pipeline1Selector)).toBeInDOM();
+    expect(helper.byTestId(pipeline1Selector, configRepoAssociated)).toBeInDOM();
   });
 
   it("should not render config repo pipelines section when no config repo associated pipelines are available", () => {
     modal.pipelinesVM.environment.pipelines().pop();
     m.redraw.sync();
 
-    const configRepoAssociated = helper.findByDataTestId(`pipelines-associated-with-this-environment-in-configuration-repository`);
-    expect(configRepoAssociated).not.toBeInDOM();
+    const configRepoAssociated = helper.byTestId(`pipelines-associated-with-this-environment-in-configuration-repository`);
+    expect(configRepoAssociated).toBeFalsy();
   });
 
   it("should render unavailable pipelines which are associated in another environment", () => {
-    const otherEnvAssociated = helper.findByDataTestId(`unavailable-pipelines-already-associated-with-environments`);
+    const otherEnvAssociated = helper.byTestId(`unavailable-pipelines-already-associated-with-environments`);
     const expectedMsg        = "Unavailable pipelines (Already associated with environments):";
     const pipelines          = pipelineGroupsJSON.groups[0].pipelines;
     const pipelineSelector   = `pipeline-list-item-for-${pipelines[2].name}`;
 
     expect(otherEnvAssociated).toBeInDOM();
     expect(otherEnvAssociated).toContainText(expectedMsg);
-    expect(helper.findIn(otherEnvAssociated, pipelineSelector)).toBeInDOM();
+    expect(helper.byTestId(pipelineSelector, otherEnvAssociated)).toBeInDOM();
   });
 
   it("should not render unavailable pipelines which are associated in other environment when none present", () => {
     modal.pipelinesVM.pipelineGroups()![0].pipelines().pop();
     m.redraw.sync();
 
-    const otherEnvAssociated = helper.findByDataTestId(`unavailable-pipelines-already-associated-with-environments`);
-    expect(otherEnvAssociated).not.toBeInDOM();
+    const otherEnvAssociated = helper.byTestId(`unavailable-pipelines-already-associated-with-environments`);
+    expect(otherEnvAssociated).toBeFalsy();
   });
 
   it("should render unavailable pipelines which are defined in config repository", () => {
-    const definedInConfigRepo = helper.findByDataTestId(`unavailable-pipelines-defined-in-config-repository`);
+    const definedInConfigRepo = helper.byTestId(`unavailable-pipelines-defined-in-config-repository`);
     const expectedMsg         = "Unavailable pipelines (Defined in config repository):";
     const pipelineSelector    = `pipeline-list-item-for-${pipelineGroupsJSON.groups[0].pipelines[1].name}`;
 
     expect(definedInConfigRepo).toBeInDOM();
     expect(definedInConfigRepo).toContainText(expectedMsg);
-    expect(helper.findIn(definedInConfigRepo, pipelineSelector)).toBeInDOM();
+    expect(helper.byTestId(pipelineSelector, definedInConfigRepo)).toBeInDOM();
   });
 
   it("should not render unavailable pipelines which are defined in config repository when none present", () => {
@@ -124,21 +124,21 @@ describe("Edit Pipelines Modal", () => {
     modal.pipelinesVM.pipelineGroups()![0].pipelines().pop();
     m.redraw.sync();
 
-    const definedInConfigRepo = helper.findByDataTestId(`unavailable-pipelines-defined-in-config-repository`);
-    expect(definedInConfigRepo).not.toBeInDOM();
+    const definedInConfigRepo = helper.byTestId(`unavailable-pipelines-defined-in-config-repository`);
+    expect(definedInConfigRepo).toBeFalsy();
   });
 
   it("should render pipeline search box", () => {
-    const searchInput = helper.findByDataTestId("form-field-input-pipeline-search")[0] as HTMLInputElement;
+    const searchInput = helper.byTestId("form-field-input-pipeline-search");
     expect(searchInput).toBeInDOM();
-    expect(searchInput.getAttribute("placeholder")).toEqual("pipeline name");
+    expect(searchInput.getAttribute("placeholder")).toBe("pipeline name");
   });
 
   it("should bind search text with pipelines vm", () => {
     const searchText = "search-text";
     modal.pipelinesVM.searchText(searchText);
     m.redraw.sync();
-    const searchInput = helper.findByDataTestId("form-field-input-pipeline-search")[0] as HTMLInputElement;
+    const searchInput = helper.byTestId("form-field-input-pipeline-search");
     expect(searchInput).toHaveValue(searchText);
   });
 
@@ -149,21 +149,21 @@ describe("Edit Pipelines Modal", () => {
     const selectorForPipeline4 = `pipeline-checkbox-for-${pipelineGroupsJSON.groups[1].pipelines[0].name}`;
     const selectorForPipeline5 = `pipeline-checkbox-for-${pipelineGroupsJSON.groups[1].pipelines[1].name}`;
 
-    expect(helper.findByDataTestId(selectorForPipeline1)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline2)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline3)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline4)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline5)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline1)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline2)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline3)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline4)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline5)).toBeInDOM();
 
     const searchText = pipelineGroupsJSON.groups[0].pipelines[0].name;
     modal.pipelinesVM.searchText(searchText);
     m.redraw.sync();
 
-    expect(helper.findByDataTestId(selectorForPipeline1)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline2)).not.toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline3)).not.toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline4)).not.toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline5)).not.toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline1)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline2)).toBeFalsy();
+    expect(helper.byTestId(selectorForPipeline3)).toBeFalsy();
+    expect(helper.byTestId(selectorForPipeline4)).toBeFalsy();
+    expect(helper.byTestId(selectorForPipeline5)).toBeFalsy();
   });
 
   it("should search for a partial pipeline name match", () => {
@@ -173,21 +173,21 @@ describe("Edit Pipelines Modal", () => {
     const selectorForPipeline4 = `pipeline-checkbox-for-${pipelineGroupsJSON.groups[1].pipelines[0].name}`;
     const selectorForPipeline5 = `pipeline-checkbox-for-${pipelineGroupsJSON.groups[1].pipelines[1].name}`;
 
-    expect(helper.findByDataTestId(selectorForPipeline1)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline2)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline3)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline4)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline5)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline1)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline2)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline3)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline4)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline5)).toBeInDOM();
 
     const searchText = "pipeline-";
     modal.pipelinesVM.searchText(searchText);
     m.redraw.sync();
 
-    expect(helper.findByDataTestId(selectorForPipeline1)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline2)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline3)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline4)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline5)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline1)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline2)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline3)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline4)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline5)).toBeInDOM();
   });
 
   it("should show no pipelines matching search text message when no pipelines matched the search text", () => {
@@ -197,23 +197,23 @@ describe("Edit Pipelines Modal", () => {
     const selectorForPipeline4 = `pipeline-checkbox-for-${pipelineGroupsJSON.groups[1].pipelines[0].name}`;
     const selectorForPipeline5 = `pipeline-checkbox-for-${pipelineGroupsJSON.groups[1].pipelines[1].name}`;
 
-    expect(helper.findByDataTestId(selectorForPipeline1)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline2)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline3)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline4)).toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline5)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline1)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline2)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline3)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline4)).toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline5)).toBeInDOM();
 
     const searchText = "blah-is-my-pipeline-name";
     modal.pipelinesVM.searchText(searchText);
     m.redraw.sync();
 
-    expect(helper.findByDataTestId(selectorForPipeline1)).not.toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline2)).not.toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline3)).not.toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline4)).not.toBeInDOM();
-    expect(helper.findByDataTestId(selectorForPipeline5)).not.toBeInDOM();
+    expect(helper.byTestId(selectorForPipeline1)).toBeFalsy();
+    expect(helper.byTestId(selectorForPipeline2)).toBeFalsy();
+    expect(helper.byTestId(selectorForPipeline3)).toBeFalsy();
+    expect(helper.byTestId(selectorForPipeline4)).toBeFalsy();
+    expect(helper.byTestId(selectorForPipeline5)).toBeFalsy();
 
     const expectedMessage = "No pipelines matching search text 'blah-is-my-pipeline-name' found!";
-    expect(helper.findByDataTestId("flash-message-info")).toContainText(expectedMessage);
+    expect(helper.textByTestId("flash-message-info")).toContain(expectedMessage);
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environment_body_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environment_body_widget_spec.tsx
@@ -34,45 +34,45 @@ describe("Environments Body Widget", () => {
     helper.mount(() => <EnvironmentBody environment={environment} environments={environments}/>);
   });
 
-  afterEach(helper.unmount.bind(helper));
+  afterEach(() => helper.unmount());
 
   it("should render pipelines section", () => {
-    expect(helper.findByDataTestId("pipelines-for-" + environment.name())).toBeInDOM();
+    expect(helper.byTestId("pipelines-for-" + environment.name())).toBeInDOM();
   });
 
   it("should render agents section", () => {
-    expect(helper.findByDataTestId("agents-for-" + environment.name())).toBeInDOM();
+    expect(helper.byTestId("agents-for-" + environment.name())).toBeInDOM();
   });
 
   it("should render environment variables section", () => {
-    expect(helper.findByDataTestId("environment-variables-for-" + environment.name())).toBeInDOM();
+    expect(helper.byTestId("environment-variables-for-" + environment.name())).toBeInDOM();
   });
 
   describe("Environment Pipelines", () => {
     it("should render pipeline header", () => {
-      expect(helper.findByDataTestId("pipelines-header")).toContainText("Pipelines");
+      expect(helper.textByTestId("pipelines-header")).toContain("Pipelines");
     });
 
     it("should render pipeline names", () => {
-      expect(helper.findByDataTestId("pipelines-content")).toContainText(environment.pipelines()[0].name());
-      expect(helper.findByDataTestId("pipelines-content")).toContainText(environment.pipelines()[1].name());
+      expect(helper.textByTestId("pipelines-content")).toContain(environment.pipelines()[0].name());
+      expect(helper.textByTestId("pipelines-content")).toContain(environment.pipelines()[1].name());
     });
   });
 
   describe("Environment Agents", () => {
     it("should render agent header", () => {
-      expect(helper.findByDataTestId("agents-header")).toContainText("Agents");
+      expect(helper.textByTestId("agents-header")).toContain("Agents");
     });
 
     it("should render agent uuids", () => {
-      expect(helper.findByDataTestId("agents-content")).toContainText(environment.agents()[0].uuid());
-      expect(helper.findByDataTestId("agents-content")).toContainText(environment.agents()[1].uuid());
+      expect(helper.textByTestId("agents-content")).toContain(environment.agents()[0].uuid());
+      expect(helper.textByTestId("agents-content")).toContain(environment.agents()[1].uuid());
     });
   });
 
   describe("Environment Environment Variables", () => {
     it("should render environment variable header", () => {
-      expect(helper.findByDataTestId("environment-variables-header")).toContainText("Environment Variables");
+      expect(helper.textByTestId("environment-variables-header")).toContain("Environment Variables");
     });
 
     it("should render help message when no plain text environment variables are specified", () => {
@@ -83,7 +83,7 @@ describe("Environments Body Widget", () => {
       m.redraw.sync();
 
       const expectedMessage = "No Plain Text Environment Variables are defined.";
-      expect(helper.find("#no-plain-text-env-var")).toContainText(expectedMessage);
+      expect(helper.text("#no-plain-text-env-var")).toContain(expectedMessage);
     });
 
     it("should render help message when no secure environment variables are specified", () => {
@@ -94,14 +94,14 @@ describe("Environments Body Widget", () => {
       m.redraw.sync();
 
       const expectedMessage = "No Secure Environment Variables are defined.";
-      expect(helper.find("#no-secure-env-var")).toContainText(expectedMessage);
+      expect(helper.text("#no-secure-env-var")).toContain(expectedMessage);
     });
 
     it("should render inner environment variable header", () => {
       const plainTextEnvVarHeader = "Plain Text Environment Variables";
       const secureEnvVarHeader    = "Secure Environment Variables";
-      expect(helper.findByDataTestId("environment-variables-content")).toContainText(plainTextEnvVarHeader);
-      expect(helper.findByDataTestId("environment-variables-content")).toContainText(secureEnvVarHeader);
+      expect(helper.textByTestId("environment-variables-content")).toContain(plainTextEnvVarHeader);
+      expect(helper.textByTestId("environment-variables-content")).toContain(secureEnvVarHeader);
     });
 
     it("should render plain text environment variable", () => {
@@ -109,16 +109,16 @@ describe("Environments Body Widget", () => {
       const plainTextEnvVar1     = environmentVariables[0].name() + " = " + environmentVariables[0].value();
       const plainTextEnvVar2     = environmentVariables[1].name() + " = " + environmentVariables[1].value();
 
-      expect(helper.findByDataTestId("environment-variables-content")).toContainText(plainTextEnvVar1);
-      expect(helper.findByDataTestId("environment-variables-content")).toContainText(plainTextEnvVar2);
+      expect(helper.textByTestId("environment-variables-content")).toContain(plainTextEnvVar1);
+      expect(helper.textByTestId("environment-variables-content")).toContain(plainTextEnvVar2);
     });
 
     it("should render secure environment variable", () => {
       const secureEnvVar1 = environment.environmentVariables().secureVariables()[0].name() + " = ******";
       const secureEnvVar2 = environment.environmentVariables().secureVariables()[0].name() + " = ******";
 
-      expect(helper.findByDataTestId("environment-variables-content")).toContainText(secureEnvVar1);
-      expect(helper.findByDataTestId("environment-variables-content")).toContainText(secureEnvVar2);
+      expect(helper.textByTestId("environment-variables-content")).toContain(secureEnvVar1);
+      expect(helper.textByTestId("environment-variables-content")).toContain(secureEnvVar2);
     });
   });
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environment_header_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environment_header_widget_spec.tsx
@@ -33,17 +33,17 @@ describe("Environments Header Widget", () => {
   afterEach(helper.unmount.bind(helper));
 
   it("should render name of environment", () => {
-    expect(helper.findByDataTestId("environment-header-for-" + environment.name())).toBeInDOM();
-    expect(helper.findByDataTestId("env-name")).toHaveText(environment.name());
+    expect(helper.byTestId("environment-header-for-" + environment.name())).toBeInDOM();
+    expect(helper.textByTestId("env-name")).toBe(environment.name());
   });
 
   it("should render pipeline count", () => {
-    expect(helper.findByDataTestId("key-value-key-pipeline-count")).toHaveText("Pipeline Count");
-    expect(helper.findByDataTestId("key-value-value-pipeline-count")).toHaveText("2");
+    expect(helper.textByTestId("key-value-key-pipeline-count")).toBe("Pipeline Count");
+    expect(helper.textByTestId("key-value-value-pipeline-count")).toBe("2");
   });
 
   it("should render agent count", () => {
-    expect(helper.findByDataTestId("key-value-key-agent-count")).toHaveText("Agent Count");
-    expect(helper.findByDataTestId("key-value-value-agent-count")).toHaveText("2");
+    expect(helper.textByTestId("key-value-key-agent-count")).toBe("Agent Count");
+    expect(helper.textByTestId("key-value-value-agent-count")).toBe("2");
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environments_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environments_widget_spec.tsx
@@ -40,20 +40,20 @@ describe("Environments Widget", () => {
   afterEach(helper.unmount.bind(helper));
 
   it("should render collapsible panel for each environment", () => {
-    expect(helper.findByDataTestId("collapsible-panel-for-env-" + xmlEnv.name)).toBeInDOM();
-    expect(helper.findByDataTestId("collapsible-panel-for-env-" + configRepoEnv.name)).toBeInDOM();
-    expect(helper.findByDataTestId("collapsible-panel-for-env-" + env.name)).toBeInDOM();
+    expect(helper.byTestId("collapsible-panel-for-env-" + xmlEnv.name)).toBeInDOM();
+    expect(helper.byTestId("collapsible-panel-for-env-" + configRepoEnv.name)).toBeInDOM();
+    expect(helper.byTestId("collapsible-panel-for-env-" + env.name)).toBeInDOM();
   });
 
   it("should render environment header for all the environments", () => {
-    expect(helper.findByDataTestId("environment-header-for-" + xmlEnv.name)).toBeInDOM();
-    expect(helper.findByDataTestId("environment-header-for-" + configRepoEnv.name)).toBeInDOM();
-    expect(helper.findByDataTestId("environment-header-for-" + env.name)).toBeInDOM();
+    expect(helper.byTestId("environment-header-for-" + xmlEnv.name)).toBeInDOM();
+    expect(helper.byTestId("environment-header-for-" + configRepoEnv.name)).toBeInDOM();
+    expect(helper.byTestId("environment-header-for-" + env.name)).toBeInDOM();
   });
 
   it("should render environment body for all the environments", () => {
-    expect(helper.findByDataTestId("environment-body-for-" + xmlEnv.name)).toBeInDOM();
-    expect(helper.findByDataTestId("environment-body-for-" + configRepoEnv.name)).toBeInDOM();
-    expect(helper.findByDataTestId("environment-body-for-" + env.name)).toBeInDOM();
+    expect(helper.byTestId("environment-body-for-" + xmlEnv.name)).toBeInDOM();
+    expect(helper.byTestId("environment-body-for-" + configRepoEnv.name)).toBeInDOM();
+    expect(helper.byTestId("environment-body-for-" + env.name)).toBeInDOM();
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_agents/spec/agent_analytics_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_agents/spec/agent_analytics_widget_spec.tsx
@@ -37,7 +37,7 @@ describe("AgentAnalyticsWidget", () => {
     const agent = Agent.fromJSON(AgentsTestData.idleAgent());
     mount(agent, {} as { [key: string]: AnalyticsCapability[] });
 
-    helper.clickByDataTestId(`analytics-icon-${agent.uuid}`);
+    helper.clickByTestId(`analytics-icon-${agent.uuid}`);
     m.redraw.sync();
 
     expect(helper.fromModalByTestId("modal-title")).toBeInDOM();

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_agents/spec/agent_header_panel_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_agents/spec/agent_header_panel_spec.tsx
@@ -111,7 +111,7 @@ describe("AgentHeaderPanel", () => {
       agentsVM.selectAgent(agentA.uuid);
       mount(agentsVM);
 
-      helper.clickByDataTestId("delete-agents");
+      helper.clickByTestId("delete-agents");
 
       expect(onDelete).toHaveBeenCalled();
     });
@@ -122,7 +122,7 @@ describe("AgentHeaderPanel", () => {
       agentsVM.selectAgent(agentA.uuid);
       mount(agentsVM);
 
-      helper.clickByDataTestId("enable-agents");
+      helper.clickByTestId("enable-agents");
 
       expect(onEnable).toHaveBeenCalled();
     });
@@ -133,7 +133,7 @@ describe("AgentHeaderPanel", () => {
       agentsVM.selectAgent(agentA.uuid);
       mount(agentsVM);
 
-      helper.clickByDataTestId("disable-agents");
+      helper.clickByTestId("disable-agents");
 
       expect(onDisable).toHaveBeenCalled();
     });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_agents/spec/environment_dropdown_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_agents/spec/environment_dropdown_spec.tsx
@@ -56,7 +56,7 @@ describe("EnvironmentsDropdownButton", () => {
     expect(staticAgentsVM.showResources()).toBeTruthy();
     expect(staticAgentsVM.showEnvironments()).toBeFalsy();
 
-    helper.clickByDataTestId("modify-environments-association");
+    helper.clickByTestId("modify-environments-association");
 
     expect(staticAgentsVM.showResources()).toBeFalsy();
     expect(staticAgentsVM.showEnvironments()).toBeTruthy();
@@ -66,7 +66,7 @@ describe("EnvironmentsDropdownButton", () => {
     staticAgentsVM.selectAgent(agent.uuid);
     mount(staticAgentsVM, new DummyService([]));
 
-    helper.clickByDataTestId("modify-environments-association");
+    helper.clickByTestId("modify-environments-association");
     m.redraw.sync();
 
     expect(helper.byTestId("association")).toBeInDOM();
@@ -85,7 +85,7 @@ describe("EnvironmentsDropdownButton", () => {
 
     mount(staticAgentsVM, new MockService());
 
-    helper.clickByDataTestId("modify-environments-association");
+    helper.clickByTestId("modify-environments-association");
     m.redraw.sync();
 
     expect(helper.byTestId("spinner")).not.toBeInDOM();
@@ -95,7 +95,7 @@ describe("EnvironmentsDropdownButton", () => {
     staticAgentsVM.selectAgent(agent.uuid);
     mount(staticAgentsVM, new DummyService([]));
 
-    helper.clickByDataTestId("modify-environments-association");
+    helper.clickByTestId("modify-environments-association");
     m.redraw.sync();
 
     expect(helper.byTestId("association")).toContainText("No environments are defined.");
@@ -106,7 +106,7 @@ describe("EnvironmentsDropdownButton", () => {
     staticAgentsVM.selectAgent(agent.uuid);
     mount(staticAgentsVM, new DummyService(["prod", "test"]));
 
-    helper.clickByDataTestId("modify-environments-association");
+    helper.clickByTestId("modify-environments-association");
     m.redraw.sync();
 
     expect(helper.byTestId("association")).toContainText("prod");
@@ -119,7 +119,7 @@ describe("EnvironmentsDropdownButton", () => {
       staticAgentsVM.selectAgent(agent.uuid);
       mount(staticAgentsVM, new DummyService(["prod", "test"]));
 
-      helper.clickByDataTestId("modify-environments-association");
+      helper.clickByTestId("modify-environments-association");
       m.redraw.sync();
 
       expect(helper.byTestId("form-field-input-prod")).not.toBeChecked();
@@ -131,7 +131,7 @@ describe("EnvironmentsDropdownButton", () => {
       agent.environments.push(new AgentsEnvironment("prod", "gocd"));
       mount(staticAgentsVM, new DummyService(["prod", "test"]));
 
-      helper.clickByDataTestId("modify-environments-association");
+      helper.clickByTestId("modify-environments-association");
       m.redraw.sync();
 
       expect(helper.byTestId("form-field-input-prod")).toBeChecked();
@@ -146,7 +146,7 @@ describe("EnvironmentsDropdownButton", () => {
       agent.environments.push(new AgentsEnvironment("prod", "gocd"));
       mount(staticAgentsVM, new DummyService(["prod", "test"]));
 
-      helper.clickByDataTestId("modify-environments-association");
+      helper.clickByTestId("modify-environments-association");
       m.redraw.sync();
 
       expect(helper.byTestId("form-field-input-prod")).toHaveProp("indeterminate", true);

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_agents/spec/resources_dropdown_button_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_agents/spec/resources_dropdown_button_spec.tsx
@@ -56,7 +56,7 @@ describe("ResourcesDropdownButton", () => {
     expect(agentsVM.showEnvironments()).toBeTruthy();
     expect(agentsVM.showResources()).toBeFalsy();
 
-    helper.clickByDataTestId("modify-resources-association");
+    helper.clickByTestId("modify-resources-association");
 
     expect(agentsVM.showEnvironments()).toBeFalsy();
     expect(agentsVM.showResources()).toBeTruthy();
@@ -66,7 +66,7 @@ describe("ResourcesDropdownButton", () => {
     agentsVM.selectAgent(agent.uuid);
     mount(agentsVM, new DummyService([]));
 
-    helper.clickByDataTestId("modify-resources-association");
+    helper.clickByTestId("modify-resources-association");
     m.redraw.sync();
 
     expect(helper.byTestId("association")).toBeInDOM();
@@ -76,7 +76,7 @@ describe("ResourcesDropdownButton", () => {
     agentsVM.selectAgent(agent.uuid);
     mount(agentsVM, new DummyService(["firefox", "chrome"]));
 
-    helper.clickByDataTestId("modify-resources-association");
+    helper.clickByTestId("modify-resources-association");
     m.redraw.sync();
 
     expect(helper.byTestId("association")).toContainText("firefox");
@@ -90,7 +90,7 @@ describe("ResourcesDropdownButton", () => {
       agentsVM.selectAgent(agent.uuid);
       mount(agentsVM, new DummyService(["chrome", "test"]));
 
-      helper.clickByDataTestId("modify-resources-association");
+      helper.clickByTestId("modify-resources-association");
       m.redraw.sync();
 
       expect(helper.byTestId("form-field-input-chrome")).not.toBeChecked();
@@ -102,7 +102,7 @@ describe("ResourcesDropdownButton", () => {
       agent.resources.push("chrome");
       mount(agentsVM, new DummyService(["chrome", "test"]));
 
-      helper.clickByDataTestId("modify-resources-association");
+      helper.clickByTestId("modify-resources-association");
       m.redraw.sync();
 
       expect(helper.byTestId("form-field-input-chrome")).toBeChecked();
@@ -117,7 +117,7 @@ describe("ResourcesDropdownButton", () => {
       agent.resources.push("chrome");
       mount(agentsVM, new DummyService(["chrome", "test"]));
 
-      helper.clickByDataTestId("modify-resources-association");
+      helper.clickByTestId("modify-resources-association");
       m.redraw.sync();
 
       expect(helper.byTestId("form-field-input-chrome")).toHaveProp("indeterminate", true);
@@ -128,7 +128,7 @@ describe("ResourcesDropdownButton", () => {
       agentsVM.selectAgent(agent.uuid);
       mount(agentsVM, new DummyService(["chrome"]));
 
-      helper.clickByDataTestId("modify-resources-association");
+      helper.clickByTestId("modify-resources-association");
       m.redraw.sync();
       helper.oninput("input", "firefox", helper.byTestId("resource-to-add"));
       m.redraw.sync();

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/spec/plugins_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/spec/plugins_widget_spec.tsx
@@ -40,44 +40,42 @@ describe("New Plugins Widget", () => {
   });
 
   it("should render all plugin infos", () => {
-    expect(helper.findByDataTestId("plugins-list").get(0).children).toHaveLength(5);
+    expect(helper.byTestId("plugins-list").children).toHaveLength(5);
   });
 
   it("should render plugin name and image", () => {
-    expect(helper.findByDataTestId("plugins-list").get(0).children).toHaveLength(5);
+    expect(helper.byTestId("plugins-list").children).toHaveLength(5);
 
-    expect(helper.findByDataTestId("plugin-name").get(0)).toContainText(getEAPluginInfo().about!.name);
-    expect(helper.find(`.${headerIconStyles.headerIcon} img`).get(0))
-      .toHaveAttr("src", getEAPluginInfo()._links.image!.href);
-    expect(helper.findByDataTestId("plugin-name").get(2)).toContainText(getNotificationPluginInfo().about!.name);
+    expect(helper.textByTestId("plugin-name")).toContain(getEAPluginInfo().about!.name);
+    expect(helper.q(`.${headerIconStyles.headerIcon} img`)).toHaveAttr("src", getEAPluginInfo()._links.image!.href);
+    expect(helper.allByTestId("plugin-name").item(2).textContent).toContain(getNotificationPluginInfo().about!.name);
   });
 
   it("should render plugin version", () => {
-    expect(helper.findByDataTestId("plugins-list").get(0).children).toHaveLength(5);
+    expect(helper.byTestId("plugins-list").children).toHaveLength(5);
 
-    const EAPluginHeader           = helper.findByDataTestId("collapse-header").get(0);
-    const notificationPluginHeader = helper.findByDataTestId("collapse-header").get(2);
+    const EAPluginHeader           = helper.allByTestId("collapse-header").item(0);
+    const notificationPluginHeader = helper.allByTestId("collapse-header").item(2);
 
-    expect(helper.findIn(EAPluginHeader, "key-value-key-version")).toContainText("Version");
-    expect(helper.findIn(EAPluginHeader, "key-value-value-version")).toContainText(getEAPluginInfo().about!.version);
+    expect(helper.textByTestId("key-value-key-version", EAPluginHeader)).toContain("Version");
+    expect(helper.textByTestId("key-value-value-version", EAPluginHeader)).toContain(getEAPluginInfo().about!.version);
 
-    expect(helper.findIn(notificationPluginHeader, "key-value-key-version")).toContainText("Version");
-    expect(helper.findIn(notificationPluginHeader, "key-value-value-version"))
-      .toContainText(getNotificationPluginInfo().about!.version);
+    expect(helper.textByTestId("key-value-key-version", notificationPluginHeader)).toContain("Version");
+    expect(helper.textByTestId("key-value-value-version", notificationPluginHeader)).toContain(getNotificationPluginInfo().about!.version);
   });
 
   it("should render all invalid plugin infos expanded", () => {
-    expect(helper.findByDataTestId("plugins-list").get(0).children).toHaveLength(5);
+    expect(helper.byTestId("plugins-list").children).toHaveLength(5);
 
-    const invalidPluginInfo = helper.find(`.${collapsiblePanelStyles.collapse}`).get(3);
+    const invalidPluginInfo = helper.qa(`.${collapsiblePanelStyles.collapse}`).item(3);
     expect(invalidPluginInfo).toHaveClass(collapsiblePanelStyles.expanded);
   });
 
   it("should toggle expanded state of plugin infos on click", () => {
-    expect(helper.findByDataTestId("plugins-list").get(0).children).toHaveLength(5);
+    expect(helper.byTestId("plugins-list").children).toHaveLength(5);
 
-    const EAPluginInfoHeader           = helper.findByDataTestId("collapse-header").get(0);
-    const NotificationPluginInfoHeader = helper.findByDataTestId("collapse-header").get(1);
+    const EAPluginInfoHeader           = helper.allByTestId("collapse-header").item(0);
+    const NotificationPluginInfoHeader = helper.allByTestId("collapse-header").item(1);
 
     expect(EAPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
     expect(NotificationPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
@@ -106,14 +104,14 @@ describe("New Plugins Widget", () => {
   });
 
   it("should render plugin infos information in collapsed body", () => {
-    expect(helper.findByDataTestId("plugins-list").get(0).children).toHaveLength(5);
+    expect(helper.byTestId("plugins-list").children).toHaveLength(5);
 
-    const EAPluginInfoHeader           = helper.findByDataTestId("collapse-header").get(0);
-    const NotificationPluginInfoHeader = helper.findByDataTestId("collapse-header").get(2);
+    const EAPluginInfoHeader           = helper.allByTestId("collapse-header").item(0);
+    const NotificationPluginInfoHeader = helper.allByTestId("collapse-header").item(2);
     simulateEvent.simulate(EAPluginInfoHeader, "click");
     simulateEvent.simulate(NotificationPluginInfoHeader, "click");
 
-    const EAPluginInfoBody = helper.findByDataTestId("collapse-body").get(0);
+    const EAPluginInfoBody = helper.byTestId("collapse-body");
 
     expect(EAPluginInfoBody).toContainText("Id");
     expect(EAPluginInfoBody).toContainText(getEAPluginInfo().id);
@@ -133,7 +131,7 @@ describe("New Plugins Widget", () => {
     expect(EAPluginInfoBody).toContainText("Target GoCD Version");
     expect(EAPluginInfoBody).toContainText("16.12.0");
 
-    const NotificationPluginInfoBody = helper.findByDataTestId("collapse-body").get(2);
+    const NotificationPluginInfoBody = helper.allByTestId("collapse-body").item(2);
 
     expect(NotificationPluginInfoBody).toContainText("Description");
     expect(NotificationPluginInfoBody).toContainText(getNotificationPluginInfo().about!.description);
@@ -152,53 +150,41 @@ describe("New Plugins Widget", () => {
   });
 
   it("should render plugin settings icon for plugins supporting settings", () => {
-    expect(helper.findByDataTestId("edit-plugin-settings").get(0)).toBeInDOM();
-    expect(helper.findByDataTestId("edit-plugin-settings").get(1)).toBeInDOM();
-    expect(helper.findByDataTestId("edit-plugin-settings")).toHaveLength(2);
+    expect(helper.allByTestId("edit-plugin-settings")).toHaveLength(2);
+    expect(helper.allByTestId("edit-plugin-settings").item(0)).toBeInDOM();
+    expect(helper.allByTestId("edit-plugin-settings").item(1)).toBeInDOM();
   });
 
   it("should render status report link for ea plugins supporting status report", () => {
-    expect(helper.findByDataTestId("status-report-link").get(0)).toBeInDOM();
-    expect(helper.findByDataTestId("status-report-link")).toHaveLength(2);
+    expect(helper.allByTestId("status-report-link")).toHaveLength(2);
+    expect(helper.byTestId("status-report-link")).toBeInDOM();
   });
 
   it("should render error messages for plugins in invalid/error state", () => {
-    const yumPluginInfoBody = helper.findByDataTestId("collapse-body").get(4);
-    expect(yumPluginInfoBody).toContainText("There were errors loading the plugin");
-    expect(yumPluginInfoBody)
-      .toContainText(
-        "Plugin with ID (yum) is not valid: Incompatible with current operating system 'Mac OS X'. Valid operating systems are: [Linux].");
-    expect(helper.find(`.${collapsiblePanelStyles.collapse}`).get(3)).toHaveClass(collapsiblePanelStyles.error);
+    const yumPluginInfoBody = helper.allByTestId("collapse-body").item(4);
+    expect(yumPluginInfoBody.textContent).toContain("There were errors loading the plugin");
+    expect(yumPluginInfoBody.textContent).toContain("Plugin with ID (yum) is not valid: Incompatible with current operating system 'Mac OS X'. Valid operating systems are: [Linux].");
+    expect(helper.qa(`.${collapsiblePanelStyles.collapse}`).item(3)).toHaveClass(collapsiblePanelStyles.error);
   });
 
   it("should display deprecation message for elastic agent plugins not supporting cluster profile", () => {
-    expect(helper.findByDataTestId("collapse-header").get(0)).toContainText(getEAPluginInfo().about!.name);
-    expect(helper.findIn(helper.findByDataTestId("collapse-header").get(0), "deprecation-warning-icon")).toBeInDOM();
-    expect(helper.findByDataTestId("collapse-header").get(0)).toHaveClass(collapsiblePanelStyles.warning);
-    expect(helper.findIn(helper.findByDataTestId("collapse-header").get(0), "deprecation-warning-tooltip-content"))
-      .toHaveText(
-        "Version 0.6.1 of plugin is deprecated as it does not support ClusterProfiles. This version of plugin will stop working in upcoming release of GoCD, update to latest version of the plugin.");
+    expect(helper.textByTestId("collapse-header")).toContain(getEAPluginInfo().about!.name);
+    expect(helper.byTestId("deprecation-warning-icon", helper.byTestId("collapse-header"))).toBeInDOM();
+    expect(helper.byTestId("collapse-header")).toHaveClass(collapsiblePanelStyles.warning);
+    expect(helper.textByTestId("deprecation-warning-tooltip-content", helper.byTestId("collapse-header")))
+      .toBe("Version 0.6.1 of plugin is deprecated as it does not support ClusterProfiles. This version of plugin will stop working in upcoming release of GoCD, update to latest version of the plugin.");
   });
 
   it("should not display deprecation message for elastic agent plugins supporting cluster profile", () => {
-    expect(helper.findByDataTestId("collapse-header").get(1))
-      .toContainText(getEAPluginInfoSupportingClusterProfile().about!.name);
-    expect(helper.findIn(helper.findByDataTestId("collapse-header").get(1), "deprecation-warning-icon"))
-      .not
-      .toBeInDOM();
-    expect(helper.findIn(helper.findByDataTestId("collapse-header").get(1), "deprecation-warning-tooltip-content"))
-      .not
-      .toBeInDOM();
+    expect(helper.allByTestId("collapse-header").item(1).textContent).toContain(getEAPluginInfoSupportingClusterProfile().about!.name);
+    expect(helper.byTestId("deprecation-warning-icon", helper.allByTestId("collapse-header").item(1))).toBeFalsy();
+    expect(helper.byTestId("deprecation-warning-tooltip-content", helper.allByTestId("collapse-header").item(1))).toBeFalsy();
   });
 
   it("should not display deprecation message for plugins not using elastic agent extension", () => {
-    expect(helper.findByDataTestId("collapse-header").get(4)).toContainText(getYumPluginInfo().about!.name);
-    expect(helper.findIn(helper.findByDataTestId("collapse-header").get(4), "deprecation-warning-icon"))
-      .not
-      .toBeInDOM();
-    expect(helper.findIn(helper.findByDataTestId("collapse-header").get(4), "deprecation-warning-tooltip-content"))
-      .not
-      .toBeInDOM();
+    expect(helper.allByTestId("collapse-header").item(4).textContent).toContain(getYumPluginInfo().about!.name);
+    expect(helper.byTestId("deprecation-warning-icon", helper.allByTestId("collapse-header").item(4))).toBeFalsy();
+    expect(helper.byTestId("deprecation-warning-tooltip-content", helper.allByTestId("collapse-header").item(4))).toBeFalsy();
   });
 
   function getEAPluginInfo(): PluginInfoJSON {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/partials/spec/site_footer_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/partials/spec/site_footer_spec.tsx
@@ -40,7 +40,7 @@ describe("SiteFooter", () => {
     expect(helper.root).toContainElement(`a[href="/go/assets/dependency-license-report-${GoCDVersion.fullVersion}"]`);
     expect(helper.root).toContainText(`GoCD Version: ${GoCDVersion.formattedVersion}`);
     expect(helper.root).not.toContainText("maintenance");
-    expect(helper.findByDataTestId("maintenance-mode-banner")).not.toBeInDOM();
+    expect(helper.byTestId("maintenance-mode-banner")).toBeFalsy();
     expect(helper.root).not.toContainText("unsupported browser");
   });
 
@@ -57,9 +57,9 @@ describe("SiteFooter", () => {
     };
     mount(attrs);
 
-    expect(helper.findByDataTestId("maintenance-mode-banner")).toBeInDOM();
-    expect(helper.findByDataTestId("maintenance-mode-banner"))
-      .toContainText(`bob turned on maintenance mode at ${timeFormatter.format(attrs.maintenanceModeUpdatedOn)}`);
+    expect(helper.byTestId("maintenance-mode-banner")).toBeInDOM();
+    expect(helper.textByTestId("maintenance-mode-banner"))
+      .toContain(`bob turned on maintenance mode at ${timeFormatter.format(attrs.maintenanceModeUpdatedOn)}`);
     expect(helper.root).toContainText("maintenance");
     expect(helper.root).not.toContainText("unsupported browser");
   });
@@ -77,8 +77,8 @@ describe("SiteFooter", () => {
     };
     mount(attrs);
 
-    expect(helper.findByDataTestId("maintenance-mode-banner")).not.toBeInDOM();
-    expect(helper.findByDataTestId("unsupported-browser-banner")).toBeInDOM();
+    expect(helper.byTestId("maintenance-mode-banner")).toBeFalsy();
+    expect(helper.byTestId("unsupported-browser-banner")).toBeInDOM();
     expect(helper.root).not.toContainText("maintenance");
     expect(helper.root).toContainText("unsupported browser");
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/partials/spec/site_header_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/partials/spec/site_header_spec.tsx
@@ -49,7 +49,7 @@ describe("Site Header", () => {
             canViewAdminPage: false,
             showAnalyticsDashboard: false
           });
-    expect(helper.find(`.${styles.userLink}`)).toHaveText("Jon Doe");
+    expect(helper.text(`.${styles.userLink}`)).toBe("Jon Doe");
     expect(findMenuItem("/go/preferences/notifications")).toHaveText("Preferences");
     expect(findMenuItem("/go/access_tokens")).toHaveText("Personal Access Tokens");
     expect(findMenuItem("/go/auth/logout")).toHaveText("Sign out");
@@ -66,10 +66,10 @@ describe("Site Header", () => {
             canViewAdminPage: false,
             showAnalyticsDashboard: false
           });
-    expect(helper.find(`.${styles.userLink}`)).not.toBeInDOM();
-    expect(findMenuItem("/go/preferences/notifications")).not.toBeInDOM();
-    expect(findMenuItem("/go/access_tokens")).not.toBeInDOM();
-    expect(findMenuItem("/go/auth/logout")).not.toBeInDOM();
+    expect(helper.q(`.${styles.userLink}`)).toBeFalsy();
+    expect(findMenuItem("/go/preferences/notifications")).toBeFalsy();
+    expect(findMenuItem("/go/access_tokens")).toBeFalsy();
+    expect(findMenuItem("/go/auth/logout")).toBeFalsy();
     expect(findMenuItem("https://gocd.org/help")).toHaveText("Need Help?");
   });
 
@@ -83,6 +83,6 @@ describe("Site Header", () => {
   }
 
   function findMenuItem(href: string) {
-    return helper.find(`a[href='${href}']`);
+    return helper.q(`a[href='${href}']`);
   }
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/materials/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/materials/spec/index_spec.tsx
@@ -22,7 +22,6 @@ import {
   Material, Materials,
   P4MaterialAttributes, TfsMaterialAttributes
 } from "models/new_pipeline_configs/materials";
-import simulateEvent from "simulate-event";
 import * as collapsiblePanelStyles from "views/components/collapsible_panel/index.scss";
 import {MaterialsWidget} from "views/pages/pipeline_configs/materials/index";
 import {TestHelper} from "views/pages/spec/test_helper";
@@ -54,93 +53,89 @@ describe("MaterialsWidgetSpec", () => {
   });
 
   it("should render materials collapsible panel", () => {
-    expect(helper.findByDataTestId("pipeline-materials-container")).toBeInDOM();
-    expect(helper.findByDataTestId("pipeline-materials-container")).toHaveClass(collapsiblePanelStyles.expanded);
+    expect(helper.byTestId("pipeline-materials-container")).toBeInDOM();
+    expect(helper.byTestId("pipeline-materials-container")).toHaveClass(collapsiblePanelStyles.expanded);
   });
 
   it("material toggle expanded state of materials panel", () => {
-    expect(helper.findByDataTestId("pipeline-materials-container")).toHaveClass(collapsiblePanelStyles.expanded);
+    expect(helper.byTestId("pipeline-materials-container")).toHaveClass(collapsiblePanelStyles.expanded);
 
-    const materialsPanelHeader = helper.findIn(helper.findByDataTestId("pipeline-materials-container"), "collapse-header")[0];
+    helper.clickByTestId("collapse-header", helper.byTestId("pipeline-materials-container"));
 
-    simulateEvent.simulate(materialsPanelHeader, "click");
-    m.redraw.sync();
-
-    expect(helper.findByDataTestId("pipeline-materials-container")).not.toHaveClass(collapsiblePanelStyles.expanded);
+    expect(helper.byTestId("pipeline-materials-container")).not.toHaveClass(collapsiblePanelStyles.expanded);
   });
 
   it("should render 'Add Material' button", () => {
-    expect(helper.findByDataTestId("add-material-button")).toBeInDOM();
-    expect(helper.findByDataTestId("add-material-button")).toContainText("Add Material");
+    expect(helper.byTestId("add-material-button")).toBeInDOM();
+    expect(helper.textByTestId("add-material-button")).toContain("Add Material");
   });
 
   it("should render materials table", () => {
-    expect(helper.findByDataTestId("materials-index-table")).toBeInDOM();
-    expect(helper.findByDataTestId("materials-index-table")).toContainHeaderCells(["Material Name", "Type", "Url", ""]);
+    expect(helper.byTestId("materials-index-table")).toBeInDOM();
+    expect(helper.byTestId("materials-index-table")).toContainHeaderCells(["Material Name", "Type", "Url", ""]);
 
-    const gitRepo = helper.findByDataTestId("materials-index-table").find("tr")[1];
+    const gitRepo = helper.qa("tr", helper.byTestId("materials-index-table"))[1];
     expect(gitRepo.children[0]).toContainText("Test git repo");
     expect(gitRepo.children[1]).toContainText("Git");
     expect(gitRepo.children[2]).toContainText("http://foo.git");
-    expect(helper.findIn(gitRepo, "delete-material-button")).toBeInDOM();
-    expect(helper.findIn(gitRepo, "edit-material-button")).toBeInDOM();
+    expect(helper.byTestId("delete-material-button", gitRepo)).toBeInDOM();
+    expect(helper.byTestId("edit-material-button", gitRepo)).toBeInDOM();
 
-    const hgRepo = helper.findByDataTestId("materials-index-table").find("tr")[2];
+    const hgRepo = helper.qa("tr", helper.byTestId("materials-index-table"))[2];
     expect(hgRepo.children[0]).toContainText("Test mercurial repo");
     expect(hgRepo.children[1]).toContainText("Mercurial");
     expect(hgRepo.children[2]).toHaveText("http://foo.hg");
-    expect(helper.findIn(hgRepo, "delete-material-button")).toBeInDOM();
-    expect(helper.findIn(hgRepo, "edit-material-button")).toBeInDOM();
+    expect(helper.byTestId("delete-material-button", hgRepo)).toBeInDOM();
+    expect(helper.byTestId("edit-material-button", hgRepo)).toBeInDOM();
 
-    const p4Repo = helper.findByDataTestId("materials-index-table").find("tr")[3];
+    const p4Repo = helper.qa("tr", helper.byTestId("materials-index-table"))[3];
     expect(p4Repo.children[0]).toContainText("Test p4 repo");
     expect(p4Repo.children[1]).toContainText("Perforce");
     expect(p4Repo.children[2]).toHaveText("127.0.0.1:3000");
-    expect(helper.findIn(p4Repo, "delete-material-button")).toBeInDOM();
-    expect(helper.findIn(p4Repo, "edit-material-button")).toBeInDOM();
+    expect(helper.byTestId("delete-material-button", p4Repo)).toBeInDOM();
+    expect(helper.byTestId("edit-material-button", p4Repo)).toBeInDOM();
 
-    const tfsRepo = helper.findByDataTestId("materials-index-table").find("tr")[4];
+    const tfsRepo = helper.qa("tr", helper.byTestId("materials-index-table"))[4];
     expect(tfsRepo.children[0]).toContainText("Test tfs repo");
     expect(tfsRepo.children[1]).toContainText("Team Foundation Server");
     expect(tfsRepo.children[2]).toHaveText("http://foo.tfs");
-    expect(helper.findIn(tfsRepo, "delete-material-button")).toBeInDOM();
-    expect(helper.findIn(tfsRepo, "edit-material-button")).toBeInDOM();
+    expect(helper.byTestId("delete-material-button", tfsRepo)).toBeInDOM();
+    expect(helper.byTestId("edit-material-button", tfsRepo)).toBeInDOM();
 
-    const svnRepo = helper.findByDataTestId("materials-index-table").find("tr")[5];
+    const svnRepo = helper.qa("tr", helper.byTestId("materials-index-table"))[5];
+
     expect(svnRepo.children[0]).toContainText("Test svn repo");
     expect(svnRepo.children[1]).toContainText("Subversion");
     expect(svnRepo.children[2]).toHaveText("http://foo.svn");
-    expect(helper.findIn(svnRepo, "delete-material-button")).toBeInDOM();
-    expect(helper.findIn(svnRepo, "edit-material-button")).toBeInDOM();
+    expect(helper.byTestId("delete-material-button", svnRepo)).toBeInDOM();
+    expect(helper.byTestId("edit-material-button", svnRepo)).toBeInDOM();
 
-    const dependencyMaterial = helper.findByDataTestId("materials-index-table").find("tr")[6];
+    const dependencyMaterial = helper.qa("tr", helper.byTestId("materials-index-table"))[6];
     expect(dependencyMaterial.children[0]).toContainText("Dependent pipeline");
     expect(dependencyMaterial.children[1]).toContainText("Another Pipeline");
     expect(dependencyMaterial.children[2]).toHaveText("pipeline / stage");
-    expect(helper.findIn(dependencyMaterial, "delete-material-button")).toBeInDOM();
-    expect(helper.findIn(dependencyMaterial, "edit-material-button")).toBeInDOM();
+    expect(helper.byTestId("delete-material-button", dependencyMaterial)).toBeInDOM();
+    expect(helper.byTestId("edit-material-button", dependencyMaterial)).toBeInDOM();
   });
 
   it("click on edit material should open a modal", () => {
-    const gitRepo = helper.findByDataTestId("materials-index-table").find("tr")[1];
+    const gitRepo = helper.qa("tr", helper.byTestId("materials-index-table"))[1];
 
-    expect(document.querySelectorAll("[data-test-id='material-form']").length).toBe(0);
+    expect(helper.byTestId("material-form", document.body)).toBeFalsy();
 
-    simulateEvent.simulate(helper.findIn(gitRepo, "edit-material-button")[0], "click");
-    m.redraw.sync();
+    helper.clickByTestId("edit-material-button", gitRepo);
 
-    expect(document.querySelectorAll("[data-test-id='material-form']").length).toBe(1);
+    expect(helper.allByTestId("material-form", document.body).length).toBe(1);
 
     helper.closeModal();
   });
 
   it("click on add material should open a modal", () => {
-    expect(document.querySelectorAll("[data-test-id='material-form']").length).toBe(0);
+    expect(helper.byTestId("material-form", document.body)).toBeFalsy();
 
-    simulateEvent.simulate(helper.findByDataTestId("add-material-button")[0], "click");
-    m.redraw.sync();
+    helper.clickByTestId("add-material-button");
 
-    expect(document.querySelectorAll("[data-test-id='material-form']").length).toBe(1);
+    expect(helper.allByTestId("material-form", document.body).length).toBe(1);
 
     helper.closeModal();
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/materials/spec/modals_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/materials/spec/modals_spec.tsx
@@ -16,7 +16,6 @@
 
 import _ from "lodash";
 import {GitMaterialAttributes, Material} from "models/new_pipeline_configs/materials";
-import * as simulateEvent from "simulate-event";
 import {AddMaterialModal, EditMaterialModal} from "views/pages/pipeline_configs/materials/modals";
 import {TestHelper} from "views/pages/spec/test_helper";
 
@@ -127,8 +126,7 @@ describe("EditMaterialModal", () => {
 
     describe("invalid material", () => {
       it("should not update material", () => {
-        helper.findByDataTestId("form-field-input-repository-url").val("");
-        simulateEvent.simulate(helper.findByDataTestId("form-field-input-repository-url").get(0), "input");
+        helper.oninput(helper.byTestId("form-field-input-repository-url"), "");
         // As `onSuccessfulUpdate` is a private function, `spyOn` needs a type.
         const onSuccessfulEditSpyFunction = spyOn<any>(editMaterialModal, "onSuccessfulEdit");
 
@@ -138,8 +136,7 @@ describe("EditMaterialModal", () => {
       });
 
       it("should not close modal", () => {
-        helper.findByDataTestId("form-field-input-repository-url").val("");
-        simulateEvent.simulate(helper.findByDataTestId("form-field-input-repository-url").get(0), "input");
+        helper.oninput(helper.byTestId("form-field-input-repository-url"), "");
 
         const closeSpyFunction = spyOn(editMaterialModal, "close");
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/materials/spec/scm_material_fields_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/materials/spec/scm_material_fields_spec.tsx
@@ -112,7 +112,7 @@ describe("AddPipeline: SCM Material Fields", () => {
 
     for (const id of keys) {
       expect(helper.byTestId(`form-field-label-${id}`)).toBeTruthy();
-      expect(helper.findByDataTestId(`form-field-label-${id}`).text().startsWith(idsToLabels[id])).toBe(true);
+      expect(helper.textByTestId(`form-field-label-${id}`).startsWith(idsToLabels[id])).toBe(true);
       expect(helper.byTestId(`form-field-input-${id}`)).toBeTruthy();
     }
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/materials/spec/test_connection_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/materials/spec/test_connection_spec.tsx
@@ -60,7 +60,7 @@ describe("Materials: TestConnection", () => {
       }}/>);
 
       expect(helper.byTestId("test-connection-button")).toBeVisible();
-      helper.clickByDataTestId("test-connection-button");
+      helper.clickByTestId("test-connection-button");
       expect(jasmine.Ajax.requests.count()).toEqual(1);
     });
   });
@@ -93,7 +93,7 @@ describe("Materials: TestConnection", () => {
       }}/>);
 
       expect(helper.byTestId("test-connection-button")).toBeVisible();
-      helper.clickByDataTestId("test-connection-button");
+      helper.clickByTestId("test-connection-button");
       expect(jasmine.Ajax.requests.count()).toEqual(1);
     });
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/environment_variables_editor_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/environment_variables_editor_spec.tsx
@@ -55,20 +55,20 @@ describe("EnvironmentVariablesEditor", () => {
   });
 
   function plainVars(): Element {
-    return helper.find(sel.envVars).get(0);
+    return helper.q(sel.envVars);
   }
 
   function secureVars(): Element {
-    return helper.find(sel.envVars).get(1);
+    return helper.qa(sel.envVars).item(1);
   }
 
   function addVariable(section: Element, name: string, value: string): Element {
     helper.click("button", section);
-    const variable = helper.findIn(section, "table-row").last();
-    const fields = variable.find("input");
-    helper.oninput(fields.get(0), name);
-    helper.oninput(fields.get(1), value);
-    return variable.get(0);
+    const variable = Array.from(helper.allByTestId("table-row", section)).pop()!;
+    const fields = helper.qa("input", variable);
+    helper.oninput(fields.item(0), name);
+    helper.oninput(fields.item(1), value);
+    return variable;
   }
 
   function removeVariable(variable: Element) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/parameters_editor_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/parameters_editor_spec.tsx
@@ -55,13 +55,13 @@ describe("ParametersEditor", () => {
   });
 
   function addVariable(name: string, value: string): Element {
-    const context = helper.find(sel.envVars).get(0);
+    const context = helper.q(sel.envVars);
     helper.click("button", context);
-    const variable = helper.findIn(context, "table-row").last();
-    const fields = variable.find("input");
-    helper.oninput(fields.get(0), name);
-    helper.oninput(fields.get(1), value);
-    return variable.get(0);
+    const variable = Array.from(helper.allByTestId("table-row", context)).pop()!;
+    const fields = helper.qa("input", variable);
+    helper.oninput(fields.item(0), name);
+    helper.oninput(fields.item(1), value);
+    return variable;
   }
 
   function removeVariable(variable: Element) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/pipeline_config_create_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/pipeline_config_create_widget_spec.tsx
@@ -17,7 +17,6 @@
 import _ from "lodash";
 import m from "mithril";
 import {PipelineConfig} from "models/new_pipeline_configs/pipeline_config";
-import * as simulateEvent from "simulate-event";
 import {PipelineConfigCreateWidget} from "views/pages/pipeline_configs/pipeline_config_create_widget";
 import {TestHelper} from "views/pages/spec/test_helper";
 
@@ -38,25 +37,21 @@ describe("PipelineCreateWidgetSpec", () => {
                                                    onPipelineSettingsEdit={pipelineSettingsCallback}/>);
   });
 
-  afterEach(() => {
-    helper.unmount();
-  });
+  afterEach(() => helper.unmount());
 
   it("should render pipeline name field", () => {
     const pipelineNameHelpText = "No spaces. Only letters, numbers, hyphens, underscores and period. Max 255 chars";
 
-    expect(helper.findByDataTestId("form-field-label-pipeline-name")).toContainText("Pipeline name");
-    expect(helper.findByDataTestId("pipeline-name-input")).toHaveLength(1);
-    expect(helper.findByDataTestId("pipeline-name-input")).toHaveProp("required");
-    expect(helper.findByDataTestId("pipeline-details-container")).toContainText(pipelineNameHelpText);
+    expect(helper.textByTestId("form-field-label-pipeline-name")).toContain("Pipeline name");
+    expect(helper.allByTestId("pipeline-name-input")).toHaveLength(1);
+    expect(helper.byTestId("pipeline-name-input")).toHaveProp("required");
+    expect(helper.textByTestId("pipeline-details-container")).toContain(pipelineNameHelpText);
   });
 
   it("should bind pipeline name field", () => {
     const pipelineName = "Test-pipeline";
 
-    helper.findByDataTestId("pipeline-name-input").val(pipelineName);
-    simulateEvent.simulate(helper.findByDataTestId("pipeline-name-input")[0], "input");
-    m.redraw.sync();
+    helper.oninput(helper.byTestId("pipeline-name-input"), pipelineName);
 
     expect(pipelineConfig.name()).toBe(pipelineName);
 
@@ -64,23 +59,20 @@ describe("PipelineCreateWidgetSpec", () => {
     pipelineConfig.name(updatedPipelineName);
     m.redraw.sync();
 
-    expect(helper.findByDataTestId("pipeline-name-input").val()).toBe(updatedPipelineName);
+    expect(helper.byTestId("pipeline-name-input")).toHaveValue(updatedPipelineName);
   });
 
   it("should display error on name field for invalid input format", () => {
     const pipelineName = "Test pipeline";
     const errorText    = "Only letters, numbers, hyphens, underscores, and periods are allowed.";
 
-    helper.findByDataTestId("pipeline-name-input").val(pipelineName);
-    simulateEvent.simulate(helper.findByDataTestId("pipeline-name-input")[0], "input");
-    m.redraw.sync();
+    helper.oninput(helper.byTestId("pipeline-name-input"), pipelineName);
 
-    expect(helper.findByDataTestId("pipeline-details-container")).toContainText(errorText);
+    expect(helper.textByTestId("pipeline-details-container")).toContain(errorText);
   });
 
   it("should open pipeline settings modal", () => {
-    const element = helper.findByDataTestId("pipeline-settings-button");
-    element.click();
+    helper.clickByTestId("pipeline-settings-button");
     expect(pipelineSettingsCallback).toHaveBeenCalled();
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/stages/jobs/artifacts_tab_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/stages/jobs/artifacts_tab_widget_spec.tsx
@@ -18,7 +18,6 @@ import m from "mithril";
 import Stream from "mithril/stream";
 import {ArtifactType, BuildArtifact, TestArtifact} from "models/new_pipeline_configs/artifact";
 import {Artifacts} from "models/new_pipeline_configs/artifacts";
-import * as simulateEvent from "simulate-event";
 import {ArtifactsTab} from "views/pages/pipeline_configs/stages/jobs/artifacts_tab_widget";
 import {TestHelper} from "views/pages/spec/test_helper";
 
@@ -43,37 +42,37 @@ describe("Pipeline Config - Artifacts Tab", () => {
   });
 
   it("should render artifacts tab", () => {
-    expect(helper.findByDataTestId("artifacts-tab")).toBeInDOM();
+    expect(helper.byTestId("artifacts-tab")).toBeInDOM();
   });
 
   it("should render artifacts heading", () => {
-    expect(helper.findByDataTestId("artifacts-heading")).toContainText("Artifacts");
+    expect(helper.textByTestId("artifacts-heading")).toContain("Artifacts");
   });
 
   it("should render artifacts help text", () => {
     const helpText = "Artifacts are the files created during a job run, by one of the tasks. Publish your artifacts so that it can be used by downstream pipelines.";
-    expect(helper.find("#help-artifacts")).toContainText(helpText);
+    expect(helper.text("#help-artifacts")).toContain(helpText);
   });
 
   it("should render doc link for artifact help text", () => {
-    const docLink      = helper.find("#help-artifacts a")[0];
+    const docLink      = helper.q("#help-artifacts a");
     const expectedLink = "/configuration/dev_upload_test_report.html";
     expect((docLink as HTMLAnchorElement).getAttribute("href")).toContain(expectedLink);
   });
 
   describe("Built-in Artifact", () => {
     it("should render build artifact", () => {
-      const buildArtifacts = helper.findByDataTestId("Build-artifact");
+      const buildArtifacts = helper.allByTestId("Build-artifact");
       expect(buildArtifacts).toHaveLength(1);
     });
 
     it("should render test artifact", () => {
-      const testArtifacts = helper.findByDataTestId("Test-artifact");
+      const testArtifacts = helper.allByTestId("Test-artifact");
       expect(testArtifacts).toHaveLength(1);
     });
 
     it("should render headings for built in artifact", () => {
-      const headingContainers = helper.findByDataTestId("artifact-item-headings");
+      const headingContainers = helper.allByTestId("artifact-item-headings");
       expect(headingContainers).toHaveLength(2);
 
       expect(headingContainers).toContainText("Type");
@@ -83,170 +82,148 @@ describe("Pipeline Config - Artifacts Tab", () => {
 
     it("should render help text for type", () => {
       const helpText = "There are 3 types of artifacts - build, test and external. When 'Test Artifact' is selected, Go will use this artifact to generate a test report. Test information is placed in the Failures and Test sub-tabs. Test results from multiple jobs are aggregated on the stage detail pages. This allows you to see the results of tests from both functional and unit tests even if they are run in different jobs. When artifact type external is selected, you can configure the external artifact store to which you can push an artifact.";
-      expect(helper.find("#help-artifact-type")).toContainText(helpText);
+      expect(helper.text("#help-artifact-type")).toContain(helpText);
     });
 
     it("should render help text for source", () => {
       const helpText = "The file or folders to publish to the server. Go will only upload files that are in the working directory of the job. You can use wildcards to specify the files and folders to upload (** means any path, * means any file or folder name).";
-      expect(helper.find("#help-artifact-source")).toContainText(helpText);
+      expect(helper.text("#help-artifact-source")).toContain(helpText);
     });
 
     it("should render help text for destination", () => {
       const helpText = "The destination is relative to the artifacts folder of the current instance on the server side. If it is not specified, the artifact will be stored in the root of the artifacts directory";
-      expect(helper.find("#help-artifact-destination")).toContainText(helpText);
+      expect(helper.text("#help-artifact-destination")).toContain(helpText);
     });
 
     describe("Build", () => {
       it("should render type of build artifact", () => {
-        const artifactType = helper.findSelectorIn(helper.findByDataTestId("Build-artifact-content"), "span");
-        expect(artifactType).toContainText("Build Artifact");
+        expect(helper.text("span", helper.byTestId("Build-artifact-content"))).toContain("Build Artifact");
       });
 
       it("should render input field for build artifact source", () => {
-        const inputWrapper             = helper.findByDataTestId("Build-artifact-source-input-wrapper");
-        const buildArtifactSourceInput = helper.findSelectorIn(inputWrapper, "input");
-        expect(buildArtifactSourceInput).toBeInDOM();
+        expect(helper.q("input", helper.byTestId("Build-artifact-source-input-wrapper"))).toBeInDOM();
       });
 
       it("should bind input field with model source field", () => {
-        const inputWrapper = helper.findByDataTestId("Build-artifact-source-input-wrapper");
-        expect(helper.findSelectorIn(inputWrapper, "input")).toHaveValue(buildArtifact.source()!);
+        const input = helper.q("input", helper.byTestId("Build-artifact-source-input-wrapper"));
+        expect(input).toHaveValue(buildArtifact.source()!);
 
         const newValue = "new-file.txt";
         buildArtifact.source(newValue);
         m.redraw.sync();
 
-        expect(buildArtifact.source()).toEqual(newValue);
-        expect(helper.findSelectorIn(inputWrapper, "input")).toHaveValue(newValue);
+        expect(buildArtifact.source()).toBe(newValue);
+        expect(input).toHaveValue(newValue);
       });
 
       it("should render input field for build artifact destination", () => {
-        const inputWrapper                  = helper.findByDataTestId("Build-artifact-destination-input-wrapper");
-        const buildArtifactDestinationInput = helper.findSelectorIn(inputWrapper, "input");
-        expect(buildArtifactDestinationInput).toBeInDOM();
+        const input = helper.q("input", helper.byTestId("Build-artifact-destination-input-wrapper"));
+        expect(input).toBeInDOM();
 
-        expect(buildArtifactDestinationInput).toHaveValue(buildArtifact.destination()!);
+        expect(input).toHaveValue(buildArtifact.destination()!);
       });
 
       it("should bind input field with model destination field", () => {
-        const inputWrapper = helper.findByDataTestId("Build-artifact-destination-input-wrapper");
-        expect(helper.findSelectorIn(inputWrapper, "input")).toHaveValue(buildArtifact.destination()!);
+        const input = helper.q("input", helper.byTestId("Build-artifact-destination-input-wrapper"));
+        expect(input).toHaveValue(buildArtifact.destination()!);
 
         const newValue = "new-file.txt";
         buildArtifact.destination(newValue);
         m.redraw.sync();
 
-        expect(buildArtifact.destination()).toEqual(newValue);
-        expect(helper.findSelectorIn(inputWrapper, "input")).toHaveValue(newValue);
+        expect(buildArtifact.destination()).toBe(newValue);
+        expect(input).toHaveValue(newValue);
       });
     });
 
     describe("Test", () => {
       it("should render type of test artifact", () => {
-        const artifactType = helper.findSelectorIn(helper.findByDataTestId("Test-artifact-content"), "span");
-        expect(artifactType).toContainText("Test Artifact");
+        expect(helper.text("span", helper.byTestId("Test-artifact-content"))).toContain("Test Artifact");
       });
 
       it("should render input field for test artifact source", () => {
-        const inputWrapper            = helper.findByDataTestId("Test-artifact-source-input-wrapper");
-        const testArtifactSourceInput = helper.findSelectorIn(inputWrapper, "input");
-        expect(testArtifactSourceInput).toBeInDOM();
+        expect(helper.q("input", helper.byTestId("Test-artifact-source-input-wrapper"))).toBeInDOM();
       });
 
       it("should bind input field with model source field", () => {
-        const inputWrapper = helper.findByDataTestId("Test-artifact-source-input-wrapper");
-        expect(helper.findSelectorIn(inputWrapper, "input")).toHaveValue(testArtifact.source()!);
+        const input = helper.q("input", helper.byTestId("Test-artifact-source-input-wrapper"));
+        expect(input).toHaveValue(testArtifact.source()!);
 
         const newValue = "new-file.txt";
         testArtifact.source(newValue);
         m.redraw.sync();
 
-        expect(testArtifact.source()).toEqual(newValue);
-        expect(helper.findSelectorIn(inputWrapper, "input")).toHaveValue(newValue);
+        expect(testArtifact.source()).toBe(newValue);
+        expect(input).toHaveValue(newValue);
       });
 
       it("should render input field for test artifact destination", () => {
-        const inputWrapper                 = helper.findByDataTestId("Test-artifact-destination-input-wrapper");
-        const testArtifactDestinationInput = helper.findSelectorIn(inputWrapper, "input");
-        expect(testArtifactDestinationInput).toBeInDOM();
+        const input = helper.q("input", helper.byTestId("Test-artifact-destination-input-wrapper"));
+        expect(input).toBeInDOM();
 
-        expect(testArtifactDestinationInput).toHaveValue(testArtifact.destination()!);
+        expect(input).toHaveValue(testArtifact.destination()!);
       });
 
       it("should bind input field with model destination field", () => {
-        const inputWrapper = helper.findByDataTestId("Test-artifact-destination-input-wrapper");
-        expect(helper.findSelectorIn(inputWrapper, "input")).toHaveValue(testArtifact.destination()!);
+        const input = helper.q("input", helper.byTestId("Test-artifact-destination-input-wrapper"));
+        expect(input).toHaveValue(testArtifact.destination()!);
 
         const newValue = "new-file.txt";
         testArtifact.destination(newValue);
         m.redraw.sync();
 
-        expect(testArtifact.destination()).toEqual(newValue);
-        expect(helper.findSelectorIn(inputWrapper, "input")).toHaveValue(newValue);
+        expect(testArtifact.destination()).toBe(newValue);
+        expect(input).toHaveValue(newValue);
       });
     });
 
     it("should remove the artifact on cancel", () => {
-      const closeIconForBuildArtifact = helper.findByDataTestId("Close-icon")[0];
-      const closeIconForTestArtifact  = helper.findByDataTestId("Close-icon")[1];
+      const closeIconForBuildArtifact = helper.allByTestId("Close-icon")[0];
+      const closeIconForTestArtifact  = helper.allByTestId("Close-icon")[1];
 
-      expect(artifacts.count()).toEqual(2);
-      expect(helper.findByDataTestId("Build-artifact")).toBeInDOM();
-      expect(helper.findByDataTestId("Test-artifact")).toBeInDOM();
+      expect(artifacts.count()).toBe(2);
+      expect(helper.byTestId("Build-artifact")).toBeInDOM();
+      expect(helper.byTestId("Test-artifact")).toBeInDOM();
 
       //remove build artifact
-      simulateEvent.simulate(closeIconForBuildArtifact, "click");
-      m.redraw.sync();
+      helper.click(closeIconForBuildArtifact);
 
-      expect(artifacts.count()).toEqual(1);
-      expect(helper.findByDataTestId("Build-artifact")).not.toBeInDOM();
-      expect(helper.findByDataTestId("Test-artifact")).toBeInDOM();
+      expect(artifacts.count()).toBe(1);
+      expect(helper.byTestId("Build-artifact")).toBeFalsy();
+      expect(helper.byTestId("Test-artifact")).toBeInDOM();
 
       //remove test artifact
-      simulateEvent.simulate(closeIconForTestArtifact, "click");
-      m.redraw.sync();
+      helper.click(closeIconForTestArtifact);
 
-      expect(artifacts.count()).toEqual(0);
-      expect(helper.findByDataTestId("Build-artifact")).not.toBeInDOM();
-      expect(helper.findByDataTestId("Test-artifact")).not.toBeInDOM();
+      expect(artifacts.count()).toBe(0);
+      expect(helper.byTestId("Build-artifact")).toBeFalsy();
+      expect(helper.byTestId("Test-artifact")).toBeFalsy();
     });
 
     it("should add a new build artifact", () => {
-      expect(artifacts.count()).toEqual(2);
-      expect(helper.findByDataTestId("Build-artifact")).toHaveLength(1);
-      expect(helper.findByDataTestId("Test-artifact")).toHaveLength(1);
+      expect(artifacts.count()).toBe(2);
+      expect(helper.allByTestId("Build-artifact")).toHaveLength(1);
+      expect(helper.allByTestId("Test-artifact")).toHaveLength(1);
 
-      const selectDropdown: any = helper.findByDataTestId("form-field-input-artifact-type")[0];
-      selectDropdown.value      = ArtifactType.Build;
-      simulateEvent.simulate(selectDropdown, "change");
-      m.redraw.sync();
+      helper.onchange(helper.byTestId("form-field-input-artifact-type"), ArtifactType.Build);
+      helper.click("button");
 
-      const addButton = helper.find("button");
-      simulateEvent.simulate(addButton[0], "click");
-      m.redraw.sync();
-
-      expect(artifacts.count()).toEqual(3);
-      expect(helper.findByDataTestId("Build-artifact")).toHaveLength(2);
-      expect(helper.findByDataTestId("Test-artifact")).toHaveLength(1);
+      expect(artifacts.count()).toBe(3);
+      expect(helper.allByTestId("Build-artifact")).toHaveLength(2);
+      expect(helper.allByTestId("Test-artifact")).toHaveLength(1);
     });
 
     it("should add a new test artifact", () => {
-      expect(artifacts.count()).toEqual(2);
-      expect(helper.findByDataTestId("Build-artifact")).toHaveLength(1);
-      expect(helper.findByDataTestId("Test-artifact")).toHaveLength(1);
+      expect(artifacts.count()).toBe(2);
+      expect(helper.allByTestId("Build-artifact")).toHaveLength(1);
+      expect(helper.allByTestId("Test-artifact")).toHaveLength(1);
 
-      const selectDropdown: any = helper.findByDataTestId("form-field-input-artifact-type")[0];
-      selectDropdown.value      = ArtifactType.Test;
-      simulateEvent.simulate(selectDropdown, "change");
-      m.redraw.sync();
+      helper.onchange(helper.byTestId("form-field-input-artifact-type"), ArtifactType.Test);
+      helper.click("button");
 
-      const addButton = helper.find("button");
-      simulateEvent.simulate(addButton[0], "click");
-      m.redraw.sync();
-
-      expect(artifacts.count()).toEqual(3);
-      expect(helper.findByDataTestId("Build-artifact")).toHaveLength(1);
-      expect(helper.findByDataTestId("Test-artifact")).toHaveLength(2);
+      expect(artifacts.count()).toBe(3);
+      expect(helper.allByTestId("Build-artifact")).toHaveLength(1);
+      expect(helper.allByTestId("Test-artifact")).toHaveLength(2);
     });
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/stages/on_create/task_description_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/stages/on_create/task_description_widget_spec.tsx
@@ -16,7 +16,6 @@
 
 import m from "mithril";
 import {ExecTask} from "models/new_pipeline_configs/task";
-import * as simulateEvent from "simulate-event";
 import {TaskDescriptionWidget} from "views/pages/pipeline_configs/stages/on_create/task_description_widget";
 import task_terminal_styles from "views/pages/pipeline_configs/stages/on_create/task_terminal.scss";
 import {TestHelper} from "views/pages/spec/test_helper";
@@ -37,50 +36,49 @@ describe("Pipeline Config - Job Settings Modal - Tasks Widget - Task Description
     });
 
     it("should render the task description", () => {
-      expect(helper.findByDataTestId("exec-task-description")).toBeInDOM();
+      expect(helper.byTestId("exec-task-description")).toBeInDOM();
     });
 
     describe("Task Editor", () => {
       it("should render the task editor", () => {
-        expect(helper.find("code")).toBeInDOM();
+        expect(helper.q("code")).toBeInDOM();
       });
 
       it("should represent the task in the task editor window", () => {
-        expect(helper.find("pre")).toHaveText(task.represent()!);
+        expect(helper.text("pre")).toBe(task.represent()!);
       });
 
       it("should render the caveats in the task editor", () => {
-        expect(helper.findByDataTestId("caveats-container")).toBeInDOM();
-        expect(helper.findByDataTestId("caveats-container")).toContainText("Caveats");
+        expect(helper.byTestId("caveats-container")).toBeInDOM();
+        expect(helper.textByTestId("caveats-container")).toContain("Caveats");
       });
 
       it("should display caveats description on click of expand icon", () => {
         const caveatsDesc = "This is not a real shell:";
 
-        expect(helper.findByDataTestId("caveats-container")).not.toHaveClass(task_terminal_styles.open);
+        expect(helper.byTestId("caveats-container")).not.toHaveClass(task_terminal_styles.open);
 
-        simulateEvent.simulate(helper.findByDataTestId("caveats-toggle-btn").get(0), "click");
-        m.redraw.sync();
+        helper.clickByTestId("caveats-toggle-btn");
 
-        expect(helper.findByDataTestId("caveats-container")).toHaveClass(task_terminal_styles.open);
-        expect(helper.findByDataTestId("caveats-container")).toContainText(caveatsDesc);
+        expect(helper.byTestId("caveats-container")).toHaveClass(task_terminal_styles.open);
+        expect(helper.textByTestId("caveats-container")).toContain(caveatsDesc);
       });
 
       it("should display editor instructions", () => {
         const caveatsInstructions = "# Press <enter> to save, <shift-enter> for newline";
 
-        expect(helper.findByDataTestId("caveats-instructions")).toBeInDOM();
-        expect(helper.findByDataTestId("caveats-instructions")).toContainText(caveatsInstructions);
+        expect(helper.byTestId("caveats-instructions")).toBeInDOM();
+        expect(helper.textByTestId("caveats-instructions")).toContain(caveatsInstructions);
       });
     });
 
     describe("run if conditions", () => {
       it("should render the run if conditions", () => {
-        expect(helper.findByDataTestId("run-if-conditions-container")).toBeInDOM();
+        expect(helper.byTestId("run-if-conditions-container")).toBeInDOM();
       });
 
       it("should render all run if condition options", () => {
-        const runIfConditionsContainer = helper.findByDataTestId("run-if-conditions-container");
+        const runIfConditionsContainer = helper.byTestId("run-if-conditions-container");
 
         expect(runIfConditionsContainer).toContainText("Run If Conditions");
         expect(runIfConditionsContainer).toContainText("Passed");
@@ -90,36 +88,41 @@ describe("Pipeline Config - Job Settings Modal - Tasks Widget - Task Description
 
       it("should select passed by default", () => {
         expect(task.runIfCondition()).toBe("Passed");
-        const passedRadioField = helper.findByDataTestId("input-field-for-Passed");
-        expect(helper.findSelectorIn(passedRadioField, "label")).toContainText(task.runIfCondition());
-        expect(helper.findSelectorIn(passedRadioField, "input")).toBeChecked();
+
+        const passedRadioField = helper.byTestId("input-field-for-Passed");
+
+        expect(helper.text("label", passedRadioField)).toContain(task.runIfCondition());
+        expect(helper.q("input", passedRadioField)).toBeChecked();
       });
 
       it("should select another run if condition on click", () => {
         expect(task.runIfCondition()).toBe("Passed");
-        const passedRadioField = helper.findByDataTestId("input-field-for-Passed");
-        expect(helper.findSelectorIn(passedRadioField, "label")).toContainText(task.runIfCondition());
-        expect(helper.findSelectorIn(passedRadioField, "input")).toBeChecked();
 
-        let failedRadioField = helper.findByDataTestId("input-field-for-Failed");
-        simulateEvent.simulate(helper.findSelectorIn(failedRadioField, "input")[0], "click");
-        m.redraw.sync();
+        const passedRadioField = helper.byTestId("input-field-for-Passed");
 
-        failedRadioField = helper.findByDataTestId("input-field-for-Failed");
+        expect(helper.text("label", passedRadioField)).toContain(task.runIfCondition());
+        expect(helper.q("input", passedRadioField)).toBeChecked();
+
+        click(helper.q("input", helper.byTestId("input-field-for-Failed")));
+
+        const failedRadioField = helper.byTestId("input-field-for-Failed");
         expect(task.runIfCondition()).toBe("Failed");
-        expect(helper.findSelectorIn(failedRadioField, "label")).toContainText(task.runIfCondition());
-        expect(helper.findSelectorIn(failedRadioField, "input")).toBeChecked();
+        expect(helper.text("label", failedRadioField)).toContain(task.runIfCondition());
+        expect(helper.q("input", failedRadioField)).toBeChecked();
 
-        let anyRadioField = helper.findByDataTestId("input-field-for-Any");
-        simulateEvent.simulate(helper.findSelectorIn(anyRadioField, "input")[0], "click");
-        m.redraw.sync();
+        click(helper.q("input", helper.byTestId("input-field-for-Any")));
 
-        anyRadioField = helper.findByDataTestId("input-field-for-Any");
+        const anyRadioField = helper.byTestId("input-field-for-Any");
         expect(task.runIfCondition()).toBe("Any");
-        expect(helper.findSelectorIn(anyRadioField, "label")).toContainText(task.runIfCondition());
-        expect(helper.findSelectorIn(anyRadioField, "input")).toBeChecked();
+        expect(helper.text("label", anyRadioField)).toContain(task.runIfCondition());
+        expect(helper.q("input", anyRadioField)).toBeChecked();
       });
     });
+
+    function click(el: Element) {
+      (el as HTMLElement).click();
+      helper.redraw();
+    }
   });
 
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/stages/on_create/tasks_list_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/stages/on_create/tasks_list_widget_spec.tsx
@@ -18,7 +18,6 @@ import m from "mithril";
 import Stream from "mithril/stream";
 import {ExecTask} from "models/new_pipeline_configs/task";
 import {Tasks} from "models/new_pipeline_configs/tasks";
-import * as simulateEvent from "simulate-event";
 import {TasksTab} from "views/pages/pipeline_configs/stages/on_create/tasks_widget";
 import {TestHelper} from "views/pages/spec/test_helper";
 
@@ -39,11 +38,11 @@ describe("Pipeline Config - Job Settings Modal - Tasks Widget - Tasks List", () 
   });
 
   it("should render the tasks list", () => {
-    expect(helper.findByDataTestId("tasks-list")).toBeInDOM();
+    expect(helper.byTestId("tasks-list")).toBeInDOM();
   });
 
   it("should list all tasks", () => {
-    const tasks = helper.findByDataTestId("task-representation");
+    const tasks = helper.allByTestId("task-representation");
 
     expect(tasks).toHaveLength(2);
     expect(tasks[0]).toHaveText("ls foo");
@@ -51,20 +50,19 @@ describe("Pipeline Config - Job Settings Modal - Tasks Widget - Tasks List", () 
   });
 
   it("should render delete icon for all the tasks", () => {
-    const deleteIcons = helper.findByDataTestId("Delete-icon");
+    const deleteIcons = helper.allByTestId("Delete-icon");
 
     expect(deleteIcons).toHaveLength(2);
   });
 
   it("should delete a task", () => {
-    expect(helper.findByDataTestId("task-representation").get(0)).toContainText("ls foo");
+    expect(helper.textByTestId("task-representation")).toContain("ls foo");
 
-    simulateEvent.simulate(helper.findByDataTestId("Delete-icon").get(0), "click");
-    m.redraw.sync();
+    helper.clickByTestId("Delete-icon");
 
-    const firstTask = helper.findByDataTestId("task-representation")[0];
+    const firstTask = helper.byTestId("task-representation");
 
-    expect(firstTask).not.toContainText("ls foo");
-    expect(firstTask).toContainText("sleep 30");
+    expect(firstTask.textContent).not.toContain("ls foo");
+    expect(firstTask.textContent).toContain("sleep 30");
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/stages/on_create/tasks_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/stages/on_create/tasks_widget_spec.tsx
@@ -18,7 +18,6 @@ import m from "mithril";
 import Stream from "mithril/stream";
 import {ExecTask, Task} from "models/new_pipeline_configs/task";
 import {Tasks} from "models/new_pipeline_configs/tasks";
-import simulateEvent from "simulate-event";
 import {TasksTab} from "views/pages/pipeline_configs/stages/on_create/tasks_widget";
 import {TestHelper} from "views/pages/spec/test_helper";
 
@@ -39,33 +38,31 @@ describe("Pipeline Config - Job Settings Modal - Tasks Widget", () => {
   });
 
   it("should render the tasks tab", () => {
-    expect(helper.findByDataTestId("tasks-tab")).toBeInDOM();
+    expect(helper.byTestId("tasks-tab")).toBeInDOM();
   });
 
   it("should render first task by default", () => {
-    expect(helper.findByDataTestId("selected-task")).toHaveText(lsTask.represent());
-    expect(helper.find("pre")).toHaveText(lsTask.represent());
+    expect(helper.textByTestId("selected-task")).toBe(lsTask.represent());
+    expect(helper.text("pre")).toBe(lsTask.represent());
   });
 
   it("should display appropriate task in task editor on click of task from tasks list", () => {
-    expect(helper.findByDataTestId("selected-task")).toHaveText(lsTask.represent());
-    expect(helper.find("pre")).toHaveText(lsTask.represent());
+    expect(helper.textByTestId("selected-task")).toBe(lsTask.represent());
+    expect(helper.text("pre")).toBe(lsTask.represent());
 
-    simulateEvent.simulate(helper.findByDataTestId("task-representation")[1], "click");
-    m.redraw.sync();
+    helper.click(helper.allByTestId("task-representation")[1]);
 
-    expect(helper.findByDataTestId("selected-task")).toHaveText(sleepTask.represent());
-    expect(helper.find("pre")).toHaveText(sleepTask.represent());
+    expect(helper.textByTestId("selected-task")).toBe(sleepTask.represent());
+    expect(helper.text("pre")).toBe(sleepTask.represent());
   });
 
   it("should select and render the next task when the currently selected task is deleted", () => {
-    expect(helper.findByDataTestId("selected-task")).toHaveText(lsTask.represent());
-    expect(helper.find("pre")).toHaveText(lsTask.represent());
+    expect(helper.textByTestId("selected-task")).toBe(lsTask.represent());
+    expect(helper.text("pre")).toBe(lsTask.represent());
 
-    simulateEvent.simulate(helper.findByDataTestId("Delete-icon").get(0), "click");
-    m.redraw.sync();
+    helper.clickByTestId("Delete-icon");
 
-    expect(helper.findByDataTestId("selected-task")).toHaveText(sleepTask.represent());
-    expect(helper.find("pre")).toHaveText(sleepTask.represent());
+    expect(helper.textByTestId("selected-task")).toBe(sleepTask.represent());
+    expect(helper.text("pre")).toBe(sleepTask.represent());
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/stages/settings/stage_settings_modal_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/stages/settings/stage_settings_modal_spec.tsx
@@ -17,12 +17,12 @@
 import m from "mithril";
 import Stream from "mithril/stream";
 import {StageConfig} from "models/new_pipeline_configs/stage_configuration";
-import * as simulateEvent from "simulate-event";
 import {StageSettingsModal} from "views/pages/pipeline_configs/stages/settings/stage_settings_modal";
 import {TestHelper} from "views/pages/spec/test_helper";
 
 describe("Pipeline Config - Stage Settings Modal", () => {
   const helper = new TestHelper();
+  const body = document.body;
 
   let stage: StageConfig;
   let modal: StageSettingsModal;
@@ -41,52 +41,46 @@ describe("Pipeline Config - Stage Settings Modal", () => {
   it("should render modal title", () => {
     const modalTitle = "Stage Settings";
 
-    expect(modal.title()).toEqual(modalTitle);
-    expect(helper.findIn($("body"), "modal-title")).toContainText(modalTitle);
+    expect(modal.title()).toBe(modalTitle);
+    expect(helper.textByTestId("modal-title", body)).toContain(modalTitle);
   });
 
   it("should render tab headings", () => {
-    const body = $("body");
 
-    expect(helper.findIn(body, "tab-header-0")).toContainText("Stage Settings");
-    expect(helper.findIn(body, "tab-header-1")).toContainText("Environment Variables");
-    expect(helper.findIn(body, "tab-header-2")).toContainText("Permissions");
+    expect(helper.textByTestId("tab-header-0", body)).toContain("Stage Settings");
+    expect(helper.textByTestId("tab-header-1", body)).toContain("Environment Variables");
+    expect(helper.textByTestId("tab-header-2", body)).toContain("Permissions");
   });
 
   it("should render stage settings widget by default", () => {
-    const body = $("body");
+    expect(helper.textByTestId("tab-header-0", body)).toContain("Stage Settings");
+    expect(helper.byTestId("stage-settings-tab", body)).toBeInDOM();
 
-    expect(helper.findIn(body, "tab-header-0")).toContainText("Stage Settings");
-    expect(helper.findIn(body, "stage-settings-tab")).toBeInDOM();
-
-    expect(isHidden("tab-content-0")).toEqual(false);
-    expect(isHidden("tab-content-1")).toEqual(true);
-    expect(isHidden("tab-content-2")).toEqual(true);
+    expect(isHidden("tab-content-0")).toBe(false);
+    expect(isHidden("tab-content-1")).toBe(true);
+    expect(isHidden("tab-content-2")).toBe(true);
   });
 
   it("should render stage settings permission widget on click", () => {
-    const body = $("body");
+    expect(helper.textByTestId("tab-header-0", body)).toContain("Stage Settings");
+    expect(helper.byTestId("stage-settings-tab", body)).toBeInDOM();
 
-    expect(helper.findIn(body, "tab-header-0")).toContainText("Stage Settings");
-    expect(helper.findIn(body, "stage-settings-tab")).toBeInDOM();
+    expect(helper.textByTestId("tab-header-2", body)).toContain("Permissions");
+    expect(helper.byTestId("stage-permissions-tab", body)).toBeInDOM();
 
-    expect(helper.findIn(body, "tab-header-2")).toContainText("Permissions");
-    expect(helper.findIn(body, "stage-permissions-tab")).toBeInDOM();
+    expect(isHidden("tab-content-0")).toBe(false);
+    expect(isHidden("tab-content-1")).toBe(true);
+    expect(isHidden("tab-content-2")).toBe(true);
 
-    expect(isHidden("tab-content-0")).toEqual(false);
-    expect(isHidden("tab-content-1")).toEqual(true);
-    expect(isHidden("tab-content-2")).toEqual(true);
+    helper.clickByTestId("tab-header-2", body);
 
-    simulateEvent.simulate(helper.findIn(body, "tab-header-2")[0], "click");
-    m.redraw.sync();
-
-    expect(isHidden("tab-content-0")).toEqual(true);
-    expect(isHidden("tab-content-1")).toEqual(true);
-    expect(isHidden("tab-content-2")).toEqual(false);
+    expect(isHidden("tab-content-0")).toBe(true);
+    expect(isHidden("tab-content-1")).toBe(true);
+    expect(isHidden("tab-content-2")).toBe(false);
   });
 
   function isHidden(tab: string) {
-    const classList = helper.findIn($("body"), tab)[0].classList;
-    return Array.from(classList).some((c: any) => c.indexOf("hide") >= 0);
+    const classList = helper.byTestId(tab, body).classList;
+    return Array.from(classList).some((c) => c.indexOf("hide") !== -1);
   }
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/stages/settings/tabs/permissions_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/stages/settings/tabs/permissions_spec.tsx
@@ -17,7 +17,6 @@
 import m from "mithril";
 import Stream from "mithril/stream";
 import {StageConfig} from "models/new_pipeline_configs/stage_configuration";
-import * as simulateEvent from "simulate-event";
 import {StagePermissionsTab} from "views/pages/pipeline_configs/stages/settings/tabs/permissions";
 import {TestHelper} from "views/pages/spec/test_helper";
 
@@ -34,50 +33,48 @@ describe("Pipeline Config - Stage Settings Modal - Stage Permissions Tab", () =>
   });
 
   it("should render stage permissions tab", () => {
-    const body = $("body");
-    expect(helper.findIn(body, "stage-permissions-tab")).toBeInDOM();
+    expect(helper.byTestId("stage-permissions-tab", document.body)).toBeInDOM();
   });
 
   it("should render the default permission message", () => {
     const msg      = "All System Administrators and Pipeline Group Administrators can operate on this pipeline.";
     const helpText = "(This permission can not be overridden!)";
 
-    expect(helper.findByDataTestId("default-permission-message-body")).toContainText(msg);
-    expect(helper.findByDataTestId("default-permission-help-message")).toContainText(helpText);
+    expect(helper.textByTestId("default-permission-message-body")).toContain(msg);
+    expect(helper.textByTestId("default-permission-help-message")).toContain(helpText);
   });
 
   it("should render Inherit permissions from Pipeline Group checkbox", () => {
-    expect(helper.findByDataTestId("switch-wrapper")).toBeInDOM();
-    expect(helper.findByDataTestId("switch-label")).toContainText("Inherit permissions from Pipeline Group:");
+    expect(helper.byTestId("switch-wrapper")).toBeInDOM();
+    expect(helper.textByTestId("switch-label")).toContain("Inherit permissions from Pipeline Group:");
 
-    expect((helper.findByDataTestId("switch-checkbox")[0] as HTMLInputElement).checked).toEqual(true);
+    expect(checked("switch-checkbox")).toBe(true);
   });
 
   it("should allow toggling Inherit permissions from Pipeline Group checkbox", () => {
-    expect(helper.findByDataTestId("switch-wrapper")).toBeInDOM();
-    expect(helper.findByDataTestId("switch-label")).toContainText("Inherit permissions from Pipeline Group:");
+    expect(helper.byTestId("switch-wrapper")).toBeInDOM();
+    expect(helper.textByTestId("switch-label")).toContain("Inherit permissions from Pipeline Group:");
 
-    expect((helper.findByDataTestId("switch-checkbox")[0] as HTMLInputElement).checked).toEqual(true);
+    expect(checked("switch-checkbox")).toBe(true);
     expect(stageConfig.approval().inheritFromPipelineGroup()).toEqual(true);
 
-    simulateEvent.simulate(helper.findByDataTestId("switch-checkbox")[0], "click");
-    m.redraw.sync();
+    click("switch-checkbox");
 
-    expect((helper.findByDataTestId("switch-checkbox")[0] as HTMLInputElement).checked).toEqual(false);
+    expect(checked("switch-checkbox")).toBe(false);
     expect(stageConfig.approval().inheritFromPipelineGroup()).toEqual(false);
   });
 
   it("should not render Specify Permissions locally when permissions are inherited from pipeline group", () => {
-    expect((helper.findByDataTestId("switch-checkbox")[0] as HTMLInputElement).checked).toEqual(true);
-    expect(helper.findByDataTestId("specify-stage-permissions-locally")).not.toBeInDOM();
+    expect(checked("switch-checkbox")).toBe(true);
+    expect(helper.byTestId("specify-stage-permissions-locally")).toBeFalsy();
   });
 
   it("should render Specify Permissions locally when permissions are not inherited from pipeline group", () => {
     stageConfig.approval().inheritFromPipelineGroup(false);
     m.redraw.sync();
 
-    expect((helper.findByDataTestId("switch-checkbox")[0] as HTMLInputElement).checked).toEqual(false);
-    expect(helper.findByDataTestId("specify-stage-permissions-locally")).toBeInDOM();
+    expect(checked("switch-checkbox")).toBe(false);
+    expect(helper.byTestId("specify-stage-permissions-locally")).toBeInDOM();
   });
 
   describe("Specify Stage Permissions Locally", () => {
@@ -87,15 +84,15 @@ describe("Pipeline Config - Stage Settings Modal - Stage Permissions Tab", () =>
     });
 
     it("should render specify locally message", () => {
-      expect(helper.findByDataTestId("specify-stage-permissions-locally")).toBeInDOM();
-      expect(helper.findByDataTestId("specify-stage-permissions-locally")).toContainText("Specify locally:");
+      expect(helper.byTestId("specify-stage-permissions-locally")).toBeInDOM();
+      expect(helper.textByTestId("specify-stage-permissions-locally")).toContain("Specify locally:");
     });
 
     describe("Users", () => {
       it("should render user input field", () => {
-        expect(helper.findByDataTestId("User-permissions")).toBeInDOM();
-        expect(helper.findByDataTestId("User-permissions")).toContainText("Users");
-        expect(helper.findByDataTestId("User-input")).toBeInDOM();
+        expect(helper.byTestId("User-permissions")).toBeInDOM();
+        expect(helper.textByTestId("User-permissions")).toContain("Users");
+        expect(helper.byTestId("User-input")).toBeInDOM();
       });
 
       it("should show existing users on the UI", () => {
@@ -103,23 +100,16 @@ describe("Pipeline Config - Stage Settings Modal - Stage Permissions Tab", () =>
         stageConfig.approval().authorization()!.users.add("John");
         m.redraw.sync();
 
-        expect(helper.findByDataTestId("show-User-Bob")).toBeInDOM();
-        expect(helper.findByDataTestId("show-User-John")).toBeInDOM();
+        expect(helper.byTestId("show-User-Bob")).toBeInDOM();
+        expect(helper.byTestId("show-User-John")).toBeInDOM();
       });
 
       it("should allow adding users", () => {
         const username = "Bob";
         expect(stageConfig.approval().authorization()!.users.list()).toEqual([]);
 
-        const inputSelector = helper.findByDataTestId("User-input").find("input");
-        inputSelector.val(username);
-
-        simulateEvent.simulate(inputSelector[0], "input");
-        m.redraw.sync();
-
-        const addBtnSelector = helper.findByDataTestId("User-input").find("button");
-        simulateEvent.simulate(addBtnSelector[0], "click");
-        m.redraw.sync();
+        helper.oninput("input", username, helper.byTestId("User-input"));
+        helper.click("button", helper.byTestId("User-input"));
 
         expect(stageConfig.approval().authorization()!.users.list()).toEqual([username]);
       });
@@ -129,22 +119,21 @@ describe("Pipeline Config - Stage Settings Modal - Stage Permissions Tab", () =>
         stageConfig.approval().authorization()!.users.add("John");
         m.redraw.sync();
 
-        expect(helper.findByDataTestId("show-User-Bob")).toBeInDOM();
-        expect(helper.findByDataTestId("show-User-John")).toBeInDOM();
+        expect(helper.byTestId("show-User-Bob")).toBeInDOM();
+        expect(helper.byTestId("show-User-John")).toBeInDOM();
 
-        simulateEvent.simulate(helper.findByDataTestId("Close-icon")[0], "click");
-        m.redraw.sync();
+        helper.clickByTestId("Close-icon");
 
-        expect(helper.findByDataTestId("show-User-Bob")).not.toBeInDOM();
-        expect(helper.findByDataTestId("show-User-John")).toBeInDOM();
+        expect(helper.byTestId("show-User-Bob")).toBeFalsy();
+        expect(helper.byTestId("show-User-John")).toBeInDOM();
       });
     });
 
     describe("Roles", () => {
       it("should render role input field", () => {
-        expect(helper.findByDataTestId("Role-permissions")).toBeInDOM();
-        expect(helper.findByDataTestId("Role-permissions")).toContainText("Roles");
-        expect(helper.findByDataTestId("User-input")).toBeInDOM();
+        expect(helper.byTestId("Role-permissions")).toBeInDOM();
+        expect(helper.textByTestId("Role-permissions")).toContain("Roles");
+        expect(helper.byTestId("User-input")).toBeInDOM();
       });
 
       it("should show existing roles on the UI", () => {
@@ -152,23 +141,16 @@ describe("Pipeline Config - Stage Settings Modal - Stage Permissions Tab", () =>
         stageConfig.approval().authorization()!.roles.add("Dev");
         m.redraw.sync();
 
-        expect(helper.findByDataTestId("show-Role-Admin")).toBeInDOM();
-        expect(helper.findByDataTestId("show-Role-Dev")).toBeInDOM();
+        expect(helper.byTestId("show-Role-Admin")).toBeInDOM();
+        expect(helper.byTestId("show-Role-Dev")).toBeInDOM();
       });
 
       it("should allow removing roles", () => {
         const role = "Admin";
         expect(stageConfig.approval().authorization()!.roles.list()).toEqual([]);
 
-        const inputSelector = helper.findByDataTestId("Role-input").find("input");
-        inputSelector.val(role);
-
-        simulateEvent.simulate(inputSelector[0], "input");
-        m.redraw.sync();
-
-        const addBtnSelector = helper.findByDataTestId("Role-input").find("button");
-        simulateEvent.simulate(addBtnSelector[0], "click");
-        m.redraw.sync();
+        helper.oninput("input", role, helper.byTestId("Role-input"));
+        helper.click("button", helper.byTestId("Role-input"));
 
         expect(stageConfig.approval().authorization()!.roles.list()).toEqual([role]);
       });
@@ -178,14 +160,13 @@ describe("Pipeline Config - Stage Settings Modal - Stage Permissions Tab", () =>
         stageConfig.approval().authorization()!.roles.add("Dev");
         m.redraw.sync();
 
-        expect(helper.findByDataTestId("show-Role-Admin")).toBeInDOM();
-        expect(helper.findByDataTestId("show-Role-Dev")).toBeInDOM();
+        expect(helper.byTestId("show-Role-Admin")).toBeInDOM();
+        expect(helper.byTestId("show-Role-Dev")).toBeInDOM();
 
-        simulateEvent.simulate(helper.findByDataTestId("Close-icon")[0], "click");
-        m.redraw.sync();
+        helper.clickByTestId("Close-icon");
 
-        expect(helper.findByDataTestId("show-Role-Admin")).not.toBeInDOM();
-        expect(helper.findByDataTestId("show-Role-Dev")).toBeInDOM();
+        expect(helper.byTestId("show-Role-Admin")).toBeFalsy();
+        expect(helper.byTestId("show-Role-Dev")).toBeInDOM();
       });
     });
   });
@@ -193,4 +174,13 @@ describe("Pipeline Config - Stage Settings Modal - Stage Permissions Tab", () =>
   afterEach(() => {
     helper.unmount();
   });
+
+  function click(id: string) {
+    (helper.byTestId(id) as HTMLElement).click();
+    m.redraw.sync();
+  }
+
+  function checked(id: string) {
+    return (helper.byTestId(id) as HTMLInputElement).checked;
+  }
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/stages/settings/tabs/settings_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipeline_configs/spec/stages/settings/tabs/settings_spec.tsx
@@ -17,7 +17,6 @@
 import m from "mithril";
 import Stream from "mithril/stream";
 import {StageConfig} from "models/new_pipeline_configs/stage_configuration";
-import * as simulateEvent from "simulate-event";
 import {StageSettingsTab} from "views/pages/pipeline_configs/stages/settings/tabs/settings";
 import {TestHelper} from "views/pages/spec/test_helper";
 
@@ -38,10 +37,10 @@ describe("Pipeline Config - Stage Settings Modal - Stage Settings Tab", () => {
   });
 
   it("should render stage name input field", () => {
-    expect(helper.findByDataTestId("form-field-label-stage-name")).toContainText("Stage Name");
-    expect(helper.findByDataTestId("form-field-input-stage-name")).toBeInDOM();
+    expect(helper.byTestId("form-field-label-stage-name")).toContainText("Stage Name");
+    expect(helper.byTestId("form-field-input-stage-name")).toBeInDOM();
 
-    expect((helper.findByDataTestId("form-field-input-stage-name")[0] as HTMLInputElement).value)
+    expect((helper.byTestId("form-field-input-stage-name") as HTMLInputElement).value)
       .toEqual(stageConfig.name());
   });
 
@@ -51,88 +50,87 @@ describe("Pipeline Config - Stage Settings Modal - Stage Settings Tab", () => {
     m.redraw.sync();
 
     expect(stageConfig.name()).toEqual(newStageName);
-    expect((helper.findByDataTestId("form-field-input-stage-name")[0] as HTMLInputElement).value).toEqual(newStageName);
+    expect((helper.byTestId("form-field-input-stage-name") as HTMLInputElement).value).toEqual(newStageName);
   });
 
   it("should update stage name model property when stage name input field is updated", () => {
     const newStageName = "another_new_stage_name";
-    helper.findByDataTestId("form-field-input-stage-name").val(newStageName);
-    simulateEvent.simulate(helper.findByDataTestId("form-field-input-stage-name")[0], "input");
-    m.redraw.sync();
+    (helper.byTestId("form-field-input-stage-name") as HTMLInputElement).value = newStageName;
+    helper.oninput(helper.byTestId("form-field-input-stage-name"), newStageName);
 
     expect(stageConfig.name()).toEqual(newStageName);
-    expect((helper.findByDataTestId("form-field-input-stage-name")[0] as HTMLInputElement).value).toEqual(newStageName);
+    expect((helper.byTestId("form-field-input-stage-name") as HTMLInputElement).value).toEqual(newStageName);
   });
 
   it("should render approval type switch", () => {
-    expect(helper.findByDataTestId("switch-wrapper")).toBeInDOM();
-    expect(helper.findByDataTestId("switch-label")).toContainText("Automatically run this stage on upstream changes:");
-    expect((helper.findByDataTestId("switch-checkbox")[0] as HTMLInputElement).checked).toEqual(true);
+    expect(helper.byTestId("switch-wrapper")).toBeInDOM();
+    expect(helper.textByTestId("switch-label")).toContain("Automatically run this stage on upstream changes:");
+    expect(checked("switch-checkbox")).toBe(true);
   });
 
   it("should allow toggling approval switch", () => {
-    expect(helper.findByDataTestId("switch-wrapper")).toBeInDOM();
+    expect(helper.byTestId("switch-wrapper")).toBeInDOM();
 
     expect(stageConfig.approval().state()).toEqual(true);
-    expect((helper.findByDataTestId("switch-checkbox")[0] as HTMLInputElement).checked).toEqual(true);
+    expect(checked("switch-checkbox")).toBe(true);
 
-    helper.findByDataTestId("switch-checkbox").val("off");
-    simulateEvent.simulate(helper.findByDataTestId("switch-checkbox")[0], "click");
-    m.redraw.sync();
+    click("switch-checkbox");
 
-    expect(stageConfig.approval().state()).toEqual(false);
-    expect((helper.findByDataTestId("switch-checkbox")[0] as HTMLInputElement).checked).toEqual(false);
+    expect(stageConfig.approval().state()).toBe(false);
+    expect(checked("switch-checkbox")).toBe(false);
   });
 
   it("should render fetch materials checkbox", () => {
-    expect(helper.findByDataTestId("form-field-input-fetch-materials")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-label-fetch-materials")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-fetch-materials")).toBeInDOM();
+    expect(helper.byTestId("form-field-label-fetch-materials")).toBeInDOM();
 
-    expect((helper.findByDataTestId("form-field-input-fetch-materials")[0] as HTMLInputElement).checked).toEqual(false);
-    expect(helper.findByDataTestId("form-field-label-fetch-materials")).toContainText("Fetch Materials");
+    expect(checked("form-field-input-fetch-materials")).toBe(false);
+    expect(helper.textByTestId("form-field-label-fetch-materials")).toContain("Fetch Materials");
   });
 
   it("should allow toggling fetch materials checkbox", () => {
-    expect((helper.findByDataTestId("form-field-input-fetch-materials")[0] as HTMLInputElement).checked).toEqual(false);
+    expect(checked("form-field-input-fetch-materials")).toBe(false);
 
-    helper.findByDataTestId("form-field-input-fetch-materials").val("on");
-    simulateEvent.simulate(helper.findByDataTestId("form-field-input-fetch-materials")[0], "click");
-
-    expect((helper.findByDataTestId("form-field-input-fetch-materials")[0] as HTMLInputElement).checked).toEqual(true);
+    click("form-field-input-fetch-materials");
+    expect(checked("form-field-input-fetch-materials")).toBe(true);
   });
 
   it("should render Never Cleanup Artifacts checkbox", () => {
-    expect(helper.findByDataTestId("form-field-input-never-cleanup-artifacts")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-label-never-cleanup-artifacts")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-never-cleanup-artifacts")).toBeInDOM();
+    expect(helper.byTestId("form-field-label-never-cleanup-artifacts")).toBeInDOM();
 
-    expect((helper.findByDataTestId("form-field-input-never-cleanup-artifacts")[0] as HTMLInputElement).checked).toEqual(false);
-    expect(helper.findByDataTestId("form-field-label-never-cleanup-artifacts")).toContainText("Never Cleanup Artifacts");
+    expect(checked("form-field-input-never-cleanup-artifacts")).toBe(false);
+    expect(helper.textByTestId("form-field-label-never-cleanup-artifacts")).toContain("Never Cleanup Artifacts");
   });
 
   it("should allow toggling Never Cleanup Artifacts checkbox", () => {
-    expect((helper.findByDataTestId("form-field-input-never-cleanup-artifacts")[0] as HTMLInputElement).checked).toEqual(false);
+    expect(checked("form-field-input-never-cleanup-artifacts")).toBe(false);
 
-    helper.findByDataTestId("form-field-input-never-cleanup-artifacts").val("on");
-    simulateEvent.simulate(helper.findByDataTestId("form-field-input-never-cleanup-artifacts")[0], "click");
-
-    expect((helper.findByDataTestId("form-field-input-never-cleanup-artifacts")[0] as HTMLInputElement).checked).toEqual(true);
+    click("form-field-input-never-cleanup-artifacts");
+    expect(checked("form-field-input-never-cleanup-artifacts")).toBe(true);
   });
 
   it("should render Clean Working Directory checkbox", () => {
-    expect(helper.findByDataTestId("form-field-input-clean-working-directory")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-label-clean-working-directory")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-clean-working-directory")).toBeInDOM();
+    expect(helper.byTestId("form-field-label-clean-working-directory")).toBeInDOM();
 
-    expect((helper.findByDataTestId("form-field-input-clean-working-directory")[0] as HTMLInputElement).checked).toEqual(false);
-    expect(helper.findByDataTestId("form-field-label-clean-working-directory")).toContainText("Clean Working Directory");
+    expect(checked("form-field-input-clean-working-directory")).toBe(false);
+    expect(helper.textByTestId("form-field-label-clean-working-directory")).toContain("Clean Working Directory");
   });
 
   it("should allow toggling Clean Working Directory checkbox", () => {
-    expect((helper.findByDataTestId("form-field-input-clean-working-directory")[0] as HTMLInputElement).checked).toEqual(false);
+    expect(checked("form-field-input-clean-working-directory")).toBe(false);
 
-    helper.findByDataTestId("form-field-input-clean-working-directory").val("on");
-    simulateEvent.simulate(helper.findByDataTestId("form-field-input-clean-working-directory")[0], "click");
-
-    expect((helper.findByDataTestId("form-field-input-clean-working-directory")[0] as HTMLInputElement).checked).toEqual(true);
+    click("form-field-input-clean-working-directory");
+    expect(checked("form-field-input-clean-working-directory")).toBe(true);
   });
 
+  function click(id: string) {
+    (helper.byTestId(id) as HTMLElement).click();
+    m.redraw.sync();
+  }
+
+  function checked(id: string) {
+    return (helper.byTestId(id) as HTMLInputElement).checked;
+  }
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/environment_variables_editor_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/environment_variables_editor_spec.tsx
@@ -56,20 +56,20 @@ describe("EnvironmentVariablesEditor", () => {
   });
 
   function plainVars(): Element {
-    return helper.find(sel.envVars).get(0);
+    return helper.q(sel.envVars);
   }
 
   function secureVars(): Element {
-    return helper.find(sel.envVars).get(1);
+    return helper.qa(sel.envVars).item(1);
   }
 
   function addVariable(section: Element, name: string, value: string): Element {
     helper.click("button", section);
-    const variable = helper.findIn(section, "table-row").last();
-    const fields = variable.find("input");
-    helper.oninput(fields.get(0), name);
-    helper.oninput(fields.get(1), value);
-    return variable.get(0);
+    const variable = Array.from(helper.allByTestId("table-row", section)).pop()!;
+    const fields = helper.qa("input", variable);
+    helper.oninput(fields.item(0), name);
+    helper.oninput(fields.item(1), value);
+    return variable;
   }
 
   function removeVariable(variable: Element) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/template_editor_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/template_editor_spec.tsx
@@ -45,7 +45,7 @@ describe("AddPipeline: TemplateEditor", () => {
   it("should display flash when no templates are defined", () => {
     helper.mount(() => <TemplateEditor pipelineConfig={config} isUsingTemplate={isUsingTemplate} cache={new EmptyTestCache()} paramList={paramList}/>);
 
-    helper.clickByDataTestId("switch-paddle");
+    helper.clickByTestId("switch-paddle");
     expect(isUsingTemplate()).toBeTruthy();
     const flash = helper.byTestId("flash-message-warning");
     expect(flash).toBeInDOM();
@@ -56,7 +56,7 @@ describe("AddPipeline: TemplateEditor", () => {
     stubGetTemplateWith(new TemplateConfig("one", []));
     helper.mount(() => <TemplateEditor pipelineConfig={config} isUsingTemplate={isUsingTemplate} cache={new TestCache()} paramList={paramList}/>);
 
-    helper.clickByDataTestId("switch-paddle");
+    helper.clickByTestId("switch-paddle");
     expect(isUsingTemplate()).toBeTruthy();
     expect(config.template()).toBe("one");
     expect(TemplateConfig.getTemplate).toHaveBeenCalledTimes(1);
@@ -65,7 +65,7 @@ describe("AddPipeline: TemplateEditor", () => {
     expect(dropdown).toBeInDOM();
     expect(helper.qa("option", dropdown).length).toBe(2);
 
-    helper.clickByDataTestId("switch-paddle");
+    helper.clickByTestId("switch-paddle");
     expect(isUsingTemplate()).toBe(false);
     expect(config.template()).toBeUndefined();
     expect(TemplateConfig.getTemplate).toHaveBeenCalledTimes(1);
@@ -74,7 +74,7 @@ describe("AddPipeline: TemplateEditor", () => {
   it("should not display dropdown and should display flash when cache fails to populate", () => {
     helper.mount(() => <TemplateEditor pipelineConfig={config} isUsingTemplate={isUsingTemplate} cache={new FailedTestCache()} paramList={paramList}/>);
 
-    helper.clickByDataTestId("switch-paddle");
+    helper.clickByTestId("switch-paddle");
     expect(isUsingTemplate()).toBeTruthy();
 
     const flash = helper.byTestId("flash-message-warning");
@@ -94,7 +94,7 @@ describe("AddPipeline: TemplateEditor", () => {
 
     helper.mount(() => <TemplateEditor pipelineConfig={config} isUsingTemplate={isUsingTemplate} cache={new TestCache()} paramList={paramList}/>);
 
-    helper.clickByDataTestId("switch-paddle");
+    helper.clickByTestId("switch-paddle");
     expect(isUsingTemplate()).toBeTruthy();
     expect(TemplateConfig.getTemplate).toHaveBeenCalled();
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/gocd_role_modal_body_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/gocd_role_modal_body_widget_spec.tsx
@@ -16,7 +16,6 @@
 
 import m from "mithril";
 import {GoCDRole, Role} from "models/roles/roles";
-import * as simulateEvent from "simulate-event";
 import {GoCDRoleModalBodyWidget} from "views/pages/roles/role_modal_body_widget";
 import {RolesTestData} from "views/pages/roles/spec/test_data";
 import {TestHelper} from "views/pages/spec/test_helper";
@@ -34,41 +33,39 @@ describe("GoCDRoleModalBodyWidget", () => {
   it("should render view", () => {
     helper.mount(() => <GoCDRoleModalBodyWidget role={gocdRole} isNameDisabled={false}/>);
 
-    expect(helper.findByDataTestId("form-field-input-role-name")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-role-name")).not.toBeDisabled();
-    expect(helper.findByDataTestId("form-field-input-role-name").prop("readonly")).toBeFalsy();
+    expect(helper.byTestId("form-field-input-role-name")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-role-name")).not.toBeDisabled();
+    expect(helper.byTestId("form-field-input-role-name").hasAttribute("readonly")).toBe(false);
 
-    expect(helper.findByDataTestId("form-field-input-role-users")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-role-users")).not.toBeDisabled();
+    expect(helper.byTestId("form-field-input-role-users")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-role-users")).not.toBeDisabled();
 
-    expect(helper.findByDataTestId("role-add-user-button")).toBeInDOM();
-    expect(helper.findByDataTestId("role-add-user-button")).not.toBeDisabled();
+    expect(helper.byTestId("role-add-user-button")).toBeInDOM();
+    expect(helper.byTestId("role-add-user-button")).not.toBeDisabled();
   });
 
   it("should disable role name when isNameDisabled is set to true", () => {
     helper.mount(() => <GoCDRoleModalBodyWidget role={gocdRole} isNameDisabled={true}/>);
 
-    expect(helper.findByDataTestId("form-field-input-role-name")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-role-name").prop("readonly")).toBeTruthy();
+    expect(helper.byTestId("form-field-input-role-name")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-role-name").hasAttribute("readonly")).toBe(true);
 
-    expect(helper.findByDataTestId("form-field-input-role-users")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-role-users")).not.toBeDisabled();
+    expect(helper.byTestId("form-field-input-role-users")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-role-users")).not.toBeDisabled();
 
-    expect(helper.findByDataTestId("role-add-user-button")).toBeInDOM();
-    expect(helper.findByDataTestId("role-add-user-button")).not.toBeDisabled();
+    expect(helper.byTestId("role-add-user-button")).toBeInDOM();
+    expect(helper.byTestId("role-add-user-button")).not.toBeDisabled();
   });
 
   it("should add user when add user button is clicked", () => {
     helper.mount(() => <GoCDRoleModalBodyWidget role={gocdRole} isNameDisabled={false}/>);
 
-    expect(gocdRole.attributes().hasUser("John")).toBeFalsy();
+    expect(gocdRole.attributes().hasUser("John")).toBe(false);
 
-    helper.findByDataTestId("form-field-input-role-users").val("John");
-    simulateEvent.simulate(helper.findByDataTestId("form-field-input-role-users").get(0), "input");
-    helper.findByDataTestId("role-add-user-button").click();
-    m.redraw.sync();
+    helper.oninput(helper.byTestId("form-field-input-role-users"), "John");
+    helper.clickByTestId("role-add-user-button");
 
-    expect(gocdRole.attributes().hasUser("John")).toBeTruthy();
+    expect(gocdRole.attributes().hasUser("John")).toBe(true);
   });
 
   it("should delete user when delete icon on user's tag is clicked", () => {
@@ -76,8 +73,7 @@ describe("GoCDRoleModalBodyWidget", () => {
 
     expect(gocdRole.attributes().users.length).toEqual(3);
 
-    simulateEvent.simulate(helper.find(`.${styles.roleUserDeleteIcon}`).get(0), "click");
-    m.redraw.sync();
+    helper.click(`.${styles.roleUserDeleteIcon}`);
 
     expect(gocdRole.attributes().users.length).toEqual(2);
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/plugin_role_modal_body_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/plugin_role_modal_body_widget_spec.tsx
@@ -20,7 +20,6 @@ import {TestData} from "models/auth_configs/spec/test_data";
 import {Role} from "models/roles/roles";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {AuthorizationPluginInfo} from "models/shared/plugin_infos_new/spec/test_data";
-import * as simulateEvent from "simulate-event";
 import {PluginRoleModalBodyWidget} from "views/pages/roles/role_modal_body_widget";
 import {RolesTestData} from "views/pages/roles/spec/test_data";
 import {TestHelper} from "views/pages/spec/test_helper";
@@ -41,33 +40,29 @@ describe("PluginRoleModalBodyWidget", () => {
   it("should render plugin role view", () => {
     mount();
 
-    expect(helper.findByDataTestId("form-field-input-role-name")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-role-name").prop("readonly")).toBeFalsy();
+    expect(helper.byTestId("form-field-input-role-name")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-role-name").hasAttribute("readonly")).toBe(false);
 
-    expect(helper.findByDataTestId("form-field-input-auth-config-id")).toBeInDOM();
-    expect(helper.find(".plugin-view")).toBeInDOM();
-    expect(helper.find(".plugin-view")).toContainText("This is ldap role config view.");
+    expect(helper.byTestId("form-field-input-auth-config-id")).toBeInDOM();
+    expect(helper.q(".plugin-view")).toBeInDOM();
+    expect(helper.text(".plugin-view")).toContain("This is ldap role config view.");
   });
 
   it("should disable role name when isNameDisabled is set to true", () => {
     mount(true);
 
-    expect(helper.findByDataTestId("form-field-input-role-name")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-role-name").prop("readonly")).toBeTruthy();
+    expect(helper.byTestId("form-field-input-role-name")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-role-name").hasAttribute("readonly")).toBe(true);
   });
 
   it("should change role view on change of auth config id", () => {
     mount();
 
-    expect(helper.find(".plugin-view")).toContainText("This is ldap role config view.");
+    expect(helper.text(".plugin-view")).toContain("This is ldap role config view.");
 
-    const authConfigDropDown = helper.findByDataTestId("form-field-input-auth-config-id");
-    authConfigDropDown.val("github");
-    simulateEvent.simulate(authConfigDropDown.get(0), "change");
-    //Had to do this as m.redraw.sync() was't working :(
-    m.redraw.sync();
+    helper.onchange(helper.byTestId("form-field-input-auth-config-id"), "github");
 
-    expect(helper.find(".plugin-view")).toContainText("This is github role config view.");
+    expect(helper.text(".plugin-view")).toContain("This is github role config view.");
   });
 
   function mount(isNameDisabled = false) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/role_modal_body_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/role_modal_body_spec.tsx
@@ -21,7 +21,6 @@ import {TestData} from "models/auth_configs/spec/test_data";
 import {Role, RoleType} from "models/roles/roles";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {AuthorizationPluginInfo} from "models/shared/plugin_infos_new/spec/test_data";
-import * as simulateEvent from "simulate-event";
 import {Action, RoleModalBody} from "views/pages/roles/role_modal_body";
 import {RolesTestData} from "views/pages/roles/spec/test_data";
 import {TestHelper} from "views/pages/spec/test_helper";
@@ -43,7 +42,7 @@ describe("RoleModalBody", () => {
                                         authConfigs={authConfigs}
                                         action={Action.NEW}
                                         changeRoleType={changeRoleType}/>);
-      expect(helper.findByDataTestId("flash-message-alert").text()).toEqual("Something went wrong contact your admin!!!");
+      expect(helper.textByTestId("flash-message-alert")).toBe("Something went wrong contact your admin!!!");
     });
 
     it("should not show error message when one is not present", () => {
@@ -53,7 +52,7 @@ describe("RoleModalBody", () => {
                                         action={Action.NEW}
                                         changeRoleType={changeRoleType}/>);
 
-      expect(helper.findByDataTestId("flash-message-alert").get(0)).not.toBeInDOM();
+      expect(helper.byTestId("flash-message-alert")).toBeFalsy();
     });
   });
 
@@ -65,7 +64,7 @@ describe("RoleModalBody", () => {
                                         authConfigs={authConfigs}
                                         changeRoleType={changeRoleType}/>);
 
-      expect(helper.findByDataTestId("role-type-selector").get(0)).toBeInDOM();
+      expect(helper.byTestId("role-type-selector")).toBeInDOM();
     });
 
     it("should not show role type selector for clone action", () => {
@@ -75,7 +74,7 @@ describe("RoleModalBody", () => {
                                         action={Action.CLONE}
                                         changeRoleType={changeRoleType}/>);
 
-      expect(helper.findByDataTestId("role-type-selector").get(0)).not.toBeInDOM();
+      expect(helper.byTestId("role-type-selector")).toBeFalsy();
     });
 
     it("should not show role type selector for edit action", () => {
@@ -85,7 +84,7 @@ describe("RoleModalBody", () => {
                                         action={Action.EDIT}
                                         changeRoleType={changeRoleType}/>);
 
-      expect(helper.findByDataTestId("role-type-selector").get(0)).not.toBeInDOM();
+      expect(helper.byTestId("role-type-selector")).toBeFalsy();
     });
 
   });
@@ -97,8 +96,8 @@ describe("RoleModalBody", () => {
                                         pluginInfos={pluginInfos}
                                         authConfigs={new AuthConfigs()}
                                         changeRoleType={changeRoleType}/>);
-      expect(helper.find("#plugin-role").get(0)).toBeInDOM();
-      expect(helper.find("#plugin-role").get(0)).toBeDisabled();
+      expect(helper.q("#plugin-role")).toBeInDOM();
+      expect(helper.q("#plugin-role")).toBeDisabled();
     });
 
     it("should enable when auth configs are defined", () => {
@@ -107,8 +106,8 @@ describe("RoleModalBody", () => {
                                         pluginInfos={pluginInfos}
                                         authConfigs={authConfigs}
                                         changeRoleType={changeRoleType}/>);
-      expect(helper.find("#plugin-role").get(0)).toBeInDOM();
-      expect(helper.find("#plugin-role").get(0)).not.toBeDisabled();
+      expect(helper.q("#plugin-role")).toBeInDOM();
+      expect(helper.q("#plugin-role")).not.toBeDisabled();
     });
 
   });
@@ -121,13 +120,13 @@ describe("RoleModalBody", () => {
                                         authConfigs={authConfigs}
                                         changeRoleType={changeRoleType}/>);
 
-      expect(helper.find("#plugin-role").get(0)).toBeInDOM();
-      expect(helper.find("#plugin-role").get(0)).not.toBeDisabled();
+      expect(helper.q("#plugin-role")).toBeInDOM();
+      expect(helper.q("#plugin-role")).not.toBeDisabled();
 
-      simulateEvent.simulate(helper.find("#plugin-role").get(0), "click");
+      helper.click("#plugin-role");
       expect(changeRoleType).toHaveBeenCalledWith(RoleType.plugin, jasmine.any(Event));
 
-      simulateEvent.simulate(helper.find("#core-role").get(0), "click");
+      helper.click("#core-role");
       expect(changeRoleType).toHaveBeenCalledWith(RoleType.gocd, jasmine.any(Event));
     });
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/roles_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/roles_widget_spec.tsx
@@ -19,7 +19,6 @@ import {TestData} from "models/auth_configs/spec/test_data";
 import {GoCDRole, PluginRole, Role, Roles} from "models/roles/roles";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {AuthorizationPluginInfo} from "models/shared/plugin_infos_new/spec/test_data";
-import * as simulateEvent from "simulate-event";
 import s from "underscore.string";
 import {RolesWidget} from "views/pages/roles/roles_widget";
 import {RolesTestData} from "views/pages/roles/spec/test_data";
@@ -51,64 +50,62 @@ describe("RolesWidgetSpec", () => {
   it("should show that no user is present and action buttons for gocd role with no users", () => {
     mount(new Roles(Role.fromJSON(RolesTestData.EmptyGoCDRoleJSON())), authConfigs, pluginInfos);
 
-    expect(helper.findByDataTestId("key-value-key-name")).toContainText("Name");
-    expect(helper.findByDataTestId("key-value-value-name").get(0)).toContainText("spacetiger");
-    expect(helper.findByDataTestId("no-users-message").text()).toBe("No users in this role.");
-    expect(helper.findByDataTestId("role-edit")).toBeInDOM();
-    expect(helper.findByDataTestId("role-clone")).toBeInDOM();
-    expect(helper.findByDataTestId("role-delete")).toBeInDOM();
+    expect(helper.textByTestId("key-value-key-name")).toContain("Name");
+    expect(helper.textByTestId("key-value-value-name")).toContain("spacetiger");
+    expect(helper.textByTestId("no-users-message")).toBe("No users in this role.");
+    expect(helper.byTestId("role-edit")).toBeInDOM();
+    expect(helper.byTestId("role-clone")).toBeInDOM();
+    expect(helper.byTestId("role-delete")).toBeInDOM();
 
-    expect(helper.findByDataTestId("role-edit")).not.toBeDisabled();
-    expect(helper.findByDataTestId("role-clone")).not.toBeDisabled();
-    expect(helper.findByDataTestId("role-delete")).not.toBeDisabled();
+    expect(helper.byTestId("role-edit")).not.toBeDisabled();
+    expect(helper.byTestId("role-clone")).not.toBeDisabled();
+    expect(helper.byTestId("role-delete")).not.toBeDisabled();
   });
 
   it("should render user info and action buttons for gocd role", () => {
     mount(new Roles(Role.fromJSON(RolesTestData.GoCDRoleJSON())), authConfigs, pluginInfos);
 
-    expect(helper.findByDataTestId("key-value-key-name")).toContainText("Name");
-    expect(helper.findByDataTestId("key-value-value-name").get(0)).toContainText("spacetiger");
-    expect(helper.findByDataTestId("collapse-body").get(0)).toContainText("alice");
-    expect(helper.findByDataTestId("collapse-body").get(0)).toContainText("bob");
-    expect(helper.findByDataTestId("collapse-body").get(0)).toContainText("robin");
-    expect(helper.findByDataTestId("role-edit")).toBeInDOM();
-    expect(helper.findByDataTestId("role-clone")).toBeInDOM();
-    expect(helper.findByDataTestId("role-delete")).toBeInDOM();
+    expect(helper.textByTestId("key-value-key-name")).toContain("Name");
+    expect(helper.textByTestId("key-value-value-name")).toContain("spacetiger");
+    expect(helper.textByTestId("collapse-body")).toContain("alice");
+    expect(helper.textByTestId("collapse-body")).toContain("bob");
+    expect(helper.textByTestId("collapse-body")).toContain("robin");
+    expect(helper.byTestId("role-edit")).toBeInDOM();
+    expect(helper.byTestId("role-clone")).toBeInDOM();
+    expect(helper.byTestId("role-delete")).toBeInDOM();
 
-    expect(helper.findByDataTestId("role-edit")).not.toBeDisabled();
-    expect(helper.findByDataTestId("role-clone")).not.toBeDisabled();
-    expect(helper.findByDataTestId("role-delete")).not.toBeDisabled();
+    expect(helper.byTestId("role-edit")).not.toBeDisabled();
+    expect(helper.byTestId("role-clone")).not.toBeDisabled();
+    expect(helper.byTestId("role-delete")).not.toBeDisabled();
   });
 
   it("should render user info and action buttons for plugin role", () => {
     mount(new Roles(Role.fromJSON(RolesTestData.LdapPluginRoleJSON())), authConfigs, pluginInfos);
 
-    expect(helper.findByDataTestId("key-value-key-name")).toContainText("Name");
-    expect(helper.findByDataTestId("key-value-value-name").get(0)).toContainText("blackbird");
-    expect(helper.findByDataTestId("key-value-key-auth-config-id")).toContainText("Auth Config Id");
-    expect(helper.findByDataTestId("key-value-value-auth-config-id")).toContainText("ldap");
-    expect(helper.findByDataTestId("key-value-key-plugin")).toContainText("Plugin");
-    expect(helper.findByDataTestId("key-value-value-plugin")).toContainText("LDAP Authorization Plugin for GoCD");
-    expect(helper.findByDataTestId("key-value-key-usergroupmembershipattribute"))
-      .toContainText("UserGroupMembershipAttribute");
-    expect(helper.findByDataTestId("key-value-value-usergroupmembershipattribute")).toContainText("memberOf");
-    expect(helper.findByDataTestId("key-value-key-groupidentifiers")).toContainText("GroupIdentifiers");
-    expect(helper.findByDataTestId("key-value-value-groupidentifiers"))
-      .toContainText("ou=admins,ou=groups,ou=system,dc=example,dc=com");
+    expect(helper.textByTestId("key-value-key-name")).toContain("Name");
+    expect(helper.textByTestId("key-value-value-name")).toContain("blackbird");
+    expect(helper.textByTestId("key-value-key-auth-config-id")).toContain("Auth Config Id");
+    expect(helper.textByTestId("key-value-value-auth-config-id")).toContain("ldap");
+    expect(helper.textByTestId("key-value-key-plugin")).toContain("Plugin");
+    expect(helper.textByTestId("key-value-value-plugin")).toContain("LDAP Authorization Plugin for GoCD");
+    expect(helper.textByTestId("key-value-key-usergroupmembershipattribute")).toContain("UserGroupMembershipAttribute");
+    expect(helper.textByTestId("key-value-value-usergroupmembershipattribute")).toContain("memberOf");
+    expect(helper.textByTestId("key-value-key-groupidentifiers")).toContain("GroupIdentifiers");
+    expect(helper.textByTestId("key-value-value-groupidentifiers")).toContain("ou=admins,ou=groups,ou=system,dc=example,dc=com");
 
-    expect(helper.findByDataTestId("role-edit")).toBeInDOM();
-    expect(helper.findByDataTestId("role-clone")).toBeInDOM();
-    expect(helper.findByDataTestId("role-delete")).toBeInDOM();
+    expect(helper.byTestId("role-edit")).toBeInDOM();
+    expect(helper.byTestId("role-clone")).toBeInDOM();
+    expect(helper.byTestId("role-delete")).toBeInDOM();
 
-    expect(helper.findByDataTestId("role-edit")).not.toBeDisabled();
-    expect(helper.findByDataTestId("role-clone")).not.toBeDisabled();
-    expect(helper.findByDataTestId("role-delete")).not.toBeDisabled();
+    expect(helper.byTestId("role-edit")).not.toBeDisabled();
+    expect(helper.byTestId("role-clone")).not.toBeDisabled();
+    expect(helper.byTestId("role-delete")).not.toBeDisabled();
   });
 
   it("should callback the edit function when edit button is clicked", () => {
     mount(roles, authConfigs, pluginInfos);
 
-    simulateEvent.simulate(helper.findByDataTestId("role-edit").get(0), "click");
+    helper.clickByTestId("role-edit");
 
     expect(onEdit).toHaveBeenCalledWith(roles[0], jasmine.any(Event));
   });
@@ -116,7 +113,7 @@ describe("RolesWidgetSpec", () => {
   it("should callback the clone function when clone button is clicked", () => {
     mount(roles, authConfigs, pluginInfos);
 
-    simulateEvent.simulate(helper.findByDataTestId("role-clone").get(0), "click");
+    helper.clickByTestId("role-clone");
 
     expect(onClone).toHaveBeenCalledWith(roles[0], jasmine.any(Event));
   });
@@ -124,16 +121,16 @@ describe("RolesWidgetSpec", () => {
   it("should callback the delete function when delete button is clicked", () => {
     mount(roles, authConfigs, pluginInfos);
 
-    simulateEvent.simulate(helper.findByDataTestId("role-delete").get(0), "click");
+    helper.clickByTestId("role-delete");
 
     expect(onDelete).toHaveBeenCalledWith(roles[0], jasmine.any(Event));
   });
 
   it("should disable edit & clone button when no authorization plugin installed.", () => {
     mount(new Roles(Role.fromJSON(RolesTestData.LdapPluginRoleJSON())), authConfigs, new PluginInfos());
-    expect(helper.findByDataTestId("role-edit")).toBeDisabled();
-    expect(helper.findByDataTestId("role-clone")).toBeDisabled();
-    expect(helper.findByDataTestId("role-delete")).not.toBeDisabled();
+    expect(helper.byTestId("role-edit")).toBeDisabled();
+    expect(helper.byTestId("role-clone")).toBeDisabled();
+    expect(helper.byTestId("role-delete")).not.toBeDisabled();
   });
 
   it("should only disable edit & clone button of auth config for which plugin is not installed", () => {
@@ -144,14 +141,14 @@ describe("RolesWidgetSpec", () => {
     const ldapRole   = Role.fromJSON(RolesTestData.LdapPluginRoleJSON());
     mount(new Roles(githubRole, ldapRole), authConfigs, pluginInfos);
 
-    const ldapRolePanel = helper.findByDataTestId(`role-${s.slugify(ldapRole.name())}`);
-    expect(helper.findIn(ldapRolePanel, "role-edit")).not.toBeDisabled();
-    expect(helper.findIn(ldapRolePanel, "role-clone")).not.toBeDisabled();
-    expect(helper.findIn(ldapRolePanel, "role-delete")).not.toBeDisabled();
+    const ldapRolePanel = helper.byTestId(`role-${s.slugify(ldapRole.name())}`);
+    expect(helper.byTestId("role-edit", ldapRolePanel)).not.toBeDisabled();
+    expect(helper.byTestId("role-clone", ldapRolePanel)).not.toBeDisabled();
+    expect(helper.byTestId("role-delete", ldapRolePanel)).not.toBeDisabled();
 
-    const githubRolePanel = helper.findByDataTestId(`role-${s.slugify(githubRole.name())}`);
-    expect(helper.findIn(githubRolePanel, "role-edit")).toBeDisabled();
-    expect(helper.findIn(githubRolePanel, "role-clone")).toBeDisabled();
-    expect(helper.findIn(githubRolePanel, "role-delete")).not.toBeDisabled();
+    const githubRolePanel = helper.byTestId(`role-${s.slugify(githubRole.name())}`);
+    expect(helper.byTestId("role-edit", githubRolePanel)).toBeDisabled();
+    expect(helper.byTestId("role-clone", githubRolePanel)).toBeDisabled();
+    expect(helper.byTestId("role-delete", githubRolePanel)).not.toBeDisabled();
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/spec/modals_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/spec/modals_spec.tsx
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-import m from "mithril";
 import Stream from "mithril/stream";
 import {SecretConfig, SecretConfigs} from "models/secret_configs/secret_configs";
 import {secretConfigsTestData, secretConfigTestData} from "models/secret_configs/spec/test_data";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {SecretPluginInfo} from "models/shared/plugin_infos_new/spec/test_data";
-import * as simulateEvent from "simulate-event";
 import {TestSecretConfigModal} from "views/pages/secret_configs/spec/test_modal";
 import {TestHelper} from "views/pages/spec/test_helper";
 
@@ -39,14 +37,13 @@ describe("SecretConfigModal", () => {
     helper.mount(modal.body.bind(modal));
 
     expect(modal.title()).toEqual("Modal title for Secret Configuration");
-    expect(helper.findByDataTestId("form-field-label-id")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-label-plugin")).toBeInDOM();
+    expect(helper.byTestId("form-field-label-id")).toBeInDOM();
+    expect(helper.byTestId("form-field-label-plugin")).toBeInDOM();
 
-    expect(helper.findByDataTestId("form-field-input-plugin")).toBeInDOM();
-    expect(helper.findByDataTestId("form-field-input-plugin").get(0).children[0])
-      .toContainText("File based secrets plugin");
+    expect(helper.byTestId("form-field-input-plugin")).toBeInDOM();
+    expect(helper.byTestId("form-field-input-plugin").children[0]).toContainText("File based secrets plugin");
 
-    expect(helper.findByDataTestId("rules-widget")).toBeInDOM();
+    expect(helper.byTestId("rules-widget")).toBeInDOM();
     helper.unmount();
   });
 
@@ -58,8 +55,8 @@ describe("SecretConfigModal", () => {
     modal.setErrorMessageForTest("some error message");
     helper.mount(modal.body.bind(modal));
 
-    expect(helper.findByDataTestId("flash-message-alert")).toBeInDOM();
-    expect(helper.findByDataTestId("flash-message-alert")).toContainText("some error message");
+    expect(helper.byTestId("flash-message-alert")).toBeInDOM();
+    expect(helper.textByTestId("flash-message-alert")).toContain("some error message");
 
     helper.unmount();
   });
@@ -73,7 +70,7 @@ describe("SecretConfigModal", () => {
                                             onSuccessfulSave);
     helper.mount(modal.body.bind(modal));
 
-    expect(helper.findByDataTestId("form-field-input-id").parent()).toContainText("should be unique");
+    expect(helper.byTestId("form-field-input-id").parentElement).toContainText("should be unique");
 
     helper.unmount();
   });
@@ -86,7 +83,7 @@ describe("SecretConfigModal", () => {
                                               onSuccessfulSave, resourceHelper, true);
       helper.mount(modal.body.bind(modal));
 
-      expect(helper.findByDataTestId("form-field-input-id")).toBeDisabled();
+      expect(helper.byTestId("form-field-input-id")).toBeDisabled();
 
       helper.unmount();
     });
@@ -100,8 +97,8 @@ describe("SecretConfigModal", () => {
                                               onSuccessfulSave);
       helper.mount(modal.body.bind(modal));
 
-      expect(helper.findByDataTestId("form-field-input-id")).toBeInDOM();
-      expect(helper.findByDataTestId("form-field-input-id")).not.toBeDisabled();
+      expect(helper.byTestId("form-field-input-id")).toBeInDOM();
+      expect(helper.byTestId("form-field-input-id")).not.toBeDisabled();
 
       helper.unmount();
     });
@@ -113,13 +110,11 @@ describe("SecretConfigModal", () => {
                                               onSuccessfulSave);
       helper.mount(modal.body.bind(modal));
 
-      expect(helper.findByDataTestId("table-body").find("tr").length).toBe(2);
+      expect(helper.qa("tr", helper.byTestId("table-body")).length).toBe(2);
 
-      const addRuleButton = helper.findByDataTestId("add-rule-button")[0];
-      simulateEvent.simulate(addRuleButton, "click");
-      m.redraw.sync();
+      helper.clickByTestId("add-rule-button");
 
-      expect(helper.findByDataTestId("table-body").find("tr").length).toBe(3);
+      expect(helper.qa("tr", helper.byTestId("table-body")).length).toBe(3);
 
       helper.unmount();
     });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/spec/rules_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/spec/rules_widget_spec.tsx
@@ -18,7 +18,6 @@ import m from "mithril";
 import Stream from "mithril/stream";
 import {Rule, Rules} from "models/secret_configs/rules";
 import {rulesTestData, ruleTestData} from "models/secret_configs/spec/test_data";
-import * as simulateEvent from "simulate-event";
 import {RulesWidget} from "views/pages/secret_configs/rules_widget";
 import {TestHelper} from "views/pages/spec/test_helper";
 
@@ -29,9 +28,9 @@ describe("RulesWidget", () => {
   it("should show info for rules", () => {
     const rules = new Rules();
     mount(rules);
-    expect(helper.findByDataTestId("flash-message-info")).toBeInDOM();
+    expect(helper.byTestId("flash-message-info")).toBeInDOM();
     const infoAboutRules = "The default rule is to deny access to this secret configuration for all GoCD entities. Configure rules below to override that behavior.";
-    expect(helper.findByDataTestId("flash-message-info")).toContainText(infoAboutRules);
+    expect(helper.textByTestId("flash-message-info")).toContain(infoAboutRules);
   });
 
   it("should show rule if it is present", () => {
@@ -40,24 +39,24 @@ describe("RulesWidget", () => {
 
     mount(rules);
 
-    const tableBody   = helper.findByDataTestId("table-body");
-    const tableRow    = tableBody.find("tr");
-    const tableHeader = helper.findByDataTestId("table-header");
+    const tableBody   = helper.byTestId("table-body");
+    const tableRow    = helper.q("tr", tableBody);
+    const tableHeader = helper.byTestId("table-header");
 
-    expect(helper.findByDataTestId("rules-table")).toBeInDOM();
+    expect(helper.byTestId("rules-table")).toBeInDOM();
     expect(tableHeader).toBeInDOM();
-    expect(tableHeader.find("th").length).toBe(5);
-    expect(tableHeader.eq(0)).toContainText("Directive");
-    expect(tableHeader.eq(0)).toContainText("Type");
-    expect(tableHeader.eq(0)).toContainText("Resources");
+    expect(helper.qa("th", tableHeader).length).toBe(5);
+    expect(tableHeader).toContainText("Directive");
+    expect(tableHeader).toContainText("Type");
+    expect(tableHeader).toContainText("Resources");
 
     expect(tableBody).toBeInDOM();
 
-    expect(tableRow.find("td").length).toBe(5);
-    expect(helper.findByDataTestId("rule-directive").get(0)).toHaveValue("allow");
-    expect(helper.findByDataTestId("rule-directive").get(0)).toContainText("DenyAllow");
-    expect(helper.findByDataTestId("rule-type").get(0)).toHaveValue("pipeline_group");
-    expect(helper.findByDataTestId("rule-resource").get(0)).toHaveValue("DeployPipelines");
+    expect(helper.qa("td", tableRow).length).toBe(5);
+    expect(helper.byTestId("rule-directive")).toHaveValue("allow");
+    expect(helper.textByTestId("rule-directive")).toContain("DenyAllow");
+    expect(helper.byTestId("rule-type")).toHaveValue("pipeline_group");
+    expect(helper.byTestId("rule-resource")).toHaveValue("DeployPipelines");
 
   });
 
@@ -65,7 +64,7 @@ describe("RulesWidget", () => {
     const rulesJSON = rulesTestData();
     const rules     = Rules.fromJSON(rulesJSON);
     mount(rules);
-    expect(helper.findByDataTestId("table-body").find("tr").length).toBe(2);
+    expect(helper.qa("tr", helper.byTestId("table-body")).length).toBe(2);
   });
 
   it("should callback the remove function and remove rule when cancel button is clicked", () => {
@@ -75,9 +74,7 @@ describe("RulesWidget", () => {
 
     expect(rules.length).toBe(2);
 
-    const tableBody        = helper.findByDataTestId("table-body");
-    const deleteRuleButton = helper.findIn(tableBody, "rule-delete")[0];
-    simulateEvent.simulate(deleteRuleButton, "click");
+    helper.clickByTestId("rule-delete", helper.byTestId("table-body"));
     expect(rules.length).toBe(1);
   });
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/spec/secret_configs_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/spec/secret_configs_widget_spec.tsx
@@ -20,7 +20,6 @@ import {SecretConfigs} from "models/secret_configs/secret_configs";
 import {secretConfigsTestData} from "models/secret_configs/spec/test_data";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {SecretPluginInfo} from "models/shared/plugin_infos_new/spec/test_data";
-import * as simulateEvent from "simulate-event";
 import {SecretConfigsWidget} from "views/pages/secret_configs/secret_configs_widget";
 import {TestHelper} from "views/pages/spec/test_helper";
 
@@ -38,115 +37,112 @@ describe("SecretConfigsWidget", () => {
   it("should show flash message when no secret plugin installed", () => {
     mount([], new PluginInfos());
 
-    expect(helper.findByDataTestId("flash-message-info")).toBeInDOM();
-    expect(helper.findByDataTestId("flash-message-info").text()).toEqual("No secret plugin installed.");
+    expect(helper.byTestId("flash-message-info")).toBeInDOM();
+    expect(helper.textByTestId("flash-message-info")).toBe("No secret plugin installed.");
   });
 
   it("should render action buttons", () => {
     mount(secretConfigs, pluginInfos);
 
-    const groups = helper.findByDataTestId("secret-configs-group");
-    expect(helper.findIn(groups.eq(0), "secret-config-edit")).toBeInDOM();
-    expect(helper.findIn(groups.eq(0), "secret-config-clone")).toBeInDOM();
-    expect(helper.findIn(groups.eq(0), "secret-config-delete")).toBeInDOM();
-    expect(helper.findIn(groups.eq(0), "secret-config-edit")).not.toBeDisabled();
-    expect(helper.findIn(groups.eq(0), "secret-config-clone")).not.toBeDisabled();
-    expect(helper.findIn(groups.eq(0), "secret-config-delete")).not.toBeDisabled();
+    const groups = helper.byTestId("secret-configs-group");
+    expect(helper.byTestId("secret-config-edit", groups)).toBeInDOM();
+    expect(helper.byTestId("secret-config-clone", groups)).toBeInDOM();
+    expect(helper.byTestId("secret-config-delete", groups)).toBeInDOM();
+    expect(helper.byTestId("secret-config-edit", groups)).not.toBeDisabled();
+    expect(helper.byTestId("secret-config-clone", groups)).not.toBeDisabled();
+    expect(helper.byTestId("secret-config-delete", groups)).not.toBeDisabled();
   });
 
   it("should disable edit and clone button when plugin is not installed", () => {
     mount(secretConfigs, new PluginInfos());
-    const groups = helper.findByDataTestId("secret-configs-group");
 
-    expect(helper.findIn(groups.eq(0), "secret-config-edit")).toBeInDOM();
-    expect(helper.findIn(groups.eq(0), "secret-config-clone")).toBeInDOM();
-    expect(helper.findIn(groups.eq(0), "secret-config-delete")).toBeInDOM();
-    expect(helper.findIn(groups.eq(0), "secret-config-edit")).toBeDisabled();
-    expect(helper.findIn(groups.eq(0), "secret-config-clone")).toBeDisabled();
-    expect(helper.findIn(groups.eq(0), "secret-config-delete")).not.toBeDisabled();
+    const groups = helper.byTestId("secret-configs-group");
+    expect(helper.byTestId("secret-config-edit", groups)).toBeInDOM();
+    expect(helper.byTestId("secret-config-clone", groups)).toBeInDOM();
+    expect(helper.byTestId("secret-config-delete", groups)).toBeInDOM();
+    expect(helper.byTestId("secret-config-edit", groups)).toBeDisabled();
+    expect(helper.byTestId("secret-config-clone", groups)).toBeDisabled();
+    expect(helper.byTestId("secret-config-delete", groups)).not.toBeDisabled();
   });
 
   it("should render secret config properties", () => {
     mount(secretConfigs, pluginInfos);
 
-    const groups = helper.findByDataTestId("secret-configs-group");
+    const groups = helper.byTestId("secret-configs-group");
 
-    expect(helper.findIn(groups.eq(0), "key-value-key-secrets-file-path")).toContainText("secrets_file_path");
-    expect(helper.findIn(groups.eq(0), "key-value-value-secrets-file-path")).toContainText("/home/secret/secret.dat");
+    expect(helper.textByTestId("key-value-key-secrets-file-path", groups)).toContain("secrets_file_path");
+    expect(helper.textByTestId("key-value-value-secrets-file-path", groups)).toContain("/home/secret/secret.dat");
 
-    expect(helper.findIn(groups.eq(0), "key-value-key-cipher-file-path")).toContainText("cipher_file_path");
-    expect(helper.findIn(groups.eq(0), "key-value-value-cipher-file-path"))
-      .toContainText("/home/secret/secret-key.aes");
+    expect(helper.textByTestId("key-value-key-cipher-file-path", groups)).toContain("cipher_file_path");
+    expect(helper.textByTestId("key-value-value-cipher-file-path", groups)).toContain("/home/secret/secret-key.aes");
 
-    expect(helper.findIn(groups.eq(0), "key-value-key-secret-password")).toContainText("secret_password");
-    expect(helper.findIn(groups.eq(0), "key-value-value-secret-password")).toContainText("********");
+    expect(helper.textByTestId("key-value-key-secret-password", groups)).toContain("secret_password");
+    expect(helper.textByTestId("key-value-value-secret-password", groups)).toContain("********");
   });
 
   it("should callback the edit function when edit button is clicked", () => {
     mount(secretConfigs, pluginInfos);
-    const groups = helper.findByDataTestId("secret-configs-group");
-    simulateEvent.simulate(helper.findIn(groups.eq(0), "secret-config-edit").get(0), "click");
+    const groups = helper.byTestId("secret-configs-group");
+    helper.clickByTestId("secret-config-edit", groups);
 
     expect(onEdit).toHaveBeenCalledWith(secretConfigs[0](), jasmine.any(Event));
   });
 
   it("should callback the clone function when clone button is clicked", () => {
     mount(secretConfigs, pluginInfos);
-    const groups = helper.findByDataTestId("secret-configs-group");
-    simulateEvent.simulate(helper.findIn(groups.eq(0), "secret-config-clone").get(0), "click");
+    const groups = helper.byTestId("secret-configs-group");
+    helper.clickByTestId("secret-config-clone", groups);
 
     expect(onClone).toHaveBeenCalledWith(secretConfigs[0](), jasmine.any(Event));
   });
 
   it("should callback the delete function when delete button is clicked", () => {
     mount(secretConfigs, pluginInfos);
-    const groups = helper.findByDataTestId("secret-configs-group");
-    simulateEvent.simulate(helper.findIn(groups.eq(0), "secret-config-delete").get(0), "click");
+    const groups = helper.byTestId("secret-configs-group");
+    helper.clickByTestId("secret-config-delete", groups);
 
     expect(onDelete).toHaveBeenCalledWith(secretConfigs[0](), jasmine.any(Event));
   });
 
   it("should list secret configs", () => {
     mount(secretConfigs, pluginInfos);
-    const groups = helper.findByDataTestId("secret-configs-group");
+    const groups = helper.allByTestId("secret-configs-group");
 
-    expect(groups.length).toEqual(2);
-    expect(helper.findByDataTestId("secret-config-description").eq(0).text())
-      .toEqual("This is used to lookup for secrets for the team X.");
-    expect(helper.findIn(groups.eq(0), "key-value-value-plugin-id").text()).toEqual("cd.go.secrets.file");
-    expect(helper.findIn(groups.eq(0), "key-value-value-id").text()).toEqual("file");
-    expect(helper.findIn(groups.eq(1), "key-value-value-plugin-id").text()).toBe("cd.go.secrets.aws");
-    expect(helper.findIn(groups.eq(1), "key-value-value-id").text()).toEqual("aws");
+    expect(groups.length).toBe(2);
+    expect(helper.textByTestId("secret-config-description")).toBe("This is used to lookup for secrets for the team X.");
+    expect(helper.textByTestId("key-value-value-plugin-id", groups.item(0))).toBe("cd.go.secrets.file");
+    expect(helper.textByTestId("key-value-value-id", groups.item(0))).toBe("file");
+    expect(helper.textByTestId("key-value-value-plugin-id", groups.item(1))).toBe("cd.go.secrets.aws");
+    expect(helper.textByTestId("key-value-value-id", groups.item(1))).toBe("aws");
 
   });
 
   it("should list rules information for secrets", () => {
     mount(secretConfigs, pluginInfos);
-    const table = helper.findByDataTestId("rule-table").eq(0);
+    const table = helper.byTestId("rule-table");
 
-    const headerRow = helper.findIn(table, "table-header").find("th");
-    expect(headerRow.length).toEqual(3);
-    expect(headerRow.eq(0)).toContainText("Directive");
-    expect(headerRow.eq(1)).toContainText("Type");
-    expect(headerRow.eq(2)).toContainText("Resource");
+    const headerRow = helper.qa("th", helper.byTestId("table-header", table));
+    expect(headerRow.length).toBe(3);
+    expect(headerRow.item(0)).toContainText("Directive");
+    expect(headerRow.item(1)).toContainText("Type");
+    expect(headerRow.item(2)).toContainText("Resource");
 
-    const ruleBodyRow = helper.findIn(table, "table-body").find("td");
-    expect(ruleBodyRow.eq(0)).toContainText("allow");
-    expect(ruleBodyRow.eq(1)).toContainText("pipeline_group");
-    expect(ruleBodyRow.eq(2)).toContainText("DeployPipelines");
+    const ruleBodyRow = helper.qa("td", helper.byTestId("table-body", table));
+    expect(ruleBodyRow.item(0)).toContainText("allow");
+    expect(ruleBodyRow.item(1)).toContainText("pipeline_group");
+    expect(ruleBodyRow.item(2)).toContainText("DeployPipelines");
 
-    expect(ruleBodyRow.eq(3)).toContainText("deny");
-    expect(ruleBodyRow.eq(4)).toContainText("pipeline_group");
-    expect(ruleBodyRow.eq(5)).toContainText("TestPipelines");
+    expect(ruleBodyRow.item(3)).toContainText("deny");
+    expect(ruleBodyRow.item(4)).toContainText("pipeline_group");
+    expect(ruleBodyRow.item(5)).toContainText("TestPipelines");
   });
 
   it("should display info when no secret configs are present", () => {
     mount([], pluginInfos);
-    const groups = helper.findByDataTestId("secret-configs-group");
 
-    expect(groups).not.toBeInDOM();
-    expect(helper.findByDataTestId("secret-config-info")).toBeInDOM();
-    expect(helper.findByDataTestId("secret-config-info").text())
+    expect(helper.byTestId("secret-configs-group")).toBeFalsy();
+    expect(helper.byTestId("secret-config-info")).toBeInDOM();
+    expect(helper.textByTestId("secret-config-info"))
       .toBe(
         "Click on \"Add\" to add new secret configuration.A secret configuration can be used to access secrets from a secret management store.");
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/server_info/spec/server_info_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/server_info/spec/server_info_widget_spec.tsx
@@ -35,23 +35,23 @@ describe("Server Info Widget", () => {
   it("should show Sever Information", () => {
     mount();
 
-    expect(helper.findByDataTestId("about-page")).toContainText("Go Server Version:");
-    expect(helper.findByDataTestId("about-page")).toContainText(metaInfo.go_server_version);
+    expect(helper.textByTestId("about-page")).toContain("Go Server Version:");
+    expect(helper.textByTestId("about-page")).toContain(metaInfo.go_server_version);
 
-    expect(helper.findByDataTestId("about-page")).toContainText("JVM version:");
-    expect(helper.findByDataTestId("about-page")).toContainText(metaInfo.jvm_version);
+    expect(helper.textByTestId("about-page")).toContain("JVM version:");
+    expect(helper.textByTestId("about-page")).toContain(metaInfo.jvm_version);
 
-    expect(helper.findByDataTestId("about-page")).toContainText("OS Information:");
-    expect(helper.findByDataTestId("about-page")).toContainText(metaInfo.os_information);
+    expect(helper.textByTestId("about-page")).toContain("OS Information:");
+    expect(helper.textByTestId("about-page")).toContain(metaInfo.os_information);
 
-    expect(helper.findByDataTestId("about-page")).toContainText("Usable space in artifacts repository:");
-    expect(helper.findByDataTestId("about-page")).toContainText(filesize(metaInfo.usable_space_in_artifacts_repository));
+    expect(helper.textByTestId("about-page")).toContain("Usable space in artifacts repository:");
+    expect(helper.textByTestId("about-page")).toContain(filesize(metaInfo.usable_space_in_artifacts_repository));
 
-    expect(helper.findByDataTestId("about-page")).toContainText("Database schema version:");
-    expect(helper.findByDataTestId("about-page")).toContainText(metaInfo.database_schema_version);
+    expect(helper.textByTestId("about-page")).toContain("Database schema version:");
+    expect(helper.textByTestId("about-page")).toContain(metaInfo.database_schema_version);
 
-    expect(helper.findByDataTestId("about-page")).toContainText("Pipelines Count:");
-    expect(helper.findByDataTestId("about-page")).toContainText(`${metaInfo.pipeline_count}`);
+    expect(helper.textByTestId("about-page")).toContain("Pipelines Count:");
+    expect(helper.textByTestId("about-page")).toContain(`${metaInfo.pipeline_count}`);
   });
 
   function mount() {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/spec/access_token_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/spec/access_token_spec.tsx
@@ -35,18 +35,17 @@ describe("AccessTokenPage", () => {
     document.body.setAttribute("data-meta", JSON.stringify({pluginId: "cd.go.ldap", supportsAccessToken: false}));
     mount();
 
-    expect(helper.findByDataTestId("generate-token-button")).toBeDisabled();
-    expect(helper.findByDataTestId("flash-message-info")).toBeInDOM();
-    expect(helper.findByDataTestId("flash-message-info"))
-      .toHaveText("Creation of access token is not supported by the plugin cd.go.ldap.");
+    expect(helper.byTestId("generate-token-button")).toBeDisabled();
+    expect(helper.byTestId("flash-message-info")).toBeInDOM();
+    expect(helper.textByTestId("flash-message-info")).toBe("Creation of access token is not supported by the plugin cd.go.ldap.");
   });
 
   it("should not disable generate token button when in meta supportsAccessToken set to true", () => {
     document.body.setAttribute("data-meta", JSON.stringify({pluginId: "cd.go.ldap", supportsAccessToken: true}));
     mount();
 
-    expect(helper.findByDataTestId("flash-message-info")).not.toBeInDOM();
-    expect(helper.findByDataTestId("generate-token-button")).not.toBeDisabled();
+    expect(helper.byTestId("flash-message-info")).toBeFalsy();
+    expect(helper.byTestId("generate-token-button")).not.toBeDisabled();
   });
 
   function mount() {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/spec/secret_configs_page_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/spec/secret_configs_page_spec.tsx
@@ -36,17 +36,16 @@ describe("SecretConfigPage", () => {
 
   it("should disable add secret config button if secret plugin not found", () => {
     mount([]);
-    expect(helper.findByDataTestId("add-secret-config")).toBeDisabled();
-    expect(helper.findByDataTestId("flash-message-info")).toBeInDOM();
-    expect(helper.findByDataTestId("flash-message-info"))
-      .toHaveText("No secret plugin installed.");
+    expect(helper.byTestId("add-secret-config")).toBeDisabled();
+    expect(helper.byTestId("flash-message-info")).toBeInDOM();
+    expect(helper.textByTestId("flash-message-info")).toBe("No secret plugin installed.");
   });
 
   it("should not disable add secret config button if secret plugin not found", () => {
     mount([PluginInfo.fromJSON(SecretPluginInfo.file())]);
 
-    expect(helper.findByDataTestId("add-secret-config")).not.toBeDisabled();
-    expect(helper.findByDataTestId("flash-message-info")).not.toBeInDOM();
+    expect(helper.byTestId("add-secret-config")).not.toBeDisabled();
+    expect(helper.byTestId("flash-message-info")).toBeFalsy();
   });
 
   function mount(pluginInfos: any[]) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/spec/test_helper.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/spec/test_helper.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import $ from "jquery";
+
 import m from "mithril";
 import * as simulateEvent from "simulate-event";
 import {Page} from "views/pages/page";
@@ -76,19 +76,19 @@ export class TestHelper {
   }
 
   // native implementations - prefer these
-  byTestId(id: string, context?: Element): Element {
+  byTestId(id: string, context?: Element) {
     return this.q(dataTestIdSelector(id), context);
   }
 
-  allByTestId(id: string, context?: Element): NodeListOf<Element> {
+  allByTestId(id: string, context?: Element): NodeListOf<HTMLElement> {
     return this.qa(dataTestIdSelector(id), context);
   }
 
-  q(selector: string, context?: Element): Element {
-    return (context || this.root!).querySelector(selector)!;
+  q(selector: string, context?: Element) {
+    return (context || this.root!).querySelector(selector) as HTMLElement;
   }
 
-  qa(selector: string, context?: Element): NodeListOf<Element> {
+  qa(selector: string, context?: Element): NodeListOf<HTMLElement> {
     return (context || this.root!).querySelectorAll(selector);
   }
 
@@ -112,13 +112,21 @@ export class TestHelper {
     return modalContainer;
   }
 
-  text(selector: string, context?: Element): string {
-    return (this.q(selector, context).textContent || "").trim();
+  textByTestId(id: string, context?: Element): string {
+    return this.text(this.byTestId(id, context));
   }
 
-  textAll(selector: string, context?: Element): string[] {
+  textAllByTestId(id: string, context?: Element): string[] {
+    return this.textAll(this.allByTestId(id, context));
+  }
+
+  text(selector: string | Element, context?: Element): string {
+    return (this._el(selector, context).textContent || "").trim();
+  }
+
+  textAll(selector: string | NodeList | Element[], context?: Element): string[] {
     const result: string[] = [];
-    const elements         = Array.from(this.qa(selector, context));
+    const elements         = Array.from("string" === typeof selector ? this.qa(selector, context) : selector);
 
     for (const el of elements) {
       result.push((el.textContent || "").trim());
@@ -168,29 +176,12 @@ export class TestHelper {
     console.log(this.root!.innerHTML);
   }
 
-  clickByDataTestId(id: string) {
-    this.click(dataTestIdSelector(id));
+  clickByTestId(id: string, context?: Element) {
+    this.click(dataTestIdSelector(id), context);
   }
 
   findByClass(className: string) {
     return this.root!.getElementsByClassName(className);
-  }
-
-  // jQuery implementations
-  findByDataTestId(id: string) {
-    return $(this.root!).find(`[data-test-id='${id}']`);
-  }
-
-  find(selector: string) {
-    return $(this.root!).find(selector);
-  }
-
-  findIn(elem: any, id: string) {
-    return $(elem).find(dataTestIdSelector(id));
-  }
-
-  findSelectorIn(elem: any, id: string) {
-    return $(elem).find(id);
   }
 
   private _el(selector: string | Element, context?: Element): Element {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/spec/super_admin_toggle_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/spec/super_admin_toggle_widget_spec.tsx
@@ -41,41 +41,39 @@ describe("Super Admin Toggle", () => {
   afterEach(helper.unmount.bind(helper));
 
   it("should render YES when the user is an admin", () => {
-    expect(helper.findByDataTestId("is-admin-text")).toContainText("YES");
+    expect(helper.textByTestId("is-admin-text")).toContain("YES");
   });
 
   it("should render NO when the user is not an admin", () => {
     user.isAdmin(false);
     helper.redraw();
 
-    expect(helper.findByDataTestId("is-admin-text")).toContainText("NO");
+    expect(helper.textByTestId("is-admin-text")).toContain("NO");
   });
 
   it("should render Not Specified when system administrators are not configured", () => {
     userViewHelper().systemAdmins().users([]);
     helper.redraw();
 
-    expect(helper.findByDataTestId("is-admin-text")).toContainText("Not Specified");
+    expect(helper.textByTestId("is-admin-text")).toContain("Not Specified");
   });
 
   it("should render enabled toggle button when the user is an admin", () => {
-    // @ts-ignore
-    expect(helper.findByDataTestId("switch-checkbox").get(0).checked).toBe(true);
+    expect(helper.byTestId("switch-checkbox")).toBeChecked();
   });
 
   it("should render disabled toggle button when the user is NOT an admin", () => {
     user.isAdmin(false);
     helper.redraw();
 
-    // @ts-ignore
-    expect(helper.findByDataTestId("switch-checkbox").get(0).checked).toBe(false);
+    expect(helper.byTestId("switch-checkbox")).not.toBeChecked();
   });
 
   it("should render disabled toggle system administrators are not configured", () => {
     userViewHelper().systemAdmins().users([]);
     helper.redraw();
 
-    expect(helper.findByDataTestId("switch-checkbox")).not.toBeChecked();
+    expect(helper.byTestId("switch-checkbox")).not.toBeChecked();
   });
 
   it("should render make current user admin tooltip when system administrators are not configured", () => {
@@ -84,12 +82,12 @@ describe("Super Admin Toggle", () => {
 
     const expectedTooltipContent = "Explicitly making 'bob' user a system administrator will result into other users not having system administrator privileges.";
 
-    expect(helper.findByDataTestId("tooltip-wrapper")).toBeInDOM();
-    expect(helper.findByDataTestId("tooltip-content")).toContainText(expectedTooltipContent);
+    expect(helper.byTestId("tooltip-wrapper")).toBeInDOM();
+    expect(helper.textByTestId("tooltip-content")).toContain(expectedTooltipContent);
   });
 
   it("should NOT render make current user admin tooltip when system administrators are configured", () => {
-    expect(helper.findByDataTestId("tooltip-wrapper")).not.toBeInDOM();
+    expect(helper.byTestId("tooltip-wrapper")).toBeFalsy();
   });
 
   it("should make a request to make admin on toggling non admin user privilege", () => {
@@ -97,7 +95,7 @@ describe("Super Admin Toggle", () => {
     helper.redraw();
 
     expect(onToggleAdmin).not.toHaveBeenCalled();
-    helper.clickByDataTestId('switch-paddle');
+    helper.clickByTestId('switch-paddle');
     expect(onToggleAdmin).toHaveBeenCalled();
   });
 
@@ -109,8 +107,8 @@ describe("Super Admin Toggle", () => {
 
     const expectedTooltipContent = "'bob' user has the system administrator privileges because the user is assigned the group administrative role. To remove this user from system administrators, assigned role needs to be removed.";
 
-    expect(helper.findByDataTestId("tooltip-wrapper")).toBeInDOM();
-    expect(helper.findByDataTestId("tooltip-content")).toContainText(expectedTooltipContent);
+    expect(helper.byTestId("tooltip-wrapper")).toBeInDOM();
+    expect(helper.textByTestId("tooltip-content")).toContain(expectedTooltipContent);
   });
 
   it("should disable switch if user is admin because of the role", () => {
@@ -120,7 +118,7 @@ describe("Super Admin Toggle", () => {
 
     helper.redraw();
 
-    expect(helper.findByDataTestId("switch-checkbox").prop("disabled")).toBe(true);
+    expect(helper.byTestId("switch-checkbox").hasAttribute("disabled")).toBe(true);
   });
 
   function mount() {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/spec/user_actions_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/spec/user_actions_widget_spec.tsx
@@ -96,9 +96,9 @@ describe("User Actions Widget", () => {
     users(new Users(bob(), alice(), john()));
     m.redraw.sync();
 
-    expect(helper.findByDataTestId("users-total")).toHaveText("3");
-    expect(helper.findByDataTestId("users-enabled")).toHaveText("1");
-    expect(helper.findByDataTestId("users-disabled")).toHaveText("2");
+    expect(helper.textByTestId("users-total")).toBe("3");
+    expect(helper.textByTestId("users-enabled")).toBe("1");
+    expect(helper.textByTestId("users-disabled")).toBe("2");
   });
 
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/spec/users_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/spec/users_widget_spec.tsx
@@ -83,24 +83,24 @@ describe("UsersWidget", () => {
   }
 
   it("should render a list of user attributes", () => {
-    expect(helper.findByDataTestId("users-table")).toBeInDOM();
-    expect(helper.findByDataTestId("users-header")[0].children[1]).toContainText("Username");
-    expect(helper.findByDataTestId("users-header")[0].children[2]).toContainText("Display name");
-    expect(helper.findByDataTestId("users-header")[0].children[4]).toContainText("System Admin");
-    expect(helper.findByDataTestId("users-header")[0].children[5]).toContainText("Email");
-    expect(helper.findByDataTestId("users-header")[0].children[6]).toContainText("Enabled");
+    expect(helper.byTestId("users-table")).toBeInDOM();
+    expect(helper.byTestId("users-header").children[1]).toContainText("Username");
+    expect(helper.byTestId("users-header").children[2]).toContainText("Display name");
+    expect(helper.byTestId("users-header").children[4]).toContainText("System Admin");
+    expect(helper.byTestId("users-header").children[5]).toContainText("Email");
+    expect(helper.byTestId("users-header").children[6]).toContainText("Enabled");
 
-    expect(helper.findByDataTestId("user-row")).toHaveLength(2);
+    expect(helper.allByTestId("user-row")).toHaveLength(2);
 
-    expect(helper.findByDataTestId("user-username")[0]).toContainText("bob");
-    expect(helper.findByDataTestId("user-display-name")[0]).toContainText("Bob");
-    expect(helper.findByDataTestId("user-email")[0]).toContainText("bob@example.com");
-    expect(helper.findByDataTestId("user-enabled")[0]).toContainText("Yes");
+    expect(helper.textByTestId("user-username")).toContain("bob");
+    expect(helper.textByTestId("user-display-name")).toContain("Bob");
+    expect(helper.textByTestId("user-email")).toContain("bob@example.com");
+    expect(helper.textByTestId("user-enabled")).toContain("Yes");
 
-    expect(helper.findByDataTestId("user-username")[1]).toContainText("alice");
-    expect(helper.findByDataTestId("user-display-name")[1]).toContainText("Alice");
-    expect(helper.findByDataTestId("user-email")[1]).toContainText("alice@example.com");
-    expect(helper.findByDataTestId("user-enabled")[1]).toContainText("No");
+    expect(helper.allByTestId("user-username")[1].textContent).toContain("alice");
+    expect(helper.allByTestId("user-display-name")[1].textContent).toContain("Alice");
+    expect(helper.allByTestId("user-email")[1].textContent).toContain("alice@example.com");
+    expect(helper.allByTestId("user-enabled")[1].textContent).toContain("No");
   });
 
   it("should render in progress icon if update operation is in progress", () => {
@@ -109,7 +109,7 @@ describe("UsersWidget", () => {
 
     m.redraw.sync();
 
-    expect(helper.findIn(helper.findByDataTestId("user-super-admin-switch")[0], "Spinner-icon")).toBeInDOM();
+    expect(helper.byTestId("Spinner-icon", helper.byTestId("user-super-admin-switch"))).toBeInDOM();
   });
 
   it("should render success icon is update operation is successful", () => {
@@ -118,8 +118,7 @@ describe("UsersWidget", () => {
 
     m.redraw.sync();
 
-    expect(helper.findByDataTestId("user-super-admin-switch"));
-    expect(helper.findIn(helper.findByDataTestId("user-super-admin-switch")[0], "update-successful")).toBeInDOM();
+    expect(helper.byTestId("update-successful", helper.byTestId("user-super-admin-switch"))).toBeInDOM();
   });
 
   it("should render error icon with message if update operation is unsuccessful", () => {
@@ -128,8 +127,7 @@ describe("UsersWidget", () => {
 
     m.redraw.sync();
 
-    expect(helper.findIn(helper.findByDataTestId("user-super-admin-switch")[0], "update-unsuccessful")).toBeInDOM();
-    expect(helper.findByDataTestId("user-update-error-message")).toContainText("boom!");
-
+    expect(helper.byTestId("update-unsuccessful", helper.byTestId("user-super-admin-switch"))).toBeInDOM();
+    expect(helper.textByTestId("user-update-error-message")).toContain("boom!");
   });
 });


### PR DESCRIPTION
Removes jQuery methods from `TestHelper` and all (but 1) test (the fix for that text involves more work).

Ultimately, will remove jQuery altogether 🤞 from the pages built by webpack.