### PR TITLE
#7172 - Fix issue when GOCD_AGENT_JVM_OPTS are not passed in

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-agent/docker-entrypoint.sh
+++ b/buildSrc/src/main/resources/gocd-docker-agent/docker-entrypoint.sh
@@ -142,6 +142,7 @@ if [ "$1" = "${AGENT_WORK_DIR}/bin/go-agent" ]; then
     echo "wrapper.java.additional.${tanuki_index}=${AGENT_BOOTSTRAPPER_JVM_ARGS[$array_index]}" >> /go-agent/wrapper-config/wrapper-properties.conf
   done
 
+  echo "set.default.GOCD_AGENT_JVM_OPTS=" >> /go-agent/wrapper-config/wrapper-properties.conf
   echo "set.AGENT_STARTUP_ARGS=%AGENT_STARTUP_ARGS% -Dgo.console.stdout=true %GOCD_AGENT_JVM_OPTS%" >> /go-agent/wrapper-config/wrapper-properties.conf
 fi
 


### PR DESCRIPTION
Issue: #7172 - #7181

Description: When no GOCD_AGENT_JVM_OPTS are provided, `%GOCD_AGENT_JVM_OPTS%` was sent to the launcher Java process and would stop the agent from starting up.

/cc @rajiesh found this issue. Thank you and sorry I didn't realize this.

