### PR TITLE
Style the initial state of the preview pane to make it look "not-editable"

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/preview_pane.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/preview_pane.tsx
@@ -48,7 +48,7 @@ export class PreviewPane extends MithrilComponent<Attrs> {
   content(language: LanguageSpec, content: string) {
     return content ?
       m.trust(Prism.highlight(content, language.grammar, language.name)) :
-      this.comments(language, "Your Pipelines as Code definition will automatically update here");
+      this.comments(language, "Your Pipelines as Code definition\nwill automatically update here");
   }
 
   comments(language: LanguageSpec, ...lines: string[]) {
@@ -56,7 +56,8 @@ export class PreviewPane extends MithrilComponent<Attrs> {
     const classes = classnames(defaultStyles.token, defaultStyles.comment);
     const token = language.comment;
 
-    return lines.reduce((memo, line, i) => {
+    return <span class={defaultStyles.initialMessage}>{
+    lines.reduce((memo, line, i) => {
       const parts = line.split("\n");
 
       for (let k = 0, plen = parts.length; k < plen; k++) {
@@ -71,7 +72,7 @@ export class PreviewPane extends MithrilComponent<Attrs> {
       }
 
       return memo;
-    }, [] as m.ChildArray);
+    }, [] as m.ChildArray)}</span>;
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/spec/preview_pane_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/spec/preview_pane_spec.tsx
@@ -40,12 +40,12 @@ describe("AddPaC: PreviewPane", () => {
     mime("application/x-yaml");
     m.redraw.sync();
 
-    expect(helper.text(sel.previewPane)).toBe("# Your Pipelines as Code definition will automatically update here");
+    expect(helper.text(sel.previewPane)).toBe("# Your Pipelines as Code definition\n# will automatically update here");
 
     mime("application/json");
     m.redraw.sync();
 
-    expect(helper.text(sel.previewPane)).toBe("// Your Pipelines as Code definition will automatically update here");
+    expect(helper.text(sel.previewPane)).toBe("// Your Pipelines as Code definition\n// will automatically update here");
   });
 
   it("renders content when available", () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/styles.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/styles.scss
@@ -20,6 +20,8 @@
 
 $syntax-bg: #282923;
 $error-container-width: 450px;
+$initial-message-bg: rgba(255, 255, 255, 0.5);
+$initial-message-z: 10;
 
 .builder-form {
   max-width: 50%;
@@ -45,12 +47,30 @@ $error-container-width: 450px;
 }
 
 .preview-pane[class*="language-"] { // scss-lint:disable-line
+  position: relative;
   margin: 0;
   width: 50%;
 
   code {
     overflow-y: auto;
     display: block;
+  }
+
+  .initial-message {
+    position: absolute;
+    top: 250px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 30px;
+    border-radius: 5px;
+    background: $initial-message-bg;
+    z-index: $initial-message-z;
+
+    .comment {
+      display: block;
+      margin: 0;
+      line-height: 0;
+    }
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/styles.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/styles.scss.d.ts
@@ -41,6 +41,7 @@ export const iconGear: string;
 export const iconRemove: string;
 export const iconSpinner: string;
 export const important: string;
+export const initialMessage: string;
 export const inserted: string;
 export const intro: string;
 export const italic: string;


### PR DESCRIPTION
Fixes #7111

Looks like this now:

![image](https://user-images.githubusercontent.com/723642/67722489-71baf800-f996-11e9-9564-d2406c9b886c.png)
