### PR TITLE
Making the new agents spa default page

### DIFF
--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -33,8 +33,8 @@
     },
     {
       "key": "show_new_agents_spa",
-      "description": "Switch to the new agents SPA. Default is false.",
-      "value": false
+      "description": "Switch to the new agents SPA. Default is true.",
+      "value": true
     }
   ]
 }


### PR DESCRIPTION
Turning on the toggle for showing new agents SPA by default.
To turn it off:
```
 curl 'http://localhost:8154/go/api/admin/feature_toggles/show_new_agents_spa'  
 -H 'Accept: application/vnd.go.cd.v1+json' 
 -X PUT 
 -d '{"toggle_value": "off"}'
```

