### PR TITLE
Updated validations for purge settings and API bug fix

### DIFF
--- a/api/api-artifact-config-v1/src/main/java/com/thoughtworks/go/apiv1/artifactconfig/represernter/ArtifactConfigRepresenter.java
+++ b/api/api-artifact-config-v1/src/main/java/com/thoughtworks/go/apiv1/artifactconfig/represernter/ArtifactConfigRepresenter.java
@@ -61,8 +61,8 @@ public class ArtifactConfigRepresenter {
         purge_settings.ifPresent(filterReader -> {
             PurgeStart purgeStart = updatedArtifactConfig.getPurgeSettings().getPurgeStart();
             PurgeUpto purgeUpto = updatedArtifactConfig.getPurgeSettings().getPurgeUpto();
-            filterReader.readStringIfPresent("purge_start_disk_space", purgeStart::setPurgeStartDiskSpace);
-            filterReader.readStringIfPresent("purge_upto_disk_space", purgeUpto::setPurgeUptoDiskSpace);
+            filterReader.readDoubleIfPresent("purge_start_disk_space", purgeStart::setPurgeStartDiskSpace);
+            filterReader.readDoubleIfPresent("purge_upto_disk_space", purgeUpto::setPurgeUptoDiskSpace);
         });
 
         return updatedArtifactConfig;

--- a/api/api-base/src/main/java/com/thoughtworks/go/api/representers/JsonReader.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/representers/JsonReader.java
@@ -72,6 +72,17 @@ public class JsonReader {
         return Optional.empty();
     }
 
+    public Optional<Double> optDouble(String property) {
+        if (hasJsonObject(property)) {
+            try {
+                return Optional.ofNullable(jsonObject.get(property).getAsDouble());
+            } catch (Exception e) {
+                throw haltBecausePropertyIsNotAJsonString(property, jsonObject);
+            }
+        }
+        return Optional.empty();
+    }
+
     public Optional<String> optString(String property) {
         if (hasJsonObject(property)) {
             try {
@@ -189,6 +200,11 @@ public class JsonReader {
 
     public JsonReader readBooleanIfPresent(String key, Consumer<Boolean> consumer) {
         optBoolean(key).ifPresent(consumer);
+        return this;
+    }
+
+    public JsonReader readDoubleIfPresent(String key, Consumer<Double> consumer) {
+        optDouble(key).ifPresent(consumer);
         return this;
     }
 }

--- a/api/api-base/src/test/groovy/com/thoughtworks/go/api/representers/JsonReaderTest.groovy
+++ b/api/api-base/src/test/groovy/com/thoughtworks/go/api/representers/JsonReaderTest.groovy
@@ -185,4 +185,30 @@ class JsonReaderTest {
       assertThat(reader.getBooleanOrDefault("non-existing-property", false)).isFalse()
     }
   }
+
+  @Nested
+  class Double {
+    @Test
+    void 'should read optional value when present'() {
+      double doubleValue = 2.3456
+      def reader = GsonTransformer.instance.jsonReaderFrom(["foo": 2.3456])
+      assertThat(reader.optDouble("foo").get()).isEqualTo(doubleValue)
+    }
+
+    @Test
+    void 'should read optional value when absent'() {
+      def reader = GsonTransformer.instance.jsonReaderFrom(["xyz": 2.3456])
+      assertThat(reader.optDouble("foo").isPresent()).isFalse()
+    }
+
+    @Test
+    void 'should blow up if reading wrong type'() {
+      def reader = GsonTransformer.instance.jsonReaderFrom(["foo": ["bar": "baz"]])
+      assertThatExceptionOfType(HaltException.class)
+        .isThrownBy({ reader.optDouble("foo") })
+      assertThatExceptionOfType(HaltException.class)
+        .isThrownBy({ reader.optDouble("foo") })
+    }
+  }
+
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PurgeSettings.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PurgeSettings.java
@@ -21,6 +21,7 @@ import lombok.*;
 import lombok.experimental.Accessors;
 
 import static com.thoughtworks.go.config.ServerConfig.PURGE_START;
+import static com.thoughtworks.go.config.ServerConfig.PURGE_UPTO;
 
 @Getter
 @Setter
@@ -45,14 +46,16 @@ public class PurgeSettings implements Validatable {
         Double purgeUptoDiskSpace = purgeUpto.getPurgeUptoDiskSpace();
         Double purgeStartDiskSpace = purgeStart.getPurgeStartDiskSpace();
 
-        if (purgeUptoDiskSpace == null) {
+        if (purgeUptoDiskSpace == null && purgeStartDiskSpace == null) {
             return;
         }
 
-        if (purgeStartDiskSpace == null || purgeStartDiskSpace == 0) {
-            errors().add(PURGE_START, "Error in artifact cleanup values. The trigger value is has to be specified when a goal is set");
-        } else if (purgeStartDiskSpace > purgeUptoDiskSpace) {
+        if (purgeUptoDiskSpace != null && (purgeStartDiskSpace == null || purgeStartDiskSpace == 0)) {
+            errors().add(PURGE_START, "Error in artifact cleanup values. The trigger value has to be specified when a goal is set");
+        } else if (purgeUptoDiskSpace != null && purgeStartDiskSpace > purgeUptoDiskSpace) {
             errors().add(PURGE_START, String.format("Error in artifact cleanup values. The trigger value (%sGB) should be less than the goal (%sGB)", purgeStartDiskSpace, purgeUptoDiskSpace));
+        } else if (purgeUptoDiskSpace == null) {
+            errors().add(PURGE_UPTO, "Error in artifact cleanup values. Please specify goal value");
         }
     }
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PurgeStart.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PurgeStart.java
@@ -30,11 +30,4 @@ public class PurgeStart {
     @ConfigValue
     private Double purgeStartDiskSpace;
 
-    public PurgeStart(String purgeStartDiskSpace) {
-        this.purgeStartDiskSpace = Double.valueOf(purgeStartDiskSpace);
-    }
-
-    public void setPurgeStartDiskSpace(String purgeStart) {
-        this.purgeStartDiskSpace = Double.valueOf(purgeStart);
-    }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PurgeUpto.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PurgeUpto.java
@@ -30,12 +30,4 @@ public class PurgeUpto {
     @ConfigValue
     private Double purgeUptoDiskSpace;
 
-    public PurgeUpto(String purgeUptoDiskSpace) {
-
-        this.purgeUptoDiskSpace = Double.valueOf(purgeUptoDiskSpace);
-    }
-
-    public void setPurgeUptoDiskSpace(String purgeUpto) {
-        purgeUptoDiskSpace = Double.valueOf(purgeUpto);
-    }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/ServerConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/ServerConfig.java
@@ -68,6 +68,7 @@ public class ServerConfig implements Validatable {
     public static final String NEVER_TIMEOUT = "neverTimeout";
     public static final String OVERRIDE_TIMEOUT = "overrideTimeout";
     public static final String PURGE_START = "purgeStart";
+    public static final String PURGE_UPTO = "purgeUpto";
     public static final String ARTIFACT_DIR = "artifactsDir";
 
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PurgeSettingsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PurgeSettingsTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertThat;
 public class PurgeSettingsTest {
 
     @Test
-    public void validate_shouldFailIfThePurgeStartIsBiggerThanPurgeUpto() {
+    public void validate_shouldAddErrorsIfThePurgeStartIsBiggerThanPurgeUpto() {
         PurgeSettings purgeSettings = createPurgeSettings(20.1, 20.05);
 
         assertThat(purgeSettings.errors().isEmpty(), is(true));
@@ -36,7 +36,7 @@ public class PurgeSettingsTest {
     }
 
     @Test
-    public void validate_shouldFailIfThePurgeStartIsNotSpecifiedButPurgeUptoIs() {
+    public void validate_shouldAddErrorsIfThePurgeStartIsNotSpecifiedButPurgeUptoIs() {
         PurgeSettings purgeSettings = createPurgeSettings(null, 20.05);
 
         assertThat(purgeSettings.errors().isEmpty(), is(true));
@@ -44,11 +44,11 @@ public class PurgeSettingsTest {
         purgeSettings.validate(null);
 
         assertThat(purgeSettings.errors().isEmpty(), is(false));
-        assertThat(purgeSettings.errors().on(ServerConfig.PURGE_START), is("Error in artifact cleanup values. The trigger value is has to be specified when a goal is set"));
+        assertThat(purgeSettings.errors().on(ServerConfig.PURGE_START), is("Error in artifact cleanup values. The trigger value has to be specified when a goal is set"));
     }
 
     @Test
-    public void validate_shouldFailIfThePurgeStartIs0SpecifiedButPurgeUptoIs() {
+    public void validate_shouldAddErrorsIfThePurgeStartIs0SpecifiedButPurgeUptoIs() {
         PurgeSettings purgeSettings = createPurgeSettings(0.0, 20.05);
 
         assertThat(purgeSettings.errors().isEmpty(), is(true));
@@ -56,11 +56,11 @@ public class PurgeSettingsTest {
         purgeSettings.validate(null);
 
         assertThat(purgeSettings.errors().isEmpty(), is(false));
-        assertThat(purgeSettings.errors().on(ServerConfig.PURGE_START), is("Error in artifact cleanup values. The trigger value is has to be specified when a goal is set"));
+        assertThat(purgeSettings.errors().on(ServerConfig.PURGE_START), is("Error in artifact cleanup values. The trigger value has to be specified when a goal is set"));
     }
 
     @Test
-    public void validate_shouldPassIfThePurgeStartIsSmallerThanPurgeUpto() {
+    public void validate_shouldNotAddErrorsIfThePurgeStartIsSmallerThanPurgeUpto() {
         PurgeSettings purgeSettings = createPurgeSettings(20.0, 20.05);
 
         assertThat(purgeSettings.errors().isEmpty(), is(true));
@@ -71,7 +71,7 @@ public class PurgeSettingsTest {
     }
 
     @Test
-    public void validate_shouldPassIfThePurgeStartAndPurgeUptoAreBothNotSet() {
+    public void validate_shouldNotAddErrorsIfThePurgeStartAndPurgeUptoAreBothNotSet() {
         PurgeSettings purgeSettings = createPurgeSettings(null, null);
 
         assertThat(purgeSettings.errors().isEmpty(), is(true));
@@ -79,6 +79,30 @@ public class PurgeSettingsTest {
         purgeSettings.validate(null);
 
         assertThat(purgeSettings.errors().isEmpty(), is(true));
+    }
+
+    @Test
+    public void validate_shouldAddErrorIfThePurgeUptoIsNull() {
+        PurgeSettings purgeSettings = createPurgeSettings(10.0, null);
+
+        assertThat(purgeSettings.errors().isEmpty(), is(true));
+
+        purgeSettings.validate(null);
+
+        assertThat(purgeSettings.errors().isEmpty(), is(false));
+        assertThat(purgeSettings.errors().on(ServerConfig.PURGE_UPTO), is("Error in artifact cleanup values. Please specify goal value"));
+    }
+
+    @Test
+    public void validate_shouldNotAddErrorIfThePurgeUptoAndPurgeStartIsZero() {
+        PurgeSettings purgeSettings = createPurgeSettings(0.0, 0.0);
+
+        assertThat(purgeSettings.errors().isEmpty(), is(true));
+
+        purgeSettings.validate(null);
+
+        assertThat(purgeSettings.errors().isEmpty(), is(false));
+        assertThat(purgeSettings.errors().on(ServerConfig.PURGE_START), is("Error in artifact cleanup values. The trigger value has to be specified when a goal is set"));
     }
 
     private PurgeSettings createPurgeSettings(Double purgeStart, Double purgeUpto) {

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateArtifactConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateArtifactConfigCommandTest.java
@@ -78,9 +78,9 @@ public class UpdateArtifactConfigCommandTest {
             cruiseConfig.server().setArtifactConfig(artifactConfig);
             UpdateArtifactConfigCommand updateArtifactConfigCommand = new UpdateArtifactConfigCommand(artifactConfig);
 
-            assertThatCode(() -> updateArtifactConfigCommand.isValid(cruiseConfig)).isInstanceOf(GoConfigInvalidException.class).hasMessage("Error in artifact cleanup values. The trigger value is has to be specified when a goal is set");
+            assertThatCode(() -> updateArtifactConfigCommand.isValid(cruiseConfig)).isInstanceOf(GoConfigInvalidException.class).hasMessage("Error in artifact cleanup values. The trigger value has to be specified when a goal is set");
             assertThat(artifactConfig.getPurgeSettings().errors().size()).isEqualTo(1);
-            assertThat(artifactConfig.getPurgeSettings().errors().firstError()).isEqualTo("Error in artifact cleanup values. The trigger value is has to be specified when a goal is set");
+            assertThat(artifactConfig.getPurgeSettings().errors().firstError()).isEqualTo("Error in artifact cleanup values. The trigger value has to be specified when a goal is set");
 
         }
     }


### PR DESCRIPTION
 - Updated validations. `PurgeStartDiskSpace` and `PurgeUptoDiskSpace` cannot be set to zero. Either both can be set to `null` or non-zero value

- Introduced method `readDoubleIfPresent` to convert string value in the request to double. Added above change for `purgeStartDiskSpace` and `purgeUptoDiskSpace`