### PR TITLE
Return user friendly errors for server site urls

### DIFF
--- a/api/api-server-site-urls-config-v1/src/main/java/com/thoughtworks/go/apiv1/serversiteurlsconfig/ServerSiteUrlsConfigControllerV1.java
+++ b/api/api-server-site-urls-config-v1/src/main/java/com/thoughtworks/go/apiv1/serversiteurlsconfig/ServerSiteUrlsConfigControllerV1.java
@@ -91,14 +91,12 @@ public class ServerSiteUrlsConfigControllerV1 extends ApiController implements S
             return MessageJson.create(errorMessage, jsonWriter(siteUrls));
         }
 
-        return index(request, response);
+        return writerForTopLevelObject(request, response, writer -> ServerSiteUrlsConfigRepresenter.toJSON(writer, siteUrls));
     }
 
     String index(Request request, Response response) throws IOException {
         SiteUrls serverSiteUrls = serverConfigService.getServerSiteUrls();
-        return writerForTopLevelObject(request, response, writer -> {
-            ServerSiteUrlsConfigRepresenter.toJSON(writer, serverSiteUrls);
-        });
+        return writerForTopLevelObject(request, response, writer -> ServerSiteUrlsConfigRepresenter.toJSON(writer, serverSiteUrls));
     }
 
     private SiteUrls buildEntityFromRequestBody(Request req) {

--- a/api/api-server-site-urls-config-v1/src/main/java/com/thoughtworks/go/apiv1/serversiteurlsconfig/representers/ServerSiteUrlsConfigRepresenter.java
+++ b/api/api-server-site-urls-config-v1/src/main/java/com/thoughtworks/go/apiv1/serversiteurlsconfig/representers/ServerSiteUrlsConfigRepresenter.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.api.representers.ErrorGetter;
 import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.config.SiteUrls;
+import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.SecureSiteUrl;
 import com.thoughtworks.go.domain.SiteUrl;
 import com.thoughtworks.go.spark.Routes;
@@ -38,11 +39,15 @@ public class ServerSiteUrlsConfigRepresenter {
                 .add("site_url", siteUrls.getSiteUrl().toString())
                 .add("secure_site_url", siteUrls.getSecureSiteUrl().toString());
 
-        if (!siteUrls.errors().isEmpty()) {
+        if (!siteUrls.getSiteUrl().errors().isEmpty() || !siteUrls.getSecureSiteUrl().errors().isEmpty()) {
             Map<String, String> fieldMapping = new HashMap<>();
             fieldMapping.put("siteUrl", "site_url");
             fieldMapping.put("secureSiteUrl", "secure_site_url");
-            writer.addChild("errors", errorWriter -> new ErrorGetter(fieldMapping).toJSON(errorWriter, siteUrls));
+            writer.addChild("errors", errorWriter -> {
+                ErrorGetter errorGetter = new ErrorGetter(fieldMapping);
+                errorGetter.toJSON(errorWriter, siteUrls.getSiteUrl());
+                errorGetter.toJSON(errorWriter, siteUrls.getSecureSiteUrl());
+            });
         }
     }
 

--- a/api/api-server-site-urls-config-v1/src/main/java/com/thoughtworks/go/apiv1/serversiteurlsconfig/representers/ServerSiteUrlsConfigRepresenter.java
+++ b/api/api-server-site-urls-config-v1/src/main/java/com/thoughtworks/go/apiv1/serversiteurlsconfig/representers/ServerSiteUrlsConfigRepresenter.java
@@ -17,11 +17,15 @@
 package com.thoughtworks.go.apiv1.serversiteurlsconfig.representers;
 
 import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.api.representers.ErrorGetter;
 import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.config.SiteUrls;
 import com.thoughtworks.go.domain.SecureSiteUrl;
 import com.thoughtworks.go.domain.SiteUrl;
 import com.thoughtworks.go.spark.Routes;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl;
 
@@ -33,6 +37,13 @@ public class ServerSiteUrlsConfigRepresenter {
                 .addLink("self", Routes.ServerSiteUrlsConfig.BASE))
                 .add("site_url", siteUrls.getSiteUrl().toString())
                 .add("secure_site_url", siteUrls.getSecureSiteUrl().toString());
+
+        if (!siteUrls.errors().isEmpty()) {
+            Map<String, String> fieldMapping = new HashMap<>();
+            fieldMapping.put("siteUrl", "site_url");
+            fieldMapping.put("secureSiteUrl", "secure_site_url");
+            writer.addChild("errors", errorWriter -> new ErrorGetter(fieldMapping).toJSON(errorWriter, siteUrls));
+        }
     }
 
     public static SiteUrls fromJson(JsonReader jsonReader) {

--- a/api/api-server-site-urls-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/serversiteurlsconfig/ServerSiteUrlsConfigControllerV1Test.groovy
+++ b/api/api-server-site-urls-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/serversiteurlsconfig/ServerSiteUrlsConfigControllerV1Test.groovy
@@ -126,6 +126,7 @@ class ServerSiteUrlsConfigControllerV1Test implements SecurityServiceTrait, Cont
         def jsonPayload = ["site_url"       : "http://foo",
                            "secure_site_url": "https://foo"]
 
+        when(serverConfigService.getServerSiteUrls()).thenReturn(siteUrls)
         postWithApiHeader(controller.controllerBasePath(), jsonPayload)
 
         assertThatResponse()
@@ -196,6 +197,7 @@ class ServerSiteUrlsConfigControllerV1Test implements SecurityServiceTrait, Cont
         def jsonPayload = ["site_url"       : "http://foo",
                            "secure_site_url": "https://foo"]
 
+        when(serverConfigService.getServerSiteUrls()).thenReturn(siteUrls)
         putWithApiHeader(controller.controllerBasePath(), jsonPayload)
 
         assertThatResponse()

--- a/api/api-server-site-urls-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/serversiteurlsconfig/representers/ServerSiteUrlsConfigRepresenterTest.groovy
+++ b/api/api-server-site-urls-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/serversiteurlsconfig/representers/ServerSiteUrlsConfigRepresenterTest.groovy
@@ -42,6 +42,37 @@ class ServerSiteUrlsConfigRepresenterTest {
   }
 
   @Test
+  void 'should add errors if site urls are invalid'() {
+    def siteUrls = new SiteUrls(new SiteUrl("htt://foo"), new SecureSiteUrl("http://bar"))
+    siteUrls.addError("siteUrl", "Invalid format for site url. 'htp://foo' must start with http/s")
+    siteUrls.addError("secureSiteUrl", "Invalid format for secure site url. 'http://foo' must start with https")
+
+    def json = toObjectString({ ServerSiteUrlsConfigRepresenter.toJSON(it, siteUrls) })
+    def expectedJson = [
+      "_links"         : [
+        "doc" : [
+          "href": "https://api.gocd.org/19.10.0/#create-site-url"
+        ],
+        "self": [
+          "href": "http://test.host/go/api/admin/config/server/site_urls"
+        ]
+      ],
+      "site_url"       : "htt://foo",
+      "secure_site_url": "http://bar",
+      "errors"         : [
+        "secure_site_url": [
+          "Invalid format for secure site url. 'http://foo' must start with https"
+        ],
+        "site_url"       : [
+          "Invalid format for site url. 'htp://foo' must start with http/s"
+        ]
+      ]
+    ]
+
+    assertThatJson(json).isEqualTo(expectedJson)
+  }
+
+  @Test
   void 'should deserialize site urls configuration'() {
     def json = ["site_url"       : "http://foo",
                 "secure_site_url": "https://foo"]

--- a/api/api-server-site-urls-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/serversiteurlsconfig/representers/ServerSiteUrlsConfigRepresenterTest.groovy
+++ b/api/api-server-site-urls-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/serversiteurlsconfig/representers/ServerSiteUrlsConfigRepresenterTest.groovy
@@ -44,14 +44,14 @@ class ServerSiteUrlsConfigRepresenterTest {
   @Test
   void 'should add errors if site urls are invalid'() {
     def siteUrls = new SiteUrls(new SiteUrl("htt://foo"), new SecureSiteUrl("http://bar"))
-    siteUrls.addError("siteUrl", "Invalid format for site url. 'htp://foo' must start with http/s")
-    siteUrls.addError("secureSiteUrl", "Invalid format for secure site url. 'http://foo' must start with https")
+    siteUrls.siteUrl.addError("siteUrl", "Invalid format for site url. 'htp://foo' must start with http/s")
+    siteUrls.secureSiteUrl.addError("secureSiteUrl", "Invalid format for secure site url. 'http://foo' must start with https")
 
     def json = toObjectString({ ServerSiteUrlsConfigRepresenter.toJSON(it, siteUrls) })
     def expectedJson = [
       "_links"         : [
         "doc" : [
-          "href": "https://api.gocd.org/19.10.0/#create-site-url"
+          "href": apiDocsUrl('#siteurls-config')
         ],
         "self": [
           "href": "http://test.host/go/api/admin/config/server/site_urls"

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/SiteUrls.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/SiteUrls.java
@@ -61,12 +61,8 @@ public class SiteUrls implements Validatable {
     }
 
     public void validate(ValidationContext validationContext) {
-        if (!Pattern.matches("(https?://.+)?", siteUrl.toString())) {
-            errors().add("siteUrl", String.format("Invalid format for site url. '%s' must start with http/s", siteUrl.toString()));
-        }
-        if (!Pattern.matches("(https://.+)?", secureSiteUrl.toString())) {
-            errors().add("secureSiteUrl", String.format("Invalid format for secure site url. '%s' must start with https", secureSiteUrl.toString()));
-        }
+        siteUrl.validate(validationContext);
+        secureSiteUrl.validate(validationContext);
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/SiteUrls.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/SiteUrls.java
@@ -16,18 +16,23 @@
 
 package com.thoughtworks.go.config;
 
+import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.SecureSiteUrl;
 import com.thoughtworks.go.domain.SiteUrl;
+import org.springframework.validation.Errors;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 @ConfigTag("siteUrls")
-public class SiteUrls {
+public class SiteUrls implements Validatable {
     @ConfigSubtag
     private SiteUrl siteUrl;
 
     @ConfigSubtag
     private SecureSiteUrl secureSiteUrl;
+
+    private ConfigErrors errors = new ConfigErrors();
 
     public SiteUrls() {
         this.siteUrl = new SiteUrl();
@@ -53,6 +58,25 @@ public class SiteUrls {
 
     public void setSecureSiteUrl(SecureSiteUrl secureSiteUrl) {
         this.secureSiteUrl = secureSiteUrl;
+    }
+
+    public void validate(ValidationContext validationContext) {
+        if (!Pattern.matches("(https?://.+)?", siteUrl.toString())) {
+            errors().add("siteUrl", String.format("Invalid format for site url. '%s' must start with http/s", siteUrl.toString()));
+        }
+        if (!Pattern.matches("(https://.+)?", secureSiteUrl.toString())) {
+            errors().add("secureSiteUrl", String.format("Invalid format for secure site url. '%s' must start with https", secureSiteUrl.toString()));
+        }
+    }
+
+    @Override
+    public ConfigErrors errors() {
+        return errors;
+    }
+
+    @Override
+    public void addError(String fieldName, String message) {
+        errors.add(fieldName, message);
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/SecureSiteUrl.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/SecureSiteUrl.java
@@ -17,13 +17,40 @@
 package com.thoughtworks.go.domain;
 
 import com.thoughtworks.go.config.ConfigTag;
+import com.thoughtworks.go.config.Validatable;
+import com.thoughtworks.go.config.ValidationContext;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.regex.Pattern;
 
 @ConfigTag("secureSiteUrl")
-public class SecureSiteUrl extends ServerSiteUrlConfig {
+public class SecureSiteUrl extends ServerSiteUrlConfig implements Validatable {
+    private ConfigErrors errors = new ConfigErrors();
+
     public SecureSiteUrl() {
     }
 
     public SecureSiteUrl(String url) {
         super(url);
+    }
+
+    @Override
+    public void validate(ValidationContext validationContext) {
+        if (StringUtils.isBlank(url)) {
+            return;
+        }
+        if (!Pattern.matches("(https://.+)?", url)) {
+            errors().add("secureSiteUrl", String.format("Invalid format for secure site url. '%s' must start with https", url));
+        }
+    }
+
+    @Override
+    public ConfigErrors errors() {
+        return errors;
+    }
+
+    @Override
+    public void addError(String fieldName, String message) {
+        errors.add(fieldName, message);
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/SiteUrl.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/SiteUrl.java
@@ -17,13 +17,40 @@
 package com.thoughtworks.go.domain;
 
 import com.thoughtworks.go.config.ConfigTag;
+import com.thoughtworks.go.config.Validatable;
+import com.thoughtworks.go.config.ValidationContext;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.regex.Pattern;
 
 @ConfigTag("siteUrl")
-public class SiteUrl extends ServerSiteUrlConfig {
+public class SiteUrl extends ServerSiteUrlConfig implements Validatable {
+    private ConfigErrors errors = new ConfigErrors();
+
     public SiteUrl() {
     }
 
     public SiteUrl(String url) {
         super(url);
+    }
+
+    @Override
+    public void validate(ValidationContext validationContext) {
+        if (StringUtils.isBlank(url)) {
+            return;
+        }
+        if (!Pattern.matches("(https?://.+)?", url)) {
+            errors().add("siteUrl", String.format("Invalid format for site url. '%s' must start with http/s", url));
+        }
+    }
+
+    @Override
+    public ConfigErrors errors() {
+        return errors;
+    }
+
+    @Override
+    public void addError(String fieldName, String message) {
+        errors.add(fieldName, message);
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/SiteUrlsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/SiteUrlsTest.java
@@ -42,7 +42,7 @@ class SiteUrlsTest {
 
         siteUrls.validate(null);
 
-        assertThat(siteUrls.errors())
+        assertThat(siteUrls.getSiteUrl().errors())
                 .hasSize(1)
                 .containsEntry("siteUrl", Collections.singletonList("Invalid format for site url. 'htp://foo.bar' must start with http/s"));
     }
@@ -53,7 +53,7 @@ class SiteUrlsTest {
 
         siteUrls.validate(null);
 
-        assertThat(siteUrls.errors())
+        assertThat(siteUrls.getSecureSiteUrl().errors())
                 .hasSize(1)
                 .containsEntry("secureSiteUrl", Collections.singletonList("Invalid format for secure site url. 'http://foo.bar' must start with https"));
     }
@@ -64,9 +64,11 @@ class SiteUrlsTest {
 
         siteUrls.validate(null);
 
-        assertThat(siteUrls.errors())
-                .hasSize(2)
-                .containsEntry("siteUrl", Collections.singletonList("Invalid format for site url. 'htp://foo.bar' must start with http/s"))
+        assertThat(siteUrls.getSiteUrl().errors())
+                .hasSize(1)
+                .containsEntry("siteUrl", Collections.singletonList("Invalid format for site url. 'htp://foo.bar' must start with http/s"));
+        assertThat(siteUrls.getSecureSiteUrl().errors())
+                .hasSize(1)
                 .containsEntry("secureSiteUrl", Collections.singletonList("Invalid format for secure site url. 'http://foo.bar' must start with https"));
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/SiteUrlsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/SiteUrlsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.domain.SecureSiteUrl;
+import com.thoughtworks.go.domain.SiteUrl;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SiteUrlsTest {
+
+    @Test
+    void shouldNotAddErrorsIfSiteUrlsAreValid() {
+        SiteUrls siteUrls = new SiteUrls(new SiteUrl("http://foo.bar"), new SecureSiteUrl("https://foo.bar"));
+
+        siteUrls.validate(null);
+
+        assertThat(siteUrls.errors())
+                .hasSize(0);
+    }
+
+    @Test
+    void shouldAddErrorsIfSiteUrlIsInvalid() {
+        SiteUrls siteUrls = new SiteUrls(new SiteUrl("htp://foo.bar"), new SecureSiteUrl("https://foo.bar"));
+
+        siteUrls.validate(null);
+
+        assertThat(siteUrls.errors())
+                .hasSize(1)
+                .containsEntry("siteUrl", Collections.singletonList("Invalid format for site url. 'htp://foo.bar' must start with http/s"));
+    }
+
+    @Test
+    void shouldAddErrorsIfSecureSiteUrlIsInvalid() {
+        SiteUrls siteUrls = new SiteUrls(new SiteUrl("http://foo.bar"), new SecureSiteUrl("http://foo.bar"));
+
+        siteUrls.validate(null);
+
+        assertThat(siteUrls.errors())
+                .hasSize(1)
+                .containsEntry("secureSiteUrl", Collections.singletonList("Invalid format for secure site url. 'http://foo.bar' must start with https"));
+    }
+
+    @Test
+    void shouldAddErrorsIfSiteUrlsAreInvalid() {
+        SiteUrls siteUrls = new SiteUrls(new SiteUrl("htp://foo.bar"), new SecureSiteUrl("http://foo.bar"));
+
+        siteUrls.validate(null);
+
+        assertThat(siteUrls.errors())
+                .hasSize(2)
+                .containsEntry("siteUrl", Collections.singletonList("Invalid format for site url. 'htp://foo.bar' must start with http/s"))
+                .containsEntry("secureSiteUrl", Collections.singletonList("Invalid format for secure site url. 'http://foo.bar' must start with https"));
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/config/update/CreateOrUpdateConfigServerSiteUrlsCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/CreateOrUpdateConfigServerSiteUrlsCommand.java
@@ -50,7 +50,7 @@ public class CreateOrUpdateConfigServerSiteUrlsCommand implements EntityConfigUp
         List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(newSiteUrls);
 
         if (!allErrors.isEmpty()) {
-            throw new GoConfigInvalidException(preprocessedConfig, allErrors);
+            return false;
         }
 
         return true;

--- a/server/src/main/java/com/thoughtworks/go/config/update/CreateOrUpdateConfigServerSiteUrlsCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/CreateOrUpdateConfigServerSiteUrlsCommand.java
@@ -16,11 +16,18 @@
 
 package com.thoughtworks.go.config.update;
 
+import com.thoughtworks.go.config.BasicCruiseConfig;
+import com.thoughtworks.go.config.ConfigSaveValidationContext;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.SiteUrls;
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
+import com.thoughtworks.go.config.exceptions.GoConfigInvalidException;
+import com.thoughtworks.go.domain.ConfigErrors;
+import com.thoughtworks.go.config.ErrorCollector;
 
-public class CreateOrUpdateConfigServerSiteUrlsCommand implements EntityConfigUpdateCommand {
+import java.util.List;
+
+public class CreateOrUpdateConfigServerSiteUrlsCommand implements EntityConfigUpdateCommand<SiteUrls> {
     private final SiteUrls newSiteUrls;
     private SiteUrls preprocessedSiteUrls;
 
@@ -37,15 +44,25 @@ public class CreateOrUpdateConfigServerSiteUrlsCommand implements EntityConfigUp
     @Override
     public boolean isValid(CruiseConfig preprocessedConfig) {
         preprocessedSiteUrls = preprocessedConfig.server().getSiteUrls();
+        preprocessedSiteUrls.validate(new ConfigSaveValidationContext(preprocessedConfig));
+
+        BasicCruiseConfig.copyErrors(preprocessedSiteUrls, newSiteUrls);
+        List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(newSiteUrls);
+
+        if (!allErrors.isEmpty()) {
+            throw new GoConfigInvalidException(preprocessedConfig, allErrors);
+        }
+
         return true;
     }
 
     @Override
     public void clearErrors() {
+        BasicCruiseConfig.clearErrors(this.preprocessedSiteUrls);
     }
 
     @Override
-    public Object getPreprocessedEntityConfig() {
+    public SiteUrls getPreprocessedEntityConfig() {
         return preprocessedSiteUrls;
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateOrUpdateConfigServerSiteUrlsCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateOrUpdateConfigServerSiteUrlsCommandTest.java
@@ -54,15 +54,13 @@ public class CreateOrUpdateConfigServerSiteUrlsCommandTest {
         }
 
         @Test
-        void shouldThrowExceptionForInvalidSiteUrls() {
+        void shouldReturnFalseForInvalidSiteUrls() {
             SiteUrls siteUrls = new SiteUrls(new SiteUrl("htp://foo.bar"), new SecureSiteUrl("http://foo.bar"));
             cruiseConfig.server().setSiteUrl(siteUrls.getSiteUrl().toString());
             cruiseConfig.server().setSecureSiteUrl(siteUrls.getSecureSiteUrl().toString());
             CreateOrUpdateConfigServerSiteUrlsCommand command = new CreateOrUpdateConfigServerSiteUrlsCommand(siteUrls);
 
-            assertThatCode(() -> command.isValid(cruiseConfig))
-                    .isInstanceOf(GoConfigInvalidException.class)
-                    .hasMessage("Invalid format for site url. 'htp://foo.bar' must start with http/s, Invalid format for secure site url. 'http://foo.bar' must start with https");
+            assertFalse(command.isValid(cruiseConfig));
         }
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateOrUpdateConfigServerSiteUrlsCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateOrUpdateConfigServerSiteUrlsCommandTest.java
@@ -18,11 +18,16 @@ package com.thoughtworks.go.config.update;
 
 import com.thoughtworks.go.config.BasicCruiseConfig;
 import com.thoughtworks.go.config.SiteUrls;
+import com.thoughtworks.go.config.exceptions.GoConfigInvalidException;
 import com.thoughtworks.go.domain.SecureSiteUrl;
 import com.thoughtworks.go.domain.SiteUrl;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Java6Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CreateOrUpdateConfigServerSiteUrlsCommandTest {
     private BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
@@ -34,5 +39,30 @@ public class CreateOrUpdateConfigServerSiteUrlsCommandTest {
         command.update(cruiseConfig);
 
         assertThat(cruiseConfig.server().getSiteUrls()).isEqualTo(siteUrls);
+    }
+
+    @Nested
+    class Validate {
+        @Test
+        void shouldReturnTrueForValidSiteUrls() {
+            SiteUrls siteUrls = new SiteUrls(new SiteUrl("http://foo.bar"), new SecureSiteUrl("https://foo.bar"));
+            cruiseConfig.server().setSiteUrl(siteUrls.getSiteUrl().toString());
+            cruiseConfig.server().setSecureSiteUrl(siteUrls.getSecureSiteUrl().toString());
+            CreateOrUpdateConfigServerSiteUrlsCommand command = new CreateOrUpdateConfigServerSiteUrlsCommand(siteUrls);
+
+            assertTrue(command.isValid(cruiseConfig));
+        }
+
+        @Test
+        void shouldThrowExceptionForInvalidSiteUrls() {
+            SiteUrls siteUrls = new SiteUrls(new SiteUrl("htp://foo.bar"), new SecureSiteUrl("http://foo.bar"));
+            cruiseConfig.server().setSiteUrl(siteUrls.getSiteUrl().toString());
+            cruiseConfig.server().setSecureSiteUrl(siteUrls.getSecureSiteUrl().toString());
+            CreateOrUpdateConfigServerSiteUrlsCommand command = new CreateOrUpdateConfigServerSiteUrlsCommand(siteUrls);
+
+            assertThatCode(() -> command.isValid(cruiseConfig))
+                    .isInstanceOf(GoConfigInvalidException.class)
+                    .hasMessage("Invalid format for site url. 'htp://foo.bar' must start with http/s, Invalid format for secure site url. 'http://foo.bar' must start with https");
+        }
     }
 }


### PR DESCRIPTION
Issue: #4189 #6921 

Description:
- Currently both UI and Api directly show the xsd validation errors for server site urls.
- Added errors on Site Urls in order to return user friendly errors.

Error Response:
```
{
  "message" : "Validations failed for siteUrls. Error(s): [Invalid format for site url. 'htp://foo.bar' must start with http/s, Invalid format for secure site url. 'http://foo.bar' must start with https]. Please correct and resubmit.",
  "data" : {
    "site_url" : "htp://foo.bar",
    "secure_site_url" : "http://foo.bar",
    "errors" : {
      "site_url" : [ "Invalid format for site url. 'htp://foo.bar' must start with http/s" ],
      "secure_site_url" : [ "Invalid format for secure site url. 'http://foo.bar' must start with https" ]
    }
  }
}

