### PR TITLE
Added toggle for Agents SPA

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/AgentsPageToggle.java
+++ b/server/src/main/java/com/thoughtworks/go/server/AgentsPageToggle.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server;
+
+import com.thoughtworks.go.server.service.support.toggle.Toggles;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class AgentsPageToggle {
+    public void agentsPage(HttpServletRequest request, HttpServletResponse response) {
+        basedOnToggle(Toggles.SHOW_NEW_AGENTS_SPA, request);
+    }
+
+    @SuppressWarnings({"PMD.UnusedPrivateMethod", "unused"})
+    private void basedOnToggle(String toggle, HttpServletRequest request) {
+        if (Toggles.isToggleOn(toggle)) {
+            request.setAttribute("url", "/spark/new-agents");
+        } else {
+            request.setAttribute("url", "/spark/agents");
+        }
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -22,6 +22,7 @@ public class Toggles {
     public static String TEST_DRIVE = "test_drive";
     public static String NEW_PIPELINE_DROPDOWN = "new_pipeline_dropdown";
     public static String SHOW_NEW_ENVIRONMENTS_SPA = "show_new_environments_spa";
+    public static String SHOW_NEW_AGENTS_SPA = "show_new_agents_spa";
 
     private static FeatureToggleService service;
 

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -30,6 +30,11 @@
       "key": "show_new_environments_spa",
       "description": "Switch to the new environments SPA. Default is false.",
       "value": false
+    },
+    {
+      "key": "show_new_agents_spa",
+      "description": "Switch to the new agents SPA. Default is true.",
+      "value": true
     }
   ]
 }

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -33,8 +33,8 @@
     },
     {
       "key": "show_new_agents_spa",
-      "description": "Switch to the new agents SPA. Default is true.",
-      "value": true
+      "description": "Switch to the new agents SPA. Default is false.",
+      "value": false
     }
   ]
 }

--- a/server/webapp/WEB-INF/rails/webpack/models/new_agent/agents_crud.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/new_agent/agents_crud.ts
@@ -19,7 +19,7 @@ import {SparkRoutes} from "helpers/spark_routes";
 import {AgentConfigState, Agents} from "models/new_agent/agents";
 
 export class AgentsCRUD {
-  private static API_VERSION_HEADER = ApiVersion.v5;
+  private static API_VERSION_HEADER = ApiVersion.latest;
 
   static all() {
     return ApiRequestBuilder.GET(SparkRoutes.agentsPath(), this.API_VERSION_HEADER)

--- a/server/webapp/WEB-INF/rails/webpack/models/new_agent/spec/agents_crud_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/new_agent/spec/agents_crud_spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AgentsCRUD} from "../agents_crud";
+import {AgentsJSON} from "../agents_json";
+import {AgentsTestData} from "./agents_test_data";
+
+describe('AgentsCRUD', () => {
+  beforeEach(() => jasmine.Ajax.install());
+  afterEach(() => jasmine.Ajax.uninstall());
+
+  it("should make get request", () => {
+    jasmine.Ajax.stubRequest("/go/api/agents").andReturn(listAgentsResponse());
+
+    AgentsCRUD.all();
+
+    const request = jasmine.Ajax.requests.mostRecent();
+    expect(request.url).toEqual("/go/api/agents");
+    expect(request.method).toEqual("GET");
+    expect(request.data()).toEqual(toJSON({} as AgentsJSON));
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
+  });
+
+  it("should make a delete request", () => {
+    jasmine.Ajax.stubRequest("/go/api/agents").andReturn(listAgentsResponse());
+
+    const agentUuids = ['agent1', 'agent2'];
+    AgentsCRUD.delete(agentUuids);
+
+    const request = jasmine.Ajax.requests.mostRecent();
+    expect(request.url).toEqual("/go/api/agents");
+    expect(request.method).toEqual("DELETE");
+    expect(request.data()).toEqual({ uuids: agentUuids });
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
+  });
+
+});
+
+function toJSON(object: any) {
+  return JSON.parse(JSON.stringify(object));
+}
+
+function listAgentsResponse() {
+  return {
+    status: 200,
+    responseHeaders: {
+      "Content-Type": "application/vnd.go.cd.v6+json; charset=utf-8"
+    },
+    responseText: JSON.stringify(AgentsTestData.list())
+  };
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_agent.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_agent.tsx
@@ -108,14 +108,17 @@ export class NewAgentPage extends Page<null, State> {
 
   fetchData(vnode: m.Vnode<null, State>): Promise<any> {
     return Promise.all([AgentsCRUD.all(), PluginInfoCRUD.all({})])
-                  .then((results) => {
-                    results[0].do((successResponse) => NewAgentPage.syncVMState(vnode, successResponse.body),
-                                  this.setErrorState);
-                    results[1].do((successResponse) => vnode.state.pluginInfos(successResponse.body),
-                                  this.setErrorState);
-                  }).finally(() => {
-        this.pageState = PageState.OK;
-      });
+        .then((results) => {
+          results[0].do((successResponse) => NewAgentPage.syncVMState(vnode, successResponse.body),
+              (errorResponse) => {
+                this.onFailure(errorResponse);
+                this.setErrorState();
+              });
+          results[1].do((successResponse) => vnode.state.pluginInfos(successResponse.body),
+              this.setErrorState);
+        }).finally(() => {
+          this.pageState = PageState.OK;
+        });
   }
 
   private static syncVMState(vnode: m.Vnode<null, State>, agents: Agents) {

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -41,11 +41,6 @@
     <from>^/admin/pipeline_configs(/?)$</from>
     <to last="true">/spark/admin/pipeline_configs</to>
   </rule>
-  <rule>
-    <name>new-agent UI</name>
-    <from>^/new-agents(/?)$</from>
-    <to last="true">/spark/new-agents</to>
-  </rule>
 
   <rule>
     <name>mail_server UI</name>
@@ -426,7 +421,8 @@
   <rule>
     <name>Agents SPA</name>
     <from>^/agents(/?)$</from>
-    <to last="true">/spark/agents</to>
+    <run class="com.thoughtworks.go.server.AgentsPageToggle" method="agentsPage"/>
+    <to last="true">%{attribute:url}</to>
   </rule>
 
   <rule>


### PR DESCRIPTION
Description: Moving the new Agents SPA behind a toggle `show_new_agents_spa`. Default is `false`.
To turn it on:
```
curl http://localhost:8153/go/api/admin/feature_toggles/show_new_agents_spa -d toggle_value=on -H 'Confirm:true' -u username:password
```
Also, updated the new agents SPA to utilise `ApiVersion.latest`



