### PR TITLE
Use UpdatePipelineConfigCommand on Pipeline config pages

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineConfigService.java
@@ -26,6 +26,7 @@ import com.thoughtworks.go.domain.PipelineGroups;
 import com.thoughtworks.go.domain.Task;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.presentation.CanDeleteResult;
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 import com.thoughtworks.go.server.service.tasks.PluggableTaskService;
 import com.thoughtworks.go.util.Node;
@@ -151,6 +152,14 @@ public class PipelineConfigService {
         validatePluggableTasks(pipelineConfig);
         UpdatePipelineConfigCommand updatePipelineConfigCommand = new UpdatePipelineConfigCommand(goConfigService, entityHashingService, pipelineConfig, updatedGroupName, currentUser, md5, result, externalArtifactsService);
         update(currentUser, pipelineConfig, result, updatePipelineConfigCommand);
+    }
+
+    //called from rails
+    //Result a result object instead of mutating the arg, to make it easier to test
+    public LocalizedOperationResult updatePipelineConfig(final Username currentUser, final PipelineConfig pipelineConfig, String updatedGroupName, final String md5) {
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        updatePipelineConfig(currentUser, pipelineConfig, updatedGroupName, md5, result);
+        return result;
     }
 
     public PipelineGroups viewableGroupsFor(Username username) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -22,6 +22,7 @@ public class Toggles {
     public static String TEST_DRIVE = "test_drive";
     public static String NEW_PIPELINE_DROPDOWN = "new_pipeline_dropdown";
     public static String SHOW_NEW_ENVIRONMENTS_SPA = "show_new_environments_spa";
+    public static String FAST_PIPELINE_SAVE = "fast_pipeline_save";
 
     private static FeatureToggleService service;
 
@@ -41,5 +42,9 @@ public class Toggles {
             throw new RuntimeException("Toggles not initialized with feature toggle service");
         }
         return service.isToggleOn(key);
+    }
+
+    public static boolean isToggleOff(String key) {
+        return !isToggleOn(key);
     }
 }

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -30,6 +30,11 @@
       "key": "show_new_environments_spa",
       "description": "Switch to the new environments SPA. Default is false.",
       "value": false
+    },
+    {
+      "key": "fast_pipeline_save",
+      "description": "Use the pipeline config service to speed up save, instead of doing a full config save",
+      "value": true
     }
   ]
 }

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/jobs_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/jobs_controller.rb
@@ -15,11 +15,13 @@
 #
 
 module Admin
-  class JobsController < AdminController
+  class JobsController < FastAdminController
     include StageConfigLoader
     helper AdminHelper
     helper UiPatternHelper
     helper FlashMessagesHelper
+
+    CLONER = GoConfigCloner.new
 
     load_stage_except_for :create, :update, :destroy
 
@@ -83,33 +85,23 @@ module Admin
     end
 
     def update
-      save_popup(params[:config_md5], Class.new(::ConfigUpdate::SaveAsPipelineOrTemplateAdmin) do
-        include ::ConfigUpdate::JobNode
-        include ::ConfigUpdate::NodeAsSubject
-        include ::ConfigUpdate::RefsAsUpdatedRefs
-
-        def initialize params, user, security_service, external_artifacts_service, go_config_service
-          super(params, user, security_service)
-          @external_artifacts_service = external_artifacts_service
-          @go_config_service = go_config_service
-        end
-
-        def updatedNode(cruise_config)
-          stage = load_stage(cruise_config)
-          load_job_from_stage_named(stage, CaseInsensitiveString.new(params[:job][:name] || params[:job_name]))
-        end
-
-        def update(job)
-          job.setConfigAttributes(params[:job])
-          job.artifactTypeConfigs().getPluggableArtifactConfigs().each do |external_artifact_config|
-            @external_artifacts_service.validateExternalArtifactConfig(external_artifact_config, @go_config_service.artifactStores().find(external_artifact_config.getStoreId), false)
-          end
-        end
-      end.new(params, current_user.getUsername(), security_service, external_artifacts_service, go_config_service), failure_handler({:action => params[:current_tab], :layout => nil}), {:current_tab => params[:current_tab], :action => :edit, :job_name => params[:job][:name] || params[:job_name]}) do
+      pipeline_name = params[:pipeline_name]
+      original_pipeline_config = pipeline_config_service.getPipelineConfig(pipeline_name)
+      @pipeline = CLONER.deep_clone(original_pipeline_config)
+      @stage = @pipeline.getStage(params[:stage_name])
+      @job = @stage.jobConfigByConfigName(params[:job_name])
+      @job.setConfigAttributes(params[:job])
+      @job.artifactTypeConfigs().getPluggableArtifactConfigs().each do |external_artifact_config|
+        external_artifacts_service.validateExternalArtifactConfig(external_artifact_config, go_config_service.artifactStores().find(external_artifact_config.getStoreId), false)
+      end
+      fast_save_popup(failure_handler({:action => params[:current_tab], :layout => nil}), {:current_tab => params[:current_tab], :action => :edit, :job_name => params[:job][:name] || params[:job_name]}) do
         @should_not_render_layout = true
         load_pipeline_and_stage
-        assert_load :job, @node
+        assert_load :job, @job
         load_artifact_related_data
+        assert_load :pipeline_md5, params[:pipeline_md5]
+        assert_load :pipeline_group_name, params[:pipeline_group_name]
+        assert_load :pipeline_name, params[:pipeline_name]
       end
     end
 
@@ -156,7 +148,7 @@ module Admin
     end
 
     def load_resources_and_elastic_profile_ids_for_autocomplete
-      resources = @processed_cruise_config.getAllResources().map(&:getName) + agent_service.getListOfResourcesAcrossAgents()
+      resources = @cruise_config.getAllResources().map(&:getName) + agent_service.getListOfResourcesAcrossAgents()
       resources = resources.uniq
       assert_load :autocomplete_resources, resources.sort.to_json
       assert_load :elastic_profile_ids, elastic_profile_service.listAll().keys.sort.to_json
@@ -169,7 +161,6 @@ module Admin
     def failure_handler(render_options)
       proc do |update_result, all_errors_on_other_objects|
         load_pipeline_and_stage
-        assert_load :processed_cruise_config, @config_after
         load_resources_and_elastic_profile_ids_for_autocomplete
         load_store_ids_for_autocomplete
         render_error(update_result, all_errors_on_other_objects, render_options)

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/jobs_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/jobs_controller.rb
@@ -85,7 +85,7 @@ module Admin
     end
 
     def update
-      if params[:stage_parent] == 'templates'
+      if params[:stage_parent] == 'templates' or Toggles.isToggleOff(Toggles.FAST_PIPELINE_SAVE)
         old_update
         return
       end

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/jobs_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/jobs_controller.rb
@@ -86,7 +86,7 @@ module Admin
 
     def update
       if params[:stage_parent] == 'templates'
-        update_on_template
+        old_update
         return
       end
       pipeline_name = params[:pipeline_name]
@@ -109,7 +109,7 @@ module Admin
       end
     end
 
-    def update_on_template
+    def old_update
       save_popup(params[:config_md5], Class.new(::ConfigUpdate::SaveAsPipelineOrTemplateAdmin) do
         include ::ConfigUpdate::JobNode
         include ::ConfigUpdate::NodeAsSubject

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/jobs_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/jobs_controller.rb
@@ -95,9 +95,6 @@ module Admin
       @stage = @pipeline.getStage(params[:stage_name])
       @job = @stage.jobConfigByConfigName(params[:job_name])
       @job.setConfigAttributes(params[:job])
-      @job.artifactTypeConfigs().getPluggableArtifactConfigs().each do |external_artifact_config|
-        external_artifacts_service.validateExternalArtifactConfig(external_artifact_config, go_config_service.artifactStores().find(external_artifact_config.getStoreId), false)
-      end
       fast_save_popup(failure_handler({:action => params[:current_tab], :layout => nil}), {:current_tab => params[:current_tab], :action => :edit, :job_name => params[:job][:name] || params[:job_name]}) do
         @should_not_render_layout = true
         load_pipeline_and_stage

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
@@ -179,6 +179,9 @@ module Admin
     end
 
     def save_tab(error_rendering_options_or_proc)
+      if Toggles.isToggleOff(Toggles.FAST_PIPELINE_SAVE)
+        save_tab_old(error_rendering_options_or_proc)
+      end
       pipeline_name = params[:pipeline_name]
       @original_params = Struct.new(:params).new
       @original_pipeline_config = pipeline_config_service.getPipelineConfig(pipeline_name)
@@ -190,6 +193,27 @@ module Admin
         assert_load(:pipeline, @pipeline)
         assert_load(:pipeline_group_name, params[:pipeline_group_name])
         assert_load(:pipeline_md5, params[:pipeline_md5])
+        load_pause_info
+      end
+    end
+
+    def save_tab_old(error_rendering_options_or_proc)
+      @original_params = Struct.new(:params).new
+      save_page(params[:config_md5], pipeline_edit_path(:pipeline_name => params[:pipeline_name], :stage_parent=>"pipelines", :current_tab => params[:current_tab]), error_rendering_options_or_proc, Class.new(::ConfigUpdate::SaveAsPipelineAdmin) do
+        include ConfigUpdate::PipelineNode
+        include ConfigUpdate::NodeAsSubject
+
+        def initialize(params, user, security_service, original_params)
+          super(params, user, security_service)
+          @original_params = original_params
+        end
+
+        def update(pipeline)
+          @original_params.params = CLONER.deepClone(pipeline.getParams())
+          pipeline.setConfigAttributes(params[:pipeline])
+        end
+      end.new(params, current_user.getUsername(), security_service, @original_params)) do
+        assert_load(:pipeline, @node)
         load_pause_info
       end
     end
@@ -218,7 +242,8 @@ module Admin
     end
 
     def config_param_errors_matching(pattern)
-      @pipeline.getAllErrors().
+      node_for_errors = Toggles.isToggleOff(Toggles.FAST_PIPELINE_SAVE) ? @cruise_config : @pipeline
+      node_for_errors.getAllErrors().
               collect { |config_error| config_error.getAll().to_a }.
               flatten.
               collect { |err_msg| err_msg =~ pattern ? $1 : nil }.

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
@@ -188,6 +188,8 @@ module Admin
       redirect_url = pipeline_edit_path(:pipeline_name => params[:pipeline_name], :stage_parent => "pipelines", :current_tab => params[:current_tab])
       fast_save_page(redirect_url, error_rendering_options_or_proc) do
         assert_load(:pipeline, @pipeline)
+        assert_load(:pipeline_group_name, params[:pipeline_group_name])
+        assert_load(:pipeline_md5, params[:pipeline_md5])
         load_pause_info
       end
     end
@@ -216,7 +218,7 @@ module Admin
     end
 
     def config_param_errors_matching(pattern)
-      @cruise_config.getAllErrors().
+      @pipeline.getAllErrors().
               collect { |config_error| config_error.getAll().to_a }.
               flatten.
               collect { |err_msg| err_msg =~ pattern ? $1 : nil }.

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
@@ -15,7 +15,7 @@
 #
 
 module Admin
-  class PipelinesController < AdminController
+  class PipelinesController < ExperimentAdminController
     helper ::Admin::AdminHelper
     helper ::Admin::PipelinesHelper
     helper FlashMessagesHelper
@@ -179,6 +179,10 @@ module Admin
     end
 
     def save_tab(error_rendering_options_or_proc)
+      pipeline_name = params[:pipeline_name]
+      @original_pipeline_config = pipeline_config_service.getPipelineConfig(pipeline_name)
+      @pipeline = CLONER.deep_clone(@original_pipeline_config)
+      @pipeline.setConfigAttributes(params['pipeline'])
       @original_params = Struct.new(:params).new
       save_page(params[:config_md5], pipeline_edit_path(:pipeline_name => params[:pipeline_name], :stage_parent=>"pipelines", :current_tab => params[:current_tab]), error_rendering_options_or_proc, Class.new(::ConfigUpdate::SaveAsPipelineAdmin) do
         include ConfigUpdate::PipelineNode
@@ -194,7 +198,7 @@ module Admin
           pipeline.setConfigAttributes(params[:pipeline])
         end
       end.new(params, current_user.getUsername(), security_service, @original_params)) do
-        assert_load(:pipeline, @node)
+        assert_load(:pipeline, @pipeline)
         load_pause_info
       end
     end

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/stages_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/stages_controller.rb
@@ -52,8 +52,6 @@ module Admin
       @pipeline = CLONER.deep_clone(original_pipeline_config)
       assert_load :stage, new_stage
       @stage.setConfigAttributes(params[:stage], task_view_service)
-      task = @stage.getJobs().first().getTasks().first()
-      pluggable_task_service.validate(task) if task.instance_of? com.thoughtworks.go.config.pluggabletask.PluggableTask
       @pipeline.addStageWithoutValidityAssertion(@stage)
       fast_save_popup({:action => :new, :layout => false}, {:current_tab => params[:current_tab]}) do
         assert_load(:pipeline, @pipeline)

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/stages_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/stages_controller.rb
@@ -84,6 +84,9 @@ module Admin
         @should_not_render_layout = true
         assert_load(:pipeline, ConfigUpdate::LoadConfig.for(params).load_pipeline_or_template(@cruise_config))
         assert_load(:stage, @stage_to_be_updated)
+        assert_load(:pipeline_md5, params[:pipeline_md5])
+        assert_load(:pipeline_group_name, params[:pipeline_group_name])
+        assert_load(:pipeline_name, params[:pipeline_name])
 
         load_data_for_permissions
         load_pause_info

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/stages_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/stages_controller.rb
@@ -72,7 +72,7 @@ module Admin
     end
 
     def update
-      if params[:stage_parent] == 'templates'
+      if params[:stage_parent] == 'templates' or Toggles.isToggleOff(Toggles.FAST_PIPELINE_SAVE)
         update_on_template
         return
       end

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/experiment_admin_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/experiment_admin_controller.rb
@@ -1,0 +1,87 @@
+#
+# Copyright 2019 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class ExperimentAdminController < AdminController
+  include ::Admin::AuthorizationHelper
+
+  protected
+  def save_popup(md5, save_action, render_error_options_or_proc = {:action => :new, :layout => false}, url_options = {}, flash_success_message = "Saved successfully.", &load_data)
+    render_error_options_or_proc.reverse_merge(:layout => false) unless render_error_options_or_proc.is_a?(Proc)
+    save(md5, render_error_options_or_proc, save_action, flash_success_message, load_data) do |message|
+      render(:plain => 'Saved successfully', :location => url_options_with_flash(message, {:action => :index, :class => 'success'}.merge(url_options)))
+    end
+  end
+
+  def set_save_redirect_url url
+    @onsuccess_redirect_uri = url
+  end
+
+  def save_page(md5, redirect_url, render_error_options_or_proc, save_action, success_message = "Saved successfully.", &load_data)
+    set_save_redirect_url redirect_url
+    save(md5, render_error_options_or_proc, save_action, success_message, load_data) do |message|
+      url = com.thoughtworks.go.util.UrlUtil.urlWithQuery(@onsuccess_redirect_uri, "fm", set_flash_message(message, "success"))
+      redirect_to(url)
+    end
+  end
+
+  protected
+
+  private
+
+  def save(md5, render_error_options_or_proc, save_action, success_message, load_data)
+    @update_result = HttpLocalizedOperationResult.new
+    @cruise_config = go_config_service.getCurrentConfig
+
+    # TODO read the group as a param
+    # group = @cruise_config.findGroupOfPipeline(@pipeline).group
+
+    # correct_md5 = entity_hashing_service.md5ForEntity(@pipeline, group)
+    puts "params: #{params}"
+    pipeline_config_service.updatePipelineConfig(current_user, @pipeline, params[:pipeline_group_name], params[:pipeline_md5], @update_result)
+    # update_response = go_config_service.updateConfigFromUI(save_action, md5, current_user, @update_result)
+    # @cruise_config, @node, @subject, @config_after = update_response.getCruiseConfig(), update_response.getNode(), update_response.getSubject(), update_response.configAfterUpdate()
+
+    # if @update_result.isSuccessful()
+      # success_message = "#{success_message} #{'The configuration was modified by someone else, but your changes were merged successfully.'}" if update_response.wasMerged()
+      # yield success_message
+    unless @update_result.isSuccessful
+      @config_file_conflict = (@update_result.httpCode() == 409)
+      flash.now[:error] = @update_result.message()
+      response.headers[GO_CONFIG_ERROR_HEADER] = flash[:error]
+    end
+
+    begin
+      load_data.call
+    rescue
+      Rails.logger.error $!
+      render_assertion_failure({})
+    end
+    return if @error_rendered
+
+    if @update_result.isSuccessful
+      yield success_message
+    else
+      # all_errors_on_other_objects = update_response.getCruiseConfig().getAllErrorsExceptFor(@subject)
+      all_errors_on_other_objects = []
+      if render_error_options_or_proc.is_a?(Proc)
+        render_error_options_or_proc.call(@update_result, all_errors_on_other_objects)
+      else
+        render_error(@update_result, all_errors_on_other_objects, render_error_options_or_proc)
+      end
+    end
+  end
+
+end

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/fast_admin_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/fast_admin_controller.rb
@@ -46,12 +46,7 @@ class FastAdminController < AdminController
   def fast_save(render_error_options_or_proc, success_message, load_data)
     @cruise_config = go_config_service.getCurrentConfig
     @update_result = pipeline_config_service.updatePipelineConfig(current_user, @pipeline, params[:pipeline_group_name], params[:pipeline_md5])
-    # update_response = go_config_service.updateConfigFromUI(save_action, md5, current_user, @update_result)
-    # @cruise_config, @node, @subject, @config_after = update_response.getCruiseConfig(), update_response.getNode(), update_response.getSubject(), update_response.configAfterUpdate()
 
-    # if @update_result.isSuccessful()
-      # success_message = "#{success_message} #{'The configuration was modified by someone else, but your changes were merged successfully.'}" if update_response.wasMerged()
-      # yield success_message
     unless @update_result.isSuccessful
       @config_file_conflict = (@update_result.httpCode() == 409)
       flash.now[:error] = @update_result.message()
@@ -69,7 +64,6 @@ class FastAdminController < AdminController
     if @update_result.isSuccessful
       yield success_message
     else
-      # all_errors_on_other_objects = update_response.getCruiseConfig().getAllErrorsExceptFor(@subject)
       all_errors_on_other_objects = []
       if render_error_options_or_proc.is_a?(Proc)
         render_error_options_or_proc.call(@update_result, all_errors_on_other_objects)

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/fast_admin_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/fast_admin_controller.rb
@@ -41,6 +41,12 @@ class FastAdminController < AdminController
     end
   end
 
+  def render_error(result, errors, options)
+    @errors = flatten_all_errors(errors)
+    flash.now[:error] = result.httpCode == 422 ? "Save failed, see errors below" : result.message
+    performed? || render_error_with_options(options.merge({:status => result.httpCode()}))
+  end
+
   private
 
   def fast_save(render_error_options_or_proc, success_message, load_data)
@@ -49,7 +55,7 @@ class FastAdminController < AdminController
 
     unless @update_result.isSuccessful
       @config_file_conflict = (@update_result.httpCode() == 409)
-      flash.now[:error] = @update_result.message()
+      flash.now[:error] = @update_result.httpCode == 422 ? "Save failed, see errors below" : @update_result.message
       response.headers[GO_CONFIG_ERROR_HEADER] = flash[:error]
     end
 

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/artifacts.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/artifacts.html.erb
@@ -9,6 +9,9 @@
                           :onsubmit => "return AjaxForm.jquery_ajax_submit(this, AjaxForm.ConfigFormEditHandler);",
                           :class => "popup_form"} do |f| %>
     <%= md5_field %>
+    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
+    <%= hidden_field_tag :pipeline_name, @pipeline.name %>
     <%= register_defaultable_list("job>artifactTypeConfigs") %>
 
     <div class="fieldset">

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/environment_variables.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/environment_variables.html.erb
@@ -10,6 +10,10 @@
                        :onsubmit => "return AjaxForm.jquery_ajax_submit(this, AjaxForm.ConfigFormEditHandler);",
                        :class => "popup_form"} do |f| %>
 
+    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
+    <%= hidden_field_tag :pipeline_name, @pipeline.name %>
+
     <%= render partial: 'admin/shared/environment_variable_fieldset', locals: {
                                                                             form: f,
                                                                             collection: @job.getPlainTextVariables(),

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/settings.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/settings.html.erb
@@ -9,6 +9,9 @@
                           :onsubmit => "return AjaxForm.jquery_ajax_submit(this, AjaxForm.ConfigFormEditHandler);",
                           :class => "popup_form"} do |f| %>
     <%= md5_field %>
+    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
+    <%= hidden_field_tag :pipeline_name, @pipeline.name %>
     <%= render :partial => "job_basic_settings.html", :locals => {:scope => {:job => @job, :form => f, :cruise_config => @cruise_config}} -%>
     <%= render :partial => "admin/shared/form_submit", :locals => {:scope => {:reset_url => admin_job_edit_path(:pipeline_name => @pipeline.name(), :stage_name => params[:stage_name], :job_name => params[:job_name], :current_tab => "settings")}} %>
 <% end %>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/tabs.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/tabs.html.erb
@@ -12,6 +12,9 @@
                           :class => "popup_form"} do |f| %>
     <div class="fieldset">
         <%= md5_field %>
+        <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+        <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
+        <%= hidden_field_tag :pipeline_name, @pipeline.name %>
         <%= current_tab_field("tabs") -%>
         <%= register_defaultable_list("job>tabs") %>
         <%= render :partial => "admin/shared/tab_name_path", :locals => {:scope => {:form => f, :collection => @job.getTabs(), :collection_name => :tabs}} %>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/environment_variables.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/environment_variables.html.erb
@@ -4,6 +4,8 @@
 <span title="Environment variables defined here are set on the agents and can be used within your tasks. <a class='' href='<%= docs_url '/faq/dev_use_current_revision_in_build.html' %>' target='_blank'>More...</a>" class="contextual_help has_go_tip_right">&nbsp;</span>
 
 <%= form_for @pipeline, :as => :pipeline, :url => pipeline_update_path(:pipeline_name => @pipeline.name(), :current_tab => 'environment_variables'), :html => {:method => :put, :id => "pipeline_edit_form"} do |f| %>
+    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
     <%= render partial: 'admin/shared/environment_variable_fieldset', locals: {
                                                                             form: f,
                                                                             collection: @pipeline.getPlainTextVariables(),

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/general.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/general.html.erb
@@ -2,6 +2,7 @@
 <h3 class="section-title">Basic Settings</h3>
 
 <%= form_for @pipeline, :as => :pipeline, :url => pipeline_update_path(:pipeline_name => @pipeline.name(), :current_tab => 'general'), :html => {:method => :put, :id => "pipeline_edit_form"} do |f| %>
+    <%= md5_field %>
     <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
     <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
     <div class="fieldset">
@@ -130,21 +131,6 @@
                 enableCheckboxAndLabel();
             }
         });
-
-        //jQuery('form').submit(function (evt) {
-        //    return Rails.handleRemote.call(evt.target, evt.originalEvent);
-        //});
-
-
-        //document.body.addEventListener('ajax:beforeSend', function(event) {
-        //    var detail = event.detail;
-        //    //var data = detail[0], status = detail[1], xhr = detail[2];
-        //    var xhr = detail[0];
-        //    var md5 = document.getElementById("config_md5").value;
-        //    xhr.setRequestHeader("Accept", "application/vnd.go.cd.v10+json");
-        //    //xhr.setRequestHeader("Content-Type", "application/json");
-        //    xhr.setRequestHeader("If-Match", md5);
-        //})
     });
 </script>
 

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/general.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/general.html.erb
@@ -2,7 +2,8 @@
 <h3 class="section-title">Basic Settings</h3>
 
 <%= form_for @pipeline, :as => :pipeline, :url => pipeline_update_path(:pipeline_name => @pipeline.name(), :current_tab => 'general'), :html => {:method => :put, :id => "pipeline_edit_form"} do |f| %>
-    <%= md5_field %>
+    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
     <div class="fieldset">
         <div class="form_item">
             <div class="form_item_block required">
@@ -129,6 +130,21 @@
                 enableCheckboxAndLabel();
             }
         });
+
+        //jQuery('form').submit(function (evt) {
+        //    return Rails.handleRemote.call(evt.target, evt.originalEvent);
+        //});
+
+
+        //document.body.addEventListener('ajax:beforeSend', function(event) {
+        //    var detail = event.detail;
+        //    //var data = detail[0], status = detail[1], xhr = detail[2];
+        //    var xhr = detail[0];
+        //    var md5 = document.getElementById("config_md5").value;
+        //    xhr.setRequestHeader("Accept", "application/vnd.go.cd.v10+json");
+        //    //xhr.setRequestHeader("Content-Type", "application/json");
+        //    xhr.setRequestHeader("If-Match", md5);
+        //})
     });
 </script>
 

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/parameters.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/parameters.html.erb
@@ -4,6 +4,8 @@
 <%= form_for @pipeline, :as => :pipeline, :url => pipeline_update_path(:pipeline_name => @pipeline.name(), :current_tab => 'parameters'), :html => {:method => :put, :id => "pipeline_edit_form"} do |f| %>
     <div class="fieldset">
         <%= md5_field %>
+        <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+        <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
         <%= register_defaultable_list("pipeline>params") %>
         <%= render :partial => "admin/shared/name_value", :locals => {:scope => {:form => f, :collection => @pipeline.getParams(), :collection_name => :params}} %>
          <div class="clear"></div>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/project_management.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/project_management.html.erb
@@ -6,6 +6,8 @@
 <%= form_for @pipeline, :as => :pipeline, :url => pipeline_update_path(:pipeline_name => @pipeline.name(), :current_tab => 'project_management'), :html => {:method => :put, :id => 'pipeline_edit_form'} do |f| %>
     <div class="fieldset">
         <%= md5_field %>
+        <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+        <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
         <div id="tracking_tool_container">
             <%= f.fields_for com.thoughtworks.go.config.PipelineConfig::TRACKING_TOOL, @pipeline.trackingTool do |t| %>
                 <div class="form_item_block">

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/environment_variables.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/environment_variables.html.erb
@@ -10,6 +10,10 @@
                        :onsubmit => "return AjaxForm.jquery_ajax_submit(this, AjaxForm.ConfigFormEditHandler);",
                        :class => "popup_form"}) do |f| %>
 
+    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
+    <%= hidden_field_tag :pipeline_name, @pipeline.name %>
+
     <%= render partial: 'admin/shared/environment_variable_fieldset', locals: {
                                                                             form: f,
                                                                             collection: @stage.getPlainTextVariables(),

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/new.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/new.html.erb
@@ -9,6 +9,9 @@
                          :onsubmit => "return AjaxForm.jquery_ajax_submit(this);",
                          :class => "popup_form"}) do |f| %>
     <%= md5_field %>
+    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
+    <%= hidden_field_tag :pipeline_name, @pipeline.name %>
     <input type="hidden" name="current_tab" value="stages"/>
 
     <div class="form_content">

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/permissions.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/permissions.html.erb
@@ -10,6 +10,9 @@
                           :onsubmit => "return AjaxForm.jquery_ajax_submit(this, AjaxForm.ConfigFormEditHandler);",
                           :class => "popup_form"}) do |f| %>
         <%= md5_field %>
+        <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+        <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
+        <%= hidden_field_tag :pipeline_name, @pipeline.name %>
         <div class="fieldset">
             <% stage_has_auth_defined = @stage.hasOperatePermissionDefined() %>
             <div class="form_item security_mode checkbox_row">

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/settings.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/settings.html.erb
@@ -9,6 +9,9 @@
                          :onsubmit => "return AjaxForm.jquery_ajax_submit(this, AjaxForm.ConfigFormEditHandler);",
                          :class => "popup_form"}) do |f| %>
     <%= md5_field %>
+    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
+    <%= hidden_field_tag :pipeline_name, @pipeline.name %>
     <%= render :partial => "admin/shared/global_errors.html", :locals => {:scope => {}} -%>
     <div class="fieldset">
       <div class="form_item_block required">

--- a/server/src/main/webapp/WEB-INF/rails/lib/pipeline_config_loader.rb
+++ b/server/src/main/webapp/WEB-INF/rails/lib/pipeline_config_loader.rb
@@ -40,6 +40,8 @@ module PipelineConfigLoader
       pipeline_for_edit = template_config_service.loadForEdit(params[:pipeline_name], current_user, result)
     else
       pipeline_for_edit = go_config_service.loadForEdit(params[:pipeline_name], current_user, result)
+      @pipeline_group_name = pipeline_for_edit.getCruiseConfig.findGroupOfPipeline(pipeline_for_edit.config).group
+      @pipeline_md5 = entity_hashing_service.md5ForEntity(pipeline_for_edit.config, @pipeline_group_name)
     end
     unless result.isSuccessful()
       render_localized_operation_result result

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/materials_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/materials_controller_spec.rb
@@ -23,6 +23,7 @@ describe Admin::MaterialsController do
   before :each do
     @go_config_service = stub_service(:go_config_service)
     @pipeline_pause_service = stub_service(:pipeline_pause_service)
+    @entity_hashing_service = stub_service(:entity_hashing_service)
     allow(controller).to receive(:populate_config_validity)
   end
 
@@ -40,13 +41,18 @@ describe Admin::MaterialsController do
     before :each do
       @pause_info = PipelinePauseInfo.paused("just for fun", "loser")
       @pipeline_name = "pipeline-name"
+      pipeline_group = BasicPipelineConfigs.new
+      pipeline_group.group = "defaultGroup"
+      allow(@entity_hashing_service).to receive(:md5ForEntity).and_return('pipeline-md5')
       expect(@pipeline_pause_service).to receive(:pipelinePauseInfo).with(@pipeline_name).and_return(@pause_info)
       allow(@go_config_service).to receive(:registry).and_return(MockRegistryModule::MockRegistry.new)
       @cruise_config = double("Cruise Config")
       expect(@cruise_config).to receive(:name).and_return(@pipeline_name)
+      expect(@cruise_config).to receive(:findGroupOfPipeline).and_return(pipeline_group)
       a = double('config wrapper')
       expect(a).to receive(:getConfig).and_return(@cruise_config)
-      expect(a).to receive(:getCruiseConfig).and_return(@cruise_config)
+      expect(a).to receive(:config).twice.and_return(@cruise_config)
+      expect(a).to receive(:getCruiseConfig).twice.and_return(@cruise_config)
       expect(a).to receive(:getProcessedConfig).and_return(@cruise_config)
       expect(@go_config_service).to receive(:loadForEdit).and_return(a)
     end

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/stages_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/stages_controller_spec.rb
@@ -429,9 +429,15 @@ describe Admin::StagesController do
         result = HttpLocalizedOperationResult.new
         expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
-        put :update, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :stage_name => "stage-name", :config_md5 => "1234abcd", :current_tab => "permissions", :stage => {:approval => {:type => "manual"},:variables =>[{:name=>"key", :valueForDisplay=>"value"}]}}
+        put :update, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :stage_name => "stage-name",
+                             :config_md5 => "1234abcd", :current_tab => "permissions",
+                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :stage => {:approval => {:type => "manual"},:variables =>[{:name=>"key", :valueForDisplay=>"value"}]}}
 
         expect(assigns[:stage].getApproval().getType()).to eq("manual")
+        expect(assigns[:pipeline_md5]).to eq('pipeline-md5')
+        expect(assigns[:pipeline_group_name]).to eq('defaultGroup')
+        expect(assigns[:pipeline_name]).to eq('pipeline-name')
         environment_variable = assigns[:stage].variables().get(0)
         expect(environment_variable.name).to eq("key")
         expect(environment_variable.value).to eq("value")
@@ -445,7 +451,9 @@ describe Admin::StagesController do
         result = HttpLocalizedOperationResult.new
         expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
-        put :update, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :stage_name => "stage-name", :config_md5 => "1234abcd", :current_tab => "permissions", :stage => {:name => "new-stage-name"}}
+        put :update, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :stage_name => "stage-name",
+                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :config_md5 => "1234abcd", :current_tab => "permissions", :stage => {:name => "new-stage-name"}}
 
         expect(response.location).to match(/\/admin\/pipelines\/pipeline-name\/stages\/new-stage-name\/permissions\?fm=#{uuid_pattern}$/)
         expect(response.status).to eq(200)
@@ -469,12 +477,20 @@ describe Admin::StagesController do
         result = HttpLocalizedOperationResult.new
         expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
-        put :update, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :stage_name => "stage-name", :config_md5 => "1234abcd", :current_tab => "settings", :stage => { :securityMode => "define", :operateUsers => [{ :name => "user1"}, {:name => "user2"}], :operateRoles => [{ :name => "role1"}, {:name => "role2"}]}}
+        put :update, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :stage_name => "stage-name",
+                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :config_md5 => "1234abcd", :current_tab => "settings",
+
+                             :stage => { :securityMode => "define", :operateUsers => [{ :name => "user1"}, {:name => "user2"}],
+                                         :operateRoles => [{ :name => "role1"}, {:name => "role2"}]}}
 
         expect(assigns[:stage].getOperateUsers().get(0)).to eq(AdminUser.new(CaseInsensitiveString.new("user1")))
         expect(assigns[:stage].getOperateUsers().get(1)).to eq(AdminUser.new(CaseInsensitiveString.new("user2")))
         expect(assigns[:stage].getOperateRoles().get(0)).to eq(AdminRole.new(CaseInsensitiveString.new("role1")))
         expect(assigns[:stage].getOperateRoles().get(1)).to eq(AdminRole.new(CaseInsensitiveString.new("role2")))
+        expect(assigns[:pipeline_md5]).to eq('pipeline-md5')
+        expect(assigns[:pipeline_group_name]).to eq('defaultGroup')
+        expect(assigns[:pipeline_name]).to eq('pipeline-name')
       end
 
       it "should render the form again if save fails" do
@@ -482,7 +498,9 @@ describe Admin::StagesController do
         result.conflict("modified already")
         expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
-        put :update, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :stage_name => "stage-name", :config_md5 => "1234abcd", :current_tab => "permissions", :stage => {:name => "new-stage-name"}}
+        put :update, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :stage_name => "stage-name",
+                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :config_md5 => "1234abcd", :current_tab => "permissions", :stage => {:name => "new-stage-name"}}
 
         expect(response.location).to be_nil
         assert_template "permissions"

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks/fetch_external_task_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks/fetch_external_task_controller_spec.rb
@@ -50,6 +50,9 @@ describe Admin::TasksController, "fetch task" do
                        }
     }
     @created_task = @new_task
+
+    @entity_hashing_service = stub_service(:entity_hashing_service)
+    allow(@entity_hashing_service).to receive(:md5ForEntity).and_return('pipeline-md5')
   end
 
   it_should_behave_like :task_controller

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks/fetch_task_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks/fetch_task_controller_spec.rb
@@ -24,6 +24,8 @@ describe Admin::TasksController, "fetch task" do
   include ConfigSaveStubbing
 
   before do
+    @entity_hashing_service = stub_service(:entity_hashing_service)
+    allow(@entity_hashing_service).to receive(:md5ForEntity).and_return('pipeline-md5')
     @example_task = fetch_task_with_exec_on_cancel_task
     @task_type = @example_task.getTaskType()
     @updated_payload = {:pipelineName => 'other-pipeline', :stage => 'other-stage', :job => 'other-job', :src => 'new-src', :dest => 'new-dest', :isSourceAFile => '1', :hasCancelTask => "1", :onCancelConfig=> { :onCancelOption => 'exec', :execOnCancel => {:command => "echo", :args => "'failing'", :workingDirectory => "oncancel_working_dir"}}}

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks_controller_spec.rb
@@ -88,6 +88,7 @@ describe Admin::TasksController do
 
       @go_config_service = stub_service(:go_config_service)
       @pipeline_pause_service = stub_service(:pipeline_pause_service)
+      @entity_hashing_service = stub_service(:entity_hashing_service)
 
       @user = current_user
       @result = stub_localized_result
@@ -105,6 +106,7 @@ describe Admin::TasksController do
       expect(@go_config_service).to receive(:loadForEdit).with("pipeline.name", @user, @result).and_return(@pipeline_config_for_edit)
       expect(@pipeline_pause_service).to receive(:pipelinePauseInfo).with("pipeline.name").and_return(@pause_info)
       allow(@go_config_service).to receive(:registry).and_return(MockRegistryModule::MockRegistry.new)
+      allow(@entity_hashing_service).to receive(:md5ForEntity).and_return('pipeline-md5')
     end
 
     it "should load tasks" do

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/admin/pipelines/general_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/admin/pipelines/general_html_spec.rb
@@ -23,11 +23,13 @@ describe "admin/pipelines/general.html.erb" do
   before(:each) do
     @pipeline = PipelineConfigMother.pipelineConfigWithTimer("pipeline-name", "1 1 1 1 1 1 1")
     assign(:pipeline, @pipeline)
+    @pipeline_group_name = 'group-1'
 
     assign(:cruise_config, @cruise_config = BasicCruiseConfig.new)
-    @cruise_config.addPipeline("group-1", @pipeline)
+    @cruise_config.addPipeline(@pipeline_group_name, @pipeline)
 
     set(@cruise_config, "md5", "abc")
+    @pipeline_md5 = entity_hashing_service.md5ForEntity(@pipeline, @pipeline_group_name)
     in_params(:pipeline_name => "foo_bar", :action => "new", :controller => "admin/stages")
   end
 
@@ -36,6 +38,8 @@ describe "admin/pipelines/general.html.erb" do
 
     Capybara.string(response.body).find('#pipeline_edit_form').tap do |form|
       expect(form).to have_selector("input[type='hidden'][name='config_md5'][value='abc']", visible: :hidden)
+      expect(form).to have_selector("input[type='hidden'][name='pipeline_md5'][value='#{@pipeline_md5}']", visible: :hidden)
+      expect(form).to have_selector("input[type='hidden'][name='pipeline_group_name'][value='group-1']", visible: :hidden)
 
       expect(form).to have_selector("div[class='contextual_help has_go_tip_right']")
       expect(form).to have_selector("input[type='text'][name='pipeline[#{PipelineConfig::NAME}]'][value='pipeline-name']")

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/admin/stages/new_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/admin/stages/new_html_spec.rb
@@ -27,10 +27,13 @@ describe "admin/stages/new.html.erb" do
     assign(:stage, @stage)
 
     @pipeline_config = PipelineConfigMother.createPipelineConfig("pipeline-name", "foo", ["build-1"].to_java(java.lang.String))
-    assign(:pipeline_config, @pipeline_config)
+    assign(:pipeline, @pipeline_config)
 
     assign(:cruise_config, @cruise_config = BasicCruiseConfig.new)
-    @cruise_config.addPipeline("group-1", @pipeline_config)
+    @pipeline_group_name = 'group-1'
+    @cruise_config.addPipeline(@pipeline_group_name, @pipeline_config)
+
+    @pipeline_md5 = entity_hashing_service.md5ForEntity(@pipeline_config, @pipeline_group_name)
 
     set(@cruise_config, "md5", "abc")
     in_params(:stage_parent => "pipelines", :pipeline_name => "foo_bar", :action => "new", :controller => "admin/stages")


### PR DESCRIPTION
Issue #7229

Description: Currently the Save on Pipeline Config pages invokes `GoConfigService.updateConfigFromUI`, which is slow. This change is to instead call `PipelineConfigService.updatePipelineConfig`, which only writes the PipelineConfig object, and should be faster.

I've added a toggle to revert to the old behaviour as a fail-safe