### PR TITLE
Introduce an API to extract a template from a pipeline

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BasicCruiseConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BasicCruiseConfig.java
@@ -52,6 +52,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import static com.thoughtworks.go.config.exceptions.EntityType.Pipeline;
+import static com.thoughtworks.go.config.exceptions.EntityType.Template;
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static com.thoughtworks.go.util.ExceptionUtils.bombIfNull;
 import static java.util.stream.Collectors.toMap;
@@ -1200,10 +1201,10 @@ public class BasicCruiseConfig implements CruiseConfig {
     }
 
     @Override
-    public PipelineTemplateConfig getTemplateByName(CaseInsensitiveString pipeline) {
-        PipelineTemplateConfig template = getTemplates().templateByName(pipeline);
+    public PipelineTemplateConfig getTemplateByName(CaseInsensitiveString templateName) {
+        PipelineTemplateConfig template = getTemplates().templateByName(templateName);
         if (template == null) {
-            throw bomb(String.format("Template %s was not found.", pipeline));
+            throw new RecordNotFoundException(Template, templateName);
         }
         return template;
     }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/CruiseConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/CruiseConfig.java
@@ -198,6 +198,7 @@ public interface CruiseConfig extends Validatable, ConfigOriginTraceable {
 
     void setTemplates(TemplatesConfig templates);
 
+    @Deprecated //unused
     void makePipelineUseTemplate(CaseInsensitiveString pipelineName, CaseInsensitiveString templateName);
 
     Iterable<PipelineConfig> getDownstreamPipelines(String pipelineName);

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/EntityType.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/EntityType.java
@@ -186,4 +186,8 @@ public enum EntityType {
     public String forbiddenToDelete(CaseInsensitiveString username) {
         return format("User '%s' does not have permission to delete %s", username, entityType.toLowerCase());
     }
+
+    public String alreadyUsesATemplate() {
+        return format("%s %s '%s' already uses a template.", StringUtils.capitalize(this.entityType), this.nameOrId.descriptor, id);
+    }
 }

--- a/config/config-server/src/main/java/com/thoughtworks/go/config/commands/CheckedUpdateCommand.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/config/commands/CheckedUpdateCommand.java
@@ -18,5 +18,8 @@ package com.thoughtworks.go.config.commands;
 import com.thoughtworks.go.config.CruiseConfig;
 
 public interface CheckedUpdateCommand {
+    /**
+     * Pre update check. Passed the actual cruise config.
+     */
     boolean canContinue(CruiseConfig cruiseConfig);
 }

--- a/config/config-server/src/main/java/com/thoughtworks/go/config/commands/EntityConfigUpdateCommand.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/config/commands/EntityConfigUpdateCommand.java
@@ -18,12 +18,22 @@ package com.thoughtworks.go.config.commands;
 import com.thoughtworks.go.config.CruiseConfig;
 
 public interface EntityConfigUpdateCommand<T> extends CheckedUpdateCommand {
+    /**
+     * Perform the actual update. Passed a deep clone of the current cruise config.
+     */
     void update(CruiseConfig preprocessedConfig) throws Exception;
 
+    /**
+     * Called after {@link #update(CruiseConfig)} used to validate the new config.
+     */
     boolean isValid(CruiseConfig preprocessedConfig);
 
     void clearErrors();
 
+    /**
+     * Called after {@link #isValid(CruiseConfig)}. Return the entity that was updated.
+     * Useful to invalidate the cache used by {@link com.thoughtworks.go.server.service.EntityHashingService}
+     */
     T getPreprocessedEntityConfig();
 
     default void encrypt(CruiseConfig preProcessedConfig) {

--- a/server/src/main/java/com/thoughtworks/go/config/update/ExtractTemplateFromPipelineEntityConfigUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ExtractTemplateFromPipelineEntityConfigUpdateCommand.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.update;
+
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
+import com.thoughtworks.go.config.exceptions.BadRequestException;
+import com.thoughtworks.go.config.exceptions.ConflictException;
+import com.thoughtworks.go.config.exceptions.EntityType;
+import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
+import com.thoughtworks.go.config.validation.NameTypeValidator;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.SecurityService;
+
+public class ExtractTemplateFromPipelineEntityConfigUpdateCommand implements EntityConfigUpdateCommand<PipelineConfig> {
+
+    private final SecurityService securityService;
+    private final String pipelineName;
+    private final PipelineTemplateConfig newTemplate;
+    private final Username currentUser;
+
+    private PipelineConfig preprocessedPipelineConfig;
+
+    public ExtractTemplateFromPipelineEntityConfigUpdateCommand(SecurityService securityService,
+                                                                String pipelineName,
+                                                                String templateName,
+                                                                Username currentUser) {
+        this.securityService = securityService;
+        this.pipelineName = pipelineName;
+        this.newTemplate = new PipelineTemplateConfig(new CaseInsensitiveString(templateName));
+        this.currentUser = currentUser;
+    }
+
+    @Override
+    public void update(CruiseConfig preprocessedConfig) throws Exception {
+        // set authorization on new template
+        if (securityService.isUserGroupAdmin(currentUser)) {
+            newTemplate.setAuthorization(new Authorization(new AdminsConfig(new AdminUser(currentUser.getUsername()))));
+        }
+        // set the stages on the new template
+        preprocessedPipelineConfig = preprocessedConfig.pipelineConfigByName(new CaseInsensitiveString(pipelineName));
+        newTemplate.copyStages(preprocessedPipelineConfig);
+        // change the pointer on the pipeline
+        preprocessedPipelineConfig.templatize(this.newTemplate.name());
+
+        // add newly created template
+        preprocessedConfig.getTemplates().add(this.newTemplate);
+    }
+
+    @Override
+    public boolean isValid(CruiseConfig preprocessedConfig) {
+        return true;
+    }
+
+    @Override
+    public void clearErrors() {
+        BasicCruiseConfig.clearErrors(preprocessedPipelineConfig);
+    }
+
+    @Override
+    public PipelineConfig getPreprocessedEntityConfig() {
+        return preprocessedPipelineConfig;
+    }
+
+    @Override
+    public boolean canContinue(CruiseConfig cruiseConfig) {
+        PipelineConfig pipelineConfig = cruiseConfig.getPipelineConfigByName(new CaseInsensitiveString(pipelineName));
+        if (pipelineConfig == null) {
+            throw new RecordNotFoundException(EntityType.Pipeline, pipelineName);
+        }
+
+        if (pipelineConfig.hasTemplate()) {
+            throw new ConflictException(EntityType.Pipeline.alreadyUsesATemplate());
+        }
+
+        PipelineTemplateConfig templateByName = cruiseConfig.getTemplates().templateByName(this.newTemplate.name());
+        if (templateByName != null) {
+            throw new ConflictException(EntityType.Template.alreadyExists(this.newTemplate.name()));
+        }
+
+        if (new NameTypeValidator().isNameInvalid(this.newTemplate.name().toString())) {
+            throw new BadRequestException(NameTypeValidator.errorMessage("template", this.newTemplate.name()));
+        }
+
+        return true;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/presentation/PipelineTemplateConfigViewModel.java
+++ b/server/src/main/java/com/thoughtworks/go/presentation/PipelineTemplateConfigViewModel.java
@@ -15,18 +15,19 @@
  */
 package com.thoughtworks.go.presentation;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.ParamsAttributeAware;
 import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.PipelineTemplateConfig;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 /**
  * @understands: How to render the PipelineTemplateConfig object for new & create
  */
+@Deprecated // used only by rails
 public class PipelineTemplateConfigViewModel implements ParamsAttributeAware {
 
     public static final String TEMPLATE = "template";

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineConfigService.java
@@ -21,10 +21,7 @@ import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.exceptions.GoConfigInvalidException;
 import com.thoughtworks.go.config.pluggabletask.PluggableTask;
 import com.thoughtworks.go.config.remote.ConfigOrigin;
-import com.thoughtworks.go.config.update.ConfigUpdateCheckFailedException;
-import com.thoughtworks.go.config.update.CreatePipelineConfigCommand;
-import com.thoughtworks.go.config.update.DeletePipelineConfigCommand;
-import com.thoughtworks.go.config.update.UpdatePipelineConfigCommand;
+import com.thoughtworks.go.config.update.*;
 import com.thoughtworks.go.domain.PipelineGroups;
 import com.thoughtworks.go.domain.Task;
 import com.thoughtworks.go.server.domain.Username;
@@ -214,4 +211,11 @@ public class PipelineConfigService {
     public int totalPipelinesCount() {
         return goConfigService.getAllPipelineConfigs().size();
     }
+
+    public void extractTemplateFromPipeline(String pipelineName,
+                                            String templateName,
+                                            Username currentUser) {
+        goConfigService.updateConfig(new ExtractTemplateFromPipelineEntityConfigUpdateCommand(securityService, pipelineName, templateName, currentUser), currentUser);
+    }
+
 }

--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -383,6 +383,12 @@
   </rule>
 
   <rule>
+    <name>Spark API to extract template from pipeline config</name>
+    <from>^/api/admin/pipelines/([^/]+)/extract_to_template(/?)$</from>
+    <to last="true">/spark/api/admin/pipelines/${escape:$1}/extract_to_template</to>
+  </rule>
+
+  <rule>
     <name>Spark Pipeline Groups Index API</name>
     <from>^/api/admin/pipeline_groups(/?)$</from>
     <to last="true">/spark/api/admin/pipeline_groups</to>

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/ExtractTemplateFromPipelineEntityConfigUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/ExtractTemplateFromPipelineEntityConfigUpdateCommandTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.update;
+
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.exceptions.ConflictException;
+import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
+import com.thoughtworks.go.helper.PipelineConfigMother;
+import com.thoughtworks.go.helper.PipelineTemplateConfigMother;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.SecurityService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ExtractTemplateFromPipelineEntityConfigUpdateCommandTest {
+
+    @Test
+    void shouldUpdateConfigWhenCurrentUserIsGroupAdmin() throws Exception {
+        SecurityService securityService = mock(SecurityService.class);
+        Username currentUser = new Username("bob");
+        when(securityService.isUserGroupAdmin(currentUser)).thenReturn(true);
+
+        ExtractTemplateFromPipelineEntityConfigUpdateCommand command = new ExtractTemplateFromPipelineEntityConfigUpdateCommand(securityService, "some-pipeline", "new-template", currentUser);
+        BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
+        cruiseConfig.addPipeline("blah", PipelineConfigMother.pipelineConfig("some-pipeline"));
+
+        assertThat(cruiseConfig.getTemplates()).isEmpty();
+        command.update(cruiseConfig);
+
+        PipelineTemplateConfig template = cruiseConfig.getTemplates().templateByName(new CaseInsensitiveString("new-template"));
+
+        assertThat(template)
+                .isNotNull()
+                .hasSize(1)
+                .element(0).satisfies(stageConfig -> assertThat(stageConfig.name()).isEqualTo(new CaseInsensitiveString("mingle")));
+
+        assertThat(template.getAuthorization()).isEqualTo(new Authorization(new AdminsConfig(new AdminUser(currentUser.getUsername()))));
+    }
+
+    @Test
+    void shouldUpdateConfigWhenCurrentUserIsNotGroupAdmin() throws Exception {
+        SecurityService securityService = mock(SecurityService.class);
+        Username currentUser = new Username("bob");
+        when(securityService.isUserGroupAdmin(currentUser)).thenReturn(false);
+
+        ExtractTemplateFromPipelineEntityConfigUpdateCommand command = new ExtractTemplateFromPipelineEntityConfigUpdateCommand(securityService, "some-pipeline", "new-template", currentUser);
+        BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
+        cruiseConfig.addPipeline("blah", PipelineConfigMother.pipelineConfig("some-pipeline"));
+
+        assertThat(cruiseConfig.getTemplates()).isEmpty();
+        command.update(cruiseConfig);
+
+        PipelineTemplateConfig template = cruiseConfig.getTemplates().templateByName(new CaseInsensitiveString("new-template"));
+
+        assertThat(template)
+                .isNotNull()
+                .hasSize(1)
+                .element(0).satisfies(stageConfig -> assertThat(stageConfig.name()).isEqualTo(new CaseInsensitiveString("mingle")));
+
+        assertThat(template.getAuthorization()).isEqualTo(new Authorization());
+    }
+
+    @Nested
+    class CanContinue {
+
+        @Test
+        void shouldReturnTrueIfEverythingIsGood() {
+            ExtractTemplateFromPipelineEntityConfigUpdateCommand command = new ExtractTemplateFromPipelineEntityConfigUpdateCommand(null, "some-pipeline", "new-template", null);
+            BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
+            cruiseConfig.addPipeline("blah", PipelineConfigMother.pipelineConfig("some-pipeline"));
+            assertThat(command.canContinue(cruiseConfig)).isTrue();
+        }
+
+        @Test
+        void shouldBlowUpIfPipelineDoesNotExist() {
+            ExtractTemplateFromPipelineEntityConfigUpdateCommand command = new ExtractTemplateFromPipelineEntityConfigUpdateCommand(null, "non-existent-pipeline", "new-template", null);
+            BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
+
+            assertThatCode(() -> command.canContinue(cruiseConfig))
+                    .isInstanceOf(RecordNotFoundException.class)
+                    .hasMessage("Pipeline with name 'non-existent-pipeline' was not found!");
+        }
+
+        @Test
+        void shouldBlowUpIfPipelineAlreadyUsesTemplateDoesNotExist() {
+            ExtractTemplateFromPipelineEntityConfigUpdateCommand command = new ExtractTemplateFromPipelineEntityConfigUpdateCommand(null, "some-pipeline", "new-template", null);
+            BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
+            cruiseConfig.addPipeline("blah", PipelineConfigMother.pipelineConfigWithTemplate("some-pipeline", "blah-template"));
+
+            assertThatCode(() -> command.canContinue(cruiseConfig))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessage("Pipeline with name 'id' already uses a template.");
+        }
+
+        @Test
+        void shouldBlowUpIfTemplateWithSameNameAlreadyExist() {
+            ExtractTemplateFromPipelineEntityConfigUpdateCommand command = new ExtractTemplateFromPipelineEntityConfigUpdateCommand(null, "some-pipeline", "existing-template", null);
+            BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
+            cruiseConfig.addPipeline("blah", PipelineConfigMother.pipelineConfig("some-pipeline"));
+            cruiseConfig.addTemplate(PipelineTemplateConfigMother.createTemplate("existing-template"));
+
+            assertThatCode(() -> command.canContinue(cruiseConfig))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessage("Template with name 'existing-template' already exists!");
+        }
+    }
+}

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -381,6 +381,7 @@ public class Routes {
         public static final String SPA_BASE = "/admin/pipelines";
         public static final String BASE = "/api/admin/pipelines";
         public static final String NAME = "/:pipeline_name";
+        public static final String EXTRACT_TO_TEMPLATE = "/:pipeline_name/extract_to_template";
         public static final String DOC = apiDocsUrl("#pipeline-config");
 
         public static String find() {


### PR DESCRIPTION
Fixes #7182 

```
PUT /go/api/admin/pipelines/smoke-on-cloud/extract_to_template 
Accept: application/vnd.go.cd+json
Content-Type: application/json

{"template_name": "new-template"}
```
