### PR TITLE
Unwrap stream in pluginInfoSettings.configurations()

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/shared/angular_plugin_new_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/shared/angular_plugin_new_spec.js
@@ -19,7 +19,7 @@ import {AngularPluginNew} from "views/shared/angular_plugin_new.js.msx";
 import {TestHelper} from "views/pages/spec/test_helper";
 import Stream from "mithril/stream";
 import {Configurations, Configuration} from "models/shared/configuration";
-import {PlainTextValue} from "models/shared/config_value";
+import {PlainTextValue, EncryptedValue} from "models/shared/config_value";
 import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
 import {AuthorizationPluginInfo} from "models/shared/plugin_infos_new/spec/test_data";
 import m from "mithril";
@@ -30,20 +30,25 @@ describe("Angular Plugin View", () => {
   afterEach(helper.unmount.bind(helper));
 
   it("should ignore unknown properties", () => {
-    const pluginInfo     = PluginInfo.fromJSON(AuthorizationPluginInfo.file());
+    const pluginInfo     = PluginInfo.fromJSON(AuthorizationPluginInfo.ldap());
     const configurations = new Configurations([
-      new Configuration("PasswordFilePath", new PlainTextValue("/var/lib/pass.prop")),
+      new Configuration("Url", new PlainTextValue("some-url")),
+      new Configuration("Password", new EncryptedValue("secret-password")),
       new Configuration("UnknownField", new PlainTextValue("random-value"))
     ]);
 
-    expect(configurations.findConfiguration("PasswordFilePath")).not.toBeNull();
+    expect(configurations.findConfiguration("Url")).not.toBeNull();
+    expect(configurations.findConfiguration("Password")).not.toBeNull();
     expect(configurations.findConfiguration("UnknownField")).not.toBeNull();
     expect(configurations.findConfiguration("UnknownField")).not.toBeUndefined();
 
     mount(pluginInfo.extensions[0].authConfigSettings, configurations);
 
     expect(configurations.findConfiguration("UnknownField")).toBeUndefined();
-    expect(configurations.findConfiguration("PasswordFilePath")).not.toBeUndefined();
+    expect(configurations.findConfiguration("Url")).not.toBeUndefined();
+    expect(configurations.findConfiguration("Url").isEncrypted()).toBeFalsy();
+    expect(configurations.findConfiguration("Password")).not.toBeUndefined();
+    expect(configurations.findConfiguration("Password").isEncrypted()).toBeTruthy();
   });
 
   it("should not ignore appropriate properties", () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/shared/angular_plugin_new.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/shared/angular_plugin_new.js.msx
@@ -86,8 +86,7 @@ function onCreate(scope, args) {
           copyOverErrors(configurations, config.key);
         });
 
-        const supportedConfigKeys = pluginInfoSettings.configurations.map((configuration) => configuration.key);
-
+        const supportedConfigKeys = pluginInfoSettings.configurations().map((configuration) => configuration.key);
         _.remove(configurations.configurations, (configuration) => {
           return !_.includes(supportedConfigKeys, configuration.key);
         });


### PR DESCRIPTION
Issue: https://github.com/gocd-contrib/github-oauth-authorization-plugin/issues/82

Description:
We remove the config properties that are not supported while initializing the plugin view. This was originally done to gracefully handle plugin updates when some properties are removed from the plugin.

But the Stream `pluginInfoSettings.configurations` wasn't being unwrapped, and it would always evaluate to `undefined`. Subsequently, *all* config properties would be removed. Later in the flow, after the angular bootstrap call, they would get added back  (I'm not sure how). But when they were added back, the metadata of the config values was lost, meaning encrypted values started getting treated as plain text values, and would get re-encrypted.

Here are some console logs from `angular_plugin_new` that demonstrate the problem:
```
supportedConfigKeys: undefined
angular_plugin_new.js.msx:91 configurations before: [{"key":"Url","value":"some-url"},{"key":"Password","encrypted_value":"secret-password"},{"key":"UnknownField","value":"random-value"}]
angular_plugin_new.js.msx:95 configurations after: []
angular_plugin_new.js.msx:99 configurations after initialize: []
angular_plugin_new.js.msx:103 configurations after bootstrap: [{"key":"Url","value":"some-url"},{"key":"SearchBases"},{"key":"ManagerDN"},{"key":"Password","value":"secret-password"}]
angular_plugin_new.js.msx:90 supportedConfigKeys: undefined
angular_plugin_new.js.msx:91 configurations before: [{"key":"Url","value":"some-url"},{"key":"SearchBases"},{"key":"ManagerDN"},{"key":"Password","value":"secret-password"}]
angular_plugin_new.js.msx:95 configurations after: []
```
(Note that password becomes a `value` instead of `encrypted_value` in **configurations after bootstrap**)

In a happy path "create" flow, this wouldn't cause issues. But when editing values or doing something like a "check connection" in authorization plugins, it would cause the encrypted values to be submitted as `value` in the JSON, causing the values to get re-encrypted. In plugins like ECS, editing the cluster profile and clicking Save without changing anything would also cause the encrypted values to get re-encrypted.
