### PR TITLE
Fixed no response on deleting an auth config

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/entity_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/entity_modal.tsx
@@ -157,10 +157,12 @@ export abstract class EntityModal<T extends ValidatableMixin> extends Modal {
   }
 
   private onError(errorResponse: ErrorResponse, statusCode: number) {
-    if (422 === statusCode && errorResponse.data) {
-      this.entity(this.parseJsonToEntity(errorResponse.data));
-    } else {
-      this.errorMessage(JSON.parse(errorResponse.body!).message);
+    if (422 === statusCode) {
+      if (errorResponse.data) {
+        this.entity(this.parseJsonToEntity(errorResponse.data));
+      } else if (errorResponse.body) {
+        this.errorMessage(JSON.parse(errorResponse.body!).message);
+      }
     }
     this.operationError(errorResponse, statusCode);
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs/modals.tsx
@@ -21,8 +21,8 @@ import {AuthConfig, AuthConfigJSON} from "models/auth_configs/auth_configs";
 import {AuthConfigsCRUD} from "models/auth_configs/auth_configs_crud";
 import {Configurations} from "models/shared/configuration";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
-import {ButtonGroup} from "views/components/buttons";
 import * as Buttons from "views/components/buttons";
+import {ButtonGroup} from "views/components/buttons";
 import {MessageType} from "views/components/flash_message";
 import {Size} from "views/components/modal";
 import {EntityModal} from "views/components/modal/entity_modal";
@@ -193,7 +193,7 @@ export class DeleteAuthConfigModal extends AuthConfigModal {
   }
 
   operationError(errorResponse: any, statusCode: number) {
-    const json = JSON.parse(errorResponse.body);
+    const json = (errorResponse.body) ? JSON.parse(errorResponse.body) : errorResponse;
     this.setMessage(json.message, MessageType.alert);
     this.close();
   }


### PR DESCRIPTION
Fixed no response on deleting an auth config
 - if an auth config is utilised in a role config, the delete modal popup on auth config seemingly does nothing.
   Reason: the response from the api does not contain either `data` or `body`. Hence was failing to parse `response.body` into JSON

