### PR TITLE
Introduce versioned pipeline instance history api

### DIFF
--- a/api/api-dashboard-v3/src/main/java/com/thoughtworks/go/apiv3/dashboard/representers/PipelineInstanceRepresenter.java
+++ b/api/api-dashboard-v3/src/main/java/com/thoughtworks/go/apiv3/dashboard/representers/PipelineInstanceRepresenter.java
@@ -39,7 +39,7 @@ public class PipelineInstanceRepresenter {
     }
 
     private static Consumer<OutputLinkWriter> addLinks(PipelineInstanceModel model) {
-        return linkWriter -> linkWriter.addLink("self", Routes.Pipeline.instance(model.getName(), model.getCounter()));
+        return linkWriter -> linkWriter.addLink("self", Routes.PipelineInstance.instance(model.getName(), model.getCounter()));
     }
 
     private static Consumer<OutputListWriter> getStages(PipelineInstanceModel model) {

--- a/api/api-dashboard-v3/src/main/java/com/thoughtworks/go/apiv3/dashboard/representers/PipelineRepresenter.java
+++ b/api/api-dashboard-v3/src/main/java/com/thoughtworks/go/apiv3/dashboard/representers/PipelineRepresenter.java
@@ -83,7 +83,7 @@ public class PipelineRepresenter {
 
     private static void addLinks(OutputLinkWriter linksWriter, GoDashboardPipeline model) {
         String pipelineName = model.name().toString();
-        linksWriter.addLink("self", Routes.Pipeline.history(pipelineName))
+        linksWriter.addLink("self", Routes.PipelineInstance.history(pipelineName))
                 .addAbsoluteLink("doc", Routes.Pipeline.DOC);
     }
 }

--- a/api/api-dashboard-v4/src/main/java/com/thoughtworks/go/apiv4/dashboard/representers/PipelineInstanceRepresenter.java
+++ b/api/api-dashboard-v4/src/main/java/com/thoughtworks/go/apiv4/dashboard/representers/PipelineInstanceRepresenter.java
@@ -39,7 +39,7 @@ public class PipelineInstanceRepresenter {
     }
 
     private static Consumer<OutputLinkWriter> addLinks(PipelineInstanceModel model) {
-        return linkWriter -> linkWriter.addLink("self", Routes.Pipeline.instance(model.getName(), model.getCounter()));
+        return linkWriter -> linkWriter.addLink("self", Routes.PipelineInstance.instance(model.getName(), model.getCounter()));
     }
 
     private static Consumer<OutputListWriter> getStages(PipelineInstanceModel model) {

--- a/api/api-dashboard-v4/src/main/java/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenter.java
+++ b/api/api-dashboard-v4/src/main/java/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenter.java
@@ -92,7 +92,7 @@ public class PipelineRepresenter {
 
     private static void addLinks(OutputLinkWriter linksWriter, GoDashboardPipeline model) {
         String pipelineName = model.name().toString();
-        linksWriter.addLink("self", Routes.Pipeline.history(pipelineName))
+        linksWriter.addLink("self", Routes.PipelineInstance.history(pipelineName))
                 .addAbsoluteLink("doc", Routes.Pipeline.DOC);
     }
 }

--- a/api/api-environments-v3/src/main/java/com/thoughtworks/go/apiv3/environments/representers/PipelineRepresenter.java
+++ b/api/api-environments-v3/src/main/java/com/thoughtworks/go/apiv3/environments/representers/PipelineRepresenter.java
@@ -30,7 +30,7 @@ public class PipelineRepresenter {
 
     private static void addLinks(OutputLinkWriter linksWriter, EnvironmentPipelineConfig pipelineConfig) {
         String pipelineName = pipelineConfig.getName().toString();
-        linksWriter.addLink("self", Routes.Pipeline.history(pipelineName))
+        linksWriter.addLink("self", Routes.PipelineInstance.history(pipelineName))
                 .addAbsoluteLink("doc", Routes.Pipeline.DOC)
                 .addAbsoluteLink("find", Routes.PipelineConfig.find());
     }

--- a/api/api-pipeline-instance-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1.java
+++ b/api/api-pipeline-instance-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1.java
@@ -57,7 +57,7 @@ public class PipelineInstanceControllerV1 extends ApiController implements Spark
 
     @Override
     public String controllerBasePath() {
-        return Routes.Pipeline.BASE;
+        return Routes.PipelineInstance.BASE;
     }
 
     @Override
@@ -66,11 +66,11 @@ public class PipelineInstanceControllerV1 extends ApiController implements Spark
             before("/*", mimeType, this::setContentType);
             before("/*", mimeType, this::verifyContentType);
 
-            before(Routes.Pipeline.INSTANCE_PATH, mimeType, apiAuthenticationHelper::checkPipelineViewPermissionsAnd403);
+            before(Routes.PipelineInstance.INSTANCE_PATH, mimeType, apiAuthenticationHelper::checkPipelineViewPermissionsAnd403);
             before(Routes.PipelineInstance.HISTORY_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateOfPipelineOrGroupInURLUserAnd403);
 
             get(Routes.PipelineInstance.HISTORY_PATH, mimeType, this::getHistoryInfo);
-            get(Routes.Pipeline.INSTANCE_PATH, mimeType, this::getInstanceInfo);
+            get(Routes.PipelineInstance.INSTANCE_PATH, mimeType, this::getInstanceInfo);
         });
     }
 

--- a/api/api-pipeline-instance-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1.java
+++ b/api/api-pipeline-instance-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.apiv1.pipelineinstance.representers.PipelineInstanceM
 import com.thoughtworks.go.apiv1.pipelineinstance.representers.PipelineInstanceModelsRepresenter;
 import com.thoughtworks.go.config.exceptions.BadRequestException;
 import com.thoughtworks.go.config.exceptions.UnprocessableEntityException;
+import com.thoughtworks.go.domain.PipelineRunIdInfo;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels;
 import com.thoughtworks.go.server.service.PipelineHistoryService;
@@ -90,7 +91,7 @@ public class PipelineInstanceControllerV1 extends ApiController implements Spark
         Long after = getCursor(request, "after");
         Long before = getCursor(request, "before");
         PipelineInstanceModels pipelineInstanceModels = pipelineHistoryService.loadPipelineHistoryData(currentUsername(), pipelineName, after, before, pageSize);
-        List<Long> latestAndOldestPipelineIds = pipelineHistoryService.getOldestAndLatestPipelineId(pipelineName, currentUsername());
+        PipelineRunIdInfo latestAndOldestPipelineIds = pipelineHistoryService.getOldestAndLatestPipelineId(pipelineName, currentUsername());
         return writerForTopLevelObject(request, response, (outputWriter) -> PipelineInstanceModelsRepresenter.toJSON(outputWriter, pipelineInstanceModels, latestAndOldestPipelineIds));
     }
 

--- a/api/api-pipeline-instance-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineinstance/representers/PipelineInstanceModelsRepresenter.java
+++ b/api/api-pipeline-instance-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineinstance/representers/PipelineInstanceModelsRepresenter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineinstance.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels;
+import com.thoughtworks.go.spark.Routes;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class PipelineInstanceModelsRepresenter {
+    public static void toJSON(OutputWriter outputWriter, PipelineInstanceModels pipelineInstanceModels, List<Long> latestAndOldestPipelineId) {
+        if (pipelineInstanceModels.isEmpty()) {
+            outputWriter.addChildList("pipelines", emptyList());
+            return;
+        }
+        addLinks(outputWriter, pipelineInstanceModels, latestAndOldestPipelineId);
+        outputWriter.addChildList("pipelines", pipelinesWriter -> pipelineInstanceModels.forEach(pipelineInstanceModel -> pipelinesWriter.addChild(pipelineWriter -> PipelineInstanceModelRepresenter.toJSON(pipelineWriter, pipelineInstanceModel))));
+    }
+
+    private static void addLinks(OutputWriter outputWriter, PipelineInstanceModels pipelineInstanceModels, List<Long> latestAndOldestPipelineId) {
+        PipelineInstanceModel latest = pipelineInstanceModels.first();
+        PipelineInstanceModel oldest = pipelineInstanceModels.last();
+        String previousLink = null, nextLink = null;
+        if (latest.getId() != latestAndOldestPipelineId.get(0)) {
+            previousLink = Routes.PipelineInstance.previous(latest.getName(), latest.getId());
+        }
+        if (oldest.getId() != latestAndOldestPipelineId.get(1)) {
+            nextLink = Routes.PipelineInstance.next(latest.getName(), oldest.getId());
+        }
+        if (isNotBlank(previousLink) || isNotBlank(nextLink)) {
+            String finalPreviousLink = previousLink;
+            String finalNextLink = nextLink;
+            outputWriter.addLinks(outputLinkWriter -> {
+                outputLinkWriter.addLinkIfPresent("previous", finalPreviousLink);
+                outputLinkWriter.addLinkIfPresent("next", finalNextLink);
+            });
+        }
+    }
+}

--- a/api/api-pipeline-instance-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineinstance/representers/PipelineInstanceModelsRepresenter.java
+++ b/api/api-pipeline-instance-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineinstance/representers/PipelineInstanceModelsRepresenter.java
@@ -17,17 +17,16 @@
 package com.thoughtworks.go.apiv1.pipelineinstance.representers;
 
 import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.domain.PipelineRunIdInfo;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels;
 import com.thoughtworks.go.spark.Routes;
-
-import java.util.List;
 
 import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class PipelineInstanceModelsRepresenter {
-    public static void toJSON(OutputWriter outputWriter, PipelineInstanceModels pipelineInstanceModels, List<Long> latestAndOldestPipelineId) {
+    public static void toJSON(OutputWriter outputWriter, PipelineInstanceModels pipelineInstanceModels, PipelineRunIdInfo latestAndOldestPipelineId) {
         if (pipelineInstanceModels.isEmpty()) {
             outputWriter.addChildList("pipelines", emptyList());
             return;
@@ -36,14 +35,14 @@ public class PipelineInstanceModelsRepresenter {
         outputWriter.addChildList("pipelines", pipelinesWriter -> pipelineInstanceModels.forEach(pipelineInstanceModel -> pipelinesWriter.addChild(pipelineWriter -> PipelineInstanceModelRepresenter.toJSON(pipelineWriter, pipelineInstanceModel))));
     }
 
-    private static void addLinks(OutputWriter outputWriter, PipelineInstanceModels pipelineInstanceModels, List<Long> latestAndOldestPipelineId) {
+    private static void addLinks(OutputWriter outputWriter, PipelineInstanceModels pipelineInstanceModels, PipelineRunIdInfo latestAndOldestPipelineId) {
         PipelineInstanceModel latest = pipelineInstanceModels.first();
         PipelineInstanceModel oldest = pipelineInstanceModels.last();
         String previousLink = null, nextLink = null;
-        if (latest.getId() != latestAndOldestPipelineId.get(0)) {
+        if (latest.getId() != latestAndOldestPipelineId.getLatestRunId()) {
             previousLink = Routes.PipelineInstance.previous(latest.getName(), latest.getId());
         }
-        if (oldest.getId() != latestAndOldestPipelineId.get(1)) {
+        if (oldest.getId() != latestAndOldestPipelineId.getOldestRunId()) {
             nextLink = Routes.PipelineInstance.next(latest.getName(), oldest.getId());
         }
         if (isNotBlank(previousLink) || isNotBlank(nextLink)) {

--- a/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1Test.groovy
+++ b/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1Test.groovy
@@ -20,6 +20,7 @@ import com.thoughtworks.go.api.SecurityTestTrait
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.apiv1.pipelineinstance.representers.PipelineInstanceModelRepresenter
 import com.thoughtworks.go.apiv1.pipelineinstance.representers.PipelineInstanceModelsRepresenter
+import com.thoughtworks.go.domain.PipelineRunIdInfo
 import com.thoughtworks.go.config.CaseInsensitiveString
 import com.thoughtworks.go.domain.buildcause.BuildCause
 import com.thoughtworks.go.helper.ModificationsMother
@@ -66,7 +67,7 @@ import static org.mockito.MockitoAnnotations.initMocks
 
 class PipelineInstanceControllerV1Test implements SecurityServiceTrait, ControllerTrait<PipelineInstanceControllerV1> {
   @Mock
-  PipelineHistoryService pipelineHistoryService
+  private PipelineHistoryService pipelineHistoryService
 
   @BeforeEach
   void setUp() {
@@ -217,7 +218,7 @@ class PipelineInstanceControllerV1Test implements SecurityServiceTrait, Controll
         def pipelineInstanceModel1 = PipelineInstanceModel.createPipeline(pipelineName, 2, "label", buildCause, stageInstanceModels)
         def pipelineInstanceModel2 = PipelineInstanceModel.createPipeline(pipelineName, 3, "label", buildCause, stageInstanceModels)
         def pipelineInstanceModels = PipelineInstanceModels.createPipelineInstanceModels(pipelineInstanceModel1, pipelineInstanceModel2)
-        def ids = [pipelineInstanceModel2.id, pipelineInstanceModel1.id]
+        def ids = new PipelineRunIdInfo(pipelineInstanceModel2.id, pipelineInstanceModel1.id)
 
         when(pipelineHistoryService.totalCount(pipelineName)).thenReturn(1)
         when(pipelineHistoryService.loadPipelineHistoryData(any(Username.class), eq(pipelineName), anyLong(), anyLong(), anyInt())).thenReturn(pipelineInstanceModels)
@@ -252,7 +253,7 @@ class PipelineInstanceControllerV1Test implements SecurityServiceTrait, Controll
           pipelineInstanceModel.id = i
           pipelineInstanceModels.add(pipelineInstanceModel)
         }
-        def ids = [5L, 1L]
+        def ids = new PipelineRunIdInfo(5L, 1L)
 
         when(pipelineHistoryService.totalCount(pipelineName)).thenReturn(1)
         when(pipelineHistoryService.loadPipelineHistoryData(any(Username.class), eq(pipelineName), anyLong(), anyLong(), anyInt())).thenReturn(pipelineInstanceModels)
@@ -287,7 +288,7 @@ class PipelineInstanceControllerV1Test implements SecurityServiceTrait, Controll
           pipelineInstanceModel.id = i
           pipelineInstanceModels.add(pipelineInstanceModel)
         }
-        def ids = [5L, 1L]
+        def ids = new PipelineRunIdInfo(5L, 1L)
 
         when(pipelineHistoryService.totalCount(pipelineName)).thenReturn(1)
         when(pipelineHistoryService.loadPipelineHistoryData(any(Username.class), eq(pipelineName), anyLong(), anyLong(), anyInt())).thenReturn(pipelineInstanceModels)

--- a/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1Test.groovy
+++ b/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1Test.groovy
@@ -19,26 +19,48 @@ package com.thoughtworks.go.apiv1.pipelineinstance
 import com.thoughtworks.go.api.SecurityTestTrait
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.apiv1.pipelineinstance.representers.PipelineInstanceModelRepresenter
+import com.thoughtworks.go.apiv1.pipelineinstance.representers.PipelineInstanceModelsRepresenter
 import com.thoughtworks.go.config.CaseInsensitiveString
 import com.thoughtworks.go.domain.buildcause.BuildCause
 import com.thoughtworks.go.helper.ModificationsMother
 import com.thoughtworks.go.helper.StageMother
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels
 import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModels
 import com.thoughtworks.go.server.domain.Username
 import com.thoughtworks.go.server.service.PipelineHistoryService
 import com.thoughtworks.go.server.service.result.HttpOperationResult
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.PipelineAccessSecurity
+import com.thoughtworks.go.spark.PipelineGroupOperateUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
+
+import java.util.stream.Stream
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static org.mockito.ArgumentMatchers.any
+import static org.mockito.ArgumentMatchers.anyInt
+import static org.mockito.ArgumentMatchers.anyInt
+import static org.mockito.ArgumentMatchers.anyInt
+import static org.mockito.ArgumentMatchers.anyLong
+import static org.mockito.ArgumentMatchers.anyLong
+import static org.mockito.ArgumentMatchers.anyLong
+import static org.mockito.ArgumentMatchers.anyLong
+import static org.mockito.ArgumentMatchers.anyLong
+import static org.mockito.ArgumentMatchers.anyLong
 import static org.mockito.ArgumentMatchers.eq
+import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.verifyZeroInteractions
+import static org.mockito.Mockito.verifyZeroInteractions
 import static org.mockito.Mockito.when
 import static org.mockito.MockitoAnnotations.initMocks
 
@@ -149,5 +171,181 @@ class PipelineInstanceControllerV1Test implements SecurityServiceTrait, Controll
         return PipelineInstanceModel.createPipeline(pipelineName, 2, "label", buildCause, stageInstanceModels)
       }
     }
+  }
+
+  @Nested
+  class History {
+    private String pipelineName = "up42"
+    @Nested
+    class Security implements SecurityTestTrait, PipelineGroupOperateUserSecurity {
+
+      @Override
+      String getControllerMethodUnderTest() {
+        return "getHistoryInfo"
+      }
+
+      @Override
+      void makeHttpCall() {
+        getWithApiHeader(controller.controllerPath(pipelineName, 'history'), [:])
+      }
+
+      @Override
+      String getPipelineName() {
+        return History.this.pipelineName
+      }
+    }
+
+    @Nested
+    class AsAuthorizedUser {
+      @BeforeEach
+      void setUp() {
+        enableSecurity()
+        loginAsGroupOperateUser(pipelineName)
+      }
+
+      @Test
+      void 'should render latest pipeline history'() {
+        def date = new Date()
+        def stage = StageMother.passedStageInstance(pipelineName, "stageName", 2, "buildName", date)
+        def stageInstanceModel = StageMother.toStageInstanceModel(stage)
+        def stageInstanceModels = new StageInstanceModels()
+        stageInstanceModels.add(stageInstanceModel)
+
+        def materialRevisions = ModificationsMother.multipleModifications()
+        def buildCause = BuildCause.createWithModifications(materialRevisions, "approver")
+
+        def pipelineInstanceModel1 = PipelineInstanceModel.createPipeline(pipelineName, 2, "label", buildCause, stageInstanceModels)
+        def pipelineInstanceModel2 = PipelineInstanceModel.createPipeline(pipelineName, 3, "label", buildCause, stageInstanceModels)
+        def pipelineInstanceModels = PipelineInstanceModels.createPipelineInstanceModels(pipelineInstanceModel1, pipelineInstanceModel2)
+        def ids = [pipelineInstanceModel2.id, pipelineInstanceModel1.id]
+
+        when(pipelineHistoryService.totalCount(pipelineName)).thenReturn(1)
+        when(pipelineHistoryService.loadPipelineHistoryData(any(Username.class), eq(pipelineName), anyLong(), anyLong(), anyInt())).thenReturn(pipelineInstanceModels)
+        when(pipelineHistoryService.getOldestAndLatestPipelineId(eq(pipelineName), any(Username.class))).thenReturn(ids)
+
+        getWithApiHeader(controller.controllerPath(pipelineName, 'history'))
+
+        verify(pipelineHistoryService).loadPipelineHistoryData(any(Username.class), eq(pipelineName), eq(0L), eq(0L), eq(10))
+
+        def expectedJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, ids) })
+
+        assertThatResponse()
+          .isOk()
+          .hasContentType(controller.mimeType)
+          .hasJsonBody(expectedJson)
+      }
+
+      @Test
+      void 'should render pipeline history after the specified cursor'() {
+        def date = new Date()
+        def stage = StageMother.passedStageInstance(pipelineName, "stageName", 2, "buildName", date)
+        def stageInstanceModel = StageMother.toStageInstanceModel(stage)
+        def stageInstanceModels = new StageInstanceModels()
+        stageInstanceModels.add(stageInstanceModel)
+
+        def materialRevisions = ModificationsMother.multipleModifications()
+        def buildCause = BuildCause.createWithModifications(materialRevisions, "approver")
+
+        def pipelineInstanceModels = PipelineInstanceModels.createPipelineInstanceModels()
+        for (int i = 1; i <= 2; i++) {
+          def pipelineInstanceModel = PipelineInstanceModel.createPipeline(pipelineName, i, "label", buildCause, stageInstanceModels)
+          pipelineInstanceModel.id = i
+          pipelineInstanceModels.add(pipelineInstanceModel)
+        }
+        def ids = [5L, 1L]
+
+        when(pipelineHistoryService.totalCount(pipelineName)).thenReturn(1)
+        when(pipelineHistoryService.loadPipelineHistoryData(any(Username.class), eq(pipelineName), anyLong(), anyLong(), anyInt())).thenReturn(pipelineInstanceModels)
+        when(pipelineHistoryService.getOldestAndLatestPipelineId(eq(pipelineName), any(Username.class))).thenReturn(ids)
+
+        getWithApiHeader(controller.controllerPath(pipelineName, 'history') + "?after=3")
+
+        verify(pipelineHistoryService).loadPipelineHistoryData(any(Username.class), eq(pipelineName), eq(3L), eq(0L), eq(10))
+
+        def expectedJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, ids) })
+
+        assertThatResponse()
+          .isOk()
+          .hasContentType(controller.mimeType)
+          .hasJsonBody(expectedJson)
+      }
+
+      @Test
+      void 'should render pipeline history before the specified cursor'() {
+        def date = new Date()
+        def stage = StageMother.passedStageInstance(pipelineName, "stageName", 2, "buildName", date)
+        def stageInstanceModel = StageMother.toStageInstanceModel(stage)
+        def stageInstanceModels = new StageInstanceModels()
+        stageInstanceModels.add(stageInstanceModel)
+
+        def materialRevisions = ModificationsMother.multipleModifications()
+        def buildCause = BuildCause.createWithModifications(materialRevisions, "approver")
+
+        def pipelineInstanceModels = PipelineInstanceModels.createPipelineInstanceModels()
+        for (int i = 4; i <= 5; i++) {
+          def pipelineInstanceModel = PipelineInstanceModel.createPipeline(pipelineName, i, "label", buildCause, stageInstanceModels)
+          pipelineInstanceModel.id = i
+          pipelineInstanceModels.add(pipelineInstanceModel)
+        }
+        def ids = [5L, 1L]
+
+        when(pipelineHistoryService.totalCount(pipelineName)).thenReturn(1)
+        when(pipelineHistoryService.loadPipelineHistoryData(any(Username.class), eq(pipelineName), anyLong(), anyLong(), anyInt())).thenReturn(pipelineInstanceModels)
+        when(pipelineHistoryService.getOldestAndLatestPipelineId(eq(pipelineName), any(Username.class))).thenReturn(ids)
+
+        getWithApiHeader(controller.controllerPath(pipelineName, 'history') + "?before=3")
+
+        verify(pipelineHistoryService).loadPipelineHistoryData(any(Username.class), eq(pipelineName), eq(0L), eq(3L), eq(10))
+
+        def expectedJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, ids) })
+
+        assertThatResponse()
+          .isOk()
+          .hasContentType(controller.mimeType)
+          .hasJsonBody(expectedJson)
+      }
+
+      @Test
+      void 'should throw if the after cursor is specified as a invalid integer'() {
+        getWithApiHeader(controller.controllerPath(pipelineName, 'history') + "?after=abc")
+
+        verifyZeroInteractions(pipelineHistoryService)
+
+        assertThatResponse()
+          .isBadRequest()
+          .hasJsonMessage("The query parameter `after`, if specified, must be positive integer.")
+      }
+
+      @Test
+      void 'should throw if the before cursor is specified as a invalid integer'() {
+        getWithApiHeader(controller.controllerPath(pipelineName, 'history') + "?before=abc")
+
+        verifyZeroInteractions(pipelineHistoryService)
+
+        assertThatResponse()
+          .isBadRequest()
+          .hasJsonMessage("The query parameter `before`, if specified, must be positive integer.")
+      }
+
+      @ParameterizedTest
+      @MethodSource("pageSizes")
+      void 'should throw error if page_size is not between 10 and 100'(String input) {
+        getWithApiHeader(controller.controllerPath(pipelineName, 'history') + "?page_size=" + input)
+
+        assertThatResponse()
+          .isBadRequest()
+          .hasJsonMessage("The query parameter `page_size`, if specified must be a number between 10 and 100.")
+      }
+
+      static Stream<Arguments> pageSizes() {
+        return Stream.of(
+          Arguments.of("7"),
+          Arguments.of("107"),
+          Arguments.of("-10"),
+          Arguments.of("abc")
+        )
+      }
+    }
+
   }
 }

--- a/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/representers/PipelineInstanceModelsRepresenterTest.groovy
+++ b/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/representers/PipelineInstanceModelsRepresenterTest.groovy
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.pipelineinstance.representers
+
+import com.thoughtworks.go.domain.buildcause.BuildCause
+import com.thoughtworks.go.helper.ModificationsMother
+import com.thoughtworks.go.helper.StageMother
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModels
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObject
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class PipelineInstanceModelsRepresenterTest {
+  private PipelineInstanceModels pipelineInstanceModels = PipelineInstanceModels.createPipelineInstanceModels()
+
+  @BeforeEach
+  void setUp() {
+    for (int i = 6; i >= 2; i--) {
+      def pipelineInstanceModel = createPipelineInstance(i + 4)
+      pipelineInstanceModel.id = i
+      pipelineInstanceModels.add(pipelineInstanceModel)
+    }
+  }
+
+  @Test
+  void 'should serializer into json with next and previous links'() {
+    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, [10L, 1L]) })
+
+    def expectedJson = [
+      "_links"   : [
+        "previous": [
+          "href": "http://test.host/go/api/pipelines/pipelineName/history?before=6"
+        ],
+        "next"    : [
+          "href": "http://test.host/go/api/pipelines/pipelineName/history?after=2"
+        ]
+      ],
+      "pipelines": pipelineInstanceModels.collect { model ->
+        toObject({ PipelineInstanceModelRepresenter.toJSON(it, model) })
+      }
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should return only next link if the latest instance id is present'() {
+    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, [6L, 1L]) })
+
+    def expectedJson = [
+      "_links"   : [
+        "next": [
+          "href": "http://test.host/go/api/pipelines/pipelineName/history?after=2"
+        ]
+      ],
+      "pipelines": pipelineInstanceModels.collect { model ->
+        toObject({ PipelineInstanceModelRepresenter.toJSON(it, model) })
+      }
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should return only previous link if the oldest instance id is present'() {
+    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, [10L, 2L]) })
+
+    def expectedJson = [
+      "_links"   : [
+        "previous": [
+          "href": "http://test.host/go/api/pipelines/pipelineName/history?before=6"
+        ]
+      ],
+      "pipelines": pipelineInstanceModels.collect { model ->
+        toObject({ PipelineInstanceModelRepresenter.toJSON(it, model) })
+      }
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should return no links if passed in empty list'() {
+    pipelineInstanceModels = PipelineInstanceModels.createPipelineInstanceModels()
+    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, [10L, 1L]) })
+
+    def expectedJson = [
+      "pipelines": []
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should not return any links if there is only one page to be rendered'() {
+    def pipelineInstanceModel = createPipelineInstance(1)
+    pipelineInstanceModel.id = 1
+    pipelineInstanceModels = PipelineInstanceModels.createPipelineInstanceModels(pipelineInstanceModel)
+
+    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, [1L, 1L]) })
+
+    def expectedJson = [
+      "pipelines": pipelineInstanceModels.collect { model ->
+        toObject({ PipelineInstanceModelRepresenter.toJSON(it, model) })
+      }
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  private static def createPipelineInstance(int counter) {
+    def stage = StageMother.passedStageInstance("pipelineName", "stageName", 4, "buildName", new Date())
+    def stageInstanceModel = StageMother.toStageInstanceModel(stage)
+    def stageInstanceModels = new StageInstanceModels()
+    stageInstanceModels.add(stageInstanceModel)
+
+    def materialRevisions = ModificationsMother.multipleModifications()
+    def buildCause = BuildCause.createWithModifications(materialRevisions, "approver")
+    return PipelineInstanceModel.createPipeline("pipelineName", counter, "label", buildCause, stageInstanceModels)
+  }
+}

--- a/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/representers/PipelineInstanceModelsRepresenterTest.groovy
+++ b/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/representers/PipelineInstanceModelsRepresenterTest.groovy
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.apiv1.pipelineinstance.representers
 
+import com.thoughtworks.go.domain.PipelineRunIdInfo
 import com.thoughtworks.go.domain.buildcause.BuildCause
 import com.thoughtworks.go.helper.ModificationsMother
 import com.thoughtworks.go.helper.StageMother
@@ -43,7 +44,8 @@ class PipelineInstanceModelsRepresenterTest {
 
   @Test
   void 'should serializer into json with next and previous links'() {
-    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, [10L, 1L]) })
+    def ids = new PipelineRunIdInfo(10L, 1L)
+    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, ids) })
 
     def expectedJson = [
       "_links"   : [
@@ -64,7 +66,8 @@ class PipelineInstanceModelsRepresenterTest {
 
   @Test
   void 'should return only next link if the latest instance id is present'() {
-    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, [6L, 1L]) })
+    def ids = new PipelineRunIdInfo(6L, 1L)
+    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, ids) })
 
     def expectedJson = [
       "_links"   : [
@@ -82,7 +85,8 @@ class PipelineInstanceModelsRepresenterTest {
 
   @Test
   void 'should return only previous link if the oldest instance id is present'() {
-    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, [10L, 2L]) })
+    def ids = new PipelineRunIdInfo(10L, 2L)
+    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, ids) })
 
     def expectedJson = [
       "_links"   : [
@@ -100,8 +104,9 @@ class PipelineInstanceModelsRepresenterTest {
 
   @Test
   void 'should return no links if passed in empty list'() {
+    def ids = new PipelineRunIdInfo(10L, 1L)
     pipelineInstanceModels = PipelineInstanceModels.createPipelineInstanceModels()
-    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, [10L, 1L]) })
+    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, ids) })
 
     def expectedJson = [
       "pipelines": []
@@ -112,11 +117,12 @@ class PipelineInstanceModelsRepresenterTest {
 
   @Test
   void 'should not return any links if there is only one page to be rendered'() {
+    def ids = new PipelineRunIdInfo(1L, 1L)
     def pipelineInstanceModel = createPipelineInstance(1)
     pipelineInstanceModel.id = 1
     pipelineInstanceModels = PipelineInstanceModels.createPipelineInstanceModels(pipelineInstanceModel)
 
-    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, [1L, 1L]) })
+    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels, ids) })
 
     def expectedJson = [
       "pipelines": pipelineInstanceModels.collect { model ->

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/PipelineOperationsControllerV1Test.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/PipelineOperationsControllerV1Test.groovy
@@ -496,4 +496,3 @@ class PipelineOperationsControllerV1Test implements SecurityServiceTrait, Contro
 
   }
 }
-

--- a/domain/src/main/java/com/thoughtworks/go/domain/PipelineRunIdInfo.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/PipelineRunIdInfo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain;
+
+public class PipelineRunIdInfo {
+    private long latestRunId;
+    private long oldestRunId;
+
+    public PipelineRunIdInfo(long latestRunId, long oldestRunId) {
+        this.latestRunId = latestRunId;
+        this.oldestRunId = oldestRunId;
+    }
+
+    public long getLatestRunId() {
+        return latestRunId;
+    }
+
+    public long getOldestRunId() {
+        return oldestRunId;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/dao/FeedModifier.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/FeedModifier.java
@@ -16,7 +16,7 @@
 package com.thoughtworks.go.server.dao;
 
 public enum FeedModifier {
-    Before("Before"), Latest("");
+    Before("Before"), Latest(""), After("After");
 
     private final String suffix;
 

--- a/server/src/main/java/com/thoughtworks/go/server/dao/PipelineDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/PipelineDao.java
@@ -16,7 +16,10 @@
 package com.thoughtworks.go.server.dao;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.domain.MaterialInstance;
+import com.thoughtworks.go.domain.Pipeline;
+import com.thoughtworks.go.domain.PipelineIdentifier;
+import com.thoughtworks.go.domain.StageIdentifier;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels;
@@ -86,4 +89,8 @@ public interface PipelineDao {
     List<PipelineIdentifier> getPipelineInstancesTriggeredWithDependencyMaterial(String pipelineName, MaterialInstance materialInstance, String revision);
 
     PipelineInstanceModels loadHistoryForDashboard(List<String> pipelineNames);
+
+    PipelineInstanceModels loadHistory(String pipelineName, FeedModifier modifier, long cursor, Integer pageSize);
+
+    List<Long> getOldestAndLatestPipelineId(String pipelineName);
 }

--- a/server/src/main/java/com/thoughtworks/go/server/dao/PipelineDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/PipelineDao.java
@@ -16,10 +16,7 @@
 package com.thoughtworks.go.server.dao;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.domain.MaterialInstance;
-import com.thoughtworks.go.domain.Pipeline;
-import com.thoughtworks.go.domain.PipelineIdentifier;
-import com.thoughtworks.go.domain.StageIdentifier;
+import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels;
@@ -92,5 +89,5 @@ public interface PipelineDao {
 
     PipelineInstanceModels loadHistory(String pipelineName, FeedModifier modifier, long cursor, Integer pageSize);
 
-    List<Long> getOldestAndLatestPipelineId(String pipelineName);
+    PipelineRunIdInfo getOldestAndLatestPipelineId(String pipelineName);
 }

--- a/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
@@ -675,13 +675,11 @@ public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Initial
     }
 
     private List<Long> findPipelineIds(String pipelineName, FeedModifier modifier, long cursor, int pageSize) {
-        List<Long> ids;
         Map<String, Object> params =
                 arguments("pipelineName", pipelineName)
                         .and("cursor", cursor)
                         .and("limit", pageSize).asMap();
-        ids = getSqlMapClientTemplate().queryForList("getPipelineIds" + modifier.suffix(), params);
-        return ids;
+        return (List<Long>) getSqlMapClientTemplate().queryForList("getPipelineIds" + modifier.suffix(), params);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
@@ -685,9 +685,9 @@ public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Initial
     }
 
     @Override
-    public List<Long> getOldestAndLatestPipelineId(String pipelineName) {
+    public PipelineRunIdInfo getOldestAndLatestPipelineId(String pipelineName) {
         Map<String, Object> params = arguments("pipelineName", pipelineName).asMap();
-        return (List<Long>) getSqlMapClientTemplate().queryForList("getOldestAndLatestPipelineRun", params);
+        return (PipelineRunIdInfo) getSqlMapClientTemplate().queryForObject("getOldestAndLatestPipelineRun", params);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
@@ -19,6 +19,10 @@ import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.PipelineConfigs;
+import com.thoughtworks.go.config.exceptions.BadRequestException;
+import com.thoughtworks.go.config.exceptions.EntityType;
+import com.thoughtworks.go.config.exceptions.NotAuthorizedException;
+import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
 import com.thoughtworks.go.domain.PipelineGroups;
 import com.thoughtworks.go.domain.PipelinePauseInfo;
 import com.thoughtworks.go.domain.PipelineTimelineEntry;
@@ -26,6 +30,7 @@ import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.presentation.PipelineStatusModel;
 import com.thoughtworks.go.presentation.pipelinehistory.*;
+import com.thoughtworks.go.server.dao.FeedModifier;
 import com.thoughtworks.go.server.dao.PipelineDao;
 import com.thoughtworks.go.server.domain.PipelineTimeline;
 import com.thoughtworks.go.server.domain.Username;
@@ -48,6 +53,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static java.lang.String.format;
+
 @Service
 public class PipelineHistoryService {
     private PipelineDao pipelineDao;
@@ -62,6 +69,7 @@ public class PipelineHistoryService {
     private PipelineLockService pipelineLockService;
     private PipelinePauseService pipelinePauseService;
     private static final String NOT_AUTHORIZED_TO_VIEW_PIPELINE = "Not authorized to view pipeline";
+    public static final String BAD_CURSOR_MSG = "The query parameter `%s`, if specified, must be positive integer.";
 
     @Autowired
     public PipelineHistoryService(PipelineDao pipelineDao,
@@ -135,15 +143,52 @@ public class PipelineHistoryService {
 
         PipelineInstanceModels history = pipelineDao.loadHistory(pipelineName, pagination.getPageSize(), pagination.getOffset());
 
-        for (PipelineInstanceModel pipelineInstanceModel : history) {
-            populateMaterialRevisionsOnBuildCause(pipelineInstanceModel);
+        return populatePipelineInstanceModels(username, history);
+    }
 
+    public PipelineInstanceModels loadPipelineHistoryData(Username username, String pipelineName, long afterCursor, long beforeCursor, Integer pageSize) {
+        checkForExistenceAndAccess(username, pipelineName);
+        PipelineInstanceModels history;
+        if (validateCursor(afterCursor, "after")) {
+            history = pipelineDao.loadHistory(pipelineName, FeedModifier.After, afterCursor, pageSize);
+        } else if (validateCursor(beforeCursor, "before")) {
+            history = pipelineDao.loadHistory(pipelineName, FeedModifier.Before, beforeCursor, pageSize);
+        } else {
+            history = pipelineDao.loadHistory(pipelineName, FeedModifier.Latest, 0, pageSize);
+        }
+        return populatePipelineInstanceModels(username, history);
+    }
+
+    private boolean validateCursor(Long cursor, String key) {
+        if (cursor == 0) return false;
+        if (cursor < 0) {
+            throw new BadRequestException(format(BAD_CURSOR_MSG, key));
+        }
+        return true;
+    }
+
+    public List<Long> getOldestAndLatestPipelineId(String pipelineName, Username username) {
+        checkForExistenceAndAccess(username, pipelineName);
+        return pipelineDao.getOldestAndLatestPipelineId(pipelineName);
+    }
+
+    private PipelineInstanceModels populatePipelineInstanceModels(Username username, PipelineInstanceModels history) {
+        for (PipelineInstanceModel pipelineInstanceModel : history) {
             populatePlaceHolderStages(pipelineInstanceModel);
             populateCanRunStatus(username, pipelineInstanceModel);
             populateStageOperatePermission(pipelineInstanceModel, username);
         }
 
         return history;
+    }
+
+    private void checkForExistenceAndAccess(Username username, String pipelineName) {
+        if (!goConfigService.currentCruiseConfig().hasPipelineNamed(new CaseInsensitiveString(pipelineName))) {
+            throw new RecordNotFoundException(EntityType.Pipeline, pipelineName);
+        }
+        if (!securityService.hasViewPermissionForPipeline(username, pipelineName)) {
+            throw new NotAuthorizedException(NOT_AUTHORIZED_TO_VIEW_PIPELINE);
+        }
     }
 
     public PipelineStatusModel getPipelineStatus(String pipelineName, String username, OperationResult result) {
@@ -283,7 +328,7 @@ public class PipelineHistoryService {
 
     public boolean validate(String pipelineName, Username username, OperationResult result) {
         if (!goConfigService.hasPipelineNamed(new CaseInsensitiveString(pipelineName))) {
-            String pipelineNotKnown = String.format("Pipeline named [%s] is not known.", pipelineName);
+            String pipelineNotKnown = format("Pipeline named [%s] is not known.", pipelineName);
             result.notFound(pipelineNotKnown, pipelineNotKnown, HealthStateType.general(HealthStateScope.GLOBAL));
             return false;
         }
@@ -310,7 +355,7 @@ public class PipelineHistoryService {
             pipelineInstanceModel = PipelineInstanceModel.createEmptyPipelineInstanceModel(pipelineName, BuildCause.createWithEmptyModifications(), new StageInstanceModels());
         }
         if (pipelineInstanceModel == null) {
-            String pipelineInstanceNotFound = String.format("Pipeline [%s/%s] not found.", pipelineName, pipelineCounter);
+            String pipelineInstanceNotFound = format("Pipeline [%s/%s] not found.", pipelineName, pipelineCounter);
             result.notFound(pipelineInstanceNotFound, pipelineInstanceNotFound, HealthStateType.general(HealthStateScope.GLOBAL));
             return null;
         }

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
@@ -25,6 +25,7 @@ import com.thoughtworks.go.config.exceptions.NotAuthorizedException;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
 import com.thoughtworks.go.domain.PipelineGroups;
 import com.thoughtworks.go.domain.PipelinePauseInfo;
+import com.thoughtworks.go.domain.PipelineRunIdInfo;
 import com.thoughtworks.go.domain.PipelineTimelineEntry;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.i18n.LocalizedMessage;
@@ -167,7 +168,7 @@ public class PipelineHistoryService {
         return true;
     }
 
-    public List<Long> getOldestAndLatestPipelineId(String pipelineName, Username username) {
+    public PipelineRunIdInfo getOldestAndLatestPipelineId(String pipelineName, Username username) {
         checkForExistenceAndAccess(username, pipelineName);
         return pipelineDao.getOldestAndLatestPipelineId(pipelineName);
     }

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
@@ -227,6 +227,48 @@
         OFFSET #{offset}
     </select>
 
+    <select id="getOldestAndLatestPipelineRun" resultType="java.lang.Long">
+        (SELECT pipelines.id
+         FROM pipelines
+         WHERE pipelines.name = #{pipelineName}
+         ORDER BY pipelines.id DESC
+         LIMIT 1)
+        UNION ALL
+        (SELECT pipelines.id
+         FROM pipelines
+         WHERE pipelines.name = #{pipelineName}
+         ORDER BY pipelines.id ASC
+         LIMIT 1)
+    </select>
+
+    <select id="getPipelineIds" resultType="java.lang.Long">
+        SELECT pipelines.id
+        FROM pipelines
+        WHERE pipelines.name = #{pipelineName}
+        ORDER BY pipelines.id DESC
+        LIMIT #{limit}
+    </select>
+
+    <select id="getPipelineIdsAfter" resultType="java.lang.Long">
+        SELECT pipelines.id
+        FROM pipelines
+        WHERE pipelines.name = #{pipelineName}
+          and pipelines.id &lt; #{cursor}
+        ORDER BY pipelines.id DESC
+        LIMIT #{limit}
+    </select>
+
+    <select id="getPipelineIdsBefore" resultType="java.lang.Long">
+        SELECT id
+        FROM (SELECT pipelines.id as id
+              FROM pipelines
+              WHERE pipelines.name = #{pipelineName}
+                and pipelines.id &gt; #{cursor}
+              ORDER BY pipelines.id ASC
+              LIMIT #{limit})
+        ORDER BY id DESC
+    </select>
+
     <sql id="getPipelineHistory">
         SELECT
         pipelines.id as pipelineId, pipelines.name as pipelineName, buildCauseType, label, buildCauseMessage,

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
@@ -232,12 +232,14 @@
         OFFSET #{offset}
     </select>
 
-    <select id="getOldestAndLatestPipelineRun" resultType="latest-oldest-pipeline-identifiers">
+    <!-- Following query returns the lastest and oldest run id for the given pipeline. This helps in identifying the first and last record for the given pipeline.  -->
+    <select id="getOldestAndLatestPipelineRun" resultMap="latest-oldest-pipeline-identifiers">
         SELECT MAX(pipelines.id) as latestRunId, MIN(pipelines.id) as oldestRunId
         FROM pipelines
         WHERE pipelines.name = #{pipelineName}
     </select>
 
+    <!-- The following query will return the latest #{limit} instances for the given pipeline -->
     <select id="getPipelineIds" resultType="java.lang.Long">
         SELECT pipelines.id
         FROM pipelines
@@ -246,6 +248,7 @@
         LIMIT #{limit}
     </select>
 
+    <!-- The following query will return the #{limit} instances which are older than the given instance id for the given pipeline -->
     <select id="getPipelineIdsAfter" resultType="java.lang.Long">
         SELECT pipelines.id
         FROM pipelines
@@ -255,6 +258,7 @@
         LIMIT #{limit}
     </select>
 
+    <!-- The following query will return the #{limit} instances which are newer than the given instance id for the given pipeline -->
     <select id="getPipelineIdsBefore" resultType="java.lang.Long">
         SELECT id
         FROM (SELECT pipelines.id as id

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
@@ -22,6 +22,11 @@
         <result property="counter" column="pipelineCounter"/>
     </resultMap>
 
+    <resultMap id="latest-oldest-pipeline-identifiers" type="com.thoughtworks.go.domain.PipelineRunIdInfo">
+        <result property="oldestRunId" column="oldestRunId"/>
+        <result property="latestRunId" column="latestRunId"/>
+    </resultMap>
+
     <resultMap id="select-pipeline-pause-info" type="com.thoughtworks.go.domain.PipelinePauseInfo">
         <result property="pauseCause" column="pause_cause"/>
         <result property="pauseBy" column="pause_by"/>
@@ -227,18 +232,10 @@
         OFFSET #{offset}
     </select>
 
-    <select id="getOldestAndLatestPipelineRun" resultType="java.lang.Long">
-        (SELECT pipelines.id
-         FROM pipelines
-         WHERE pipelines.name = #{pipelineName}
-         ORDER BY pipelines.id DESC
-         LIMIT 1)
-        UNION ALL
-        (SELECT pipelines.id
-         FROM pipelines
-         WHERE pipelines.name = #{pipelineName}
-         ORDER BY pipelines.id ASC
-         LIMIT 1)
+    <select id="getOldestAndLatestPipelineRun" resultType="latest-oldest-pipeline-identifiers">
+        SELECT MAX(pipelines.id) as latestRunId, MIN(pipelines.id) as oldestRunId
+        FROM pipelines
+        WHERE pipelines.name = #{pipelineName}
     </select>
 
     <select id="getPipelineIds" resultType="java.lang.Long">

--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -122,6 +122,13 @@
   </rule>
 
   <rule>
+    <name>Pipeline History API</name>
+    <condition name="Accept">application\/vnd\.go\.cd(.v*)*\+json</condition>
+    <from>^/api/pipelines/([^/]+)/history$</from>
+    <to last="true">/spark/api/pipelines/${escape:$1}/history</to>
+  </rule>
+
+  <rule>
     <name>Feature Toggles Index API</name>
     <from>^/api/admin/feature_toggles(/?)$</from>
     <to last="true">/spark/api/admin/feature_toggles</to>

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineHistoryServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineHistoryServiceTest.java
@@ -787,16 +787,16 @@ public class PipelineHistoryServiceTest {
             Username username = new Username(new CaseInsensitiveString("can-access"));
 
             CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
-            List<Long> ids = Arrays.asList(10L, 3L);
 
             when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(true);
             when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
             when(securityService.hasViewPermissionForPipeline(username, pipelineName)).thenReturn(true);
-            when(pipelineDao.getOldestAndLatestPipelineId(pipelineName)).thenReturn(ids);
+            when(pipelineDao.getOldestAndLatestPipelineId(pipelineName)).thenReturn(new PipelineRunIdInfo(10L, 3L));
 
-            List<Long> oldestAndLatestPipelineId = pipelineHistoryService.getOldestAndLatestPipelineId(pipelineName, username);
+            PipelineRunIdInfo oldestAndLatestPipelineId = pipelineHistoryService.getOldestAndLatestPipelineId(pipelineName, username);
 
-            assertThat(oldestAndLatestPipelineId.size()).isEqualTo(2);
+            assertThat(oldestAndLatestPipelineId.getLatestRunId()).isEqualTo(10L);
+            assertThat(oldestAndLatestPipelineId.getOldestRunId()).isEqualTo(3L);
         }
 
         @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineHistoryServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineHistoryServiceTest.java
@@ -16,6 +16,9 @@
 package com.thoughtworks.go.server.service;
 
 import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.exceptions.BadRequestException;
+import com.thoughtworks.go.config.exceptions.NotAuthorizedException;
+import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.helper.ConfigFileFixture;
@@ -24,6 +27,7 @@ import com.thoughtworks.go.helper.PipelineHistoryMother;
 import com.thoughtworks.go.helper.PipelineMaterialModificationMother;
 import com.thoughtworks.go.presentation.PipelineStatusModel;
 import com.thoughtworks.go.presentation.pipelinehistory.*;
+import com.thoughtworks.go.server.dao.FeedModifier;
 import com.thoughtworks.go.server.dao.PipelineDao;
 import com.thoughtworks.go.server.domain.PipelineTimeline;
 import com.thoughtworks.go.server.domain.Username;
@@ -40,8 +44,9 @@ import com.thoughtworks.go.server.util.Pagination;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import java.util.Arrays;
@@ -51,9 +56,8 @@ import java.util.List;
 
 import static com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels.createPipelineInstanceModels;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_IMPLEMENTED;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.any;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -103,7 +107,7 @@ public class PipelineHistoryServiceTest {
     private PipelineHistoryService pipelineHistoryService;
     private PipelineConfig config;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         initMocks(this);
         when(featureToggleService.isToggleOn(Toggles.PIPELINE_COMMENT_FEATURE_TOGGLE_KEY)).thenReturn(true);
@@ -136,12 +140,12 @@ public class PipelineHistoryServiceTest {
 
         PipelineModel loadedPipeline = pipelineHistoryService.latestPipelineModel(username, pipelineName);
 
-        assertThat(loadedPipeline.canForce(), is(false));
-        assertThat(loadedPipeline.canOperate(), is(true));
-        assertThat(loadedPipeline.getLatestPipelineInstance().isLockable(), is(true));
-        assertThat(loadedPipeline.getLatestPipelineInstance().isCurrentlyLocked(), is(true));
-        assertThat(loadedPipeline.getLatestPipelineInstance(), is(pipeline));
-        assertThat(loadedPipeline.canAdminister(), is(true));
+        assertThat(loadedPipeline.canForce()).isFalse();
+        assertThat(loadedPipeline.canOperate()).isTrue();
+        assertThat(loadedPipeline.getLatestPipelineInstance().isLockable()).isTrue();
+        assertThat(loadedPipeline.getLatestPipelineInstance().isCurrentlyLocked()).isTrue();
+        assertThat(loadedPipeline.getLatestPipelineInstance()).isEqualTo(pipeline);
+        assertThat(loadedPipeline.canAdminister()).isTrue();
     }
 
     @Test
@@ -177,14 +181,14 @@ public class PipelineHistoryServiceTest {
         PipelineModel secondPipelineModel = groups.get(0).getPipelineModels().get(1);
         assertPipelineIs(secondPipelineModel, "pipeline2", true, false);
         PipelineInstanceModel secondPim = secondPipelineModel.getLatestPipelineInstance();
-        assertThat(secondPim.getTrackingTool(), is(nullValue()));
-        assertThat(secondPim.isLockable(), is(false));
+        assertThat(secondPim.getTrackingTool()).isNull();
+        assertThat(secondPim.isLockable()).isFalse();
 
         PipelineModel firstPipelineModel = groups.get(0).getPipelineModels().get(0);
         assertPipelineIs(firstPipelineModel, "pipeline1", true, true);
         PipelineInstanceModel pim = firstPipelineModel.getLatestPipelineInstance();
-        assertThat(pim.isLockable(), is(true));
-        assertThat(pim.getTrackingTool(), is(new TrackingTool("http://link", "#")));
+        assertThat(pim.isLockable()).isTrue();
+        assertThat(pim.getTrackingTool()).isEqualTo(new TrackingTool("http://link", "#"));
 
         PipelineModel nonOperatablePipelineModel = groups.get(1).getPipelineModels().get(0);
         assertPipelineIs(nonOperatablePipelineModel, "non-operatable-pipeline", false, false);
@@ -226,18 +230,18 @@ public class PipelineHistoryServiceTest {
 
         PipelineModel pipelineModel1 = group.getPipelineModels().get(0);
         PipelineInstanceModel firstPipelinePIM = pipelineModel1.getActivePipelineInstances().get(0);
-        assertThat(firstPipelinePIM.isLockable(), is(true));
-        assertThat(firstPipelinePIM.isCurrentlyLocked(), is(true));
+        assertThat(firstPipelinePIM.isLockable()).isTrue();
+        assertThat(firstPipelinePIM.isCurrentlyLocked()).isTrue();
 
         PipelineModel pipelineModel2 = group.getPipelineModels().get(1);
         PipelineInstanceModel secondPipeline = pipelineModel2.getActivePipelineInstances().get(0);
-        assertThat(secondPipeline.isLockable(), is(true));
-        assertThat(secondPipeline.isCurrentlyLocked(), is(false));
+        assertThat(secondPipeline.isLockable()).isTrue();
+        assertThat(secondPipeline.isCurrentlyLocked()).isFalse();
 
         PipelineModel pipelineModel3 = group.getPipelineModels().get(2);
         PipelineInstanceModel thirdPipeline = pipelineModel3.getActivePipelineInstances().get(0);
-        assertThat(thirdPipeline.isLockable(), is(false));
-        assertThat(thirdPipeline.isCurrentlyLocked(), is(false));
+        assertThat(thirdPipeline.isLockable()).isFalse();
+        assertThat(thirdPipeline.isCurrentlyLocked()).isFalse();
     }
 
     @Test
@@ -266,9 +270,9 @@ public class PipelineHistoryServiceTest {
 
         List<PipelineGroupModel> groups = pipelineHistoryService.allActivePipelineInstances(jez, PipelineSelections.ALL);
 
-        assertThat(groups.get(0).getPipelineModels().get(0).canAdminister(), is(true));
-        assertThat(groups.get(0).getPipelineModels().get(1).canAdminister(), is(true));
-        assertThat(groups.get(1).getPipelineModels().get(0).canAdminister(), is(false));
+        assertThat(groups.get(0).getPipelineModels().get(0).canAdminister()).isTrue();
+        assertThat(groups.get(0).getPipelineModels().get(1).canAdminister()).isTrue();
+        assertThat(groups.get(1).getPipelineModels().get(0).canAdminister()).isFalse();
 
         verify(goConfigService, times(1)).isUserAdminOfGroup(jez.getUsername(), "defaultGroup");
         verify(goConfigService, times(1)).isUserAdminOfGroup(jez.getUsername(), "foo");
@@ -284,9 +288,9 @@ public class PipelineHistoryServiceTest {
 
         List<PipelineGroupModel> groups = pipelineHistoryService.allActivePipelineInstances(jez, PipelineSelections.ALL);
 
-        assertThat(groups.get(0).getPipelineModels().get(0).canAdminister(), is(false));
-        assertThat(groups.get(0).getPipelineModels().get(1).canAdminister(), is(false));
-        assertThat(groups.get(1).getPipelineModels().get(0).canAdminister(), is(false));
+        assertThat(groups.get(0).getPipelineModels().get(0).canAdminister()).isFalse();
+        assertThat(groups.get(0).getPipelineModels().get(1).canAdminister()).isFalse();
+        assertThat(groups.get(1).getPipelineModels().get(0).canAdminister()).isFalse();
 
         verify(goConfigService, times(1)).isUserAdminOfGroup(jez.getUsername(), "defaultGroup");
         verify(goConfigService, times(1)).isUserAdminOfGroup(jez.getUsername(), "foo");
@@ -320,10 +324,10 @@ public class PipelineHistoryServiceTest {
     }
 
     private void assertPipelineIs(PipelineModel secondPipelineModel, String pipelineName, boolean canOperate, boolean canForce) {
-        assertThat(secondPipelineModel.canOperate(), is(canOperate));
-        assertThat(secondPipelineModel.canForce(), is(canForce));
+        assertThat(secondPipelineModel.canOperate()).isEqualTo(canOperate);
+        assertThat(secondPipelineModel.canForce()).isEqualTo(canForce);
         PipelineInstanceModel secondActivePipeline = secondPipelineModel.getActivePipelineInstances().get(0);
-        assertThat(secondActivePipeline.getName(), is(pipelineName));
+        assertThat(secondActivePipeline.getName()).isEqualTo(pipelineName);
     }
 
     private PipelineInstanceModel activePipeline(String pipelineName, int pipelineCounter, double naturalOrder, StageInstanceModel... moreStages) {
@@ -397,14 +401,14 @@ public class PipelineHistoryServiceTest {
 
         when(goConfigService.hasPipelineNamed(new CaseInsensitiveString(any(String.class)))).thenReturn(true);
         List<PipelineGroupModel> groups = pipelineHistoryService.allActivePipelineInstances(foo, PipelineSelectionsHelper.with(Arrays.asList("pipeline1", "pipeline2")));
-        assertThat(groups.size(), is(2));
-        assertThat(groups.get(0).getName(), is("defaultGroup"));
-        assertThat(groups.get(0).containsPipeline("pipeline1"), is(false));
-        assertThat(groups.get(0).containsPipeline("pipeline2"), is(false));
-        assertThat(groups.get(0).containsPipeline("pipeline3"), is(true));
-        assertThat(groups.get(0).containsPipeline("pipeline4"), is(true));
-        assertThat(groups.get(1).getName(), is("foo"));
-        assertThat(groups.get(1).containsPipeline("non-operatable-pipeline"), is(true));
+        assertThat(groups.size()).isEqualTo(2);
+        assertThat(groups.get(0).getName()).isEqualTo("defaultGroup");
+        assertThat(groups.get(0).containsPipeline("pipeline1")).isFalse();
+        assertThat(groups.get(0).containsPipeline("pipeline2")).isFalse();
+        assertThat(groups.get(0).containsPipeline("pipeline3")).isTrue();
+        assertThat(groups.get(0).containsPipeline("pipeline4")).isTrue();
+        assertThat(groups.get(1).getName()).isEqualTo("foo");
+        assertThat(groups.get(1).containsPipeline("non-operatable-pipeline")).isTrue();
     }
 
     @Test
@@ -417,7 +421,7 @@ public class PipelineHistoryServiceTest {
 
         List<PipelineGroupModel> groups = pipelineHistoryService.allActivePipelineInstances(bar, new PipelineSelections());
 
-        assertThat(groups.isEmpty(), is(true));
+        assertThat(groups.isEmpty()).isTrue();
     }
 
     @Test
@@ -439,9 +443,9 @@ public class PipelineHistoryServiceTest {
 
         when(goConfigService.hasPipelineNamed(new CaseInsensitiveString(any(String.class)))).thenReturn(true);
         List<PipelineGroupModel> groups = pipelineHistoryService.getActivePipelineInstance(foo, "pipeline1");
-        assertThat(groups.size(), is(1));
-        assertThat(groups.get(0).getName(), is("defaultGroup"));
-        assertThat(groups.get(0).containsPipeline("pipeline1"), is(true));
+        assertThat(groups.size()).isEqualTo(1);
+        assertThat(groups.get(0).getName()).isEqualTo("defaultGroup");
+        assertThat(groups.get(0).containsPipeline("pipeline1")).isTrue();
     }
 
     @Test
@@ -452,7 +456,7 @@ public class PipelineHistoryServiceTest {
         when(pipelineDao.loadActivePipelines()).thenReturn(createPipelineInstanceModels());
         when(goConfigService.hasPipelineNamed(new CaseInsensitiveString(any(String.class)))).thenReturn(true);
         List<PipelineGroupModel> groups = pipelineHistoryService.getActivePipelineInstance(foo, "pipeline1");
-        assertThat(groups.isEmpty(), is(true));
+        assertThat(groups.isEmpty()).isTrue();
     }
 
     @Test
@@ -475,12 +479,12 @@ public class PipelineHistoryServiceTest {
 
         when(goConfigService.hasPipelineNamed(new CaseInsensitiveString(any(String.class)))).thenReturn(true);
         List<PipelineGroupModel> groups = pipelineHistoryService.allActivePipelineInstances(foo, PipelineSelectionsHelper.with(Arrays.asList("non-operatable-pipeline")));
-        assertThat(groups.size(), is(1));
-        assertThat(groups.get(0).getName(), is("defaultGroup"));
-        assertThat(groups.get(0).containsPipeline("pipeline1"), is(true));
-        assertThat(groups.get(0).containsPipeline("pipeline2"), is(true));
-        assertThat(groups.get(0).containsPipeline("pipeline3"), is(true));
-        assertThat(groups.get(0).containsPipeline("pipeline4"), is(true));
+        assertThat(groups.size()).isEqualTo(1);
+        assertThat(groups.get(0).getName()).isEqualTo("defaultGroup");
+        assertThat(groups.get(0).containsPipeline("pipeline1")).isTrue();
+        assertThat(groups.get(0).containsPipeline("pipeline2")).isTrue();
+        assertThat(groups.get(0).containsPipeline("pipeline3")).isTrue();
+        assertThat(groups.get(0).containsPipeline("pipeline4")).isTrue();
     }
 
     @Test
@@ -521,10 +525,10 @@ public class PipelineHistoryServiceTest {
     }
 
     private void assertPipelineIs(PipelineInstanceModel pipeline, String pipelineName, String activeStageName, StageResult previousStageResult) {
-        assertThat(pipeline.getName(), is(pipelineName));
+        assertThat(pipeline.getName()).isEqualTo(pipelineName);
         StageInstanceModel activeStage = pipeline.activeStage();
-        assertThat(activeStage.getName(), is(activeStageName));
-        assertThat(activeStage.getPreviousStage().getResult(), is(previousStageResult));
+        assertThat(activeStage.getName()).isEqualTo(activeStageName);
+        assertThat(activeStage.getPreviousStage().getResult()).isEqualTo(previousStageResult);
     }
 
     @Test
@@ -537,7 +541,7 @@ public class PipelineHistoryServiceTest {
 
         PipelineInstanceModel pipelineInstance = pipelineHistoryService.findPipelineInstance("pipeline", 1, 1L, Username.ANONYMOUS, new HttpOperationResult());
         StageInstanceModels models = pipelineInstance.getStageHistory();
-        assertThat(models.size(), is(2));
+        assertThat(models.size()).isEqualTo(2);
     }
 
     @Test
@@ -550,7 +554,7 @@ public class PipelineHistoryServiceTest {
 
         PipelineInstanceModel pipelineInstance = pipelineHistoryService.findPipelineInstance("pipeline", 1, Username.ANONYMOUS, new HttpOperationResult());
         StageInstanceModels models = pipelineInstance.getStageHistory();
-        assertThat(models.size(), is(2));
+        assertThat(models.size()).isEqualTo(2);
     }
 
     @Test
@@ -562,8 +566,8 @@ public class PipelineHistoryServiceTest {
 
         HttpOperationResult operationResult = new HttpOperationResult();
         PipelineInstanceModel pipelineInstance = pipelineHistoryService.findPipelineInstance("pipeline", 1, Username.ANONYMOUS, operationResult);
-        assertThat(pipelineInstance, is(nullValue()));
-        assertThat(operationResult.httpCode(), is(404));
+        assertThat(pipelineInstance).isNull();
+        assertThat(operationResult.httpCode()).isEqualTo(404);
     }
 
     @Test
@@ -581,8 +585,8 @@ public class PipelineHistoryServiceTest {
         when(pipelineUnlockService.canUnlock(eq("pipeline"), eq(Username.ANONYMOUS), any(HttpOperationResult.class))).thenReturn(true);
 
         PipelineInstanceModel pipelineInstance = pipelineHistoryService.findPipelineInstance("pipeline", 1, Username.ANONYMOUS, new HttpOperationResult());
-        assertThat(pipelineInstance.canUnlock(), is(true));
-        assertThat(pipelineInstance.isLockable(), is(true));
+        assertThat(pipelineInstance.canUnlock()).isTrue();
+        assertThat(pipelineInstance.isLockable()).isTrue();
     }
 
     @Test
@@ -607,10 +611,10 @@ public class PipelineHistoryServiceTest {
 
         PipelineInstanceModel pipelineInstance = pipelineHistoryService.findPipelineInstance("pipeline", 1, Username.ANONYMOUS, new HttpOperationResult());
         StageInstanceModels models = pipelineInstance.getStageHistory();
-        assertThat(models.get(0).getCanRun(), is(true));
-        assertThat(models.get(1).getCanRun(), is(false));
-        assertThat(models.get(0).hasOperatePermission(), is(true));
-        assertThat(models.get(1).hasOperatePermission(), is(false));
+        assertThat(models.get(0).getCanRun()).isTrue();
+        assertThat(models.get(1).getCanRun()).isFalse();
+        assertThat(models.get(0).hasOperatePermission()).isTrue();
+        assertThat(models.get(1).hasOperatePermission()).isFalse();
     }
 
     @Test
@@ -632,15 +636,15 @@ public class PipelineHistoryServiceTest {
         ensureHasPermission(Username.ANONYMOUS, "pipeline");
 
         PipelineInstanceModel model = pipelineHistoryService.load(1, Username.ANONYMOUS, new HttpOperationResult());
-        assertThat(model.getPipelineBefore(), is(first));
-        assertThat(model.getPipelineAfter(), is(second));
-        assertThat(model.stage("auto").hasOperatePermission(), is(true));
+        assertThat(model.getPipelineBefore()).isEqualTo(first);
+        assertThat(model.getPipelineAfter()).isEqualTo(second);
+        assertThat(model.stage("auto").hasOperatePermission()).isTrue();
     }
 
     @Test
     public void shouldReturnPageNumberForAPipelineCounter() {
         when(pipelineDao.getPageNumberForCounter("some-pipeline", 100, 10)).thenReturn(1);
-        assertThat(pipelineHistoryService.getPageNumberForCounter("some-pipeline", 100, 10), is(1));
+        assertThat(pipelineHistoryService.getPageNumberForCounter("some-pipeline", 100, 10)).isEqualTo(1);
     }
 
     @Test
@@ -657,11 +661,11 @@ public class PipelineHistoryServiceTest {
 
         PipelineStatusModel pipelineStatus = pipelineHistoryService.getPipelineStatus("pipeline-name", "user-name", new HttpOperationResult());
 
-        assertThat(pipelineStatus.isPaused(), is(true));
-        assertThat(pipelineStatus.pausedCause(), is("pausing pipeline for some-reason"));
-        assertThat(pipelineStatus.pausedBy(), is("some-one"));
-        assertThat(pipelineStatus.isLocked(), is(true));
-        assertThat(pipelineStatus.isSchedulable(), is(true));
+        assertThat(pipelineStatus.isPaused()).isTrue();
+        assertThat(pipelineStatus.pausedCause()).isEqualTo("pausing pipeline for some-reason");
+        assertThat(pipelineStatus.pausedBy()).isEqualTo("some-one");
+        assertThat(pipelineStatus.isLocked()).isTrue();
+        assertThat(pipelineStatus.isSchedulable()).isTrue();
     }
 
     @Test
@@ -673,8 +677,8 @@ public class PipelineHistoryServiceTest {
         HttpOperationResult result = new HttpOperationResult();
         PipelineStatusModel pipelineStatus = pipelineHistoryService.getPipelineStatus("pipeline-name", "user-name", result);
 
-        assertThat(pipelineStatus, is(nullValue()));
-        assertThat(result.httpCode(), is(404));
+        assertThat(pipelineStatus).isNull();
+        assertThat(result.httpCode()).isEqualTo(404);
     }
 
     @Test
@@ -688,8 +692,8 @@ public class PipelineHistoryServiceTest {
         HttpOperationResult result = new HttpOperationResult();
         PipelineStatusModel pipelineStatus = pipelineHistoryService.getPipelineStatus("pipeline-name", "user-name", result);
 
-        assertThat(pipelineStatus, is(nullValue()));
-        assertThat(result.httpCode(), is(403));
+        assertThat(pipelineStatus).isNull();
+        assertThat(result.httpCode()).isEqualTo(403);
     }
 
     @Test
@@ -703,9 +707,9 @@ public class PipelineHistoryServiceTest {
         PipelineInstanceModels pipelineInstanceModels = pipelineHistoryService.loadMinimalData(pipelineName,
                 Pagination.pageFor(0, 0, 10), new Username(new CaseInsensitiveString("looser")), result);
 
-        assertThat(pipelineInstanceModels, is(nullValue()));
-        assertThat(result.httpCode(), is(404));
-        assertThat(result.detailedMessage(), is("Not Found { Pipeline " + pipelineName + " not found }\n"));
+        assertThat(pipelineInstanceModels).isNull();
+        assertThat(result.httpCode()).isEqualTo(404);
+        assertThat(result.detailedMessage()).isEqualTo("Not Found { Pipeline " + pipelineName + " not found }\n");
     }
 
     @Test
@@ -725,14 +729,14 @@ public class PipelineHistoryServiceTest {
         HttpOperationResult result = new HttpOperationResult();
         PipelineInstanceModels pipelineInstanceModels = pipelineHistoryService.loadMinimalData(pipelineName, Pagination.pageFor(0, 1, 10), noAccessUserName, result);
 
-        assertThat(pipelineInstanceModels, is(nullValue()));
-        assertThat(result.httpCode(), is(403));
+        assertThat(pipelineInstanceModels).isNull();
+        assertThat(result.httpCode()).isEqualTo(403);
 
         result = new HttpOperationResult();
         pipelineInstanceModels = pipelineHistoryService.loadMinimalData(pipelineName, Pagination.pageFor(0, 1, 10), withAccessUserName, result);
 
-        assertThat(pipelineInstanceModels, is(not(nullValue())));
-        assertThat(result.canContinue(), is(true));
+        assertThat(pipelineInstanceModels).isNotNull();
+        assertThat(result.canContinue()).isTrue();
     }
 
     @Test
@@ -770,9 +774,177 @@ public class PipelineHistoryServiceTest {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         pipelineHistoryService.updateComment(pipelineName, 1, "test comment", new Username(unauthorizedUser), result);
 
-        assertThat(result.httpCode(), is(SC_NOT_IMPLEMENTED));
-        assertThat(result.message(), is("'Pipeline Comment' feature is turned off. Please turn it on to use it."));
+        assertThat(result.httpCode()).isEqualTo(SC_NOT_IMPLEMENTED);
+        assertThat(result.message()).isEqualTo("'Pipeline Comment' feature is turned off. Please turn it on to use it.");
         verify(pipelineDao, never()).updateComment(pipelineName, 1, "test comment");
+    }
+
+    @Nested
+    class GetLatestAndOldestPipelineRunId {
+        @Test
+        void shouldReturnTheLatestAndOldestPipelineRunId() {
+            String pipelineName = "pipeline";
+            Username username = new Username(new CaseInsensitiveString("can-access"));
+
+            CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+            List<Long> ids = Arrays.asList(10L, 3L);
+
+            when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(true);
+            when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+            when(securityService.hasViewPermissionForPipeline(username, pipelineName)).thenReturn(true);
+            when(pipelineDao.getOldestAndLatestPipelineId(pipelineName)).thenReturn(ids);
+
+            List<Long> oldestAndLatestPipelineId = pipelineHistoryService.getOldestAndLatestPipelineId(pipelineName, username);
+
+            assertThat(oldestAndLatestPipelineId.size()).isEqualTo(2);
+        }
+
+        @Test
+        void shouldThrowIfPipelineDoesNotExist() {
+            String pipelineName = "pipeline";
+            Username username = new Username(new CaseInsensitiveString("can-access"));
+            CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+
+            when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+            when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(false);
+
+            assertThatCode(() -> pipelineHistoryService.getOldestAndLatestPipelineId(pipelineName, username))
+                    .isInstanceOf(RecordNotFoundException.class)
+                    .hasMessage("Pipeline with name 'pipeline' was not found!");
+        }
+
+        @Test
+        void shouldThrowIfTheUserDoesNotHaveAccess() {
+            String pipelineName = "pipeline";
+            Username username = new Username(new CaseInsensitiveString("cannot-access"));
+            CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+
+            when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+            when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(true);
+            when(securityService.hasViewPermissionForPipeline(username, pipelineName)).thenReturn(false);
+
+            assertThatCode(() -> pipelineHistoryService.getOldestAndLatestPipelineId(pipelineName, username))
+                    .isInstanceOf(NotAuthorizedException.class)
+                    .hasMessage("Not authorized to view pipeline");
+        }
+    }
+
+    @Nested
+    class LoadPipelineHistoryData {
+        @Test
+        void shouldCallDaoToFetchLatestPipelineHistoryData() {
+            String pipelineName = "pipeline";
+            Username username = new Username(new CaseInsensitiveString("can-access"));
+            CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+
+            when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(true);
+            when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+            when(securityService.hasViewPermissionForPipeline(username, pipelineName)).thenReturn(true);
+            when(pipelineDao.loadHistory(eq(pipelineName), any(), anyLong(), anyInt())).thenReturn(PipelineInstanceModels.createPipelineInstanceModels());
+
+            PipelineInstanceModels pipelineInstanceModels = pipelineHistoryService.loadPipelineHistoryData(username, pipelineName, 0, 0, 10);
+
+            verify(pipelineDao).loadHistory(pipelineName, FeedModifier.Latest, 0, 10);
+        }
+
+        @Test
+        void shouldCallDaoToFetchPipelineHistoryDataAfterTheGivenCursor() {
+            String pipelineName = "pipeline";
+            Username username = new Username(new CaseInsensitiveString("can-access"));
+            CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+
+            when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(true);
+            when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+            when(securityService.hasViewPermissionForPipeline(username, pipelineName)).thenReturn(true);
+            when(pipelineDao.loadHistory(eq(pipelineName), any(), anyLong(), anyInt())).thenReturn(PipelineInstanceModels.createPipelineInstanceModels());
+
+            PipelineInstanceModels pipelineInstanceModels = pipelineHistoryService.loadPipelineHistoryData(username, pipelineName, 3, 0, 10);
+
+            verify(pipelineDao).loadHistory(pipelineName, FeedModifier.After, 3L, 10);
+        }
+
+        @Test
+        void shouldCallDaoToFetchPipelineHistoryDataBeforeTheGivenCursor() {
+            String pipelineName = "pipeline";
+            Username username = new Username(new CaseInsensitiveString("can-access"));
+            CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+
+            when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(true);
+            when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+            when(securityService.hasViewPermissionForPipeline(username, pipelineName)).thenReturn(true);
+            when(pipelineDao.loadHistory(eq(pipelineName), any(), anyLong(), anyInt())).thenReturn(PipelineInstanceModels.createPipelineInstanceModels());
+
+            PipelineInstanceModels pipelineInstanceModels = pipelineHistoryService.loadPipelineHistoryData(username, pipelineName, 0, 6, 10);
+
+            verify(pipelineDao).loadHistory(pipelineName, FeedModifier.Before, 6L, 10);
+        }
+
+        @Test
+        void shouldThrowUpIfThePipelineDoesNotExist() {
+            String pipelineName = "pipeline";
+            Username username = new Username(new CaseInsensitiveString("can-access"));
+            CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+
+            when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(false);
+            when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+
+            assertThatCode(() -> pipelineHistoryService.loadPipelineHistoryData(username, pipelineName, 0, 0, 10))
+                    .isInstanceOf(RecordNotFoundException.class)
+                    .hasMessage("Pipeline with name 'pipeline' was not found!");
+
+            verifyZeroInteractions(pipelineDao);
+        }
+
+        @Test
+        void shouldThrowUpIfTheUserDoesNotHaveAccessToThePipeline() {
+            String pipelineName = "pipeline";
+            Username username = new Username(new CaseInsensitiveString("can-access"));
+            CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+
+            when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(true);
+            when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+            when(securityService.hasViewPermissionForPipeline(username, pipelineName)).thenReturn(false);
+
+            assertThatCode(() -> pipelineHistoryService.loadPipelineHistoryData(username, pipelineName, 0, 0, 10))
+                    .isInstanceOf(NotAuthorizedException.class)
+                    .hasMessage("Not authorized to view pipeline");
+
+            verifyZeroInteractions(pipelineDao);
+        }
+
+        @Test
+        void shouldThrowIfTheAfterCursorIsInvalid() {
+            String pipelineName = "pipeline";
+            Username username = new Username(new CaseInsensitiveString("can-access"));
+            CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+
+            when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(true);
+            when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+            when(securityService.hasViewPermissionForPipeline(username, pipelineName)).thenReturn(true);
+
+            assertThatCode(() -> pipelineHistoryService.loadPipelineHistoryData(username, pipelineName, -10L, 0, 10))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("The query parameter `after`, if specified, must be positive integer.");
+
+            verifyZeroInteractions(pipelineDao);
+        }
+
+        @Test
+        void shouldThrowIfTheBeforeCursorIsInvalid() {
+            String pipelineName = "pipeline";
+            Username username = new Username(new CaseInsensitiveString("can-access"));
+            CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+
+            when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(true);
+            when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+            when(securityService.hasViewPermissionForPipeline(username, pipelineName)).thenReturn(true);
+
+            assertThatCode(() -> pipelineHistoryService.loadPipelineHistoryData(username, pipelineName, 0, -10L, 10))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("The query parameter `before`, if specified, must be positive integer.");
+
+            verifyZeroInteractions(pipelineDao);
+        }
     }
 
     private void stubConfigServiceToReturnPipeline(String blahPipelineName, PipelineConfig blahPipelineConfig) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoIntegrationTest.java
@@ -1658,10 +1658,10 @@ public class PipelineSqlMapDaoIntegrationTest {
         dbHelper.pass(p2_1);
         Pipeline p3_1 = dbHelper.schedulePipeline(p1.config, new TestingClock(new Date()));
         dbHelper.pass(p3_1);
-        List<Long> oldestAndLatestPipelineId = pipelineDao.getOldestAndLatestPipelineId(pipelineName);
+        PipelineRunIdInfo oldestAndLatestPipelineId = pipelineDao.getOldestAndLatestPipelineId(pipelineName);
 
-        assertThat(oldestAndLatestPipelineId.get(0), is(p3_1.getId()));
-        assertThat(oldestAndLatestPipelineId.get(1), is(p1_1.getId()));
+        assertThat(oldestAndLatestPipelineId.getLatestRunId(), is(p3_1.getId()));
+        assertThat(oldestAndLatestPipelineId.getOldestRunId(), is(p1_1.getId()));
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineHistoryServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineHistoryServiceIntegrationTest.java
@@ -935,11 +935,10 @@ public class PipelineHistoryServiceIntegrationTest {
         Pipeline pipeline2 = pipelineTwo.createdPipelineWithAllStagesPassed();
         Pipeline pipeline3 = pipelineTwo.createdPipelineWithAllStagesPassed();
 
-        List<Long> oldestAndLatestPipelineId = pipelineHistoryService.getOldestAndLatestPipelineId(pipelineTwo.pipelineName, new Username(new CaseInsensitiveString("admin1")));
+        PipelineRunIdInfo oldestAndLatestPipelineId = pipelineHistoryService.getOldestAndLatestPipelineId(pipelineTwo.pipelineName, new Username(new CaseInsensitiveString("admin1")));
 
-        assertThat(oldestAndLatestPipelineId.size(), is(2));
-        assertThat(oldestAndLatestPipelineId.get(0), is(pipeline3.getId()));
-        assertThat(oldestAndLatestPipelineId.get(1), is(pipeline1.getId()));
+        assertThat(oldestAndLatestPipelineId.getLatestRunId(), is(pipeline3.getId()));
+        assertThat(oldestAndLatestPipelineId.getOldestRunId(), is(pipeline1.getId()));
     }
 
     @Test

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/api/base/JsonOutputWriter.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/api/base/JsonOutputWriter.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.internal.bind.util.ISO8601Utils;
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.spark.RequestContext;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +32,8 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.function.Consumer;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class JsonOutputWriter {
     private static final Logger log = LoggerFactory.getLogger(JsonOutputWriter.class);
@@ -180,7 +181,7 @@ public class JsonOutputWriter {
         @Override
         public JsonOutputWriterUsingJackson addWithDefaultIfBlank(String key, String value, String defaultValue) {
             return withExceptionHandling((jacksonWriter) -> {
-                if (StringUtils.isNotBlank(value)) {
+                if (isNotBlank(value)) {
                     add(key, value);
                 } else {
                     add(key, defaultValue);
@@ -399,6 +400,14 @@ public class JsonOutputWriter {
 
             JsonOutputLinkWriter(OutputWriter parentWriter) {
                 this.parentWriter = parentWriter;
+            }
+
+            @Override
+            public OutputLinkWriter addLinkIfPresent(String key, String href) {
+                if (isNotBlank(href)) {
+                    addAbsoluteLink(key, requestContext.build(key, href).getHref());
+                }
+                return this;
             }
 
             @Override

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/api/base/OutputLinkWriter.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/api/base/OutputLinkWriter.java
@@ -20,4 +20,5 @@ public interface OutputLinkWriter {
 
     OutputLinkWriter addAbsoluteLink(String key, String href);
 
+    OutputLinkWriter addLinkIfPresent(String key, String href);
 }

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -266,7 +266,6 @@ public class Routes {
         public static final String TRIGGER_OPTIONS_PATH = "/:pipeline_name/trigger_options";
 
         public static final String SCHEDULE_PATH = "/:pipeline_name/schedule";
-        public static final String INSTANCE_PATH = "/:pipeline_name/instance/:pipeline_counter";
 
         public static String triggerOptions(String pipelineName) {
             return BASE + TRIGGER_OPTIONS_PATH.replaceAll(":pipeline_name", pipelineName);
@@ -287,12 +286,6 @@ public class Routes {
         public static String unlock(String pipelineName) {
             return BASE + UNLOCK_PATH.replaceAll(":pipeline_name", pipelineName);
         }
-
-        public static String instance(String pipelineName, int pipelineCounter) {
-            return BASE + INSTANCE_PATH
-                    .replaceAll(":pipeline_name", pipelineName)
-                    .replaceAll(":pipeline_counter", String.valueOf(pipelineCounter));
-        }
     }
 
     public static class PipelineInstance {
@@ -302,7 +295,15 @@ public class Routes {
         }
 
         public static final String BASE = "/api/pipelines";
+        public static final String INSTANCE_PATH = "/:pipeline_name/instance/:pipeline_counter";
         public static final String HISTORY_PATH = "/:pipeline_name/history";
+
+
+        public static String instance(String pipelineName, int pipelineCounter) {
+            return BASE + INSTANCE_PATH
+                    .replaceAll(":pipeline_name", pipelineName)
+                    .replaceAll(":pipeline_counter", String.valueOf(pipelineCounter));
+        }
 
         public static String history(String pipelineName) {
             return BASE + HISTORY_PATH.replaceAll(":pipeline_name", pipelineName);

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -266,12 +266,7 @@ public class Routes {
         public static final String TRIGGER_OPTIONS_PATH = "/:pipeline_name/trigger_options";
 
         public static final String SCHEDULE_PATH = "/:pipeline_name/schedule";
-        public static final String HISTORY_PATH = "/:pipeline_name/history";
         public static final String INSTANCE_PATH = "/:pipeline_name/instance/:pipeline_counter";
-
-        public static String history(String pipelineName) {
-            return BASE + HISTORY_PATH.replaceAll(":pipeline_name", pipelineName);
-        }
 
         public static String triggerOptions(String pipelineName) {
             return BASE + TRIGGER_OPTIONS_PATH.replaceAll(":pipeline_name", pipelineName);
@@ -304,6 +299,21 @@ public class Routes {
         public static String vsm(String pipelineName, int pipelineCounter) {
             return StrSubstitutor.replace("/pipelines/value_stream_map/${pipeline_name}/${pipeline_counter}",
                     of("pipeline_name", pipelineName, "pipeline_counter", pipelineCounter));
+        }
+
+        public static final String BASE = "/api/pipelines";
+        public static final String HISTORY_PATH = "/:pipeline_name/history";
+
+        public static String history(String pipelineName) {
+            return BASE + HISTORY_PATH.replaceAll(":pipeline_name", pipelineName);
+        }
+
+        public static String previous(String pipelineName, long before) {
+            return BASE + HISTORY_PATH.replaceAll(":pipeline_name", pipelineName) + "?before=" + before;
+        }
+
+        public static String next(String pipelineName, long after) {
+            return BASE + HISTORY_PATH.replaceAll(":pipeline_name", pipelineName) + "?after=" + after;
         }
     }
 


### PR DESCRIPTION
Issue: #3326, #1353 

Description:
<del>Introduce versioned pipeline history api with support for providing page size and offset.
Format: 
`/api/pipelines/:pipeline_name/history?page_size=10&offset=1` </del>
<del> - Default value for `page_size: 10` and `offset:0`</del>
<del> - The end user can provide any value between 10 and 100 for page_size</del>

The current pipeline instance history uses offset-based pagination which has certain limitations. 
This PR introduces version V1 of the same using cursor-based pagination.
Format:
`/api/pipelines/:pipeline_name/history`

Query params supported:
 - `page_size`: the end user can specify the number of records they wish to see in a single page. Should be between 10 and 100
 - `after`: the cursor value for fetching the next set of records
 - `before`: the cursor value for fetching the previous set of records


## TODO
 - [x] Remove `id` from Get Pipeline Instance API (#7376)