### PR TITLE
Add Learn More link to optional upstream dependency field

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/materials/dependency/_form.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/materials/dependency/_form.html.erb
@@ -25,6 +25,7 @@
               <div class="form_item_block checkbox_row">
                 <%= f.check_box(com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig::IGNORE_FOR_SCHEDULING, {:class => "form_input"}, "true") -%>
                 <%= f.label(com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig::IGNORE_FOR_SCHEDULING, 'Do not schedule the pipeline when this material is updated') %>
+                <a href='<%= docs_url '/configuration/configuration_reference.html#pipeline-1' %>' target='_blank'>Learn More...</a>
                 <%= error_message_on(f.object, com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig::IGNORE_FOR_SCHEDULING, :css_class => "form_error") %>
               </div>
             </div>


### PR DESCRIPTION
Description: Link to the documentation for `ignoreForScheduling`

![Screenshot 2019-10-25 at 15 02 28](https://user-images.githubusercontent.com/6024038/67560626-e690f680-f738-11e9-821c-07c5eff3412d.png)


