### PR TITLE
Fix issue with hostname for auto registered agents #7002

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Agent.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Agent.java
@@ -107,12 +107,6 @@ public class Agent extends PersistentObject {
         return new Agent(uuid, "Unknown", "Unknown", "Unknown");
     }
 
-    public void setFieldValues(String cookie, String hostname, String ipaddress) {
-        this.setCookie(cookie);
-        this.setHostname(hostname);
-        this.setIpaddress(ipaddress);
-    }
-
     public void removeEnvironments(List<String> envsToRemove) {
         this.setEnvironments(remove(this.getEnvironments(), envsToRemove));
     }

--- a/server/src/main/java/com/thoughtworks/go/server/persistence/AgentDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/persistence/AgentDao.java
@@ -116,7 +116,7 @@ public class AgentDao extends HibernateDaoSupport {
                     if (agent == null) {
                         throw new UnregisteredAgentException(format("Agent [%s] is not registered.", uuid), uuid);
                     }
-                    agent.setFieldValues(cookie, agentIdentifier.getHostName(), agentIdentifier.getIpAddress());
+                    agent.setCookie(cookie);
                     getHibernateTemplate().saveOrUpdate(agent);
 
                     final Agent updatedAgent = agent;

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/AgentDaoTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/AgentDaoTest.java
@@ -256,7 +256,7 @@ public class AgentDaoTest {
 
             hibernateTemplate.execute((HibernateCallback) session -> {
                 Agent agent = (Agent) session.createQuery("from Agent where uuid = 'uuid1'").uniqueResult();
-                agent.setFieldValues("updated_cookie", agentIdentifier.getHostName(), agentIdentifier.getIpAddress());
+                agent.setCookie("updated_cookie");
                 session.update(agent);
                 return null;
             });
@@ -280,7 +280,7 @@ public class AgentDaoTest {
         private void updateCookieAndVerifyThatCookieIsUpdated(AgentIdentifier agentIdentifier, String updatedCookie) {
             hibernateTemplate.execute(session -> {
                 Agent agent = (Agent) session.createQuery("from Agent where uuid = 'uuid2'").uniqueResult();
-                agent.setFieldValues(updatedCookie, agentIdentifier.getHostName(), agentIdentifier.getIpAddress());
+                agent.setCookie(updatedCookie);
                 session.update(agent);
                 return null;
             });


### PR DESCRIPTION
* On auto registration of an agent, the db is updated
  with an host-name specified in the auto-register.properties.
  Post registration, on a request to associate cookie for the agent
  the host-name for the agent was updated to one defined in AgentIdentifier
  which is different from the one defined in the properties file.
* This commit fixes the issue by assigning just the cookie to an agent
  and not updating any other fields.

Issue: #7002 

Description:

