### PR TITLE
Show appropriate error when user does not have permissions to operate on a pipeline or pipeline group (#7177)

### DIFF
--- a/api/api-pipeline-config-v10/src/main/java/com/thoughtworks/go/apiv10/admin/pipelineconfig/PipelineConfigControllerV10.java
+++ b/api/api-pipeline-config-v10/src/main/java/com/thoughtworks/go/apiv10/admin/pipelineconfig/PipelineConfigControllerV10.java
@@ -107,7 +107,6 @@ public class PipelineConfigControllerV10 extends ApiController implements SparkS
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         pipelineConfigService.deletePipelineConfig(SessionUtils.currentUsername(), existingPipelineConfig, result);
 
-
         return renderHTTPOperationResult(result, req, res);
     }
 


### PR DESCRIPTION
#### Issue: #7177

#### Description:
* Add appropriate error on the result object in case of Update request can not be continued because of user permissions.




> Why did the API returned 200 without updating the config?

EntityConfigUpdateCommand throws `ConfigUpdateCheckFailedException` when `canContinue` method returns false. As there could be multiple reasons where `canContinue` method could return false, developers are expected either to throw an appropriate error or to add a message on the result object.
As no message was added on the result object, the result object by default says 200. Hence the API update request was aborted with a 200 response code.
