### PR TITLE
Modify Auth Config UI to support allow only known users to login attribute (#6571)

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/auth_configs/auth_configs.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/auth_configs/auth_configs.ts
@@ -23,6 +23,7 @@ import {Configurations, PropertyJSON} from "models/shared/configuration";
 export interface AuthConfigJSON {
   id: string;
   plugin_id: string;
+  allow_only_known_users_to_login: boolean;
   properties: PropertyJSON[];
   errors?: { [key: string]: string[] };
 }
@@ -38,14 +39,20 @@ export interface AuthConfigsJSON {
 export class AuthConfig extends ValidatableMixin {
   id: Stream<string | undefined>;
   pluginId: Stream<string | undefined>;
+  allowOnlyKnownUsersToLogin: Stream<boolean>;
   properties: Stream<Configurations | undefined>;
 
-  constructor(id?: string, pluginId?: string, properties?: Configurations, errors: Errors = new Errors()) {
+  constructor(id?: string,
+              pluginId?: string,
+              allowOnlyKnownUsersToLogin?: boolean,
+              properties?: Configurations,
+              errors: Errors = new Errors()) {
     super();
     ValidatableMixin.call(this);
-    this.id         = Stream(id);
-    this.pluginId   = Stream(pluginId);
-    this.properties = Stream(properties);
+    this.id                         = Stream(id);
+    this.pluginId                   = Stream(pluginId);
+    this.allowOnlyKnownUsersToLogin = Stream(allowOnlyKnownUsersToLogin || false);
+    this.properties                 = Stream(properties);
     this.errors(errors);
 
     this.validatePresenceOf("pluginId");
@@ -59,13 +66,14 @@ export class AuthConfig extends ValidatableMixin {
   static fromJSON(data: AuthConfigJSON) {
     const configurations = Configurations.fromJSON(data.properties);
     const errors         = new Errors(data.errors);
-    return new AuthConfig(data.id, data.plugin_id, configurations, errors);
+    return new AuthConfig(data.id, data.plugin_id, data.allow_only_known_users_to_login, configurations, errors);
   }
 
   toJSON(): object {
     return {
       id: this.id,
       plugin_id: this.pluginId,
+      allow_only_known_users_to_login: this.allowOnlyKnownUsersToLogin,
       properties: this.properties
     };
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/auth_configs/auth_configs_crud.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/auth_configs/auth_configs_crud.ts
@@ -19,7 +19,7 @@ import {SparkRoutes} from "helpers/spark_routes";
 import {AuthConfig, AuthConfigJSON, AuthConfigs} from "models/auth_configs/auth_configs";
 
 export class AuthConfigsCRUD {
-  private static API_VERSION_HEADER = ApiVersion.v1;
+  private static API_VERSION_HEADER = ApiVersion.latest;
 
   static all() {
     return ApiRequestBuilder.GET(SparkRoutes.authConfigPath(), this.API_VERSION_HEADER)

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/auth_configs/spec/auth_configs_crud_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/auth_configs/spec/auth_configs_crud_spec.ts
@@ -31,7 +31,7 @@ describe("AuthorizationConfigurationCRUD", () => {
     expect(request.url).toEqual("/go/api/admin/security/auth_configs");
     expect(request.method).toEqual("GET");
     expect(request.data()).toEqual(toJSON({} as AuthConfigJSON));
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
   });
 
   it("should create a new auth config", () => {
@@ -43,7 +43,7 @@ describe("AuthorizationConfigurationCRUD", () => {
     expect(request.url).toEqual("/go/api/admin/security/auth_configs");
     expect(request.method).toEqual("POST");
     expect(request.data()).toEqual(toJSON(TestData.ldapAuthConfig()));
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
     expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
   });
 
@@ -58,7 +58,7 @@ describe("AuthorizationConfigurationCRUD", () => {
     expect(request.url).toEqual(`/go/api/admin/security/auth_configs/${ldapAuthConfig.id}`);
     expect(request.method).toEqual("PUT");
     expect(request.data()).toEqual(toJSON(ldapAuthConfig));
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
     expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
     expect(request.requestHeaders["If-Match"]).toEqual("some-etag");
   });
@@ -74,7 +74,7 @@ describe("AuthorizationConfigurationCRUD", () => {
     expect(request.url).toEqual(`/go/api/admin/security/auth_configs/${ldapAuthConfig.id}`);
     expect(request.method).toEqual("DELETE");
     expect(request.data()).toEqual(toJSON({} as AuthConfigJSON));
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
     expect(request.requestHeaders["Content-Type"]).toEqual(undefined!);
     expect(request.requestHeaders["X-GoCD-Confirm"]).toEqual("true");
   });
@@ -89,7 +89,7 @@ function authConfigResponse() {
   return {
     status: 200,
     responseHeaders: {
-      "Content-Type": "application/vnd.go.cd.v1+json; charset=utf-8",
+      "Content-Type": "application/vnd.go.cd+json; charset=utf-8",
       "ETag": "some-etag"
     },
     responseText: JSON.stringify(TestData.ldapAuthConfig())
@@ -100,7 +100,7 @@ function listAuthConfigResponse() {
   return {
     status: 200,
     responseHeaders: {
-      "Content-Type": "application/vnd.go.cd.v1+json; charset=utf-8"
+      "Content-Type": "application/vnd.go.cd+json; charset=utf-8"
     },
     responseText: JSON.stringify(TestData.authConfigList(TestData.ldapAuthConfig()))
   };
@@ -110,7 +110,7 @@ function deleteAuthConfigResponse() {
   return {
     status: 200,
     responseHeaders: {
-      "Content-Type": "application/vnd.go.cd.v1+json; charset=utf-8"
+      "Content-Type": "application/vnd.go.cd+json; charset=utf-8"
     },
     responseText: JSON.stringify({message: "The auth config successfully deleted."})
   };

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/auth_configs/spec/auth_configs_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/auth_configs/spec/auth_configs_spec.ts
@@ -26,6 +26,7 @@ describe("AuthorizationConfigurationModel", () => {
 
     expect(authConfigs[0].id()).toEqual("ldap");
     expect(authConfigs[0].pluginId()).toEqual("cd.go.authorization.ldap");
+    expect(authConfigs[0].allowOnlyKnownUsersToLogin()).toEqual(true);
     expect(authConfigs[0].properties()!.count()).toEqual(3);
     expect(authConfigs[0].properties()!.valueFor("Url")).toEqual("ldap://ldap.server.url");
     expect(authConfigs[0].properties()!.valueFor("ManagerDN")).toEqual("uid=admin,ou=system");
@@ -33,6 +34,7 @@ describe("AuthorizationConfigurationModel", () => {
 
     expect(authConfigs[1].id()).toEqual("github");
     expect(authConfigs[1].pluginId()).toEqual("cd.go.authorization.github");
+    expect(authConfigs[1].allowOnlyKnownUsersToLogin()).toEqual(false);
     expect(authConfigs[1].properties()!.count()).toEqual(3);
     expect(authConfigs[1].properties()!.valueFor("Url")).toEqual("https://foo.github.com");
     expect(authConfigs[1].properties()!.valueFor("ClientKey")).toEqual("some-key");

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/auth_configs/spec/test_data.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/auth_configs/spec/test_data.ts
@@ -40,6 +40,7 @@ export class TestData {
     return {
       id: "ldap",
       plugin_id: "cd.go.authorization.ldap",
+      allow_only_known_users_to_login: true,
       properties: [
         {
           key: "Url",
@@ -61,6 +62,7 @@ export class TestData {
     return {
       id: "github",
       plugin_id: "cd.go.authorization.github",
+      allow_only_known_users_to_login: false,
       properties: [
         {
           key: "Url",

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs.tsx
@@ -57,7 +57,7 @@ export class AuthConfigsPage extends Page<null, State> {
       this.flashMessage.clear();
 
       const pluginId      = vnode.state.pluginInfos()[0].id;
-      const newAuthConfig = new AuthConfig("", pluginId, new Configurations([]));
+      const newAuthConfig = new AuthConfig("", pluginId, false, new Configurations([]));
       new CreateAuthConfigModal(newAuthConfig, vnode.state.pluginInfos(), vnode.state.onSuccessfulSave).render();
     };
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs/auth_config_modal_body.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs/auth_config_modal_body.tsx
@@ -24,7 +24,7 @@ import { AuthorizationExtension } from "models/shared/plugin_infos_new/extension
 import { PluginInfo, PluginInfos } from "models/shared/plugin_infos_new/plugin_info";
 import { FlashMessage } from "views/components/flash_message";
 import { Form, FormHeader } from "views/components/forms/form";
-import { SelectField, SelectFieldOptions, TextField } from "views/components/forms/input_fields";
+import {CheckboxField, SelectField, SelectFieldOptions, TextField} from "views/components/forms/input_fields";
 import { Message } from "views/pages/maintenance_mode";
 
 const AngularPluginNew = require('views/shared/angular_plugin_new').AngularPluginNew;
@@ -67,6 +67,10 @@ export class AuthConfigModalBody extends MithrilViewComponent<Attrs> {
               <SelectFieldOptions selected={vnode.attrs.authConfig.pluginId()}
                 items={pluginList} />
             </SelectField>
+            <CheckboxField required={false}
+                           helpText="Allow only those users to login who have explicitly been added by an administrator."
+                           label="Allow only known users to login"
+                           property={vnode.attrs.authConfig.allowOnlyKnownUsersToLogin}/>
           </Form>
         </FormHeader>
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs/modals.tsx
@@ -53,7 +53,10 @@ abstract class AuthConfigModal extends EntityModal<AuthConfig> {
   }
 
   onPluginChange(entity: Stream<AuthConfig>, pluginInfo: PluginInfo): void {
-    entity(new AuthConfig(entity().id(), pluginInfo!.id, new Configurations([])));
+    entity(new AuthConfig(entity().id(),
+                          pluginInfo!.id,
+                          entity().allowOnlyKnownUsersToLogin(),
+                          new Configurations([])));
   }
 
   buttons() {


### PR DESCRIPTION
##### Issue: #6571

##### Description:
    - Use auth config API V2(latest)
    - Add a checkbox to show allow only known users to login attribute


<img width="1103" alt="Screen Shot 2019-11-08 at 4 17 35 PM" src="https://user-images.githubusercontent.com/15275847/68471109-7fe50000-0243-11ea-9380-b65cd0b34c87.png">

