### PR TITLE
Updated Dojofile to build with java 11 by default

### DIFF
--- a/Dojofile
+++ b/Dojofile
@@ -1,2 +1,2 @@
 # For building GoCD in docker see https://github.com/kudulab/docker-gocd-dojo
-DOJO_DOCKER_IMAGE=kudulab/gocd-dojo:2.0.0
+DOJO_DOCKER_IMAGE=kudulab/gocd-dojo:2.1.0


### PR DESCRIPTION
Minor update to use java 11 when building with docker and dojo.

For more context see https://github.com/kudulab/docker-gocd-dojo
