### PR TITLE
Create versioned API for fetching pipeline instance

### DIFF
--- a/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/PipelineOperationsControllerV1.java
+++ b/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/PipelineOperationsControllerV1.java
@@ -77,12 +77,12 @@ public class PipelineOperationsControllerV1 extends ApiController implements Spa
             before("", mimeType, this::verifyContentType);
             before("/*", mimeType, this::verifyContentType);
 
-            before(Routes.Pipeline.PAUSE_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd403);
-            before(Routes.Pipeline.UNPAUSE_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd403);
-            before(Routes.Pipeline.UNLOCK_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd403);
-            before(Routes.Pipeline.TRIGGER_OPTIONS_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd403);
-            before(Routes.Pipeline.SCHEDULE_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd403);
-            before(Routes.Pipeline.INSTANCE_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd403);
+            before(Routes.Pipeline.PAUSE_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateOfPipelineOrGroupInURLUserAnd403);
+            before(Routes.Pipeline.UNPAUSE_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateOfPipelineOrGroupInURLUserAnd403);
+            before(Routes.Pipeline.UNLOCK_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateOfPipelineOrGroupInURLUserAnd403);
+            before(Routes.Pipeline.TRIGGER_OPTIONS_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateOfPipelineOrGroupInURLUserAnd403);
+            before(Routes.Pipeline.SCHEDULE_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateOfPipelineOrGroupInURLUserAnd403);
+            before(Routes.Pipeline.INSTANCE_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateOfPipelineOrGroupInURLUserAnd403);
 
             post(Routes.Pipeline.PAUSE_PATH, mimeType, this::pause);
             post(Routes.Pipeline.UNPAUSE_PATH, mimeType, this::unpause);
@@ -156,7 +156,7 @@ public class PipelineOperationsControllerV1 extends ApiController implements Spa
 
     private Integer getCounterValue(Request request) {
         try {
-            int counter = Integer.parseInt(request.params("pipeline_counter"), 10);
+            int counter = Integer.parseInt(request.params("pipeline_counter"));
             if (counter < 1) {
                 throw new UnprocessableEntityException("The pipeline counter cannot be less than 1.");
             }

--- a/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/BuildCauseRepresenter.java
+++ b/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/BuildCauseRepresenter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineoperations.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.domain.buildcause.BuildCause;
+
+public class BuildCauseRepresenter {
+    public static void toJSON(OutputWriter outputWriter, BuildCause buildCause) {
+        outputWriter
+                .add("trigger_message", buildCause.getBuildCauseMessage())
+                .add("trigger_forced", buildCause.isForced())
+                .add("approver", buildCause.getApprover())
+                .addChildList("material_revisions", listWriter -> buildCause.getMaterialRevisions()
+                        .forEach(revision -> listWriter.addChild(revisionWriter -> MaterialRevisionRepresenter.toJSON(revisionWriter, revision))));
+    }
+}

--- a/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/JobHistoryItemRepresenter.java
+++ b/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/JobHistoryItemRepresenter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineoperations.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.presentation.pipelinehistory.JobHistoryItem;
+
+public class JobHistoryItemRepresenter {
+    public static void toJSON(OutputWriter outputWriter, JobHistoryItem jobHistoryItem) {
+        outputWriter.add("id", jobHistoryItem.getId())
+                .add("name", jobHistoryItem.getName())
+                .addIfNotNull("scheduled_date", jobHistoryItem.getScheduledDate());
+        if (jobHistoryItem.getState() != null) {
+            outputWriter.add("state", jobHistoryItem.getState().toString());
+        }
+        if (jobHistoryItem.getResult() != null) {
+            outputWriter.add("result", jobHistoryItem.getResult().toString());
+        }
+    }
+}

--- a/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/MaterialRepresenter.java
+++ b/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/MaterialRepresenter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineoperations.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.domain.materials.Material;
+
+public class MaterialRepresenter {
+    public static void toJSON(OutputWriter outputWriter, Material material) {
+        outputWriter.add("id", material.getId())
+                .add("name", material.getDisplayName())
+                .add("fingerprint", material.getFingerprint())
+                .add("type", material.getTypeForDisplay())
+                .add("description", material.getLongDescription());
+    }
+}

--- a/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/MaterialRevisionRepresenter.java
+++ b/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/MaterialRevisionRepresenter.java
@@ -15,7 +15,9 @@
  */
 package com.thoughtworks.go.apiv1.pipelineoperations.representers;
 
+import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.api.representers.JsonReader;
+import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.server.domain.MaterialForScheduling;
 
 public class MaterialRevisionRepresenter {
@@ -23,5 +25,13 @@ public class MaterialRevisionRepresenter {
         String name = jsonReader.getString("fingerprint");
         String value = jsonReader.getString("revision");
         return new MaterialForScheduling(name, value);
+    }
+
+    public static void toJSON(OutputWriter outputWriter, MaterialRevision revision) {
+        outputWriter
+                .add("changed", revision.isChanged())
+                .addChild("material", materialWriter -> MaterialRepresenter.toJSON(outputWriter, revision.getMaterial()))
+                .addChildList("modifications", modificationWriter -> revision.getModifications()
+                        .forEach(modification -> modificationWriter.addChild(modWriter -> ModificationRepresenter.toJSON(modWriter, modification))));
     }
 }

--- a/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/ModificationRepresenter.java
+++ b/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/ModificationRepresenter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineoperations.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.domain.materials.Modification;
+
+public class ModificationRepresenter {
+    public static void toJSON(OutputWriter outputWriter, Modification modification) {
+        outputWriter.add("id", modification.getId())
+                .add("revision", modification.getRevision())
+                .addIfNotNull("modified_time", modification.getModifiedTime())
+                .add("user_name", modification.getUserName())
+                .add("comment", modification.getComment())
+                .add("email_address", modification.getEmailAddress());
+    }
+}

--- a/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/PipelineInstanceModelRepresenter.java
+++ b/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/PipelineInstanceModelRepresenter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineoperations.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
+
+public class PipelineInstanceModelRepresenter {
+    public static void toJSON(OutputWriter outputWriter, PipelineInstanceModel pipelineInstance) {
+        outputWriter.add("id", pipelineInstance.getId())
+                .add("name", pipelineInstance.getName())
+                .add("counter", pipelineInstance.getCounter())
+                .add("label", pipelineInstance.getLabel())
+                .add("natural_order", pipelineInstance.getNaturalOrder())
+                .add("can_run", pipelineInstance.getCanRun())
+                .add("preparing_to_schedule", pipelineInstance.isPreparingToSchedule())
+                .add("comment", pipelineInstance.getComment())
+                .addChild("build_cause", causeWriter -> BuildCauseRepresenter.toJSON(causeWriter, pipelineInstance.getBuildCause()))
+                .addChildList("stages", stagesWriter -> pipelineInstance.getStageHistory()
+                        .forEach(stageInstanceModel -> stagesWriter.addChild(stageWriter -> StageInstanceModelRepresenter.toJSON(stageWriter, stageInstanceModel))));
+    }
+}

--- a/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/StageInstanceModelRepresenter.java
+++ b/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/StageInstanceModelRepresenter.java
@@ -25,7 +25,7 @@ public class StageInstanceModelRepresenter {
             outputWriter.add("result", stageInstanceModel.getResult().toString());
         }
         if (stageInstanceModel.getRerunOfCounter() == null) {
-            outputWriter.add("rerun_of_counter", "null");
+            outputWriter.renderNull("rerun_of_counter");
         } else {
             outputWriter.add("rerun_of_counter", stageInstanceModel.getRerunOfCounter());
         }

--- a/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/StageInstanceModelRepresenter.java
+++ b/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/representers/StageInstanceModelRepresenter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineoperations.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModel;
+
+public class StageInstanceModelRepresenter {
+    public static void toJSON(OutputWriter outputWriter, StageInstanceModel stageInstanceModel) {
+        if (stageInstanceModel.getResult() != null) {
+            outputWriter.add("result", stageInstanceModel.getResult().toString());
+        }
+        if (stageInstanceModel.getRerunOfCounter() == null) {
+            outputWriter.add("rerun_of_counter", "null");
+        } else {
+            outputWriter.add("rerun_of_counter", stageInstanceModel.getRerunOfCounter());
+        }
+        outputWriter.add("id", stageInstanceModel.getId())
+                .add("name", stageInstanceModel.getName())
+                .add("counter", stageInstanceModel.getCounter())
+                .add("scheduled", stageInstanceModel.isScheduled())
+                .add("approval_type", stageInstanceModel.getApprovalType())
+                .add("approved_by", stageInstanceModel.getApprovedBy())
+                .add("operate_permission", stageInstanceModel.hasOperatePermission())
+                .add("can_run", stageInstanceModel.getCanRun())
+                .addChildList("jobs", jobsWriter -> stageInstanceModel.getBuildHistory()
+                        .forEach(jobHistoryItem -> jobsWriter.addChild(jobWriter -> JobHistoryItemRepresenter.toJSON(jobWriter, jobHistoryItem))));
+    }
+}

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/BuildCauseRepresenterTest.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/BuildCauseRepresenterTest.groovy
@@ -20,7 +20,7 @@ import com.thoughtworks.go.domain.buildcause.BuildCause
 import com.thoughtworks.go.helper.ModificationsMother
 import org.junit.jupiter.api.Test
 
-import static com.thoughtworks.go.api.base.JsonOutputWriter.jsonDate
+import static com.thoughtworks.go.api.base.JsonUtils.toObject
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 
@@ -28,7 +28,6 @@ class BuildCauseRepresenterTest {
   @Test
   void 'should serialize build cause to json'() {
     def materialRevisions = ModificationsMother.multipleModifications()
-    def modifications = materialRevisions.getMaterialRevision(0).modifications
     def buildCause = BuildCause.createWithModifications(materialRevisions, "approver")
 
     def actualJson = toObjectString({ BuildCauseRepresenter.toJSON(it, buildCause) })
@@ -37,44 +36,11 @@ class BuildCauseRepresenterTest {
       "trigger_message"   : "modified by committer <html />",
       "trigger_forced"    : false,
       "approver"          : "approver",
-      "material_revisions": [
-        [
-          "changed"      : false,
-          "material"     : [
-            "id"         : -1,
-            "name"       : "svn-material",
-            "fingerprint": "0b4bba9653593af09fb45c3195ce227b50f14d7f90405b70aa6005966b8b0a35",
-            "type"       : "Subversion",
-            "description": "URL: http://foo/bar/baz, Username: username, CheckExternals: false"
-          ],
-          "modifications": [
-            [
-              "id"           : -1,
-              "revision"     : "3",
-              "modified_time": jsonDate(modifications.get(0).modifiedTime),
-              "user_name"    : "committer <html />",
-              "comment"      : "Added the README file with <html />",
-              "email_address": "foo@bar.com"
-            ],
-            [
-              "id"           : -1,
-              "revision"     : "2",
-              "modified_time": jsonDate(modifications.get(1).modifiedTime),
-              "user_name"    : "committer",
-              "comment"      : "Added the README file",
-              "email_address": "foo@bar.com"
-            ],
-            [
-              "id"           : -1,
-              "revision"     : "1",
-              "modified_time": jsonDate(modifications.get(2).modifiedTime),
-              "user_name"    : "lgao",
-              "comment"      : "Fixing the not checked in files",
-              "email_address": "foo@bar.com"
-            ]
-          ]
-        ]
-      ]
+      "material_revisions": buildCause.getMaterialRevisions().collect { eachItem ->
+        toObject({
+          MaterialRevisionRepresenter.toJSON(it, eachItem)
+        })
+      }
     ]
 
     assertThatJson(actualJson).isEqualTo(expectedJSON)

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/BuildCauseRepresenterTest.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/BuildCauseRepresenterTest.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineoperations.representers
+
+import com.thoughtworks.go.domain.buildcause.BuildCause
+import com.thoughtworks.go.helper.ModificationsMother
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonOutputWriter.jsonDate
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class BuildCauseRepresenterTest {
+  @Test
+  void 'should serialize build cause to json'() {
+    def materialRevisions = ModificationsMother.multipleModifications()
+    def modifications = materialRevisions.getMaterialRevision(0).modifications
+    def buildCause = BuildCause.createWithModifications(materialRevisions, "approver")
+
+    def actualJson = toObjectString({ BuildCauseRepresenter.toJSON(it, buildCause) })
+
+    def expectedJSON = [
+      "trigger_message"   : "modified by committer <html />",
+      "trigger_forced"    : false,
+      "approver"          : "approver",
+      "material_revisions": [
+        [
+          "changed"      : false,
+          "material"     : [
+            "id"         : -1,
+            "name"       : "svn-material",
+            "fingerprint": "0b4bba9653593af09fb45c3195ce227b50f14d7f90405b70aa6005966b8b0a35",
+            "type"       : "Subversion",
+            "description": "URL: http://foo/bar/baz, Username: username, CheckExternals: false"
+          ],
+          "modifications": [
+            [
+              "id"           : -1,
+              "revision"     : "3",
+              "modified_time": jsonDate(modifications.get(0).modifiedTime),
+              "user_name"    : "committer <html />",
+              "comment"      : "Added the README file with <html />",
+              "email_address": "foo@bar.com"
+            ],
+            [
+              "id"           : -1,
+              "revision"     : "2",
+              "modified_time": jsonDate(modifications.get(1).modifiedTime),
+              "user_name"    : "committer",
+              "comment"      : "Added the README file",
+              "email_address": "foo@bar.com"
+            ],
+            [
+              "id"           : -1,
+              "revision"     : "1",
+              "modified_time": jsonDate(modifications.get(2).modifiedTime),
+              "user_name"    : "lgao",
+              "comment"      : "Fixing the not checked in files",
+              "email_address": "foo@bar.com"
+            ]
+          ]
+        ]
+      ]
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
+  }
+}

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/JobHistoryItemRepresenterTest.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/JobHistoryItemRepresenterTest.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineoperations.representers
+
+import com.thoughtworks.go.domain.JobResult
+import com.thoughtworks.go.domain.JobState
+import com.thoughtworks.go.presentation.pipelinehistory.JobHistoryItem
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonOutputWriter.jsonDate
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class JobHistoryItemRepresenterTest {
+  @Test
+  void 'should deserialize into json'() {
+    Date date = new Date();
+    def jobHistoryItem = new JobHistoryItem("jobName", JobState.Completed, JobResult.Passed, date)
+    jobHistoryItem.setId(5)
+
+    def actualJson = toObjectString({ JobHistoryItemRepresenter.toJSON(it, jobHistoryItem) })
+
+    def expectedJson = [
+      "id"            : 5,
+      "name"          : "jobName",
+      "scheduled_date": jsonDate(date),
+      "state"         : "Completed",
+      "result"        : "Passed"
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should not add scheduled_date if set to null'() {
+    def jobHistoryItem = new JobHistoryItem("jobName", JobState.Completed, JobResult.Passed, new Date())
+    jobHistoryItem.setId(5)
+    jobHistoryItem.setScheduledDate(null)
+
+    def actualJson = toObjectString({ JobHistoryItemRepresenter.toJSON(it, jobHistoryItem) })
+
+    def expectedJson = [
+      "id"    : 5,
+      "name"  : "jobName",
+      "state" : "Completed",
+      "result": "Passed"
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should not set state if set to null'() {
+    Date date = new Date()
+    def jobHistoryItem = new JobHistoryItem("jobName", null, JobResult.Passed, date)
+    jobHistoryItem.setId(5)
+
+    def actualJson = toObjectString({ JobHistoryItemRepresenter.toJSON(it, jobHistoryItem) })
+
+    def expectedJson = [
+      "id"            : 5,
+      "name"          : "jobName",
+      "scheduled_date": jsonDate(date),
+      "result"        : "Passed"
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+
+  @Test
+  void 'should not set result if set to null'() {
+    Date date = new Date()
+    def jobHistoryItem = new JobHistoryItem("jobName", JobState.Completed, null, date)
+    jobHistoryItem.setId(5)
+
+    def actualJson = toObjectString({ JobHistoryItemRepresenter.toJSON(it, jobHistoryItem) })
+
+    def expectedJson = [
+      "id"            : 5,
+      "name"          : "jobName",
+      "scheduled_date": jsonDate(date),
+      "state"         : "Completed"
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+}

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/MaterialRepresenterTest.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/MaterialRepresenterTest.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineoperations.representers
+
+import com.thoughtworks.go.helper.MaterialsMother
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class MaterialRepresenterTest {
+  @Test
+  void 'should render material config properties'() {
+    def material = MaterialsMother.gitMaterial("git1")
+
+    def expectedJSON = [
+      id         : -1,
+      name       : "git1",
+      fingerprint: "2fde537a026695884e2ee13e8f9730eca0610a3e407dbcc6bbce974f595c2f7c",
+      type       : "Git",
+      description: "URL: git1, Branch: master"
+    ]
+
+    def actualJson = toObjectString({ MaterialRepresenter.toJSON(it, material) })
+
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
+  }
+}

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/MaterialRevisionRepresenterTest.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/MaterialRevisionRepresenterTest.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineoperations.representers
+
+
+import com.thoughtworks.go.api.util.GsonTransformer
+import com.thoughtworks.go.helper.ModificationsMother
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonOutputWriter.jsonDate
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static com.thoughtworks.go.apiv1.pipelineoperations.representers.MaterialRevisionRepresenter.fromJSON
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+import static org.assertj.core.api.Assertions.assertThat
+
+class MaterialRevisionRepresenterTest {
+  @Test
+  void 'should render material revision with modifications'() {
+    def materialRevision = ModificationsMother.createHgMaterialRevisions().getMaterialRevision(0)
+
+    def expectedJSON = [
+      "changed"      : false,
+      "material"     : [
+        "id"         : -1,
+        "name"       : "hg-url",
+        "fingerprint": "4290e91721d0a0be34955725cfd754113588d9c27c39f9bd1a97c15e55832515",
+        "type"       : "Mercurial",
+        "description": "URL: hg-url"
+      ],
+      "modifications": [
+        [
+          "id"           : -1,
+          "revision"     : "9fdcf27f16eadc362733328dd481d8a2c29915e1",
+          "modified_time": jsonDate(materialRevision.getModification(0).modifiedTime),
+          "user_name"    : "user2",
+          "comment"      : "comment2",
+          "email_address": "email2"
+        ],
+        [
+          "id"           : -1,
+          "revision"     : "eef77acd79809fc14ed82b79a312648d4a2801c6",
+          "modified_time": jsonDate(materialRevision.getModification(1).modifiedTime),
+          "user_name"    : "user1",
+          "comment"      : "comment1",
+          "email_address": "email1"
+        ]
+      ]
+    ]
+
+    def actualJson = toObjectString({ MaterialRevisionRepresenter.toJSON(it, materialRevision) })
+
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
+  }
+
+  @Test
+  void 'should deserialize json'() {
+    def inputJson = [
+      fingerprint: "some-random-fingerprint",
+      revision   : "some-revision"
+    ]
+    def jsonReader = GsonTransformer.instance.jsonReaderFrom(inputJson)
+
+    def materialForScheduling = fromJSON(jsonReader)
+
+    assertThat(materialForScheduling.fingerprint).isEqualTo("some-random-fingerprint")
+    assertThat(materialForScheduling.revision).isEqualTo("some-revision")
+  }
+}

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/ModificationRepresenterTest.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/ModificationRepresenterTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineoperations.representers
+
+import com.thoughtworks.go.helper.ModificationsMother
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonOutputWriter.jsonDate
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class ModificationRepresenterTest {
+  @Test
+  void 'should render modified time if not null'() {
+    def modification = ModificationsMother.aCheckIn("rev1", "file1")
+
+    def expectedJSON = [
+      "id"           : -1,
+      "revision"     : "rev1",
+      "modified_time": jsonDate(ModificationsMother.TODAY_CHECKIN),
+      "user_name"    : "committer",
+      "comment"      : "Added the README file",
+      "email_address": "foo@bar.com"]
+
+    def actualJson = toObjectString({ ModificationRepresenter.toJSON(it, modification) })
+
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
+  }
+
+  @Test
+  void 'should not render modified time if set to null'() {
+    def modification = ModificationsMother.aCheckIn("rev1", "file1")
+    modification.modifiedTime = null
+
+    def expectedJSON = [
+      "id"           : -1,
+      "revision"     : "rev1",
+      "user_name"    : "committer",
+      "comment"      : "Added the README file",
+      "email_address": "foo@bar.com"]
+
+    def actualJson = toObjectString({ ModificationRepresenter.toJSON(it, modification) })
+
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
+  }
+}

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/PipelineInstanceModelRepresenterTest.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/PipelineInstanceModelRepresenterTest.groovy
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineoperations.representers
+
+import com.thoughtworks.go.domain.buildcause.BuildCause
+import com.thoughtworks.go.helper.ModificationsMother
+import com.thoughtworks.go.helper.StageMother
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModels
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonOutputWriter.jsonDate
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class PipelineInstanceModelRepresenterTest {
+  @Test
+  void 'should serialize into json'() {
+    def date = new Date()
+    def stage = StageMother.passedStageInstance("pipelineName", "stageName", 4, "buildName", date)
+    def stageInstanceModel = StageMother.toStageInstanceModel(stage)
+    def stageInstanceModels = new StageInstanceModels()
+    stageInstanceModels.add(stageInstanceModel)
+
+    def materialRevisions = ModificationsMother.multipleModifications()
+    def modifications = materialRevisions.getMaterialRevision(0).modifications
+    def buildCause = BuildCause.createWithModifications(materialRevisions, "approver")
+
+    def pipelineInstanceModel = PipelineInstanceModel.createPipeline("pipelineName", 4, "label", buildCause, stageInstanceModels)
+
+    def actualJson = toObjectString({ PipelineInstanceModelRepresenter.toJSON(it, pipelineInstanceModel) })
+
+    def expectedJson = [
+      "id"                   : 0,
+      "name"                 : "pipelineName",
+      "counter"              : 4,
+      "label"                : "label",
+      "natural_order"        : pipelineInstanceModel.getNaturalOrder(),
+      "can_run"              : false,
+      "preparing_to_schedule": false,
+      "comment"              : null,
+      "build_cause"          : [
+        "trigger_message"   : "modified by committer <html />",
+        "trigger_forced"    : false,
+        "approver"          : "approver",
+        "material_revisions": [
+          [
+            "changed"      : false,
+            "material"     : [
+              "id"         : -1,
+              "name"       : "svn-material",
+              "fingerprint": "0b4bba9653593af09fb45c3195ce227b50f14d7f90405b70aa6005966b8b0a35",
+              "type"       : "Subversion",
+              "description": "URL: http://foo/bar/baz, Username: username, CheckExternals: false"
+            ],
+            "modifications": [
+              [
+                "id"           : -1,
+                "revision"     : "3",
+                "modified_time": jsonDate(modifications.get(0).modifiedTime),
+                "user_name"    : "committer <html />",
+                "comment"      : "Added the README file with <html />",
+                "email_address": "foo@bar.com"
+              ],
+              [
+                "id"           : -1,
+                "revision"     : "2",
+                "modified_time": jsonDate(modifications.get(1).modifiedTime),
+                "user_name"    : "committer",
+                "comment"      : "Added the README file",
+                "email_address": "foo@bar.com"
+              ],
+              [
+                "id"           : -1,
+                "revision"     : "1",
+                "modified_time": jsonDate(modifications.get(2).modifiedTime),
+                "user_name"    : "lgao",
+                "comment"      : "Fixing the not checked in files",
+                "email_address": "foo@bar.com"
+              ]
+            ]
+          ]
+        ]
+      ],
+      "stages"               : [
+        [
+          "result"            : "Passed",
+          "rerun_of_counter"  : "null",
+          "id"                : 0,
+          "name"              : "stageName",
+          "counter"           : "4",
+          "scheduled"         : true,
+          "approval_type"     : "success",
+          "approved_by"       : "changes",
+          "operate_permission": false,
+          "can_run"           : false,
+          "jobs"              : [
+            [
+              "id"            : 0,
+              "name"          : "buildName",
+              "scheduled_date": jsonDate(date),
+              "state"         : "Completed",
+              "result"        : "Passed"
+            ]
+          ]
+        ]
+      ]
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+}

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/StageInstanceModelRepresenterTest.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/StageInstanceModelRepresenterTest.groovy
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineoperations.representers
+
+
+import com.thoughtworks.go.helper.StageMother
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonOutputWriter.jsonDate
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class StageInstanceModelRepresenterTest {
+  @Test
+  void 'should deserialize into json'() {
+    def date = new Date()
+    def stage = StageMother.passedStageInstance("pipelineName", "stageName", 4, "buildName", date)
+    def stageInstanceModel = StageMother.toStageInstanceModel(stage)
+
+    def actualJson = toObjectString({ StageInstanceModelRepresenter.toJSON(it, stageInstanceModel) })
+
+    def expectedJson = [
+      "result"            : "Passed",
+      "rerun_of_counter"  : "null",
+      "id"                : 0,
+      "name"              : "stageName",
+      "counter"           : "4",
+      "scheduled"         : true,
+      "approval_type"     : "success",
+      "approved_by"       : "changes",
+      "operate_permission": false,
+      "can_run"           : false,
+      "jobs"              : [
+        [
+          "id"            : 0,
+          "name"          : "buildName",
+          "scheduled_date": jsonDate(date),
+          "state"         : "Completed",
+          "result"        : "Passed"
+        ]
+      ]
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should not add result if null'() {
+    def date = new Date()
+    def stage = StageMother.passedStageInstance("pipelineName", "stageName", 4, "buildName", date)
+    def stageInstanceModel = StageMother.toStageInstanceModel(stage)
+    stageInstanceModel.result = null
+
+    def actualJson = toObjectString({ StageInstanceModelRepresenter.toJSON(it, stageInstanceModel) })
+
+    def expectedJson = [
+      "rerun_of_counter"  : "null",
+      "id"                : 0,
+      "name"              : "stageName",
+      "counter"           : "4",
+      "scheduled"         : true,
+      "approval_type"     : "success",
+      "approved_by"       : "changes",
+      "operate_permission": false,
+      "can_run"           : false,
+      "jobs"              : [
+        [
+          "id"            : 0,
+          "name"          : "buildName",
+          "scheduled_date": jsonDate(date),
+          "state"         : "Completed",
+          "result"        : "Passed"
+        ]
+      ]
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should add rerun_of_counter if not null'() {
+    def date = new Date()
+    def stage = StageMother.passedStageInstance("pipelineName", "stageName", 4, "buildName", date)
+    def stageInstanceModel = StageMother.toStageInstanceModel(stage)
+    stageInstanceModel.setRerunOfCounter(3)
+
+    def actualJson = toObjectString({ StageInstanceModelRepresenter.toJSON(it, stageInstanceModel) })
+
+    def expectedJson = [
+      "result"            : "Passed",
+      "rerun_of_counter"  : 3,
+      "id"                : 0,
+      "name"              : "stageName",
+      "counter"           : "4",
+      "scheduled"         : true,
+      "approval_type"     : "success",
+      "approved_by"       : "changes",
+      "operate_permission": false,
+      "can_run"           : false,
+      "jobs"              : [
+        [
+          "id"            : 0,
+          "name"          : "buildName",
+          "scheduled_date": jsonDate(date),
+          "state"         : "Completed",
+          "result"        : "Passed"
+        ]
+      ]
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+
+}

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/StageInstanceModelRepresenterTest.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/StageInstanceModelRepresenterTest.groovy
@@ -35,7 +35,7 @@ class StageInstanceModelRepresenterTest {
 
     def expectedJson = [
       "result"            : "Passed",
-      "rerun_of_counter"  : "null",
+      "rerun_of_counter"  : null,
       "id"                : 0,
       "name"              : "stageName",
       "counter"           : "4",
@@ -68,7 +68,7 @@ class StageInstanceModelRepresenterTest {
     def actualJson = toObjectString({ StageInstanceModelRepresenter.toJSON(it, stageInstanceModel) })
 
     def expectedJson = [
-      "rerun_of_counter"  : "null",
+      "rerun_of_counter"  : null,
       "id"                : 0,
       "name"              : "stageName",
       "counter"           : "4",

--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -87,14 +87,7 @@
 
   <rule>
     <name>Pipeline Instance API</name>
-    <condition name="Accept">application\/vnd\.go\.cd\+json</condition>
-    <from>^/api/pipelines/([^/]+)/instance/([^/]+)(/?)$</from>
-    <to last="true">/spark/api/pipelines/${escape:$1}/instance/${escape:$2}</to>
-  </rule>
-
-  <rule>
-    <name>Pipeline Instance API</name>
-    <condition name="Accept">application\/vnd\.go\.cd\.v1\+json</condition>
+    <condition name="Accept">application\/vnd\.go\.cd(.v*)*\+json</condition>
     <from>^/api/pipelines/([^/]+)/instance/([^/]+)(/?)$</from>
     <to last="true">/spark/api/pipelines/${escape:$1}/instance/${escape:$2}</to>
   </rule>

--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -86,6 +86,20 @@
   </rule>
 
   <rule>
+    <name>Pipeline Instance API</name>
+    <condition name="Accept">application\/vnd\.go\.cd\+json</condition>
+    <from>^/api/pipelines/([^/]+)/instance/([^/]+)(/?)$</from>
+    <to last="true">/spark/api/pipelines/${escape:$1}/instance/${escape:$2}</to>
+  </rule>
+
+  <rule>
+    <name>Pipeline Instance API</name>
+    <condition name="Accept">application\/vnd\.go\.cd\.v1\+json</condition>
+    <from>^/api/pipelines/([^/]+)/instance/([^/]+)(/?)$</from>
+    <to last="true">/spark/api/pipelines/${escape:$1}/instance/${escape:$2}</to>
+  </rule>
+
+  <rule>
     <name>Feature Toggles Index API</name>
     <from>^/api/admin/feature_toggles(/?)$</from>
     <to last="true">/spark/api/admin/feature_toggles</to>

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/api/base/JsonOutputWriter.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/api/base/JsonOutputWriter.java
@@ -145,6 +145,15 @@ public class JsonOutputWriter {
         }
 
         @Override
+        public OutputWriter addIfNotNull(String key, Integer value) {
+            return withExceptionHandling((jacksonWriter) -> {
+                if (value != null) {
+                    add(key, value);
+                }
+            });
+        }
+
+        @Override
         public JsonOutputWriterUsingJackson addIfNotNull(String key, CaseInsensitiveString value) {
             return withExceptionHandling((jacksonWriter) -> {
                 if (value != null) {

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/api/base/OutputWriter.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/api/base/OutputWriter.java
@@ -36,6 +36,8 @@ public interface OutputWriter extends Closeable {
 
     OutputWriter addIfNotNull(String key, Long value);
 
+    OutputWriter addIfNotNull(String key, Integer value);
+
     OutputWriter addWithDefaultIfBlank(String key, String value, String defaultValue);
 
     OutputWriter add(String key, int value);


### PR DESCRIPTION
Issue: #2990

Description:
 - timestamp in the form of `yyyy-mm-dd'T'hh:mm:ss'Z'` instead of a long value
 - added `name` property to material


