### PR TITLE
Introduce edit agent association modal to allow modifying environment-agent association

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/environments.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/environments.ts
@@ -16,7 +16,7 @@
 
 import _ from "lodash";
 import Stream from "mithril/stream";
-import {Agents, EnvironmentAgentJSON} from "models/new-environments/environment_agents";
+import {Agents, AgentWithOrigin, EnvironmentAgentJSON} from "models/new-environments/environment_agents";
 import {
   EnvironmentEnvironmentVariableJSON,
   EnvironmentVariables
@@ -72,9 +72,19 @@ export class EnvironmentWithOrigin {
     return this.pipelines().map((p) => p.name()).indexOf(name) !== -1;
   }
 
+  containsAgent(uuid: string): boolean {
+    return this.agents().map((a) => a.uuid()).indexOf(uuid) !== -1;
+  }
+
   addPipelineIfNotPresent(pipeline: PipelineWithOrigin) {
     if (!this.containsPipeline(pipeline.name())) {
       this.pipelines().push(pipeline);
+    }
+  }
+
+  addAgentIfNotPresent(agent: AgentWithOrigin) {
+    if (!this.containsAgent(agent.uuid())) {
+      this.agents().push(agent);
     }
   }
 
@@ -84,6 +94,10 @@ export class EnvironmentWithOrigin {
 
   removePipelineIfPresent(pipeline: PipelineWithOrigin) {
     _.remove(this.pipelines(), (p) => p.name() === pipeline.name());
+  }
+
+  removeAgentIfPresent(agent: AgentWithOrigin) {
+    _.remove(this.agents(), (p) => p.uuid() === agent.uuid());
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/spec/environments_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/spec/environments_spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {AgentWithOrigin} from "models/new-environments/environment_agents";
 import {PipelineWithOrigin} from "models/new-environments/environment_pipelines";
 import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
 import data from "models/new-environments/spec/test_data";
@@ -48,6 +49,15 @@ describe("Environments Model - Environments", () => {
     expect(environment.containsPipeline("non-existing-pipeline")).toBe(false);
   });
 
+  it("should tell whether environment contains an agent", () => {
+    const environment = EnvironmentWithOrigin.fromJSON(envJSON);
+
+    expect(environment.containsAgent(envJSON.agents[0].uuid)).toBe(true);
+    expect(environment.containsAgent(envJSON.agents[1].uuid)).toBe(true);
+
+    expect(environment.containsAgent("non-existing-agent")).toBe(false);
+  });
+
   it("should add a pipeline to an environment", () => {
     const environment = EnvironmentWithOrigin.fromJSON(envJSON);
 
@@ -56,6 +66,16 @@ describe("Environments Model - Environments", () => {
     expect(environment.containsPipeline(pipelineToAdd.name)).toBe(false);
     environment.addPipelineIfNotPresent(PipelineWithOrigin.fromJSON(pipelineToAdd));
     expect(environment.containsPipeline(pipelineToAdd.name)).toBe(true);
+  });
+
+  it("should add an agent to an environment", () => {
+    const environment = EnvironmentWithOrigin.fromJSON(envJSON);
+
+    const agentToAdd = data.agent_association_in_xml_json();
+
+    expect(environment.containsAgent(agentToAdd.uuid)).toBe(false);
+    environment.addAgentIfNotPresent(AgentWithOrigin.fromJSON(agentToAdd));
+    expect(environment.containsAgent(agentToAdd.uuid)).toBe(true);
   });
 
   it("should not add a pipeline to an environment when one already exists", () => {
@@ -77,6 +97,25 @@ describe("Environments Model - Environments", () => {
     expect(environment.containsPipeline(pipelineToAdd.name)).toBe(true);
   });
 
+  it("should not add an agent to an environment when one already exists", () => {
+    const environment = EnvironmentWithOrigin.fromJSON(envJSON);
+
+    const agentToAdd = data.agent_association_in_xml_json();
+
+    expect(environment.agents().length).toBe(2);
+    expect(environment.containsAgent(agentToAdd.uuid)).toBe(false);
+
+    environment.addAgentIfNotPresent(AgentWithOrigin.fromJSON(agentToAdd));
+
+    expect(environment.agents().length).toBe(3);
+    expect(environment.containsAgent(agentToAdd.uuid)).toBe(true);
+
+    environment.addAgentIfNotPresent(AgentWithOrigin.fromJSON(agentToAdd));
+
+    expect(environment.agents().length).toBe(3);
+    expect(environment.containsAgent(agentToAdd.uuid)).toBe(true);
+  });
+
   it("should remove a pipeline from an environment", () => {
     const environment  = EnvironmentWithOrigin.fromJSON(envJSON);
     const pipelineJson = data.pipeline_association_in_xml_json();
@@ -92,6 +131,22 @@ describe("Environments Model - Environments", () => {
     expect(environment.containsPipeline(pipelineJson.name)).toBe(false);
   });
 
+  it("should remove an agent from an environment", () => {
+    const environment = EnvironmentWithOrigin.fromJSON(envJSON);
+
+    const agentJson = data.agent_association_in_xml_json();
+    const agent     = AgentWithOrigin.fromJSON(agentJson);
+    environment.addAgentIfNotPresent(agent);
+
+    expect(environment.agents().length).toBe(3);
+    expect(environment.containsAgent(agentJson.uuid)).toBe(true);
+
+    environment.removeAgentIfPresent(agent);
+
+    expect(environment.agents().length).toBe(2);
+    expect(environment.containsAgent(agentJson.uuid)).toBe(false);
+  });
+
   it("should not fail to remove a non-existent pipeline from an environment", () => {
     const environment  = EnvironmentWithOrigin.fromJSON(envJSON);
     const pipelineJson = data.pipeline_association_in_xml_json();
@@ -104,6 +159,21 @@ describe("Environments Model - Environments", () => {
 
     expect(environment.pipelines().length).toBe(2);
     expect(environment.containsPipeline(pipelineJson.name)).toBe(false);
+  });
+
+  it("should not fail to remove a non-existent agent from an environment", () => {
+    const environment = EnvironmentWithOrigin.fromJSON(envJSON);
+
+    const agentJson = data.agent_association_in_xml_json();
+    const agent     = AgentWithOrigin.fromJSON(agentJson);
+
+    expect(environment.agents().length).toBe(2);
+    expect(environment.containsAgent(agentJson.uuid)).toBe(false);
+
+    environment.removeAgentIfPresent(agent);
+
+    expect(environment.agents().length).toBe(2);
+    expect(environment.containsAgent(agentJson.uuid)).toBe(false);
   });
 
   it("should answer the environment to which the specified pipeline is associated", () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_agents_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_agents_modal.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MithrilViewComponent} from "jsx/mithril-component";
+import m from "mithril";
+import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
+import {Agent, Agents} from "models/new_agent/agents";
+import s from "underscore.string";
+import {CheckboxField} from "views/components/forms/input_fields";
+import {Modal, ModalState, Size} from "views/components/modal";
+import styles from "views/pages/new-environments/edit_pipelines.scss";
+import {AgentsViewModel} from "views/pages/new-environments/models/agents_view_model";
+
+interface AgentCheckboxListWidgetAttrs {
+  readonly: boolean;
+  title: string;
+  agents: Agents;
+  agentSelectedFn: (a: any) => (a: boolean | undefined) => boolean | undefined;
+}
+
+export class AgentCheckboxListWidget extends MithrilViewComponent<AgentCheckboxListWidgetAttrs> {
+  view(vnode: m.Vnode<AgentCheckboxListWidgetAttrs>) {
+    const agents = vnode.attrs.agents;
+
+    if (agents.length === 0) {
+      return;
+    }
+
+    return <div class={styles.pipelinesContainer} data-test-id={s.slugify(vnode.attrs.title)}>
+      <div class={styles.header}>{vnode.attrs.title}</div>
+      {
+        agents.map((agent: Agent) => {
+          return <div class={styles.pipelineCheckbox} data-test-id={`agent-checkbox-for-${agent.uuid}`}>
+            <CheckboxField label={agent.hostname}
+                           dataTestId={`form-field-input-${agent.uuid}`}
+                           readonly={vnode.attrs.readonly}
+                           property={vnode.attrs.agentSelectedFn(agent)}/>
+          </div>;
+        })
+      }
+    </div>;
+  }
+}
+
+interface UnavailableElasticAgentsWidgetAttrs {
+  agents: Agents;
+}
+
+export class UnavailableElasticAgentsWidget extends MithrilViewComponent<UnavailableElasticAgentsWidgetAttrs> {
+  view(vnode: m.Vnode<UnavailableElasticAgentsWidgetAttrs>) {
+    const agents = vnode.attrs.agents;
+
+    if (agents.length === 0) {
+      return;
+    }
+
+    const title = "Unavailable Agents (Elastic Agents):";
+    return <div class={styles.pipelinesContainer} data-test-id={s.slugify(title)}>
+      <div class={styles.header}> {title} </div>
+      <ul>
+        {
+          agents.map((agent) => {
+            return <li data-test-id={`agent-list-item-for-${agent.uuid}`}>
+              <span>{agent.hostname}</span>
+            </li>;
+          })
+        }
+      </ul>
+    </div>;
+  }
+}
+
+export class EditAgentsModal extends Modal {
+  readonly agentsVM: AgentsViewModel;
+
+  constructor(env: EnvironmentWithOrigin, environments: Environments) {
+    super(Size.medium);
+    this.modalState  = ModalState.LOADING;
+    this.fixedHeight = true;
+    this.agentsVM    = new AgentsViewModel(env, environments);
+  }
+
+  oninit() {
+    super.oninit();
+    this.agentsVM.fetchAllAgents(() => {
+      this.modalState = ModalState.OK;
+    });
+  }
+
+  title(): string {
+    return "Edit Agents Association";
+  }
+
+  body(): m.Children {
+    if (!this.agentsVM.agents()) {
+      return;
+    }
+
+    return <div>
+      <div className={styles.allPipelinesWrapper}>
+        <AgentCheckboxListWidget agents={this.agentsVM.availableAgents()}
+                                 title={"Available Agents:"}
+                                 readonly={false}
+                                 agentSelectedFn={this.agentsVM.agentSelectedFn.bind(this.agentsVM)}/>
+        <AgentCheckboxListWidget agents={this.agentsVM.configRepoEnvironmentAgents()}
+                                 title={"Agents associated with this environment in configuration repository:"}
+                                 readonly={true}
+                                 agentSelectedFn={this.agentsVM.agentSelectedFn.bind(this.agentsVM)}/>
+        <AgentCheckboxListWidget agents={this.agentsVM.environmentElasticAgents()}
+                                 title={"Elastic Agents associated with this environment:"}
+                                 readonly={true}
+                                 agentSelectedFn={this.agentsVM.agentSelectedFn.bind(this.agentsVM)}/>
+        <UnavailableElasticAgentsWidget agents={this.agentsVM.elasticAgentsNotBelongingToCurrentEnv()}/>
+      </div>
+    </div>;
+  }
+
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environment_body_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environment_body_widget.tsx
@@ -21,6 +21,7 @@ import {Environments, EnvironmentWithOrigin} from "models/new-environments/envir
 import s from "underscore.string";
 import {HelpText} from "views/components/forms/input_fields";
 import * as Icons from "views/components/icons/index";
+import {EditAgentsModal} from "views/pages/new-environments/edit_agents_modal";
 import {EditPipelinesModal} from "views/pages/new-environments/edit_pipelines_modal";
 import styles from "./index.scss";
 
@@ -62,7 +63,7 @@ export class EnvironmentBody extends MithrilComponent<EnvironmentBodyAttrs, Envi
     };
 
     vnode.state.renderAgentsModal = (env: EnvironmentWithOrigin) => {
-      new EditPipelinesModal(env, vnode.attrs.environments).render();
+      new EditAgentsModal(env, vnode.attrs.environments).render();
     };
 
     vnode.state.renderEnvironmentsVariablesModal = (env: EnvironmentWithOrigin) => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/models/agents_view_model.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/models/agents_view_model.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import m from "mithril";
+import Stream from "mithril/stream";
+import {AgentWithOrigin} from "models/new-environments/environment_agents";
+import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
+import {Origin, OriginType} from "models/new-environments/origin";
+import {Agent, Agents} from "models/new_agent/agents";
+import {AgentsCRUD} from "models/new_agent/agents_crud";
+
+export class AgentsViewModel {
+  readonly searchText: Stream<string | undefined>;
+  readonly errorMessage: Stream<string | undefined>;
+  readonly agents: Stream<Agents | undefined>;
+  readonly environment: EnvironmentWithOrigin;
+  readonly environments: Environments;
+
+  constructor(environment: EnvironmentWithOrigin, environments: Environments) {
+    this.environment  = environment;
+    this.environments = environments;
+    this.searchText   = Stream();
+    this.errorMessage = Stream();
+    this.agents       = Stream();
+  }
+
+  availableAgents(): Agents {
+    return new Agents(...this.agents()!.filter((agent) => {
+      const found: AgentWithOrigin | undefined = this.environment.agents().find((a) => a.uuid() === agent.uuid);
+      const belongsToEnvironment: boolean      = !!found;
+
+      if (belongsToEnvironment) {
+        return !found!.origin().isDefinedInConfigRepo() && !agent.isElastic();
+      }
+
+      return !agent.isElastic();
+    }));
+  }
+
+  configRepoEnvironmentAgents(): Agents {
+    return new Agents(...this.agents()!.filter((agent) => {
+      const found: AgentWithOrigin | undefined = this.environment.agents().find((a) => a.uuid() === agent.uuid);
+      return found && found.origin().isDefinedInConfigRepo();
+    }));
+  }
+
+  environmentElasticAgents(): Agents {
+    return new Agents(...this.agents()!.filter((agent) => {
+      const found: AgentWithOrigin | undefined = this.environment.agents().find((a) => a.uuid() === agent.uuid);
+      return found && agent.isElastic();
+    }));
+  }
+
+  elasticAgentsNotBelongingToCurrentEnv(): Agents {
+    const self = this;
+    return new Agents(...this.agents()!.filter((agent) => {
+      return agent.isElastic() && !self.environment.containsAgent(agent.uuid);
+    }));
+  }
+
+  agentSelectedFn(selected: Agent): (value?: any) => any {
+    const self  = this;
+    const agent = new AgentWithOrigin(selected.uuid, new Origin(OriginType.GoCD));
+
+    return (value?: boolean) => {
+      if (value !== undefined) {
+        value ? self.environment.addAgentIfNotPresent(agent) : self.environment.removeAgentIfPresent(agent);
+      }
+      return self.environment.containsAgent(selected.uuid);
+    };
+  }
+
+  fetchAllAgents(callback: () => void) {
+    AgentsCRUD.all().then((result) =>
+                            result.do((successResponse) => {
+                              this.agents(successResponse.body);
+                              callback();
+                            }, (errorResponse) => {
+                              this.errorMessage(JSON.parse(errorResponse.body!).message);
+                            })).finally(m.redraw);
+  }
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_agents_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_agents_modal_spec.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
+import test_data from "models/new-environments/spec/test_data";
+import {Agents} from "models/new_agent/agents";
+import {AgentsJSON} from "models/new_agent/agents_json";
+import {AgentsTestData} from "models/new_agent/spec/agents_test_data";
+import * as simulateEvent from "simulate-event";
+import {EditAgentsModal} from "views/pages/new-environments/edit_agents_modal";
+import {TestHelper} from "views/pages/spec/test_helper";
+
+describe("Edit Agents Modal", () => {
+  const helper = new TestHelper();
+
+  let environment: EnvironmentWithOrigin,
+      environments: Environments,
+      agentsJSON: AgentsJSON;
+
+  let normalAgentAssociatedWithEnvInXml: string,
+      normalAgentAssociatedWithEnvInConfigRepo: string,
+      elasticAgentAssociatedWithEnvInXml: string,
+      unassociatedStaticAgent: string,
+      unassociatedElasticAgent: string;
+
+  let modal: EditAgentsModal;
+
+  beforeEach(() => {
+    jasmine.Ajax.install();
+
+    environments          = new Environments();
+    const environmentJSON = test_data.environment_json();
+    environmentJSON.agents.push(test_data.agent_association_in_xml_json());
+
+    environment = EnvironmentWithOrigin.fromJSON(environmentJSON);
+    environments.push(environment);
+
+    agentsJSON = AgentsTestData.list();
+
+    agentsJSON._embedded.agents.push(AgentsTestData.elasticAgent());
+    agentsJSON._embedded.agents.push(AgentsTestData.elasticAgent());
+
+    //normal agent associated with environment in xml
+    normalAgentAssociatedWithEnvInXml   = environmentJSON.agents[0].uuid;
+    agentsJSON._embedded.agents[0].uuid = normalAgentAssociatedWithEnvInXml;
+
+    //normal agent associated with environment in config repo
+    normalAgentAssociatedWithEnvInConfigRepo = environmentJSON.agents[1].uuid;
+    agentsJSON._embedded.agents[1].uuid      = normalAgentAssociatedWithEnvInConfigRepo;
+
+    //elastic agent associated with environment in xml
+    elasticAgentAssociatedWithEnvInXml  = environmentJSON.agents[2].uuid;
+    agentsJSON._embedded.agents[4].uuid = elasticAgentAssociatedWithEnvInXml;
+
+    unassociatedStaticAgent  = agentsJSON._embedded.agents[2].uuid;
+    unassociatedElasticAgent = agentsJSON._embedded.agents[3].uuid;
+
+    modal = new EditAgentsModal(environment, environments);
+    modal.agentsVM.agents(Agents.fromJSON(agentsJSON));
+
+    helper.mount(() => modal.body());
+  });
+
+  afterEach(() => {
+    helper.unmount();
+    jasmine.Ajax.uninstall();
+  });
+
+  it("should render available agents", () => {
+    const availableAgentsSection = helper.byTestId(`available-agents`);
+    const agent1Selector         = `agent-checkbox-for-${normalAgentAssociatedWithEnvInXml}`;
+    const agent2Selector         = `agent-checkbox-for-${unassociatedStaticAgent}`;
+
+    expect(availableAgentsSection).toBeInDOM();
+    expect(availableAgentsSection).toContainText("Available Agents");
+    expect(helper.byTestId(agent1Selector, availableAgentsSection)).toBeInDOM();
+    expect(helper.byTestId(agent2Selector, availableAgentsSection)).toBeInDOM();
+  });
+
+  it("should render agents defined in config repo", () => {
+    const configRepoAgentsSection = helper.byTestId(`agents-associated-with-this-environment-in-configuration-repository`);
+    const agent1Selector          = `agent-checkbox-for-${normalAgentAssociatedWithEnvInConfigRepo}`;
+
+    expect(configRepoAgentsSection).toBeInDOM();
+    expect(configRepoAgentsSection)
+      .toContainText("Agents associated with this environment in configuration repository");
+    expect(helper.byTestId(agent1Selector, configRepoAgentsSection)).toBeInDOM();
+  });
+
+  it("should render elastic agents associated with the current environment", () => {
+    const elasticAgentsSection = helper.byTestId(`elastic-agents-associated-with-this-environment`);
+    const agent1Selector       = `agent-checkbox-for-${elasticAgentAssociatedWithEnvInXml}`;
+
+    expect(elasticAgentsSection).toBeInDOM();
+    expect(elasticAgentsSection).toContainText("Elastic Agents associated with this environment");
+    expect(helper.byTestId(agent1Selector, elasticAgentsSection)).toBeInDOM();
+  });
+
+  it("should render unavailable elastic agents not belonging to the current environment", () => {
+    const elasticAgentsSection = helper.byTestId(`unavailable-agents-elastic-agents`);
+    const agent1Selector       = `agent-list-item-for-${unassociatedElasticAgent}`;
+
+    expect(elasticAgentsSection).toBeInDOM();
+    expect(elasticAgentsSection).toContainText("Unavailable Agents (Elastic Agents)");
+    expect(helper.byTestId(agent1Selector, elasticAgentsSection)).toBeInDOM();
+  });
+
+  it("should toggle agent selection from environment on click", () => {
+    const agent1Checkbox = helper.byTestId(`form-field-input-${normalAgentAssociatedWithEnvInXml}`) as HTMLInputElement;
+    const agent2Checkbox = helper.byTestId(`form-field-input-${unassociatedStaticAgent}`) as HTMLInputElement;
+
+    expect(agent1Checkbox.checked).toBe(true);
+    expect(environment.containsAgent(normalAgentAssociatedWithEnvInXml)).toBe(true);
+
+    expect(agent2Checkbox.checked).toBe(false);
+    expect(environment.containsAgent(unassociatedStaticAgent)).toBe(false);
+
+    simulateEvent.simulate(agent1Checkbox, "click");
+    helper.redraw();
+
+    expect(agent1Checkbox.checked).toBe(false);
+    expect(environment.containsAgent(normalAgentAssociatedWithEnvInXml)).toBe(false);
+
+    simulateEvent.simulate(agent2Checkbox, "click");
+    helper.redraw();
+
+    expect(agent2Checkbox.checked).toBe(true);
+    expect(environment.containsAgent(unassociatedStaticAgent)).toBe(true);
+  });
+
+  it("should not allow toggling config repo agents", () => {
+    const agent1Checkbox = helper.byTestId(`form-field-input-${normalAgentAssociatedWithEnvInConfigRepo}`) as HTMLInputElement;
+
+    expect(agent1Checkbox.checked).toBe(true);
+    expect(agent1Checkbox.disabled).toBe(true);
+  });
+
+  it("should not allow toggling elastic agents", () => {
+    const agent1Checkbox = helper.byTestId(`form-field-input-${elasticAgentAssociatedWithEnvInXml}`) as HTMLInputElement;
+
+    expect(agent1Checkbox.checked).toBe(true);
+    expect(agent1Checkbox.disabled).toBe(true);
+  });
+});

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/models/agents_view_model_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/models/agents_view_model_spec.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
+import test_data from "models/new-environments/spec/test_data";
+import {Agents} from "models/new_agent/agents";
+import {AgentsJSON} from "models/new_agent/agents_json";
+import {AgentsTestData} from "models/new_agent/spec/agents_test_data";
+import {AgentsViewModel} from "views/pages/new-environments/models/agents_view_model";
+
+describe("Agents View Model", () => {
+  let environment: EnvironmentWithOrigin;
+  let environments: Environments;
+  let agentsViewModel: AgentsViewModel;
+  let agentsJSON: AgentsJSON;
+
+  let normalAgentAssociatedWithEnvInXml: string,
+      normalAgentAssociatedWithEnvInConfigRepo: string,
+      elasticAgentAssociatedWithEnvInXml: string,
+      unassociatedStaticAgent: string,
+      unassociatedElasticAgent: string;
+
+  beforeEach(() => {
+    environments          = new Environments();
+    const environmentJSON = test_data.environment_json();
+    environmentJSON.agents.push(test_data.agent_association_in_xml_json());
+
+    environment = EnvironmentWithOrigin.fromJSON(environmentJSON);
+    environments.push(environment);
+
+    agentsViewModel = new AgentsViewModel(environment, environments);
+    agentsJSON      = AgentsTestData.list();
+
+    agentsJSON._embedded.agents.push(AgentsTestData.elasticAgent());
+    agentsJSON._embedded.agents.push(AgentsTestData.elasticAgent());
+
+    //normal agent associated with environment in xml
+    normalAgentAssociatedWithEnvInXml   = environmentJSON.agents[0].uuid;
+    agentsJSON._embedded.agents[0].uuid = normalAgentAssociatedWithEnvInXml;
+
+    //normal agent associated with environment in config repo
+    normalAgentAssociatedWithEnvInConfigRepo = environmentJSON.agents[1].uuid;
+    agentsJSON._embedded.agents[1].uuid      = normalAgentAssociatedWithEnvInConfigRepo;
+
+    //elastic agent associated with environment in xml
+    elasticAgentAssociatedWithEnvInXml  = environmentJSON.agents[2].uuid;
+    agentsJSON._embedded.agents[4].uuid = elasticAgentAssociatedWithEnvInXml;
+
+    unassociatedStaticAgent  = agentsJSON._embedded.agents[2].uuid;
+    unassociatedElasticAgent = agentsJSON._embedded.agents[3].uuid;
+
+    agentsViewModel.agents(Agents.fromJSON(agentsJSON));
+  });
+
+  it("should return available agents", () => {
+    const agents = agentsViewModel.availableAgents();
+
+    expect(agents.length).toBe(2);
+    expect(agents[0].uuid).toBe(normalAgentAssociatedWithEnvInXml);
+    expect(agents[1].uuid).toBe(unassociatedStaticAgent);
+  });
+
+  it("should return agents belonging to the environment whose association is defined in config repo", () => {
+    const agents = agentsViewModel.configRepoEnvironmentAgents();
+
+    expect(agents.length).toBe(1);
+    expect(agents[0].uuid).toBe(normalAgentAssociatedWithEnvInConfigRepo);
+  });
+
+  it("should return elastic agents belonging to the environment", () => {
+    const agents = agentsViewModel.environmentElasticAgents();
+
+    expect(agents.length).toBe(1);
+    expect(agents[0].uuid).toBe(elasticAgentAssociatedWithEnvInXml);
+  });
+
+  it("should return elastic agents not belonging to the environment", () => {
+    const agents = agentsViewModel.elasticAgentsNotBelongingToCurrentEnv();
+
+    expect(agents.length).toBe(1);
+    expect(agents[0].uuid).toBe(unassociatedElasticAgent);
+  });
+
+  it("should answer whether an agent belongs to the current environment", () => {
+    const agents = agentsViewModel.agents();
+
+    expect(agentsViewModel.agentSelectedFn(agents![0])()).toBe(true);
+    expect(agentsViewModel.agentSelectedFn(agents![0])()).toBe(environment.containsAgent(agents![0].uuid));
+
+    expect(agentsViewModel.agentSelectedFn(agents![1])()).toBe(true);
+    expect(agentsViewModel.agentSelectedFn(agents![1])()).toBe(environment.containsAgent(agents![1].uuid));
+
+    expect(agentsViewModel.agentSelectedFn(agents![2])()).toBe(false);
+    expect(agentsViewModel.agentSelectedFn(agents![2])()).toBe(environment.containsAgent(agents![2].uuid));
+
+    expect(agentsViewModel.agentSelectedFn(agents![3])()).toBe(false);
+    expect(agentsViewModel.agentSelectedFn(agents![3])()).toBe(environment.containsAgent(agents![3].uuid));
+
+    expect(agentsViewModel.agentSelectedFn(agents![4])()).toBe(true);
+    expect(agentsViewModel.agentSelectedFn(agents![4])()).toBe(environment.containsAgent(agents![4].uuid));
+  });
+
+  it("should add an agent to an environment using agentSelectedFn", () => {
+    const agents = agentsViewModel.agents();
+
+    expect(agentsViewModel.agentSelectedFn(agents![2])()).toBe(false);
+    expect(environment.containsAgent(agents![2].uuid)).toBe(false);
+
+    agentsViewModel.agentSelectedFn(agents![2])(agents![2]);
+
+    expect(agentsViewModel.agentSelectedFn(agents![2])()).toBe(true);
+    expect(environment.containsAgent(agents![2].uuid)).toBe(true);
+  });
+});


### PR DESCRIPTION
##### Issue: #6982

##### Description:

* Introduce following different categories of agents:
    - Available Agents (agents available for association/dissociation)
    - Unavailable Agents:
          - Agents association defined in config repository
	  - Elastic Agents of the current environment
	  - Other Elastic Agents

* Use list view to show agents instead of agents table.

![Screen Shot 2019-09-30 at 4 44 29 PM](https://user-images.githubusercontent.com/15275847/65933964-324dca00-e431-11e9-9b4e-fa3f29016267.png)
![Screen Shot 2019-09-30 at 4 44 34 PM](https://user-images.githubusercontent.com/15275847/65933965-324dca00-e431-11e9-8338-a29d60ba3d88.png)
