### PR TITLE
Fix sort on agents spa

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new_agent/agent_comparator.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new_agent/agent_comparator.ts
@@ -23,11 +23,9 @@ export enum SortOrder {
 
 export class AgentComparator {
   private readonly columnName: string;
-  private readonly sortOrder: SortOrder;
 
-  constructor(columnName: string, sortOrder: SortOrder) {
+  constructor(columnName: string) {
     this.columnName = columnName;
-    this.sortOrder  = sortOrder;
   }
 
   compare(agentOne: Agent, agentTwo: Agent): number {
@@ -90,16 +88,16 @@ export class AgentComparator {
   private compareAgentState(first: string, other: string) {
     const firstRank = AgentComparator.getAgentStatusRank(first);
     const otherRank = AgentComparator.getAgentStatusRank(other);
-    return this.sortOrder === SortOrder.ASC ? firstRank - otherRank : otherRank - firstRank;
+    return firstRank - otherRank;
   }
 
   private compareFreespace(first: string, other: string) {
     const firstAsNumber = _.isNaN(parseInt(first, 10)) ? Number.MAX_SAFE_INTEGER : parseInt(first, 10);
     const otherAsNumber = _.isNaN(parseInt(other, 10)) ? Number.MAX_SAFE_INTEGER : parseInt(other, 10);
-    return this.sortOrder === SortOrder.ASC ? firstAsNumber - otherAsNumber : otherAsNumber - firstAsNumber;
+    return firstAsNumber - otherAsNumber;
   }
 
   private compareString(first: string, other: string) {
-    return this.sortOrder === SortOrder.ASC ? first.localeCompare(other) : other.localeCompare(first);
+    return first.localeCompare(other);
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new_agent/agents_vm.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new_agent/agents_vm.ts
@@ -211,7 +211,7 @@ export class AgentSortHandler implements TableSortHandler {
   sort() {
     const agentComparator = new AgentComparator(this.sortableColumns.get(this.sortOnColumn) as string);
     this.agentsVM.all().sort(agentComparator.compare.bind(agentComparator));
-    if (this.sortOrder == SortOrder.DESC) {
+    if (this.sortOrder === SortOrder.DESC) {
       this.agentsVM.all().reverse();
     }
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new_agent/agents_vm.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new_agent/agents_vm.ts
@@ -185,7 +185,7 @@ export class ElasticAgentVM extends BaseVM {
 export class AgentSortHandler implements TableSortHandler {
   private readonly sortableColumns: Map<number, string>;
   private readonly agentsVM: ElasticAgentVM | StaticAgentsVM;
-  private sortOnColumn: number = -1;
+  private sortOnColumn: number = 5;
   private sortOrder: SortOrder = SortOrder.ASC;
 
   constructor(agentsVM: ElasticAgentVM | StaticAgentsVM, sortableColumns: Map<number, string>) {
@@ -209,8 +209,11 @@ export class AgentSortHandler implements TableSortHandler {
   }
 
   sort() {
-    const agentComparator = new AgentComparator(this.sortableColumns.get(this.sortOnColumn) as string, this.sortOrder);
+    const agentComparator = new AgentComparator(this.sortableColumns.get(this.sortOnColumn) as string);
     this.agentsVM.all().sort(agentComparator.compare.bind(agentComparator));
+    if (this.sortOrder == SortOrder.DESC) {
+      this.agentsVM.all().reverse();
+    }
   }
 
   currentSortedColumnIndex(): number {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new_agent/spec/agent_comaparator_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new_agent/spec/agent_comaparator_spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AgentComparator, SortOrder} from "models/new_agent/agent_comparator";
+import {AgentComparator} from "models/new_agent/agent_comparator";
 import {Agent} from "models/new_agent/agents";
 import {AgentsTestData} from "models/new_agent/spec/agents_test_data";
 
@@ -38,20 +38,11 @@ describe("AgentComparator", () => {
     });
 
     it("should sort agents in ascending order", () => {
-      const comparator = new AgentComparator("agentState", SortOrder.ASC);
+      const comparator = new AgentComparator("agentState");
 
       const sortedList = originalOrder.sort(comparator.compare.bind(comparator));
 
       const expectedAfterSort = [pending, lostContact, missing, building, buildingCancelled, idle, disabledBuilding, disabledCanceled, disabled];
-      expect(sortedList).toEqual(expectedAfterSort);
-    });
-
-    it("should sort agents in descending order", () => {
-      const comparator = new AgentComparator("agentState", SortOrder.DESC);
-
-      const sortedList = originalOrder.sort(comparator.compare.bind(comparator));
-
-      const expectedAfterSort = [disabled, disabledCanceled, disabledBuilding, idle, buildingCancelled, building, missing, lostContact, pending];
       expect(sortedList).toEqual(expectedAfterSort);
     });
   });
@@ -66,19 +57,11 @@ describe("AgentComparator", () => {
       originalOrder = [agentA, agentB, agentC, agentD];
     });
     it("should sort agents in ascending order", () => {
-      const comparator = new AgentComparator("freeSpace", SortOrder.ASC);
+      const comparator = new AgentComparator("freeSpace");
 
       const sortedList = originalOrder.sort(comparator.compare.bind(comparator));
 
       expect(sortedList).toEqual([agentA, agentC, agentB, agentD]);
-    });
-
-    it("should sort in descending order", () => {
-      const comparator = new AgentComparator("freeSpace", SortOrder.DESC);
-
-      const sortedList = originalOrder.sort(comparator.compare.bind(comparator));
-
-      expect(sortedList).toEqual([agentD, agentB, agentC, agentA]);
     });
   });
 
@@ -93,20 +76,13 @@ describe("AgentComparator", () => {
     });
 
     it("should sort in ascending order", () => {
-      const comparator = new AgentComparator("resources", SortOrder.ASC);
+      const comparator = new AgentComparator("resources");
 
       const sortedList = originalOrder.sort(comparator.compare.bind(comparator));
 
       expect(sortedList).toEqual([agentD, agentC, agentA, agentB]);
     });
 
-    it("should sort in descending order", () => {
-      const comparator = new AgentComparator("resources", SortOrder.DESC);
-
-      const sortedList = originalOrder.sort(comparator.compare.bind(comparator));
-
-      expect(sortedList).toEqual([agentB, agentA, agentC, agentD]);
-    });
   });
 
   describe("Environments", () => {
@@ -120,20 +96,12 @@ describe("AgentComparator", () => {
     });
 
     it("should sort in ascending order", () => {
-      const comparator = new AgentComparator("environments", SortOrder.ASC);
+      const comparator = new AgentComparator("environments");
 
       const sortedList = originalOrder.sort(comparator.compare.bind(comparator));
 
       expect(sortedList).toEqual([agentD, agentB, agentA, agentC]);
     });
 
-    it("should sort in descending order",
-       () => {
-         const comparator = new AgentComparator("environments", SortOrder.DESC);
-
-         const sortedList = originalOrder.sort(comparator.compare.bind(comparator));
-
-         expect(sortedList).toEqual([agentC, agentA, agentB, agentD]);
-       });
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new_agent/spec/agent_vm_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new_agent/spec/agent_vm_spec.ts
@@ -65,7 +65,7 @@ describe("AgentVM", () => {
 
       staticAgentsVM.sync(new Agents(agentOne, agentTwo, agentThree));
 
-      expect(staticAgentsVM.selectedAgentsUUID()).toEqual([agentOne.uuid, agentTwo.uuid]);
+      expect(staticAgentsVM.selectedAgentsUUID()).toEqual([agentTwo.uuid, agentOne.uuid]);
     });
   });
 
@@ -219,7 +219,7 @@ describe("AgentVM", () => {
     it("should update column index on click of a column", () => {
       const staticAgentVM = new StaticAgentsVM(new Agents());
 
-      expect(staticAgentVM.agentsSortHandler.currentSortedColumnIndex()).toBe(-1);
+      expect(staticAgentVM.agentsSortHandler.currentSortedColumnIndex()).toBe(5);
       expect(staticAgentVM.agentsSortHandler.currentSortOrder()).toBe(SortOrder.ASC);
 
       staticAgentVM.agentsSortHandler.onColumnClick(3);
@@ -237,6 +237,18 @@ describe("AgentVM", () => {
       staticAgentVM.agentsSortHandler.onColumnClick(3);
       expect(staticAgentVM.agentsSortHandler.currentSortOrder()).toBe(SortOrder.DESC);
     });
+
+    it("should reverse the result if sort order is desc", () => {
+      const productionAgent = Agent.fromJSON(AgentsTestData.withHostname("Hostname-A")),
+            buildAgent      = Agent.fromJSON(AgentsTestData.withHostname("Hostname-B"));
+      const staticAgentsVM = new StaticAgentsVM(new Agents(productionAgent, buildAgent));
+
+      staticAgentsVM.agentsSortHandler.onColumnClick(1);
+      staticAgentsVM.agentsSortHandler.onColumnClick(1);
+
+      expect(staticAgentsVM.agentsSortHandler.currentSortOrder()).toBe(SortOrder.DESC);
+      expect(staticAgentsVM.list()).toEqual([buildAgent, productionAgent]);
+    });
   });
 
   describe("ElasticAgentSortHandler", () => {
@@ -250,7 +262,7 @@ describe("AgentVM", () => {
     it("should update column index on click of the column on elastic agents", () => {
       const elasticAgentVM = new ElasticAgentVM(new Agents());
 
-      expect(elasticAgentVM.agentsSortHandler.currentSortedColumnIndex()).toBe(-1);
+      expect(elasticAgentVM.agentsSortHandler.currentSortedColumnIndex()).toBe(5);
       expect(elasticAgentVM.agentsSortHandler.currentSortOrder()).toBe(SortOrder.ASC);
 
       elasticAgentVM.agentsSortHandler.onColumnClick(3);
@@ -267,6 +279,18 @@ describe("AgentVM", () => {
 
       elasticAgentVM.agentsSortHandler.onColumnClick(3);
       expect(elasticAgentVM.agentsSortHandler.currentSortOrder()).toBe(SortOrder.DESC);
+    });
+
+    it("should reverse the result if sort order is desc", () => {
+      const productionAgent = Agent.fromJSON(AgentsTestData.withHostname("Hostname-A")),
+        buildAgent      = Agent.fromJSON(AgentsTestData.withHostname("Hostname-B"));
+      const elasticAgentVM = new ElasticAgentVM(new Agents(productionAgent, buildAgent));
+
+      elasticAgentVM.agentsSortHandler.onColumnClick(1);
+      elasticAgentVM.agentsSortHandler.onColumnClick(1);
+
+      expect(elasticAgentVM.agentsSortHandler.currentSortOrder()).toBe(SortOrder.DESC);
+      expect(elasticAgentVM.all()).toEqual([buildAgent, productionAgent]);
     });
   });
 


### PR DESCRIPTION
Issue: #7082

Description: Adding a default sort on new Agents SPA based on `agentStatus`.

