### PR TITLE
Force the user to scan the repository before allowing config repo creation

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/config_repos/spec/material_check_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/config_repos/spec/material_check_spec.tsx
@@ -131,7 +131,7 @@ describe("ConfigRepos: MaterialCheck", () => {
           m.redraw.sync();
           expect(helper.byTestId("material-check-button").matches("[disabled]")).toBe(false); // enabled on complete
           expect(helper.byTestId("material-check-icon")).toHaveClass(styles.materialCheckSuccess);
-          expect(helper.byTestId("flash-message-info")).toContainText("No config files found");
+          expect(helper.byTestId("flash-message-alert")).toContainText("No config files found");
           done();
         }, 0);
       }}/>);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/actions.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/actions.tsx
@@ -28,6 +28,7 @@ import css from "./styles.scss";
 interface Attrs {
   configRepo: Stream<ConfigRepo>;
   loc?: LocationHandler;
+  disabled?: boolean;
 }
 
 export class PacActions extends MithrilViewComponent<Attrs> {
@@ -48,7 +49,7 @@ export class PacActions extends MithrilViewComponent<Attrs> {
         <div class={css.finishBtnWrapper}>
           <div class={css.errorResponse}>{this.globalError()}</div>
 
-          <Buttons.Primary css={css} onclick={this.onSave.bind(this, vnode.attrs.configRepo())} small={false}>Finish</Buttons.Primary>
+          <Buttons.Primary css={css} onclick={this.onSave.bind(this, vnode.attrs.configRepo())} small={false} disabled={!!vnode.attrs.disabled}>Finish</Buttons.Primary>
         </div>
       </div>
     );

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/builder_form.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/builder_form.tsx
@@ -43,6 +43,7 @@ const uipCss: typeof uipStyles = override(uipStyles, {
 
 interface Attrs extends PipelineConfigVMAware {
   onContentChange?: (changed: boolean) => void;
+  onMaterialChange?: (e: Event) => void;
 }
 
 export class BuilderForm extends MithrilComponent<Attrs> {
@@ -65,7 +66,7 @@ export class BuilderForm extends MithrilComponent<Attrs> {
     const { pipeline, material, isUsingTemplate } = vnode.attrs.vm;
 
     return <div class={defaultStyles.builderForm}>
-      <UserInputPane css={uipCss} heading="Part 1: Material">
+      <UserInputPane css={uipCss} heading="Part 1: Material" onchange={vnode.attrs.onMaterialChange}>
         <MaterialEditor material={material}/>
       </UserInputPane>
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/user_input_pane.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/user_input_pane.tsx
@@ -22,15 +22,16 @@ type Styles = typeof css;
 
 interface Attrs extends RestyleAttrs<Styles> {
   heading?: m.Children;
+  onchange?: (e: Event) => void;
 }
 
 export class UserInputPane extends RestyleComponent<Styles, Attrs> {
   css: Styles = css;
 
   view(vnode: m.Vnode<Attrs>) {
-    const {heading} = vnode.attrs;
+    const {heading, onchange} = vnode.attrs;
 
-    return <section class={this.css.userInput}>
+    return <section class={this.css.userInput} onchange={onchange}>
       {heading ? <SectionHeading css={this.css}>{heading}</SectionHeading> : void 0}
       {vnode.children}
     </section>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines_as_code.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines_as_code.tsx
@@ -68,6 +68,7 @@ export class PipelinesAsCodeCreatePage extends Page {
 
   private configRepo = Stream(new ConfigRepo(undefined, this.pluginId(), new Material(this.model.material.type())));
   private useSameRepoForPaC = Stream(true); // allow material sync to be toggleable
+  private allowCreate = Stream(false);
 
   oninit(vnode: m.Vnode) {
     this.pageState = PageState.OK;
@@ -162,12 +163,16 @@ export class PipelinesAsCodeCreatePage extends Page {
         <div class={classnames(css.verifyDefsInMaterial, css.subsection)}>
           <MaterialCheck pluginId={this.pluginId()} material={this.configRepo().material()!} align="right" prerequisite={() => this.configRepo().isValid()} label={
             <p class={css.msg}>Verify that GoCD can find the configuration file in your repository by clicking the button on the right</p>
-          }/>
+          } success={(data, _) => {
+            this.allowCreate(!!data.plugins.find((p) => !!p.files.length));
+          }} failure={(err, status) => {
+            this.allowCreate(413 === status);
+          }}/>
         </div>
       </FillableSection>,
 
       <FillableSection>
-        <PacActions configRepo={this.configRepo}/>
+        <PacActions configRepo={this.configRepo} disabled={!this.allowCreate()}/>
       </FillableSection>
     ];
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines_as_code.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines_as_code.tsx
@@ -122,7 +122,11 @@ export class PipelinesAsCodeCreatePage extends Page {
 
       <CodeScroller>
         <FillableSection>
-          <BuilderForm vm={vm} onContentChange={(updated) => this.onContentChange(isSupportedScm, updated)}/>
+          <BuilderForm vm={vm} onContentChange={(updated) => this.onContentChange(isSupportedScm, updated)} onMaterialChange={(e) => {
+            if (syncConfigRepoWithMaterial()) {
+              this.allowCreate(false);
+            }
+          }}/>
           <PreviewPane content={this.content} mimeType={this.mimeType}/>
         </FillableSection>
       </CodeScroller>,
@@ -141,7 +145,7 @@ export class PipelinesAsCodeCreatePage extends Page {
       <FillableSection css={spanningFillableCss}>
         <div class={css.subheading}><SectionHeading>Register Your Pipelines as Code Repo with GoCD</SectionHeading></div>
 
-        <UserInputPane>
+        <UserInputPane onchange={(e) => { this.allowCreate(false); }}>
           <CheckboxField
             property={syncConfigRepoWithMaterial}
             label={<span>Use the same SCM repository from the form above to store my <strong>Pipelines as Code</strong> definitions <em class={css.hint}>(suitable for most setups)</em></span>}


### PR DESCRIPTION
  - Only enable "Finish" button when scan repo returns at least 1 file or when the repo clone times out
  - Change the "no config files found" message to be an alert style message and ask user to verify that they pushed the config files upstream

Fixes #7101