### PR TITLE
[Bug] Set JVM Args for agent correctly

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-agent/docker-entrypoint.sh
+++ b/buildSrc/src/main/resources/gocd-docker-agent/docker-entrypoint.sh
@@ -142,7 +142,7 @@ if [ "$1" = "${AGENT_WORK_DIR}/bin/go-agent" ]; then
     echo "wrapper.java.additional.${tanuki_index}=${AGENT_BOOTSTRAPPER_JVM_ARGS[$array_index]}" >> /go-agent/wrapper-config/wrapper-properties.conf
   done
 
-  echo "set.AGENT_STARTUP_ARGS=%AGENT_STARTUP_ARGS% -Dgo.console.stdout=true %GOCD_AGENT_JVM_OPTS%"
+  echo "set.AGENT_STARTUP_ARGS=%AGENT_STARTUP_ARGS% -Dgo.console.stdout=true %GOCD_AGENT_JVM_OPTS%" >> /go-agent/wrapper-config/wrapper-properties.conf
 fi
 
 try exec /usr/local/sbin/tini -g -- "$@"


### PR DESCRIPTION
Issue: #7172

Description:
The output of Line 145 should be written into wrapper-properties.conf. Otherwise, custom JVM properties do not get forwarded to the gocd-agent.

