### PR TITLE
Added support for group attribute in update pipeline config api

### DIFF
--- a/api/api-pipeline-config-v10/src/main/java/com/thoughtworks/go/apiv10/admin/pipelineconfig/PipelineConfigControllerV10.java
+++ b/api/api-pipeline-config-v10/src/main/java/com/thoughtworks/go/apiv10/admin/pipelineconfig/PipelineConfigControllerV10.java
@@ -199,7 +199,8 @@ public class PipelineConfigControllerV10 extends ApiController implements SparkS
 
     @Override
     public String etagFor(PipelineConfig pipelineConfig) {
-        return entityHashingService.md5ForEntity(pipelineConfig);
+        String groupName = goConfigService.findGroupNameByPipeline(pipelineConfig.name());
+        return entityHashingService.md5ForEntity(pipelineConfig, groupName);
     }
 
     @Override

--- a/api/api-pipeline-config-v10/src/main/java/com/thoughtworks/go/apiv10/admin/pipelineconfig/PipelineConfigControllerV10.java
+++ b/api/api-pipeline-config-v10/src/main/java/com/thoughtworks/go/apiv10/admin/pipelineconfig/PipelineConfigControllerV10.java
@@ -124,8 +124,9 @@ public class PipelineConfigControllerV10 extends ApiController implements SparkS
             throw haltBecauseEtagDoesNotMatch("pipeline", existingPipelineConfig.getName());
         }
 
+        String groupName = getOrHaltForGroupName(req);
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        pipelineConfigService.updatePipelineConfig(SessionUtils.currentUsername(), pipelineConfigFromRequest, etagFor(existingPipelineConfig), result);
+        pipelineConfigService.updatePipelineConfig(SessionUtils.currentUsername(), pipelineConfigFromRequest, groupName, etagFor(existingPipelineConfig), result);
         return handleCreateOrUpdateResponse(req, res, pipelineConfigFromRequest, result);
     }
 

--- a/api/api-pipeline-config-v10/src/test/groovy/com/thoughtworks/go/apiv10/pipelineconfig/PipelineConfigControllerV10Test.groovy
+++ b/api/api-pipeline-config-v10/src/test/groovy/com/thoughtworks/go/apiv10/pipelineconfig/PipelineConfigControllerV10Test.groovy
@@ -56,8 +56,7 @@ import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertTrue
-import static org.mockito.ArgumentMatchers.any
-import static org.mockito.ArgumentMatchers.eq
+import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
 import static org.mockito.MockitoAnnotations.initMocks
 
@@ -546,6 +545,31 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
       }
 
       @Test
+      void "should not update pipeline config when the group is not specified"() {
+        def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline1")
+        pipelineConfig.setOrigin(new FileConfigOrigin())
+
+        when(pipelineConfigService.getPipelineConfig("pipeline1")).thenReturn(pipelineConfig)
+        when(entityHashingService.md5ForEntity(pipelineConfig)).thenReturn('md5')
+
+        def headers = [
+          'accept'      : controller.mimeType,
+          'If-Match'    : 'md5',
+          'content-type': 'application/json'
+        ]
+
+        def json = toObject({
+          PipelineConfigRepresenter.toJSON(it, pipelineConfig, groupName)
+        })
+        json.remove("group")
+        putWithApiHeader(controller.controllerPath("/pipeline1"), headers, json)
+
+        assertThatResponse()
+          .isUnprocessableEntity()
+          .hasJsonMessage("Pipeline group must be specified for creating a pipeline.")
+      }
+
+      @Test
       void "should handle server validation errors"() {
         HttpLocalizedOperationResult result
         def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline1")
@@ -555,8 +579,8 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
 
         pipelineConfig.addError("labelTemplate", String.format(PipelineConfig.LABEL_TEMPLATE_ERROR_MESSAGE, 'foo bar'))
 
-        when(pipelineConfigService.updatePipelineConfig(any(), any(), eq("md5"), any())).then({ InvocationOnMock invocation ->
-          result = invocation.getArguments()[3]
+        when(pipelineConfigService.updatePipelineConfig(any(), any(), anyString(), eq("md5"), any())).then({ InvocationOnMock invocation ->
+          result = invocation.getArguments()[4]
           result.unprocessableEntity("message from server")
         })
 
@@ -608,7 +632,7 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
         when(goConfigService.getCurrentConfig()).thenReturn(cruiseConfig)
         when(pipelineConfigService.getPipelineConfig("pipeline1")).thenReturn(pipelineConfig)
         when(entityHashingService.md5ForEntity(pipelineConfig)).thenReturn('md5')
-        when(pipelineConfigService.updatePipelineConfig(any(), any(), any(), any())).then({ InvocationOnMock invocation ->
+        when(pipelineConfigService.updatePipelineConfig(any(), any(), anyString(), any(), any())).then({ InvocationOnMock invocation ->
           pipelineBeingSaved = invocation.getArguments()[1]
         })
 
@@ -639,7 +663,7 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
         when(pipelineConfigService.getPipelineConfig("pipeline1")).thenReturn(pipelineConfig)
         when(entityHashingService.md5ForEntity(pipelineConfig)).thenReturn('md5')
 
-        when(pipelineConfigService.updatePipelineConfig(any(), any(), any(), any())).then({ InvocationOnMock invocation ->
+        when(pipelineConfigService.updatePipelineConfig(any(), any(), anyString(), any(), any())).then({ InvocationOnMock invocation ->
           pipelineBeingSaved = invocation.getArguments()[1]
         })
 
@@ -733,6 +757,7 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
       label_template: "\${COUNT}",
       lock_behavior : "none",
       name          : "pipeline1",
+      group         : "group",
       materials     : [
         [
           type      : "svn",
@@ -757,6 +782,7 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
     return [
       label_template: "\${COUNT}",
       name          : pipeline_name,
+      group         : "group",
       materials     :
         [[
            type      : material_type,

--- a/api/api-pipeline-config-v10/src/test/groovy/com/thoughtworks/go/apiv10/pipelineconfig/PipelineConfigControllerV10Test.groovy
+++ b/api/api-pipeline-config-v10/src/test/groovy/com/thoughtworks/go/apiv10/pipelineconfig/PipelineConfigControllerV10Test.groovy
@@ -129,7 +129,7 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
         def pipelineMd5 = 'md5_for_pipeline_config'
 
         when(pipelineConfigService.getPipelineConfig('pipeline1')).thenReturn(pipeline)
-        when(entityHashingService.md5ForEntity(pipeline)).thenReturn(pipelineMd5)
+        when(entityHashingService.md5ForEntity(pipeline, groupName)).thenReturn(pipelineMd5)
 
         getWithApiHeader(controller.controllerPath("/pipeline1"))
 
@@ -148,7 +148,7 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
         def pipeline_md5 = 'md5_for_pipeline_config'
 
         when(pipelineConfigService.getPipelineConfig("pipeline1")).thenReturn(pipeline)
-        when(entityHashingService.md5ForEntity(pipeline)).thenReturn(pipeline_md5)
+        when(entityHashingService.md5ForEntity(pipeline, groupName)).thenReturn(pipeline_md5)
 
         getWithApiHeader(controller.controllerPath('/pipeline1'), ['if-none-match': '"md5_for_pipeline_config"'])
 
@@ -176,7 +176,7 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
         def pipeline_md5 = 'md5_for_pipeline_config'
 
         when(pipelineConfigService.getPipelineConfig("pipeline1")).thenReturn(pipeline)
-        when(entityHashingService.md5ForEntity(pipeline)).thenReturn(pipeline_md5)
+        when(entityHashingService.md5ForEntity(pipeline, groupName)).thenReturn(pipeline_md5)
 
         getWithApiHeader(controller.controllerPath('/pipeline1'), ['if-none-match': '"junk"'])
 
@@ -465,7 +465,7 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
       void "should update pipeline config for an admin"() {
         def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline1")
         pipelineConfig.setOrigin(new FileConfigOrigin())
-        when(entityHashingService.md5ForEntity(pipelineConfig)).thenReturn('md5')
+        when(entityHashingService.md5ForEntity(pipelineConfig, groupName)).thenReturn('md5')
         when(pipelineConfigService.getPipelineConfig("pipeline1")).thenReturn(pipelineConfig)
 
         def headers = [
@@ -550,7 +550,7 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
         pipelineConfig.setOrigin(new FileConfigOrigin())
 
         when(pipelineConfigService.getPipelineConfig("pipeline1")).thenReturn(pipelineConfig)
-        when(entityHashingService.md5ForEntity(pipelineConfig)).thenReturn('md5')
+        when(entityHashingService.md5ForEntity(pipelineConfig, groupName)).thenReturn('md5')
 
         def headers = [
           'accept'      : controller.mimeType,
@@ -574,7 +574,7 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
         HttpLocalizedOperationResult result
         def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline1")
         pipelineConfig.setOrigin(new FileConfigOrigin())
-        when(entityHashingService.md5ForEntity(pipelineConfig)).thenReturn('md5')
+        when(entityHashingService.md5ForEntity(pipelineConfig, groupName)).thenReturn('md5')
         when(pipelineConfigService.getPipelineConfig("pipeline1")).thenReturn(pipelineConfig)
 
         pipelineConfig.addError("labelTemplate", String.format(PipelineConfig.LABEL_TEMPLATE_ERROR_MESSAGE, 'foo bar'))
@@ -631,7 +631,7 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
 
         when(goConfigService.getCurrentConfig()).thenReturn(cruiseConfig)
         when(pipelineConfigService.getPipelineConfig("pipeline1")).thenReturn(pipelineConfig)
-        when(entityHashingService.md5ForEntity(pipelineConfig)).thenReturn('md5')
+        when(entityHashingService.md5ForEntity(pipelineConfig, groupName)).thenReturn('md5')
         when(pipelineConfigService.updatePipelineConfig(any(), any(), anyString(), any(), any())).then({ InvocationOnMock invocation ->
           pipelineBeingSaved = invocation.getArguments()[1]
         })
@@ -661,7 +661,7 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
 
         when(goConfigService.getCurrentConfig()).thenReturn(cruiseConfig)
         when(pipelineConfigService.getPipelineConfig("pipeline1")).thenReturn(pipelineConfig)
-        when(entityHashingService.md5ForEntity(pipelineConfig)).thenReturn('md5')
+        when(entityHashingService.md5ForEntity(pipelineConfig, groupName)).thenReturn('md5')
 
         when(pipelineConfigService.updatePipelineConfig(any(), any(), anyString(), any(), any())).then({ InvocationOnMock invocation ->
           pipelineBeingSaved = invocation.getArguments()[1]

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommand.java
@@ -87,7 +87,7 @@ public class UpdatePipelineConfigCommand extends PipelineConfigCommand {
     }
 
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
-        boolean freshRequest = entityHashingService.md5ForEntity(cruiseConfig.getPipelineConfigByName(pipelineConfig.name())).equals(md5);
+        boolean freshRequest = entityHashingService.md5ForEntity(cruiseConfig.getPipelineConfigByName(pipelineConfig.name()), getPipelineGroup()).equals(md5);
 
         if (!freshRequest) {
             result.stale(EntityType.Pipeline.staleConfig(pipelineConfig.name()));

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommand.java
@@ -78,7 +78,14 @@ public class UpdatePipelineConfigCommand extends PipelineConfigCommand {
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return canEditPipeline() && isRequestFresh(cruiseConfig);
+        return canEditPipeline() && canAccessGroups() && isRequestFresh(cruiseConfig);
+    }
+
+    private boolean canAccessGroups() {
+        if (!existingGroupName.equalsIgnoreCase(newGroupName) && goConfigService.groups().hasGroup(newGroupName)) {
+            return goConfigService.isUserAdminOfGroup(currentUser.getUsername(), newGroupName);
+        }
+        return true;
     }
 
     private boolean canEditPipeline() {

--- a/server/src/main/java/com/thoughtworks/go/server/service/EntityHashingService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EntityHashingService.java
@@ -151,6 +151,11 @@ public class EntityHashingService implements ConfigChangedListener, Initializer 
         return getDomainEntityMd5FromCache(config, cacheKey);
     }
 
+    public String md5ForEntity(PipelineConfig pipelineConfig, String groupName) {
+        String md5 = md5ForEntity(pipelineConfig);
+        return CachedDigestUtils.md5Hex(StringUtils.join(md5, SEP_CHAR, groupName));
+    }
+
     public String md5ForEntity(ConfigRepoConfig config) {
         String cacheKey = cacheKey(config, config.getId());
         return getDomainEntityMd5FromCache(config, cacheKey);

--- a/server/src/main/java/com/thoughtworks/go/server/service/EntityHashingService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EntityHashingService.java
@@ -146,13 +146,9 @@ public class EntityHashingService implements ConfigChangedListener, Initializer 
         return getDomainEntityMd5FromCache(config, cacheKey);
     }
 
-    public String md5ForEntity(PipelineConfig config) {
-        String cacheKey = cacheKey(config, config.name());
-        return getDomainEntityMd5FromCache(config, cacheKey);
-    }
-
     public String md5ForEntity(PipelineConfig pipelineConfig, String groupName) {
-        String md5 = md5ForEntity(pipelineConfig);
+        String cacheKey = cacheKey(pipelineConfig, pipelineConfig.name());
+        String md5 = getDomainEntityMd5FromCache(pipelineConfig, cacheKey);
         return CachedDigestUtils.md5Hex(StringUtils.join(md5, SEP_CHAR, groupName));
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineConfigService.java
@@ -136,9 +136,9 @@ public class PipelineConfigService {
     }
 
 
-    public void updatePipelineConfig(final Username currentUser, final PipelineConfig pipelineConfig, final String md5, final LocalizedOperationResult result) {
+    public void updatePipelineConfig(final Username currentUser, final PipelineConfig pipelineConfig, String updatedGroupName, final String md5, final LocalizedOperationResult result) {
         validatePluggableTasks(pipelineConfig);
-        UpdatePipelineConfigCommand updatePipelineConfigCommand = new UpdatePipelineConfigCommand(goConfigService, entityHashingService, pipelineConfig, currentUser, md5, result, externalArtifactsService);
+        UpdatePipelineConfigCommand updatePipelineConfigCommand = new UpdatePipelineConfigCommand(goConfigService, entityHashingService, pipelineConfig, updatedGroupName, currentUser, md5, result, externalArtifactsService);
         update(currentUser, pipelineConfig, result, updatePipelineConfigCommand);
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommandTest.java
@@ -61,7 +61,7 @@ class UpdatePipelineConfigCommandTest {
 
         when(goConfigService.findGroupNameByPipeline(pipelineConfig.name())).thenReturn("group1");
         when(goConfigService.canEditPipeline(pipelineConfig.name().toString(), username, localizedOperationResult, "group1")).thenReturn(true);
-        when(entityHashingService.md5ForEntity(pipelineConfig)).thenReturn("latest_md5");
+        when(entityHashingService.md5ForEntity(pipelineConfig, "group1")).thenReturn("latest_md5");
 
         BasicCruiseConfig basicCruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(pipelineConfig));
         assertFalse(command.canContinue(basicCruiseConfig));
@@ -161,7 +161,7 @@ class UpdatePipelineConfigCommandTest {
     }
 
     @Test
-    void shouldUpdateThePipelineGroupIfDifferent() {
+    void shouldAddGroupWithPipelineAndRemoveItFromPreviousIfTheSpecifiedGroupDoesNotExist() {
         UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, null,
                 pipelineConfig, "updated_group", username, "stale_md5", localizedOperationResult, externalArtifactsService);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommandTest.java
@@ -173,10 +173,13 @@ class UpdatePipelineConfigCommandTest {
         when(cruiseConfig.findGroup("group1")).thenReturn(pipelineConfigs);
         when(cruiseConfig.getGroups()).thenReturn(pipelineGroups);
 
+        assertThat(pipelineGroups.hasGroup("updated_group"), is(false));
+
         command.update(cruiseConfig);
         verify(cruiseConfig).update("group1", pipelineConfig.name().toString(), pipelineConfig);
 
         assertThat(pipelineGroups.findGroup("group1").size(), is(0));
+        assertThat(pipelineGroups.hasGroup("updated_group"), is(true));
         assertThat(pipelineGroups.findGroup("updated_group").size(), is(1));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/EntityHashingServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/EntityHashingServiceTest.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.server.service;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.merge.MergeEnvironmentConfig;
 import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
+import com.thoughtworks.go.helper.EnvironmentConfigMother;
 import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.domain.PluginSettings;
@@ -59,10 +60,10 @@ public class EntityHashingServiceTest {
 
     @Test
     public void shouldComputeTheMD5OfAGivenXmlPartialGeneratedFromAnObject() {
-        PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig("P1");
-        String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(pipelineConfig);
+        BasicEnvironmentConfig environment = EnvironmentConfigMother.environment("P1");
+        String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(environment);
 
-        assertThat(entityHashingService.md5ForEntity(pipelineConfig), is(CachedDigestUtils.md5Hex(xml)));
+        assertThat(entityHashingService.md5ForEntity(environment), is(CachedDigestUtils.md5Hex(xml)));
     }
 
     @Test
@@ -102,11 +103,11 @@ public class EntityHashingServiceTest {
 
     @Test
     public void entityChecksumIsIdenticalForObjectsWithCaseInsensitiveName() throws Exception {
-        PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig("UPPER_CASE_NAME");
-        when(goCache.get("GO_ETAG_CACHE", "com.thoughtworks.go.config.PipelineConfig.upper_case_name")).thenReturn("foo");
-        String checksum = entityHashingService.md5ForEntity(pipelineConfig);
+        BasicEnvironmentConfig environment = EnvironmentConfigMother.environment("UPPER_CASE_NAME");
+        when(goCache.get("GO_ETAG_CACHE", "com.thoughtworks.go.config.BasicEnvironmentConfig.upper_case_name")).thenReturn("foo");
+        String checksum = entityHashingService.md5ForEntity(environment);
         assertThat(checksum, is("foo"));
-        verify(goCache).get("GO_ETAG_CACHE", "com.thoughtworks.go.config.PipelineConfig.upper_case_name");
+        verify(goCache).get("GO_ETAG_CACHE", "com.thoughtworks.go.config.BasicEnvironmentConfig.upper_case_name");
         verifyNoMoreInteractions(goCache);
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
@@ -160,7 +160,7 @@ public class PipelineConfigServiceTest {
         PipelineConfig pipeline = PipelineConfigMother.pipelineConfig("P1", new StageConfig(new CaseInsensitiveString("S1"), new JobConfigs(job1)),
                 new StageConfig(new CaseInsensitiveString("S2"), new JobConfigs(job2)));
 
-        pipelineConfigService.updatePipelineConfig(null, pipeline, null, null);
+        pipelineConfigService.updatePipelineConfig(null, pipeline, "group", null, null);
 
         verify(pluggableTaskService).isValid(xUnit);
         verify(pluggableTaskService).isValid(docker);
@@ -223,8 +223,8 @@ public class PipelineConfigServiceTest {
         List<PipelineConfigs> pipelineConfigs = pipelineConfigService.viewableGroupsForUserIncludingConfigRepos(username);
 
         assertThat(pipelineConfigs.size(), is(2));
-        assertThat(pipelineConfigs.get(0).getGroup(),is("group2"));
-        assertThat(pipelineConfigs.get(1).getGroup(),is("group1"));
+        assertThat(pipelineConfigs.get(0).getGroup(), is("group2"));
+        assertThat(pipelineConfigs.get(1).getGroup(), is("group1"));
     }
 
 
@@ -246,6 +246,6 @@ public class PipelineConfigServiceTest {
         List<PipelineConfigs> pipelineConfigs = pipelineConfigService.viewableGroupsFor(username);
 
         assertThat(pipelineConfigs.size(), is(1));
-        assertThat(pipelineConfigs.get(0).getGroup(),is("group1"));
+        assertThat(pipelineConfigs.get(0).getGroup(), is("group1"));
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
@@ -277,7 +277,7 @@ public class BuildAssignmentServiceIntegrationTest {
         String md5 = CachedDigestUtils.md5Hex(xml);
         StageConfig devStage = pipelineConfig.findBy(new CaseInsensitiveString(fixture.devStage));
         pipelineConfig.remove(devStage);
-        pipelineConfigService.updatePipelineConfig(loserUser, pipelineConfig, md5, new HttpLocalizedOperationResult());
+        pipelineConfigService.updatePipelineConfig(loserUser, pipelineConfig, "group", md5, new HttpLocalizedOperationResult());
 
         Pipeline pipeline = pipelineDao.mostRecentPipeline(fixture.pipelineName);
         JobInstance job = pipeline.getFirstStage().getJobInstances().first();
@@ -303,7 +303,7 @@ public class BuildAssignmentServiceIntegrationTest {
         String md5 = CachedDigestUtils.md5Hex(xml);
         StageConfig devStage = pipelineConfig.findBy(new CaseInsensitiveString(fixture.devStage));
         devStage.getJobs().remove(devStage.jobConfigByConfigName(new CaseInsensitiveString(fixture.JOB_FOR_DEV_STAGE)));
-        pipelineConfigService.updatePipelineConfig(loserUser, pipelineConfig, md5, new HttpLocalizedOperationResult());
+        pipelineConfigService.updatePipelineConfig(loserUser, pipelineConfig, "group", md5, new HttpLocalizedOperationResult());
 
         Pipeline pipeline = pipelineDao.mostRecentPipeline(fixture.pipelineName);
         JobInstance deletedJob = pipeline.getFirstStage().getJobInstances().getByName(fixture.JOB_FOR_DEV_STAGE);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
@@ -471,7 +471,7 @@ public class PipelineConfigServiceIntegrationTest {
         pipelineConfig.add(stage);
         pipelineConfig.addParam(new ParamConfig("foo", "."));
 
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.toString(), result.isSuccessful(), is(false));
         assertThat(result.httpCode(), is(422));
@@ -487,7 +487,7 @@ public class PipelineConfigServiceIntegrationTest {
         String md5 = CachedDigestUtils.md5Hex(xml);
         pipelineConfig.add(new StageConfig(new CaseInsensitiveString("additional_stage"), new JobConfigs(new JobConfig(new CaseInsensitiveString("addtn_job")))));
 
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.toString(), result.isSuccessful(), is(true));
         assertThat(goConfigDao.loadConfigHolder(), is(not(goConfigHolderBeforeUpdate)));
@@ -506,7 +506,7 @@ public class PipelineConfigServiceIntegrationTest {
         String md5 = CachedDigestUtils.md5Hex(xml);
 
         pipelineConfig.setLabelTemplate("LABEL");
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.toString(), result.isSuccessful(), is(false));
         assertThat(result.httpCode(), is(422));
@@ -526,7 +526,7 @@ public class PipelineConfigServiceIntegrationTest {
         String md5 = CachedDigestUtils.md5Hex(xml);
         pipelineConfig.clear();
         pipelineConfig.setTemplateName(templateName);
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.toString(), result.isSuccessful(), is(false));
         assertThat(result.toString(), result.toString().contains("Parameter 'SOME_PARAM' is not defined"), is(true));
@@ -546,7 +546,7 @@ public class PipelineConfigServiceIntegrationTest {
         pipelineConfig.clear();
         pipelineConfig.setTemplateName(templateName);
         pipelineConfig.addStageWithoutValidityAssertion(StageConfigMother.stageConfig("local-stage"));
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.toString(), result.isSuccessful(), is(false));
         assertThat(pipelineConfig.errors().on("stages"), is(String.format("Cannot add stages to pipeline '%s' which already references template '%s'", pipelineConfig.name(), templateName)));
@@ -562,7 +562,7 @@ public class PipelineConfigServiceIntegrationTest {
         saveTemplateWithParamToConfig(templateName);
 
         GoConfigHolder goConfigHolderBeforeUpdate = goConfigDao.loadConfigHolder();
-        pipelineConfigService.updatePipelineConfig(new Username(new CaseInsensitiveString("unauthorized_user")), pipelineConfig, null, result);
+        pipelineConfigService.updatePipelineConfig(new Username(new CaseInsensitiveString("unauthorized_user")), pipelineConfig, groupName, null, result);
 
         assertThat(result.toString(), result.isSuccessful(), is(false));
         assertThat(result.toString(), result.httpCode(), is(403));
@@ -582,7 +582,7 @@ public class PipelineConfigServiceIntegrationTest {
         String md5 = CachedDigestUtils.md5Hex(xml);
 
         pipelineConfig.materialConfigs().add(scmMaterialConfig);
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.toString(), result.isSuccessful(), is(false));
         assertThat(scmMaterialConfig.errors().on(PluggableSCMMaterialConfig.FOLDER), is("Destination directory is required when specifying multiple scm materials"));
@@ -601,7 +601,7 @@ public class PipelineConfigServiceIntegrationTest {
         String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(pipelineConfig);
         String md5 = CachedDigestUtils.md5Hex(xml);
         pipelineConfig.materialConfigs().add(packageMaterialConfig);
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.toString(), result.isSuccessful(), is(false));
         assertThat(result.message(), is(String.format("Validations failed for pipeline '%s'. Error(s): [Validation failed.]. Please correct and resubmit.", pipelineConfig.name())));
@@ -706,7 +706,7 @@ public class PipelineConfigServiceIntegrationTest {
         goConfigService.register(pipelineConfigChangedListener);
         PipelineConfig pipeline = PipelineConfigMother.pipelineConfigWithTemplate(pipelineName, templateName);
         pipeline.setVariables(new EnvironmentVariablesConfig());
-        pipelineConfigService.updatePipelineConfig(user, pipeline, md5, new DefaultLocalizedOperationResult());
+        pipelineConfigService.updatePipelineConfig(user, pipeline, groupName, md5, new DefaultLocalizedOperationResult());
         assertThat(listenerInvoked[0], is(true));
     }
 
@@ -756,7 +756,7 @@ public class PipelineConfigServiceIntegrationTest {
 
         pipelineConfig.getFirstStageConfig().setName(new CaseInsensitiveString("upstream_stage_renamed"));
 
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.isSuccessful(), is(false));
         assertThat(pipelineConfig.errors().on("base"), is(String.format("Stage with name 'stage' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r1)", pipelineConfig.name())));
@@ -777,7 +777,7 @@ public class PipelineConfigServiceIntegrationTest {
         String md5 = CachedDigestUtils.md5Hex(xml);
 
         pipelineConfig.getFirstStageConfig().getJobs().first().addTask(new ExecTask("executable", new Arguments(new Argument("foo")), "working"));
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.isSuccessful(), is(true));
         CruiseConfig currentConfig = goConfigService.getCurrentConfig();
@@ -799,7 +799,7 @@ public class PipelineConfigServiceIntegrationTest {
         String md5 = CachedDigestUtils.md5Hex(xml);
 
         pipelineConfig.setVariables(new EnvironmentVariablesConfig(asList(new EnvironmentVariableConfig("key", "value"))));
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.isSuccessful(), is(true));
         CruiseConfig currentConfig = goConfigService.getCurrentConfig();
@@ -823,7 +823,7 @@ public class PipelineConfigServiceIntegrationTest {
         String md5 = CachedDigestUtils.md5Hex(xml);
 
         pipelineConfig.getFirstStageConfig().setName(new CaseInsensitiveString("new_name"));
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.isSuccessful(), is(false));
         assertThat(result.message(), is(String.format("Validations failed for pipeline '%s'. Error(s): [Validation failed.]. Please correct and resubmit.", pipelineConfig.name())));
@@ -860,7 +860,7 @@ public class PipelineConfigServiceIntegrationTest {
         String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(pipelineConfig);
         String md5 = CachedDigestUtils.md5Hex(xml);
         pipelineConfig.setVariables(new EnvironmentVariablesConfig(asList(new EnvironmentVariableConfig("key", "value"))));
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.isSuccessful(), is(true));
         currentConfig = goConfigService.getCurrentConfig();
@@ -900,7 +900,7 @@ public class PipelineConfigServiceIntegrationTest {
         String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(pipelineConfig);
         String md5 = CachedDigestUtils.md5Hex(xml);
         pipelineConfig.getFirstStageConfig().setName(new CaseInsensitiveString("upstream_stage_renamed"));
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.isSuccessful(), is(true));
         currentConfig = goConfigService.getCurrentConfig();
@@ -955,7 +955,7 @@ public class PipelineConfigServiceIntegrationTest {
         String md5 = CachedDigestUtils.md5Hex(xml);
 
         pipelineConfig.getFirstStageConfig().setName(new CaseInsensitiveString("upstream_stage_renamed"));
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.isSuccessful(), is(false));
         assertThat(result.message(), is(String.format("Validations failed for pipeline '%s'. " +
@@ -1009,7 +1009,7 @@ public class PipelineConfigServiceIntegrationTest {
         String md5 = CachedDigestUtils.md5Hex(xml);
 
         pipelineConfig.getFirstStageConfig().setName(new CaseInsensitiveString("new_name"));
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.isSuccessful(), is(false));
         assertThat(result.message(), is(String.format("Validations failed for pipeline '%s'. " +
@@ -1047,13 +1047,38 @@ public class PipelineConfigServiceIntegrationTest {
 
         String md5 = CachedDigestUtils.md5Hex(new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(pipelineConfig));
         pipelineConfig.setVariables(new EnvironmentVariablesConfig(asList(new EnvironmentVariableConfig("key", "value"))));
-        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, md5, result);
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.isSuccessful(), is(true));
         assertThat(pipelineConfigService.getPipelineConfig(remoteDownstreamPipelineName), is(not(nullValue())));
         assertThat(goConfigService.getCurrentConfig().getAllPipelineNames().contains(remoteDownstreamPipeline.name()), is(true));
         assertThat(goConfigService.getConfigForEditing().getAllPipelineNames().contains(remoteDownstreamPipeline.name()), is(false));
         assertThat(goConfigService.getMergedConfigForEditing().getAllPipelineNames().contains(remoteDownstreamPipeline.name()), is(true));
+    }
+
+    @Test
+    public void updatePipelineConfig_shouldUpdateThePipelineGroup() {
+        String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(pipelineConfig);
+        String md5 = CachedDigestUtils.md5Hex(xml);
+        pipelineConfig.add(new StageConfig(new CaseInsensitiveString("additional_stage"), new JobConfigs(new JobConfig(new CaseInsensitiveString("addtn_job")))));
+
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, "updated_group", md5, result);
+
+        assertThat(result.toString(), result.isSuccessful(), is(true));
+
+        assertThat(goConfigService.findGroupNameByPipeline(pipelineConfig.name()), is("updated_group"));
+    }
+
+    @Test
+    public void updatePipelineConfig_shouldValidateUpdatedPipelineGroupName() {
+        String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(pipelineConfig);
+        String md5 = CachedDigestUtils.md5Hex(xml);
+        pipelineConfig.add(new StageConfig(new CaseInsensitiveString("additional_stage"), new JobConfigs(new JobConfig(new CaseInsensitiveString("addtn_job")))));
+
+        pipelineConfigService.updatePipelineConfig(user, pipelineConfig, "invalid-name!@$", md5, result);
+
+        assertThat(result.httpCode(), is(500));
+        assertThat(result.message(), is("Save failed. failed to save : Name is invalid. \"invalid-name!@$\" should conform to the pattern - [a-zA-Z0-9_\\-]{1}[a-zA-Z0-9_\\-.]*"));
     }
 
     private void saveTemplateWithParamToConfig(CaseInsensitiveString templateName) throws Exception {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
@@ -114,7 +114,7 @@ public class PipelineConfigServicePerformanceTest {
                 PipelineConfig pipelineConfig = goConfigService.getConfigForEditing().pipelineConfigByName(new CaseInsensitiveString(Thread.currentThread().getName()));
                 pipelineConfig.add(new StageConfig(new CaseInsensitiveString("additional_stage"), new JobConfigs(new JobConfig(new CaseInsensitiveString("addtn_job")))));
                 PerfTimer updateTimer = PerfTimer.start("Saving pipelineConfig : " + pipelineConfig.name());
-                pipelineConfigService.updatePipelineConfig(user, pipelineConfig, entityHashingService.md5ForEntity(pipelineConfig), result);
+                pipelineConfigService.updatePipelineConfig(user, pipelineConfig, "group", entityHashingService.md5ForEntity(pipelineConfig), result);
                 updateTimer.stop();
                 results.put(Thread.currentThread().getName(), result.isSuccessful());
                 if (!result.isSuccessful()) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
@@ -114,7 +114,7 @@ public class PipelineConfigServicePerformanceTest {
                 PipelineConfig pipelineConfig = goConfigService.getConfigForEditing().pipelineConfigByName(new CaseInsensitiveString(Thread.currentThread().getName()));
                 pipelineConfig.add(new StageConfig(new CaseInsensitiveString("additional_stage"), new JobConfigs(new JobConfig(new CaseInsensitiveString("addtn_job")))));
                 PerfTimer updateTimer = PerfTimer.start("Saving pipelineConfig : " + pipelineConfig.name());
-                pipelineConfigService.updatePipelineConfig(user, pipelineConfig, "group", entityHashingService.md5ForEntity(pipelineConfig), result);
+                pipelineConfigService.updatePipelineConfig(user, pipelineConfig, "group", entityHashingService.md5ForEntity(pipelineConfig, "group"), result);
                 updateTimer.stop();
                 results.put(Thread.currentThread().getName(), result.isSuccessful());
                 if (!result.isSuccessful()) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineTriggerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineTriggerServiceIntegrationTest.java
@@ -228,7 +228,7 @@ public class PipelineTriggerServiceIntegrationTest {
         pipelineConfig.addEnvironmentVariable("ENV_VAR2", "VAL2");
         pipelineConfig.addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), "SECURE_VAR1", "SECURE_VAL", true));
         pipelineConfig.addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), "SECURE_VAR2", "SECURE_VAL2", true));
-        pipelineConfigService.updatePipelineConfig(admin, pipelineConfig, entityHashingService.md5ForEntity(pipelineConfig), new HttpLocalizedOperationResult());
+        pipelineConfigService.updatePipelineConfig(admin, pipelineConfig, "group", entityHashingService.md5ForEntity(pipelineConfig), new HttpLocalizedOperationResult());
         Integer pipelineCounterBefore = pipelineSqlMapDao.getCounterForPipeline(pipelineName);
 
         CaseInsensitiveString pipelineNameCaseInsensitive = new CaseInsensitiveString(this.pipelineName);
@@ -269,7 +269,7 @@ public class PipelineTriggerServiceIntegrationTest {
     @Test
     public void shouldScheduleAPipelineWithTheProvidedEncryptedEnvironmentVariable() throws CryptoException {
         pipelineConfig.addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), "SECURE_VAR1", "SECURE_VAL", true));
-        pipelineConfigService.updatePipelineConfig(admin, pipelineConfig, entityHashingService.md5ForEntity(pipelineConfig), new HttpLocalizedOperationResult());
+        pipelineConfigService.updatePipelineConfig(admin, pipelineConfig, "group", entityHashingService.md5ForEntity(pipelineConfig), new HttpLocalizedOperationResult());
         CaseInsensitiveString pipelineNameCaseInsensitive = new CaseInsensitiveString(this.pipelineName);
         assertThat(triggerMonitor.isAlreadyTriggered(pipelineNameCaseInsensitive), is(false));
         PipelineScheduleOptions pipelineScheduleOptions = new PipelineScheduleOptions();
@@ -291,7 +291,7 @@ public class PipelineTriggerServiceIntegrationTest {
     @Test
     public void shouldNotScheduleAPipelineWithTheJunkEncryptedEnvironmentVariable() {
         pipelineConfig.addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), "SECURE_VAR1", "SECURE_VAL", true));
-        pipelineConfigService.updatePipelineConfig(admin, pipelineConfig, entityHashingService.md5ForEntity(pipelineConfig), new HttpLocalizedOperationResult());
+        pipelineConfigService.updatePipelineConfig(admin, pipelineConfig, "group", entityHashingService.md5ForEntity(pipelineConfig), new HttpLocalizedOperationResult());
         CaseInsensitiveString pipelineNameCaseInsensitive = new CaseInsensitiveString(this.pipelineName);
         assertThat(triggerMonitor.isAlreadyTriggered(pipelineNameCaseInsensitive), is(false));
         PipelineScheduleOptions pipelineScheduleOptions = new PipelineScheduleOptions();


### PR DESCRIPTION
 - `group` attribute is mandatory for a `PUT` request
 - if the group name is different, a move operation will be performed

