### PR TITLE
Use pipeline config api v10 to create pipelines

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/api_request_builder.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/api_request_builder.ts
@@ -18,7 +18,7 @@ import _ from "lodash";
 import m from "mithril";
 import Stream from "mithril/stream";
 
-export enum ApiVersion { latest, v1, v2, v3, v4, v5, v6, v7, v8}
+export enum ApiVersion { latest, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10}
 
 export interface ObjectWithEtag<T> {
   etag: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new_pipeline_configs/pipeline_config.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new_pipeline_configs/pipeline_config.ts
@@ -72,7 +72,7 @@ export class PipelineConfig extends ValidatableMixin {
   }
 
   create(pause: boolean) {
-    return ApiRequestBuilder.POST(SparkRoutes.pipelineConfigCreatePath(), ApiVersion.v8, {
+    return ApiRequestBuilder.POST(SparkRoutes.pipelineConfigCreatePath(), ApiVersion.v10, {
       payload: this.toApiPayload(),
       headers: {"X-pause-pipeline": pause.toString()}
     });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/pipeline_config.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/pipeline_config.ts
@@ -59,7 +59,7 @@ export class PipelineConfig extends ValidatableMixin {
   }
 
   create(pause: boolean) {
-    return ApiRequestBuilder.POST(SparkRoutes.pipelineConfigCreatePath(), ApiVersion.v8, {
+    return ApiRequestBuilder.POST(SparkRoutes.pipelineConfigCreatePath(), ApiVersion.v10, {
       payload: this.toApiPayload(),
       headers: {"X-pause-pipeline": pause.toString(), "X-pause-cause": "Under construction"}
     });


### PR DESCRIPTION
Older api versions were removed, and this caused the add pipeline flow to throw a 404 for create. Using v10 of the Pipeline Config api now

