### PR TITLE
Switch parameters from Template API to internal API

### DIFF
--- a/api/api-template-config-v5/src/main/java/com/thoughtworks/go/apiv5/admin/templateconfig/TemplateConfigInternalControllerV5.java
+++ b/api/api-template-config-v5/src/main/java/com/thoughtworks/go/apiv5/admin/templateconfig/TemplateConfigInternalControllerV5.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv5.admin.templateconfig;
+
+import com.thoughtworks.go.api.ApiController;
+import com.thoughtworks.go.api.ApiVersion;
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
+import com.thoughtworks.go.apiv5.admin.templateconfig.representers.TemplatesInternalRepresenter;
+import com.thoughtworks.go.config.TemplatesConfig;
+import com.thoughtworks.go.server.service.TemplateConfigService;
+import com.thoughtworks.go.spark.Routes;
+import com.thoughtworks.go.spark.spring.SparkSpringController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import spark.Request;
+import spark.Response;
+
+import java.io.IOException;
+
+import static spark.Spark.*;
+
+@Component
+public class TemplateConfigInternalControllerV5 extends ApiController
+    implements SparkSpringController {
+
+  private final TemplateConfigService templateConfigService;
+  private final ApiAuthenticationHelper apiAuthenticationHelper;
+
+  @Autowired
+  public TemplateConfigInternalControllerV5(TemplateConfigService templateConfigService,
+      ApiAuthenticationHelper apiAuthenticationHelper) {
+    super(ApiVersion.v5);
+    this.templateConfigService = templateConfigService;
+    this.apiAuthenticationHelper = apiAuthenticationHelper;
+  }
+
+  @Override
+  public String controllerBasePath() {
+    return Routes.PipelineTemplateConfig.INTERNAL_BASE;
+  }
+
+  @Override
+  public void setupRoutes() {
+    path(controllerPath(), () -> {
+      before("", mimeType, this::setContentType);
+      before("/*", mimeType, this::setContentType);
+      before("", mimeType, this::verifyContentType);
+      before("/*", mimeType, this::verifyContentType);
+      before("", mimeType, onlyOn(apiAuthenticationHelper::checkViewAccessToTemplateAnd403, "GET", "HEAD"));
+
+      get("", mimeType, this::listTemplates);
+    });
+  }
+
+  public String listTemplates(Request req, Response res) throws IOException {
+    TemplatesConfig templateConfigs = templateConfigService.templateConfigsThatCanBeViewedBy(currentUsername());
+    return writerForTopLevelObject(req, res, writer -> TemplatesInternalRepresenter.toJSON(writer, templateConfigs));
+  }
+}

--- a/api/api-template-config-v5/src/main/java/com/thoughtworks/go/apiv5/admin/templateconfig/representers/TemplateConfigRepresenter.java
+++ b/api/api-template-config-v5/src/main/java/com/thoughtworks/go/apiv5/admin/templateconfig/representers/TemplateConfigRepresenter.java
@@ -18,7 +18,6 @@ package com.thoughtworks.go.apiv5.admin.templateconfig.representers;
 import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.api.representers.ErrorGetter;
 import com.thoughtworks.go.api.representers.JsonReader;
-import com.thoughtworks.go.apiv10.admin.shared.representers.ParamRepresenter;
 import com.thoughtworks.go.apiv10.admin.shared.representers.stages.StageRepresenter;
 import com.thoughtworks.go.config.PipelineTemplateConfig;
 import com.thoughtworks.go.spark.Routes;
@@ -40,7 +39,6 @@ public class TemplateConfigRepresenter {
         }
 
         jsonWriter.add("name", pipelineTemplateConfig.name());
-        jsonWriter.addChildList("parameters", paramsWriter -> ParamRepresenter.toJSONArray(paramsWriter, pipelineTemplateConfig.referredParams()));
         writeStages(jsonWriter, pipelineTemplateConfig);
 
     }

--- a/api/api-template-config-v5/src/main/java/com/thoughtworks/go/apiv5/admin/templateconfig/representers/TemplateSummaryInternalRepresenter.java
+++ b/api/api-template-config-v5/src/main/java/com/thoughtworks/go/apiv5/admin/templateconfig/representers/TemplateSummaryInternalRepresenter.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.apiv5.admin.templateconfig.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.config.PipelineTemplateConfig;
+
+public class TemplateSummaryInternalRepresenter {
+    public static void toJSON(OutputWriter templateWriter, PipelineTemplateConfig template) {
+        templateWriter.add("name", template.name()).addChildList("parameters", template.referredParams().getNames());
+    }
+}

--- a/api/api-template-config-v5/src/main/java/com/thoughtworks/go/apiv5/admin/templateconfig/representers/TemplatesInternalRepresenter.java
+++ b/api/api-template-config-v5/src/main/java/com/thoughtworks/go/apiv5/admin/templateconfig/representers/TemplatesInternalRepresenter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.apiv5.admin.templateconfig.representers;
+
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.config.TemplatesConfig;
+
+public class TemplatesInternalRepresenter {
+  public static void toJSON(OutputWriter jsonWriter, TemplatesConfig templatesList) {
+    jsonWriter.addChildList("templates", templatesWriter -> templatesList.forEach(template -> templatesWriter.addChild(templateWriter -> TemplateSummaryInternalRepresenter.toJSON(templateWriter, template))));
+  }
+}

--- a/api/api-template-config-v5/src/test/groovy/com/thoughtworks/go/apiv5/admin/templateconfig/TemplateConfigInternalControllerV5Test.groovy
+++ b/api/api-template-config-v5/src/test/groovy/com/thoughtworks/go/apiv5/admin/templateconfig/TemplateConfigInternalControllerV5Test.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.apiv5.admin.templateconfig
+
+import com.thoughtworks.go.api.SecurityTestTrait
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
+import com.thoughtworks.go.apiv5.admin.templateconfig.representers.TemplatesInternalRepresenter
+import com.thoughtworks.go.config.*
+import com.thoughtworks.go.server.domain.Username
+import com.thoughtworks.go.server.service.TemplateConfigService
+import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.SecurityServiceTrait
+import com.thoughtworks.go.spark.TemplateViewUserSecurity
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+
+import static org.mockito.ArgumentMatchers.any
+import static org.mockito.Mockito.when
+import static org.mockito.MockitoAnnotations.initMocks
+
+class TemplateConfigInternalControllerV5Test implements SecurityServiceTrait, ControllerTrait<TemplateConfigInternalControllerV5> {
+
+  private PipelineTemplateConfig template
+
+  @BeforeEach
+  void setUp() {
+    initMocks(this)
+    template = new PipelineTemplateConfig(new CaseInsensitiveString('some-template'), new StageConfig(new CaseInsensitiveString('stage'), new JobConfigs(new JobConfig(new CaseInsensitiveString('job')))))
+  }
+
+  @Mock
+  private TemplateConfigService templateConfigService
+
+  @Override
+  TemplateConfigInternalControllerV5 createControllerInstance() {
+    return new TemplateConfigInternalControllerV5(templateConfigService, new ApiAuthenticationHelper(securityService, goConfigService))
+  }
+
+  @Nested
+  class listTemplates {
+
+    @Nested
+    class Security implements SecurityTestTrait, TemplateViewUserSecurity {
+
+      @Override
+      String getControllerMethodUnderTest() {
+        return "listTemplates"
+      }
+
+      @Override
+      void makeHttpCall() {
+        getWithApiHeader(controller.controllerPath())
+      }
+    }
+
+    @Nested
+    class AsAdmin {
+
+      @Test
+      void 'should list all templates'() {
+        enableSecurity()
+        loginAsAdmin()
+
+        def templates = new TemplatesConfig();
+
+        when(templateConfigService.templateConfigsThatCanBeViewedBy(any(Username.class) as Username)).thenReturn(templates)
+
+        getWithApiHeader(controller.controllerPath())
+
+        assertThatResponse()
+          .isOk()
+          .hasBodyWithJsonObject(templates, TemplatesInternalRepresenter)
+      }
+    }
+  }
+}

--- a/api/api-template-config-v5/src/test/groovy/com/thoughtworks/go/apiv5/admin/templateconfig/representers/TemplateConfigRepresenterTest.groovy
+++ b/api/api-template-config-v5/src/test/groovy/com/thoughtworks/go/apiv5/admin/templateconfig/representers/TemplateConfigRepresenterTest.groovy
@@ -16,11 +16,7 @@
 package com.thoughtworks.go.apiv5.admin.templateconfig.representers
 
 import com.thoughtworks.go.api.util.GsonTransformer
-import com.thoughtworks.go.config.CaseInsensitiveString
-import com.thoughtworks.go.config.JobConfig
-import com.thoughtworks.go.config.JobConfigs
-import com.thoughtworks.go.config.PipelineTemplateConfig
-import com.thoughtworks.go.config.StageConfig
+import com.thoughtworks.go.config.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -28,7 +24,6 @@ import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import static org.junit.jupiter.api.Assertions.assertEquals
-
 
 class TemplateConfigRepresenterTest {
 
@@ -40,19 +35,14 @@ class TemplateConfigRepresenterTest {
   }
 
   @Test
-  void  'should render a template with hal representation'() {
-    def job = new JobConfig(new CaseInsensitiveString('job'))
-    job.addVariable("foo", "#{foo}")
-    def jobs = new JobConfigs(job)
-    pipelineTemplateConfig = new PipelineTemplateConfig(new CaseInsensitiveString('some-template'), new StageConfig(new CaseInsensitiveString('stage'), jobs))
-
+  void 'should render a template with hal representation'() {
     def actualJson = toObjectString({ TemplateConfigRepresenter.toJSON(it, pipelineTemplateConfig) })
 
-    assertThatJson(actualJson).isEqualTo(templateHashWithParams)
+    assertThatJson(actualJson).isEqualTo(templateHash)
   }
 
   @Test
-  void  'should deserialize given json to PipelineTemplateConfig object'() {
+  void 'should deserialize given json to PipelineTemplateConfig object'() {
     def jsonReader = GsonTransformer.instance.jsonReaderFrom(templateHash)
     def deserializedObject = TemplateConfigRepresenter.fromJSON(jsonReader)
 
@@ -60,102 +50,46 @@ class TemplateConfigRepresenterTest {
   }
 
   def templateHash =
-  [
-    _links: [
-      self: [
-        href: 'http://test.host/go/api/admin/templates/some-template'
-      ],
-      doc: [
-        href: apiDocsUrl('#template-config')
-      ],
-      find: [
-        href: 'http://test.host/go/api/admin/templates/:template_name'
-      ]
-    ],
-    name: 'some-template',
-    stages: [
-      [
-        name: "stage",
-        fetch_materials: true,
-        clean_working_directory: false,
-        never_cleanup_artifacts: false,
-        approval: [
-          type: "success",
-          authorization: [
-            roles: [],
-            users: []
-          ]
+    [
+      _links: [
+        self: [
+          href: 'http://test.host/go/api/admin/templates/some-template'
         ],
-        environment_variables: [],
-        jobs: [
-          [
-            name: "job",
-            run_instance_count: null,
-            timeout: null,
-            environment_variables: [],
-            resources: [],
-            tasks: [],
-            tabs: [],
-            artifacts: [],
+        doc : [
+          href: apiDocsUrl('#template-config')
+        ],
+        find: [
+          href: 'http://test.host/go/api/admin/templates/:template_name'
+        ]
+      ],
+      name  : 'some-template',
+      stages: [
+        [
+          name                   : "stage",
+          fetch_materials        : true,
+          clean_working_directory: false,
+          never_cleanup_artifacts: false,
+          approval               : [
+            type         : "success",
+            authorization: [
+              roles: [],
+              users: []
+            ]
+          ],
+          environment_variables  : [],
+          jobs                   : [
+            [
+              name                 : "job",
+              run_instance_count   : null,
+              timeout              : null,
+              environment_variables: [],
+              resources            : [],
+              tasks                : [],
+              tabs                 : [],
+              artifacts            : [],
+            ]
           ]
         ]
       ]
     ]
-  ]
-
-def templateHashWithParams =
-  [
-    _links: [
-      self: [
-        href: 'http://test.host/go/api/admin/templates/some-template'
-      ],
-      doc: [
-        href: apiDocsUrl('#template-config')
-      ],
-      find: [
-        href: 'http://test.host/go/api/admin/templates/:template_name'
-      ]
-    ],
-    name: 'some-template',
-    parameters: [
-      [
-        name: "foo",
-        value: null
-      ]
-    ],
-    stages: [
-      [
-        name: "stage",
-        fetch_materials: true,
-        clean_working_directory: false,
-        never_cleanup_artifacts: false,
-        approval: [
-          type: "success",
-          authorization: [
-            roles: [],
-            users: []
-          ]
-        ],
-        environment_variables: [],
-        jobs: [
-          [
-            name: "job",
-            run_instance_count: null,
-            timeout: null,
-            environment_variables: [
-              [
-                "secure":false,
-                "name":"foo",
-                "value":"#{foo}"
-              ]
-            ],
-            resources: [],
-            tasks: [],
-            tabs: [],
-            artifacts: [],
-          ]
-        ]
-      ]
-    ]
-  ]
 }

--- a/api/api-template-config-v5/src/test/groovy/com/thoughtworks/go/apiv5/admin/templateconfig/representers/TemplatesInternalRepresenterTest.groovy
+++ b/api/api-template-config-v5/src/test/groovy/com/thoughtworks/go/apiv5/admin/templateconfig/representers/TemplatesInternalRepresenterTest.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv5.admin.templateconfig.representers;
+
+import com.thoughtworks.go.config.CaseInsensitiveString
+import com.thoughtworks.go.config.ParamConfig
+import com.thoughtworks.go.config.ParamsConfig;
+import com.thoughtworks.go.config.PipelineEditabilityInfo
+import com.thoughtworks.go.config.PipelineTemplateConfig
+import com.thoughtworks.go.config.StageConfig;
+import com.thoughtworks.go.config.TemplateToPipelines
+import com.thoughtworks.go.config.TemplatesConfig;
+import org.junit.jupiter.api.Test;
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TemplatesInternalRepresenterTest {
+    @Test
+    void 'should render a template name and its associated pipelines in hal representation'() {
+        def templates = new TemplatesConfig(new TestPipelineConfigTemplate("template-name"))
+        def actualJson = toObjectString({ TemplatesInternalRepresenter.toJSON(it, templates) })
+
+        assertThatJson(actualJson).isEqualTo(indexHash)
+    }
+
+    def indexHash =
+    [
+      templates: [
+        [
+          name: "template-name",
+          parameters: ["myParam"]
+        ]
+      ]
+    ]
+}
+
+class TestPipelineConfigTemplate extends PipelineTemplateConfig {
+    TestPipelineConfigTemplate(String name) {
+        super(new CaseInsensitiveString(name))
+    }
+
+    @Override
+    ParamsConfig referredParams() {
+        return new ParamsConfig(new ParamConfig("myParam", null))
+    }
+}

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/ParamsConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/ParamsConfig.java
@@ -15,13 +15,14 @@
  */
 package com.thoughtworks.go.config;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import com.thoughtworks.go.domain.BaseCollection;
 import com.thoughtworks.go.domain.ConfigErrors;
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @ConfigTag("params")
 @ConfigCollection(ParamConfig.class)
@@ -121,4 +122,11 @@ public class ParamsConfig extends BaseCollection<ParamConfig> implements Validat
         }
     }
 
+    public List<String> getNames() {
+        List<String> names = new ArrayList<>();
+        for (ParamConfig paramConfig : this) {
+            names.add(paramConfig.getName());
+        }
+        return names;
+    }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/TemplateConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/TemplateConfigService.java
@@ -237,4 +237,15 @@ public class TemplateConfigService {
                 })
                 .collect(Collectors.toCollection(TemplatesConfig::new));
     }
+
+    public TemplatesConfig templateConfigsThatCanBeViewedBy(Username currentUsername) {
+        CruiseConfig cruiseConfig = goConfigService.cruiseConfig();
+
+        return cruiseConfig.getTemplates()
+                .stream()
+                .filter(templateConfig -> {
+                    return securityService.isAuthorizedToViewTemplate(templateConfig.name(),currentUsername);
+                })
+                .collect(Collectors.toCollection(TemplatesConfig::new));
+    }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -382,6 +382,10 @@ export class SparkRoutes {
     return "/go/api/internal/pipeline_structure";
   }
 
+  static internalTemplatesListPath() {
+    return "/go/api/admin/internal/templates";
+  }
+
   static showAnalyticsPath(pluginId: string, metric: AnalyticsCapability, params: { [key: string]: string | number }) {
     return `/go/analytics/${pluginId}/${metric.type}/${metric.id}?${m.buildQueryString(params)}`;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/templates_cache.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/templates_cache.ts
@@ -17,42 +17,25 @@
 import {ApiRequestBuilder, ApiVersion} from "helpers/api_request_builder";
 import {SparkRoutes} from "helpers/spark_routes";
 import _ from "lodash";
-import {AbstractObjCache, ObjectCache, rejectAsString} from "models/base/cache";
-import {Option} from "views/components/forms/input_fields";
+import {AbstractObjCache, rejectAsString} from "models/base/cache";
 
-interface Template {
+export interface Template {
   name: string;
+  parameters: string[];
 }
 
-export interface TemplateCache<G> extends ObjectCache<Template[]> {
-  templates: () => G[];
-}
-
-export class TemplatesCache<G> extends AbstractObjCache<Template[]> {
-  private toTemplate: (templateName: string) => G;
-
-  constructor(toTemplate: (templateName: string) => G) {
+export class TemplateCache extends AbstractObjCache<Template[]> {
+  constructor() {
     super();
-    this.toTemplate = toTemplate;
   }
 
   doFetch(resolve: (data: Template[]) => void, reject: (reason: string) => void) {
-    ApiRequestBuilder.GET(SparkRoutes.templatesPath(), ApiVersion.v5).then((res) => {
+    ApiRequestBuilder.GET(SparkRoutes.internalTemplatesListPath(), ApiVersion.v5).then((res) => {
       res.do((s) => {
-        resolve(JSON.parse(s.body)._embedded.templates);
+        resolve(JSON.parse(s.body).templates);
       }, (e) => {
         reject(e.message);
       });
     }).catch(rejectAsString(reject));
-  }
-
-  templates(): G[] {
-    return this.ready() ? _.map(this.contents(), (entry) => this.toTemplate(entry.name)) : [];
-  }
-}
-
-export class DefaultTemplatesCache extends TemplatesCache<Option> {
-  constructor() {
-    super((templateName: string) => ({id: templateName, text: templateName} as Option));
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/parameters_editor.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/parameters_editor.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {makeEvent} from "helpers/compat";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import _ from "lodash";
 import m from "mithril";
@@ -34,8 +35,14 @@ interface Attrs {
 }
 
 export class PipelineParametersEditor extends MithrilViewComponent<Attrs> {
+  notifyChange: () => void = _.noop;
+
   oninit(vnode: m.Vnode<Attrs>) {
     vnode.attrs.paramList(vnode.attrs.parameters().filter((p) => !p.isEmpty()).concat(new PipelineParameter("", "")));
+  }
+
+  oncreate(vnode: m.VnodeDOM<Attrs>) {
+    this.notifyChange = () => vnode.dom.dispatchEvent(makeEvent("change"));
   }
 
   view(vnode: m.Vnode<Attrs>) {
@@ -66,6 +73,7 @@ export class PipelineParametersEditor extends MithrilViewComponent<Attrs> {
   update(params: Stream<PipelineParameter[]>, paramsList: Stream<PipelineParameter[]>, event?: Event) {
     if (event) {event.stopPropagation(); }
     params(paramsList().filter((p) => !p.isEmpty()));
+    this.notifyChange();
   }
 
   add(paramsList: Stream<PipelineParameter[]>, event: Event) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/pipeline_info_editor.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/pipeline_info_editor.tsx
@@ -33,7 +33,7 @@ interface Attrs {
   pipelineConfig: PipelineConfig;
   cache?: PipelineGroupCache<Option>;
   isUsingTemplate: Stream<boolean>;
-  templatesCache?: TemplateCache<Option>;
+  templatesCache?: TemplateCache;
 }
 
 export class PipelineInfoEditor extends MithrilViewComponent<Attrs> {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/pipeline_info_editor_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/pipeline_info_editor_spec.tsx
@@ -64,7 +64,7 @@ class TestCache implements PipelineGroupCache<Option> {
   failed() { return false; }
 }
 
-class EmptyTemplatesTestCache implements TemplateCache<Option> {
+class EmptyTemplatesTestCache extends TemplateCache {
   ready() { return true; }
   // tslint:disable-next-line
   prime(onComplete: () => void) { onComplete(); }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/template_editor.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/template_editor.tsx
@@ -87,7 +87,7 @@ export class TemplateEditor extends MithrilComponent<Attrs, State> {
     let params = template ? _.map(template.parameters, (param) => new PipelineParameter(param, "")) : [];
     params = params.concat(new PipelineParameter("", ""));
     paramList(params);
-    config.parameters(params);
+    config.parameters(_.filter(params, (p) => (p.name() || "").trim() !== ""));
     onSetParams();
   }
 

--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -383,6 +383,12 @@
   </rule>
 
   <rule>
+    <name>Spark Template Config Internal Index API</name>
+    <from>^/api/admin/internal/templates(/?)$</from>
+    <to last="true">/spark/api/admin/internal/templates</to>
+  </rule>
+
+  <rule>
     <name>Spark Template Config Index API</name>
     <from>^/api/admin/templates(/?)$</from>
     <to last="true">/spark/api/admin/templates</to>

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/TemplateConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/TemplateConfigServiceTest.java
@@ -467,6 +467,28 @@ public class TemplateConfigServiceTest {
         assertThat(expected, is(actual));
     }
 
+    @Test
+    public void shouldReturnAllTemplatesThatCanBeViewedByUser() {
+        BasicCruiseConfig cruiseConfig = getCruiseConfigWithSecurityEnabled();
+        CaseInsensitiveString username = new CaseInsensitiveString("template-user");
+
+        PipelineTemplateConfig viewableTemplate = PipelineTemplateConfigMother.createTemplate(
+                "template",
+                new Authorization(new ViewConfig(new AdminUser(username))), StageConfigMother.manualStage("foo"));
+        PipelineTemplateConfig notViewableTemplate = PipelineTemplateConfigMother.createTemplate("not-viewable-template");
+        TemplatesConfig templates = new TemplatesConfig();
+        templates.add(viewableTemplate);
+        templates.add(notViewableTemplate);
+        cruiseConfig.setTemplates(templates);
+
+        when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
+        when(securityService.isAuthorizedToViewTemplate(new CaseInsensitiveString("template"), new Username(username))).thenReturn(true);
+
+        TemplatesConfig actual = service.templateConfigsThatCanBeViewedBy(new Username(username));
+        TemplatesConfig expected = new TemplatesConfig(viewableTemplate);
+        assertThat(expected, is(actual));
+    }
+
     private PipelineConfig createPipelineWithTemplate(String pipelineName, PipelineTemplateConfig template) {
         PipelineConfig pipelineConfig = pipelineConfig(pipelineName);
         pipelineConfig.clear();

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -400,6 +400,7 @@ public class Routes {
 
     public static class PipelineTemplateConfig {
         public static final String BASE = "/api/admin/templates";
+        public static final String INTERNAL_BASE = "/api/admin/internal/templates";
         public static final String NAME = "/:template_name";
         public static final String DOC = apiDocsUrl("#template-config");
 


### PR DESCRIPTION
Related to PR #6941 

Instead of returning the parameters as part of the get template response of the public API, this PR creates an internal API that returns a list of template names with the names of the associated parameters.
```json
{
  "templates": [
    {
      "name": "template-name", 
      "parameters": ["my-param", "your-param"]
    }
  ]
}
``` 
It allows us to make a single call to get templates and parameters. 
It also prevents us from returning parameters in the template config with null values.

Note: The documentation for TemplateConfig API was never updated so does not reflect the parameters being returned as part of the template show 