### PR TITLE
Do not update email in DB when plugin does not return one on authentication

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/UserService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/UserService.java
@@ -48,6 +48,7 @@ import java.util.*;
 
 import static com.thoughtworks.go.serverhealth.HealthStateScope.GLOBAL;
 import static com.thoughtworks.go.serverhealth.HealthStateType.general;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.join;
 
 @Service
@@ -276,7 +277,9 @@ public class UserService {
         }
     }
 
-    public void bulkEnableDisableUsers(List<String> userNames, boolean shouldEnable, BulkUpdateUsersOperationResult result) {
+    public void bulkEnableDisableUsers(List<String> userNames,
+                                       boolean shouldEnable,
+                                       BulkUpdateUsersOperationResult result) {
         synchronized (enableUserMutex) {
             boolean isValid = performUserUpdateValidation(userNames, result);
             if (isValid) {
@@ -589,7 +592,7 @@ public class UserService {
     }
 
     private boolean hasUserChanged(User newUser, User originalUser) {
-        boolean hasEmailChanged = !StringUtils.equals(originalUser.getEmail(), newUser.getEmail());
+        boolean hasEmailChanged = isNotBlank(newUser.getEmail()) && !StringUtils.equals(originalUser.getEmail(), newUser.getEmail());
         boolean hasDisplayNameChanged = !StringUtils.equals(originalUser.getDisplayName(), newUser.getDisplayName());
         if (hasEmailChanged) {
             LOGGER.debug("User [{}] has an email change. Updating the same in the DB.", originalUser.getName());

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/UserServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/UserServiceTest.java
@@ -757,6 +757,18 @@ public class UserServiceTest {
             verify(userDao).findUser(username);
             verifyNoMoreInteractions(userDao);
         }
+
+        @Test
+        void shouldNotUpdateEmailIfNewEmailFromPluginIsNull() {
+            String username = "new-user";
+            User existingUserWithEmailInDB = new User(username, null, "bob@gocd.org");
+            User newUserFromPlugin = new User(username, null, null);
+            when(userDao.findUser(username)).thenReturn(existingUserWithEmailInDB);
+            userService.addOrUpdateUser(newUserFromPlugin);
+
+            verify(userDao).findUser(username);
+            verifyNoMoreInteractions(userDao);
+        }
     }
 
     private void configureAdmin(String username, boolean isAdmin) {


### PR DESCRIPTION
Issue: #7067

- This is required as the password file plugin does not support have email.
  Without this, If the user has configured email through the Preference then
  it will be erased after logout and login.

- An ideal solution would be to introduce the `supports_email` capability to authorization extension and based on that decide to update the  email for the logged-in user