### PR TITLE
Do not cancel another building job on agent in case of canceling run on all agent job (#2048)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/messaging/JobResultListener.java
+++ b/server/src/main/java/com/thoughtworks/go/server/messaging/JobResultListener.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.server.messaging;
 
+import com.thoughtworks.go.domain.AgentInstance;
 import com.thoughtworks.go.server.service.AgentService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -36,7 +37,10 @@ public class JobResultListener implements GoMessageListener<JobResultMessage> {
 
     @Override
     public void onMessage(JobResultMessage message) {
-        // TODO - #2511 - this only works for cancelling a job.
-        agentService.notifyJobCancelledEvent(message.getAgentUuid());
+        AgentInstance agent = agentService.findAgent(message.getAgentUuid());
+        if (agent.getBuildingInfo().getBuildLocator().equals(message.getJobIdentifier().buildLocator())) {
+            // TODO - #2511 - this only works for cancelling a job.
+            agentService.notifyJobCancelledEvent(message.getAgentUuid());
+        }
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/messaging/JobResultListenerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/messaging/JobResultListenerTest.java
@@ -15,33 +15,43 @@
  */
 package com.thoughtworks.go.server.messaging;
 
+import com.thoughtworks.go.domain.AgentInstance;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.domain.JobResult;
+import com.thoughtworks.go.helper.AgentInstanceMother;
 import com.thoughtworks.go.server.service.AgentService;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class JobResultListenerTest {
     private AgentService agentService;
     private JobResultListener listener;
     private JobIdentifier jobIdentifier;
     private static final String AGENT_UUID = "uuid";
+    private AgentInstance agentInstance;
 
     @Before
     public void setup() {
         agentService = mock(AgentService.class);
         listener = new JobResultListener(new JobResultTopic(null), agentService);
-        jobIdentifier = new JobIdentifier("cruise", "1", "dev", "1", "linux-firefox");
+        jobIdentifier = new JobIdentifier("cruise", 1, "1", "dev", "1", "linux-firefox");
     }
 
     @Test
     public void shouldUpdateAgentStatusWhenAJobIsCancelled() throws Exception {
-
+        agentInstance = AgentInstanceMother.building("cruise/1/dev/1/linux-firefox");
+        when(agentService.findAgent(AGENT_UUID)).thenReturn(agentInstance);
         listener.onMessage(new JobResultMessage(jobIdentifier, JobResult.Cancelled, AGENT_UUID));
         verify(agentService).notifyJobCancelledEvent(AGENT_UUID);
     }
 
+    @Test
+    public void shouldNotUpdateAgentStatusWhenAJobIsCancelledInCaseOfAgentBuildingAnother() throws Exception {
+        agentInstance = AgentInstanceMother.building("cruise/1/dev/1/linux-firefox-2");
+        when(agentService.findAgent(AGENT_UUID)).thenReturn(agentInstance);
+        listener.onMessage(new JobResultMessage(jobIdentifier, JobResult.Cancelled, AGENT_UUID));
+        verify(agentService, never()).notifyJobCancelledEvent(AGENT_UUID);
+    }
 }


### PR DESCRIPTION
### Issue: #2048

### Description:

##### Scenario:
* In case of run on all agents, a job is created for each agent and the agent is assigned
  to the job.
* When the assigned agent is building another job, the current run on all agents job is
  in waiting state.
* When run on all agents job is cancelled, a job cancel event is sent to the agent associated
  with the current job. As the run on all agents is associated with an agent which is building
  another job, the building job on the agent is cancelled.

##### Fix:
* Do not send cancel building job event to the agent in case the completed job identifier and
  building job identifier are not same.
