### PR TITLE
Added SCM material url to the env vars

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/config/materials/ScmMaterialTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/ScmMaterialTest.java
@@ -196,7 +196,7 @@ class ScmMaterialTest {
         void shouldBeAnEmptyListInAbsenceOfSecretParamsinMaterialPassword() {
             DummyMaterial dummyMaterial = new DummyMaterial();
 
-            assertThat(dummyMaterial.getSecretParams().size(), is(0));
+            assertThat(dummyMaterial.getSecretParams(), is(nullValue()));
         }
     }
 

--- a/common/src/test/java/com/thoughtworks/go/config/materials/ScmMaterialTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/ScmMaterialTest.java
@@ -22,9 +22,9 @@ import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.materials.DummyMaterial;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -34,40 +34,40 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.*;
 
-public class ScmMaterialTest {
+class ScmMaterialTest {
     private DummyMaterial material;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         material = new DummyMaterial();
     }
 
     @Test
-    public void shouldSmudgePasswordForDescription() throws Exception{
+    void shouldSmudgePasswordForDescription() throws Exception {
         material.setUrl("http://user:password@localhost:8000/foo");
         assertThat(material.getDescription(), is("http://user:******@localhost:8000/foo"));
     }
 
-
     @Test
-    public void displayNameShouldReturnUrlWhenNameNotSet() throws Exception{
+    void displayNameShouldReturnUrlWhenNameNotSet() throws Exception {
         material.setUrl("http://user:password@localhost:8000/foo");
         assertThat(material.getDisplayName(), is("http://user:******@localhost:8000/foo"));
     }
 
     @Test
-    public void displayNameShouldReturnNameWhenSet() throws Exception{
+    void displayNameShouldReturnNameWhenSet() throws Exception {
         material.setName(new CaseInsensitiveString("blah-name"));
         assertThat(material.getDisplayName(), is("blah-name"));
     }
 
     @Test
-    public void willNeverBeUsedInAFetchArtifact() {
+    void willNeverBeUsedInAFetchArtifact() {
         assertThat(material.isUsedInFetchArtifact(new PipelineConfig()), is(false));
     }
 
     @Test
-    public void populateEnvironmentContextShouldSetFromAndToRevisionEnvironmentVariables() {
+    void populateEnvironmentContextShouldSetFromAndToRevisionEnvironmentVariables() {
+        material.setUrl("https://user:password@example.github.com");
 
         EnvironmentVariableContext ctx = new EnvironmentVariableContext();
         final ArrayList<Modification> modifications = new ArrayList<>();
@@ -88,20 +88,38 @@ public class ScmMaterialTest {
     }
 
     @Test
-    public void shouldIncludeMaterialNameInEnvVariableNameIfAvailable() {
+    void populateEnvContextShouldSetMaterialEnvVars() {
+        material.setUrl("https://user:password@example.github.com");
+
+        EnvironmentVariableContext ctx = new EnvironmentVariableContext();
+        final ArrayList<Modification> modifications = new ArrayList<>();
+
+        modifications.add(new Modification("user2", "comment2", "email2", new Date(), "24"));
+        modifications.add(new Modification("user1", "comment1", "email1", new Date(), "23"));
+
+        MaterialRevision materialRevision = new MaterialRevision(material, modifications);
+        assertThat(ctx.getProperty(ScmMaterial.GO_MATERIAL_URL), is(nullValue()));
+
+        material.populateEnvironmentContext(ctx, materialRevision, new File("."));
+
+        assertThat(ctx.getProperty(ScmMaterial.GO_MATERIAL_URL), is("https://example.github.com"));
+    }
+
+    @Test
+    void shouldIncludeMaterialNameInEnvVariableNameIfAvailable() {
         EnvironmentVariableContext context = new EnvironmentVariableContext();
         material.setVariableWithName(context, "value", "GO_PROPERTY");
         assertThat(context.getProperty("GO_PROPERTY"), is("value"));
 
         context = new EnvironmentVariableContext();
-        material.setName( new CaseInsensitiveString("dummy"));
+        material.setName(new CaseInsensitiveString("dummy"));
         material.setVariableWithName(context, "value", "GO_PROPERTY");
         assertThat(context.getProperty("GO_PROPERTY_DUMMY"), is("value"));
         assertThat(context.getProperty("GO_PROPERTY"), is(nullValue()));
     }
 
     @Test
-    public void shouldIncludeDestFolderInEnvVariableNameIfMaterialNameNotAvailable() {
+    void shouldIncludeDestFolderInEnvVariableNameIfMaterialNameNotAvailable() {
         EnvironmentVariableContext context = new EnvironmentVariableContext();
         material.setVariableWithName(context, "value", "GO_PROPERTY");
         assertThat(context.getProperty("GO_PROPERTY"), is("value"));
@@ -114,16 +132,16 @@ public class ScmMaterialTest {
     }
 
     @Test
-    public void shouldEscapeHyphenFromMaterialNameWhenUsedInEnvVariable() {
+    void shouldEscapeHyphenFromMaterialNameWhenUsedInEnvVariable() {
         EnvironmentVariableContext context = new EnvironmentVariableContext();
-        material.setName( new CaseInsensitiveString("material-name"));
+        material.setName(new CaseInsensitiveString("material-name"));
         material.setVariableWithName(context, "value", "GO_PROPERTY");
         assertThat(context.getProperty("GO_PROPERTY_MATERIAL_NAME"), is("value"));
         assertThat(context.getProperty("GO_PROPERTY"), is(nullValue()));
     }
 
     @Test
-    public void shouldEscapeHyphenFromFolderNameWhenUsedInEnvVariable() {
+    void shouldEscapeHyphenFromFolderNameWhenUsedInEnvVariable() {
         EnvironmentVariableContext context = new EnvironmentVariableContext();
         material.setFolder("folder-name");
         material.setVariableWithName(context, "value", "GO_PROPERTY");
@@ -132,12 +150,12 @@ public class ScmMaterialTest {
     }
 
     @Test
-    public void shouldReturnTrueForAnScmMaterial_supportsDestinationFolder() throws Exception {
+    void shouldReturnTrueForAnScmMaterial_supportsDestinationFolder() throws Exception {
         assertThat(material.supportsDestinationFolder(), is(true));
     }
 
     @Test
-    public void shouldGetMaterialNameForEnvironmentMaterial(){
+    void shouldGetMaterialNameForEnvironmentMaterial() {
         assertThat(material.getMaterialNameForEnvironmentVariable(), is(""));
         material.setFolder("dest-folder");
         assertThat(material.getMaterialNameForEnvironmentVariable(), is("DEST_FOLDER"));

--- a/common/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialTest.java
@@ -692,7 +692,8 @@ public class HgMaterialTest {
 
     @Test
     void populateEnvContextShouldSetMaterialEnvVars() {
-        HgMaterial material = new HgMaterial("https://user:password@example.github.com", "folder");
+        HgMaterial material = new HgMaterial("https://user:password@github.com/bob/my-project", "folder");
+        material.setBranch("branchName");
 
         EnvironmentVariableContext ctx = new EnvironmentVariableContext();
         final ArrayList<Modification> modifications = new ArrayList<>();
@@ -706,7 +707,23 @@ public class HgMaterialTest {
 
         material.populateEnvironmentContext(ctx, materialRevision, new File("."));
         String propertySuffix = material.getMaterialNameForEnvironmentVariable();
-        assertThat(ctx.getProperty(format("%s_%s", ScmMaterial.GO_MATERIAL_URL, propertySuffix))).isEqualTo("https://example.github.com");
+        assertThat(ctx.getProperty(format("%s_%s", ScmMaterial.GO_MATERIAL_URL, propertySuffix))).isEqualTo("https://github.com/bob/my-project");
+        assertThat(ctx.getProperty(format("%s_%s", GitMaterial.GO_MATERIAL_BRANCH, propertySuffix))).isEqualTo("branchName");
+    }
+
+    @Test
+    void shouldPopulateBranchWithDefaultIfNotSet() {
+        HgMaterial material = new HgMaterial("https://user:password@github.com/bob/my-project", "folder");
+
+        EnvironmentVariableContext ctx = new EnvironmentVariableContext();
+        final ArrayList<Modification> modifications = new ArrayList<>();
+
+        modifications.add(new Modification("user1", "comment1", "email1", new Date(), "23"));
+
+        MaterialRevision materialRevision = new MaterialRevision(material, modifications);
+
+        material.populateEnvironmentContext(ctx, materialRevision, new File("."));
+        String propertySuffix = material.getMaterialNameForEnvironmentVariable();
         assertThat(ctx.getProperty(format("%s_%s", GitMaterial.GO_MATERIAL_BRANCH, propertySuffix))).isEqualTo("default");
     }
 }

--- a/common/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialTest.java
@@ -20,7 +20,10 @@ import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.SecretParam;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.PasswordAwareMaterial;
+import com.thoughtworks.go.config.materials.ScmMaterial;
+import com.thoughtworks.go.config.materials.git.GitMaterial;
 import com.thoughtworks.go.domain.MaterialInstance;
+import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.mercurial.HgCommand;
 import com.thoughtworks.go.domain.materials.mercurial.HgVersion;
@@ -30,10 +33,7 @@ import com.thoughtworks.go.helper.MaterialsMother;
 import com.thoughtworks.go.helper.TestRepo;
 import com.thoughtworks.go.util.JsonValue;
 import com.thoughtworks.go.util.ReflectionUtil;
-import com.thoughtworks.go.util.command.ConsoleResult;
-import com.thoughtworks.go.util.command.HgUrlArgument;
-import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
-import com.thoughtworks.go.util.command.UrlArgument;
+import com.thoughtworks.go.util.command.*;
 import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
@@ -47,10 +47,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.thoughtworks.go.helper.MaterialConfigsMother.hg;
 import static com.thoughtworks.go.util.JsonUtils.from;
@@ -691,5 +688,25 @@ public class HgMaterialTest {
 
             assertThat(info).isEqualTo(hgMaterial.getUriForDisplay());
         }
+    }
+
+    @Test
+    void populateEnvContextShouldSetMaterialEnvVars() {
+        HgMaterial material = new HgMaterial("https://user:password@example.github.com", "folder");
+
+        EnvironmentVariableContext ctx = new EnvironmentVariableContext();
+        final ArrayList<Modification> modifications = new ArrayList<>();
+
+        modifications.add(new Modification("user2", "comment2", "email2", new Date(), "24"));
+        modifications.add(new Modification("user1", "comment1", "email1", new Date(), "23"));
+
+        MaterialRevision materialRevision = new MaterialRevision(material, modifications);
+        assertThat(ctx.getProperty(ScmMaterial.GO_MATERIAL_URL)).isNull();
+        assertThat(ctx.getProperty(GitMaterial.GO_MATERIAL_BRANCH)).isNull();
+
+        material.populateEnvironmentContext(ctx, materialRevision, new File("."));
+        String propertySuffix = material.getMaterialNameForEnvironmentVariable();
+        assertThat(ctx.getProperty(format("%s_%s", ScmMaterial.GO_MATERIAL_URL, propertySuffix))).isEqualTo("https://example.github.com");
+        assertThat(ctx.getProperty(format("%s_%s", GitMaterial.GO_MATERIAL_BRANCH, propertySuffix))).isEqualTo("default");
     }
 }

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/ScmMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/ScmMaterial.java
@@ -48,6 +48,7 @@ public abstract class ScmMaterial extends AbstractMaterial implements SecretPara
     public static final String GO_REVISION = "GO_REVISION";
     public static final String GO_TO_REVISION = "GO_TO_REVISION";
     public static final String GO_FROM_REVISION = "GO_FROM_REVISION";
+    public static final String GO_MATERIAL_URL = "GO_MATERIAL_URL";
     protected final GoCipher goCipher;
 
     protected Filter filter;
@@ -227,6 +228,11 @@ public abstract class ScmMaterial extends AbstractMaterial implements SecretPara
         String fromRevision = materialRevision.getOldestRevision().getRevision();
 
         setGoRevisionVariables(environmentVariableContext, fromRevision, toRevision);
+        setGoMaterialVariables(environmentVariableContext);
+    }
+
+    protected void setGoMaterialVariables(EnvironmentVariableContext environmentVariableContext) {
+        setVariableWithName(environmentVariableContext, this.getUrlArgument().withoutCredentials(), GO_MATERIAL_URL);
     }
 
     private void setGoRevisionVariables(EnvironmentVariableContext environmentVariableContext, String fromRevision, String toRevision) {

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -54,6 +54,7 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
     private static final Logger LOG = LoggerFactory.getLogger(GitMaterial.class);
     public static final int UNSHALLOW_TRYOUT_STEP = 100;
     public static final int DEFAULT_SHALLOW_CLONE_DEPTH = 2;
+    public static final String GO_MATERIAL_BRANCH = "GO_MATERIAL_BRANCH";
 
     private UrlArgument url;
     private String branch = GitMaterialConfig.DEFAULT_BRANCH;
@@ -449,5 +450,11 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
 
     public String branchWithDefault() {
         return isBlank(branch) ? GitMaterialConfig.DEFAULT_BRANCH : branch;
+    }
+
+    @Override
+    protected void setGoMaterialVariables(EnvironmentVariableContext environmentVariableContext) {
+        super.setGoMaterialVariables(environmentVariableContext);
+        setVariableWithName(environmentVariableContext, branchWithDefault(), GO_MATERIAL_BRANCH);
     }
 }

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.materials.PasswordAwareMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
+import com.thoughtworks.go.config.materials.git.GitMaterial;
 import com.thoughtworks.go.domain.MaterialInstance;
 import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.mercurial.HgCommand;
@@ -386,5 +387,11 @@ public class HgMaterial extends ScmMaterial implements PasswordAwareMaterial {
             return componentsOfUrl[1];
         }
         return HG_DEFAULT_BRANCH;
+    }
+
+    @Override
+    protected void setGoMaterialVariables(EnvironmentVariableContext environmentVariableContext) {
+        super.setGoMaterialVariables(environmentVariableContext);
+        setVariableWithName(environmentVariableContext, getBranch(), GitMaterial.GO_MATERIAL_BRANCH);
     }
 }

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/tfs/TfsMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/tfs/TfsMaterial.java
@@ -29,6 +29,7 @@ import com.thoughtworks.go.domain.materials.tfs.TfsMaterialInstance;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.GoConstants;
 import com.thoughtworks.go.util.command.ConsoleOutputStreamConsumer;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import com.thoughtworks.go.util.command.UrlArgument;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -42,11 +43,13 @@ import java.util.Map;
 import java.util.UUID;
 
 import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class TfsMaterial extends ScmMaterial implements PasswordAwareMaterial, PasswordEncrypter {
     private static final Logger LOGGER = LoggerFactory.getLogger(TfsMaterial.class);
 
     public static final String TYPE = "TfsMaterial";
+    public static final String GO_MATERIAL_DOMAIN = "GO_MATERIAL_DOMAIN";
 
     private UrlArgument url;
     private String domain = "";
@@ -251,5 +254,13 @@ public class TfsMaterial extends ScmMaterial implements PasswordAwareMaterial, P
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE, true);
+    }
+
+    @Override
+    protected void setGoMaterialVariables(EnvironmentVariableContext environmentVariableContext) {
+        super.setGoMaterialVariables(environmentVariableContext);
+        if (isNotBlank(domain)) {
+            setVariableWithName(environmentVariableContext, domain, GO_MATERIAL_DOMAIN);
+        }
     }
 }

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
@@ -749,7 +749,7 @@ public class GitMaterialTest {
 
     @Test
     void populateEnvContextShouldSetMaterialEnvVars() {
-        GitMaterial material = new GitMaterial("https://user:password@example.github.com");
+        GitMaterial material = new GitMaterial("https://user:password@github.com/bob/my-project", "branchName");
 
         EnvironmentVariableContext ctx = new EnvironmentVariableContext();
         final ArrayList<Modification> modifications = new ArrayList<>();
@@ -763,7 +763,22 @@ public class GitMaterialTest {
 
         material.populateEnvironmentContext(ctx, materialRevision, new File("."));
 
-        assertThat(ctx.getProperty(ScmMaterial.GO_MATERIAL_URL)).isEqualTo("https://example.github.com");
+        assertThat(ctx.getProperty(ScmMaterial.GO_MATERIAL_URL)).isEqualTo("https://github.com/bob/my-project");
+        assertThat(ctx.getProperty(GitMaterial.GO_MATERIAL_BRANCH)).isEqualTo("branchName");
+    }
+
+    @Test
+    void shouldPopulateBranchWithDefaultIfNotSet() {
+        GitMaterial material = new GitMaterial("https://user:password@github.com/bob/my-project");
+
+        EnvironmentVariableContext ctx = new EnvironmentVariableContext();
+        final ArrayList<Modification> modifications = new ArrayList<>();
+
+        modifications.add(new Modification("user1", "comment1", "email1", new Date(), "23"));
+
+        MaterialRevision materialRevision = new MaterialRevision(material, modifications);
+        material.populateEnvironmentContext(ctx, materialRevision, new File("."));
+
         assertThat(ctx.getProperty(GitMaterial.GO_MATERIAL_BRANCH)).isEqualTo("master");
     }
 


### PR DESCRIPTION
Issue: #6289 

Description:
 - material url without credentials is added to the Env Var context
 - in case of
   - GitMaterial and HgMaterial: branch is also added if present else the default value is set
   - TfsMaterial: domain is added if set
