### PR TITLE
Fix for job details page error if agent is not yet assigned #000

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/AgentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AgentService.java
@@ -52,6 +52,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import java.util.*;
 import java.util.function.Function;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.thoughtworks.go.CurrentGoCDVersion.docsUrl;
 import static com.thoughtworks.go.domain.AgentConfigStatus.Pending;
 import static com.thoughtworks.go.domain.AgentInstance.createFromAgent;
@@ -291,6 +292,10 @@ public class AgentService implements DatabaseEntityChangeListener<Agent> {
     }
 
     public Agent findAgentByUUID(String uuid) {
+        if (isNullOrEmpty(uuid)) {
+            return null;
+        }
+
         AgentInstance agentInstance = agentInstances.findAgent(uuid);
         Agent agent;
         if (agentInstance != null && !agentInstance.isNullAgent()) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/AgentServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/AgentServiceTest.java
@@ -1210,6 +1210,12 @@ class AgentServiceTest {
 
             assertThat(agent, is(nullValue()));
         }
+
+        @Test
+        void shouldReturnNullIfUUIDIsNotProvided() {
+            assertThat(agentService.findAgentByUUID(null), is(nullValue()));
+            assertThat(agentService.findAgentByUUID(" "), is(nullValue()));
+        }
     }
 
     @Nested


### PR DESCRIPTION
* Opening the job details page for a job with an agent not yet assigned
  threw NPE exception, this was due to a request to find agent for a
  null agent uuid. This commit fixes this issue.

Issue: #

Description:

