### PR TITLE
Fixes incorrect agent name in stage and job details page if agent is deleted

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
@@ -148,7 +148,7 @@ public class JobController {
             JobInstance mostRecentJobInstance = jobInstanceDao.mostRecentJobWithTransitions(requestedInstance.getIdentifier());
 
             JobStatusJsonPresentationModel presenter = new JobStatusJsonPresentationModel(mostRecentJobInstance,
-                    agentService.findRegisteredAgentByUUID(mostRecentJobInstance.getAgentUuid()),
+                    agentService.findAgentByUUID(mostRecentJobInstance.getAgentUuid()),
                     stageService.getBuildDuration(pipelineName, stageName, mostRecentJobInstance));
             json = createBuildInfo(presenter);
         } catch (Exception e) {

--- a/server/src/main/java/com/thoughtworks/go/server/persistence/AgentDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/persistence/AgentDao.java
@@ -159,22 +159,26 @@ public class AgentDao extends HibernateDaoSupport {
     }
 
     public Agent fetchAgentFromDBByUUID(final String uuid) {
-        return fetchAgent(uuid, "FROM Agent where uuid = :uuid and deleted = false");
-    }
-
-    public Agent fetchAgentFromDBByUUID(final String uuid, boolean includeDeletedAgents) {
-        if (!includeDeletedAgents) {
-            fetchAgentFromDBByUUID(uuid);
-        }
-        return fetchAgent(uuid, "FROM Agent where uuid = :uuid");
-    }
-
-    private Agent fetchAgent(String uuid, String queryString) {
         List<String> uuids = singletonList(uuid);
         AgentMutex mutex = agentMutexes.acquire(uuids);
         synchronized (mutex) {
             Agent agent = (Agent) transactionTemplate.execute((TransactionCallback) transactionStatus -> {
-                Query query = sessionFactory.getCurrentSession().createQuery(queryString);
+                Query query = sessionFactory.getCurrentSession().createQuery("FROM Agent where uuid = :uuid and deleted = false");
+                query.setCacheable(true);
+                query.setParameter("uuid", uuid);
+                return query.uniqueResult();
+            });
+            agentMutexes.release(uuids, mutex);
+            return agent;
+        }
+    }
+
+    public Agent fetchAgentFromDBByUUIDIncludingDeleted(final String uuid) {
+        List<String> uuids = singletonList(uuid);
+        AgentMutex mutex = agentMutexes.acquire(uuids);
+        synchronized (mutex) {
+            Agent agent = (Agent) transactionTemplate.execute((TransactionCallback) transactionStatus -> {
+                Query query = sessionFactory.getCurrentSession().createQuery("FROM Agent where uuid = :uuid");
                 query.setCacheable(true);
                 query.setParameter("uuid", uuid);
                 return query.uniqueResult();

--- a/server/src/main/java/com/thoughtworks/go/server/service/AgentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AgentService.java
@@ -290,12 +290,15 @@ public class AgentService implements DatabaseEntityChangeListener<Agent> {
         return cookie;
     }
 
-    public Agent findRegisteredAgentByUUID(String uuid) {
+    public Agent findAgentByUUID(String uuid) {
         AgentInstance agentInstance = agentInstances.findAgent(uuid);
-        if (agentInstance != null && agentInstance.isRegistered()) {
-            return agentInstance.getAgent();
+        Agent agent;
+        if (agentInstance != null && !agentInstance.isNullAgent()) {
+            agent = agentInstance.getAgent();
+        } else {
+            agent = agentDao.fetchAgentFromDBByUUID(uuid, true);
         }
-        return null;
+        return agent;
     }
 
     public AgentsViewModel filterAgentsViewModel(List<String> uuids) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/AgentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AgentService.java
@@ -296,7 +296,7 @@ public class AgentService implements DatabaseEntityChangeListener<Agent> {
         if (agentInstance != null && !agentInstance.isNullAgent()) {
             agent = agentInstance.getAgent();
         } else {
-            agent = agentDao.fetchAgentFromDBByUUID(uuid, true);
+            agent = agentDao.fetchAgentFromDBByUUIDIncludingDeleted(uuid);
         }
         return agent;
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/JobPresentationService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/JobPresentationService.java
@@ -48,7 +48,7 @@ public class JobPresentationService {
             if (null != agentInstance && !agentInstance.isNullAgent()) {
                 model = new JobInstanceModel(jobInstance, jobDurationStrategy, agentInstance);
             } else if (jobInstance.getAgentUuid() != null) {
-                Agent agent = agentService.findRegisteredAgentByUUID(jobInstance.getAgentUuid());
+                Agent agent = agentService.findAgentByUUID(jobInstance.getAgentUuid());
                 model = new JobInstanceModel(jobInstance, jobDurationStrategy, agent);
             } else {
                 model = new JobInstanceModel(jobInstance, jobDurationStrategy);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/controller/JobControllerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/controller/JobControllerTest.java
@@ -98,13 +98,13 @@ public class JobControllerTest {
 
         when(jobInstanceService.buildByIdWithTransitions(job.getId())).thenReturn(job);
         when(jobInstanceDao.mostRecentJobWithTransitions(job.getIdentifier())).thenReturn(newJob);
-        when(agentService.findRegisteredAgentByUUID(newJob.getAgentUuid())).thenReturn(Agent.blankAgent(newJob.getAgentUuid()));
+        when(agentService.findAgentByUUID(newJob.getAgentUuid())).thenReturn(Agent.blankAgent(newJob.getAgentUuid()));
         when(stageService.getBuildDuration(pipelineName, stageName, newJob)).thenReturn(new DurationBean(newJob.getId(), 5l));
 
         ModelAndView modelAndView = jobController.handleRequest(pipelineName, stageName, job.getId(), response);
 
         verify(jobInstanceService).buildByIdWithTransitions(job.getId());
-        verify(agentService).findRegisteredAgentByUUID(newJob.getAgentUuid());
+        verify(agentService).findAgentByUUID(newJob.getAgentUuid());
         verify(jobInstanceDao).mostRecentJobWithTransitions(job.getIdentifier());
         verify(stageService).getBuildDuration(pipelineName, stageName, newJob);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/AgentServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/AgentServiceTest.java
@@ -1195,7 +1195,7 @@ class AgentServiceTest {
             String uuidToUse = agentInstance.getUuid();
 
             when(agentInstances.findAgent(uuidToUse)).thenReturn(agentInstance);
-            when(agentDao.fetchAgentFromDBByUUID(uuidToUse, true)).thenReturn(fromDB);
+            when(agentDao.fetchAgentFromDBByUUIDIncludingDeleted(uuidToUse)).thenReturn(fromDB);
             Agent agent = agentService.findAgentByUUID(uuidToUse);
 
             assertThat(agent, is(fromDB));

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/JobPresentationServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/JobPresentationServiceTest.java
@@ -78,12 +78,12 @@ public class JobPresentationServiceTest {
         JobInstance jobWithDeletedAgent = assignedWithAgentId("dev", deletedAgentUuid);
         when(agentService.findAgentAndRefreshStatus(deletedAgentUuid)).thenReturn(null);
         Agent agentFromDb = new Agent(deletedAgentUuid,"hostname", "1.2.3.4", "cookie");
-        when(agentService.findRegisteredAgentByUUID(deletedAgentUuid)).thenReturn(agentFromDb);
+        when(agentService.findAgentByUUID(deletedAgentUuid)).thenReturn(agentFromDb);
         List<JobInstanceModel> models = new JobPresentationService(jobDurationStrategy, agentService).jobInstanceModelFor(new JobInstances(jobWithDeletedAgent));
         assertThat(models.size(), is(1));
         assertThat(models.get(0), is(new JobInstanceModel(jobWithDeletedAgent, jobDurationStrategy, agentFromDb)));
         verify(agentService, times(1)).findAgentAndRefreshStatus(deletedAgentUuid);
-        verify(agentService, times(1)).findRegisteredAgentByUUID(deletedAgentUuid);
+        verify(agentService, times(1)).findAgentByUUID(deletedAgentUuid);
         verifyNoMoreInteractions(agentService);
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/AgentDaoTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/AgentDaoTest.java
@@ -113,7 +113,7 @@ public class AgentDaoTest {
             Agent agentFromDB = agentDao.fetchAgentFromDBByUUID(uuid);
             assertThat(agentFromDB, is(nullValue()));
 
-            agentFromDB = agentDao.fetchAgentFromDBByUUID(uuid, true);
+            agentFromDB = agentDao.fetchAgentFromDBByUUIDIncludingDeleted(uuid);
             assertThat(agentFromDB, is(agent));
         }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/AgentDaoTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/AgentDaoTest.java
@@ -104,6 +104,20 @@ public class AgentDaoTest {
         }
 
         @Test
+        void shouldFetchAgentFromDBIncludingDeletedAgent() {
+            String uuid = "uuid";
+            Agent agent = new Agent(uuid, "localhost", "127.0.0.1", "cookie");
+            agentDao.saveOrUpdate(agent);
+            agentDao.bulkSoftDelete(singletonList(uuid));
+
+            Agent agentFromDB = agentDao.fetchAgentFromDBByUUID(uuid);
+            assertThat(agentFromDB, is(nullValue()));
+
+            agentFromDB = agentDao.fetchAgentFromDBByUUID(uuid, true);
+            assertThat(agentFromDB, is(agent));
+        }
+
+        @Test
         void shouldGetAgentsByUUIDsExcludingSoftDeletedAgents() {
             String uuid1 = "uuid1";
             String uuid2 = "uuid2";


### PR DESCRIPTION
Description :
 - Post moving agents out of config changes, we use to fetch agent which are pending/registered and aren't deleted
   This commit introduces an option to include deleted agents in the search range so that the correct details can be rendered on the related SPAs
even if agent is deleted

