### PR TITLE
Removed `bind` on arrow functions.

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/access_tokens.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/access_tokens.tsx
@@ -67,7 +67,7 @@ export class AccessTokensPage extends Page<null, State> {
   headerPanel(vnode: m.Vnode<null, State>): any {
     return <HeaderPanel title={this.pageName()} buttons={
       <Buttons.Primary disabled={!vnode.state.meta.supportsAccessToken}
-                       onclick={vnode.state.onAdd.bind(vnode.state)}
+                       onclick={vnode.state.onAdd}
                        data-test-id="generate-token-button">
         Generate Token
       </Buttons.Primary>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines.tsx
@@ -345,7 +345,7 @@ export class AdminPipelinesPage extends Page<null, State> {
   protected headerPanel(vnode: m.Vnode<null, State>): any {
     const headerButtons = [
       <Buttons.Primary icon={ButtonIcon.ADD}
-                       onclick={vnode.state.createPipelineGroup.bind(vnode.state)}
+                       onclick={vnode.state.createPipelineGroup}
                        data-test-id="create-new-pipeline-group">Create new pipeline group</Buttons.Primary>
     ];
     return <HeaderPanel title={this.pageName()} buttons={headerButtons}/>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/artifact_stores.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/artifact_stores.tsx
@@ -107,7 +107,7 @@ export class ArtifactStoresPage extends Page<null, State> {
   headerPanel(vnode: m.Vnode<null, State>): any {
     const disabled      = !vnode.state.pluginInfos || vnode.state.pluginInfos().length === 0;
     const headerButtons = [
-      <Buttons.Primary onclick={vnode.state.onAdd.bind(vnode.state)}
+      <Buttons.Primary onclick={vnode.state.onAdd}
                        data-test-id="add-artifact-stores-button"
                        disabled={disabled}>Add</Buttons.Primary>
     ];

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs.tsx
@@ -91,9 +91,9 @@ export class AuthConfigsPage extends Page<null, State> {
       <FlashMessage type={this.flashMessage.type} message={this.flashMessage.message}/>
       <AuthConfigsWidget authConfigs={vnode.state.authConfigs}
                          pluginInfos={vnode.state.pluginInfos}
-                         onEdit={vnode.state.onEdit.bind(vnode.state)}
-                         onClone={vnode.state.onClone.bind(vnode.state)}
-                         onDelete={vnode.state.onDelete.bind(vnode.state)}/>
+                         onEdit={vnode.state.onEdit}
+                         onClone={vnode.state.onClone}
+                         onDelete={vnode.state.onDelete}/>
     </div>;
   }
 
@@ -104,7 +104,7 @@ export class AuthConfigsPage extends Page<null, State> {
   headerPanel(vnode: m.Vnode<null, State>): any {
     const disabled      = !vnode.state.pluginInfos || vnode.state.pluginInfos().length === 0;
     const headerButtons = [
-      <Buttons.Primary onclick={vnode.state.onAdd.bind(vnode.state)}
+      <Buttons.Primary onclick={vnode.state.onAdd}
                        data-test-id="add-auth-config-button"
                        disabled={disabled}>Add</Buttons.Primary>
     ];

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs/auth_configs_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs/auth_configs_widget.tsx
@@ -65,12 +65,12 @@ export class AuthConfigsWidget extends MithrilViewComponent<Attrs> {
           <IconGroup>
             <Edit data-test-id="auth-config-edit"
                   disabled={!pluginInfo}
-                  onclick={vnode.attrs.onEdit.bind(vnode.attrs, authConfig)}/>
+                  onclick={(e) => vnode.attrs.onEdit(authConfig, e)}/>
             <Clone data-test-id="auth-config-clone"
                    disabled={!pluginInfo}
-                   onclick={vnode.attrs.onClone.bind(vnode.attrs, authConfig)}/>
+                   onclick={(e) => vnode.attrs.onClone(authConfig, e)}/>
             <Delete data-test-id="auth-config-delete"
-                    onclick={vnode.attrs.onDelete.bind(vnode.attrs, authConfig)}/>
+                    onclick={(e) => vnode.attrs.onDelete(authConfig, e)}/>
           </IconGroup>];
         return <CollapsiblePanel header={header} actions={actionButtons}>
           <KeyValuePair data={authConfig.properties()!.asMap()}/>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos.tsx
@@ -102,7 +102,7 @@ export class ConfigReposPage extends Page<null, State> {
         <SearchField property={vnode.state.searchText} dataTestId={"search-box"}
                      placeholder="Search Config Repo"/>
       </div>,
-      <Buttons.Primary onclick={vnode.state.onAdd.bind(vnode.state)}>Add</Buttons.Primary>
+      <Buttons.Primary onclick={vnode.state.onAdd}>Add</Buttons.Primary>
     ];
     return <HeaderPanel title="Config Repositories" buttons={headerButtons}/>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations.tsx
@@ -223,7 +223,7 @@ export class ElasticProfilesPage extends Page<null, State> {
                              pluginInfos={vnode.state.pluginInfos}
                              elasticAgentOperations={vnode.state.elasticAgentOperations}
                              clusterProfileOperations={vnode.state.clusterProfileOperations}
-                             onShowUsages={vnode.state.onShowUsages.bind(vnode.state)}
+                             onShowUsages={vnode.state.onShowUsages}
                              isUserAnAdmin={ElasticProfilesPage.isUserAnAdmin()}/>
     </div>;
   }
@@ -232,7 +232,7 @@ export class ElasticProfilesPage extends Page<null, State> {
     const headerButtons = [];
     const hasPlugins    = vnode.state.pluginInfos() && vnode.state.pluginInfos().length > 0;
     headerButtons.push(<Buttons.Primary disabled={!hasPlugins}
-                                        onclick={vnode.state.clusterProfileOperations.onAdd.bind(vnode.state)}>
+                                        onclick={vnode.state.clusterProfileOperations.onAdd}>
       <span title={!hasPlugins ? "Install some elastic agent plugins to add a cluster profile." : undefined}>Add Cluster Profile</span>
     </Buttons.Primary>);
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/cluster_profile_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/cluster_profile_widget.tsx
@@ -90,7 +90,7 @@ export class ClusterProfileWidget extends MithrilComponent<ClusterProfileWidgetA
       <ElasticProfilesWidget elasticProfiles={new ElasticAgentProfiles(filteredElasticAgentProfiles)}
                              pluginInfo={pluginInfo}
                              elasticAgentOperations={vnode.attrs.elasticAgentOperations}
-                             onShowUsages={vnode.attrs.onShowUsages.bind(vnode.attrs)}
+                             onShowUsages={vnode.attrs.onShowUsages}
                              isUserAnAdmin={vnode.attrs.isUserAnAdmin}/>
     </CollapsiblePanel>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/elastic_profiles_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/elastic_profiles_widget.tsx
@@ -69,8 +69,7 @@ export class ElasticProfilesWidget extends MithrilComponent<Attrs & PluginInfoAt
                                                           onDelete={vnode.attrs.elasticAgentOperations.onDelete.bind(
                                                             vnode.attrs,
                                                             profile.id()!)}
-                                                          onShowUsage={vnode.attrs.onShowUsages.bind(vnode.attrs,
-                                                                                                     profile.id()!)}
+                                                          onShowUsage={vnode.attrs.onShowUsages}
                                     />
               );
             })
@@ -91,7 +90,7 @@ export interface ProfileAttrs {
   onEdit: (e: MouseEvent) => void;
   onClone: (e: MouseEvent) => void;
   onDelete: (e: MouseEvent) => void;
-  onShowUsage: (e: MouseEvent) => void;
+  onShowUsage: (id: string, e: MouseEvent) => void;
 }
 
 export class ElasticProfileWidget extends MithrilComponent<ProfileAttrs> {
@@ -110,7 +109,8 @@ export class ElasticProfileWidget extends MithrilComponent<ProfileAttrs> {
         <Icons.Clone data-test-id="clone-elastic-profile" onclick={vnode.attrs.onClone}
                      disabled={!vnode.attrs.pluginInfo}/>
         <Icons.Delete data-test-id="delete-elastic-profile" onclick={vnode.attrs.onDelete}/>
-        <Icons.Usage data-test-id="show-usage-elastic-profile" onclick={vnode.attrs.onShowUsage}/>
+        <Icons.Usage data-test-id="show-usage-elastic-profile"
+                     onclick={(e) => vnode.attrs.onShowUsage(vnode.attrs.elasticProfile.id()!, e)}/>
       </IconGroup>
     ];
     return (

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments.tsx
@@ -89,7 +89,7 @@ export class NewEnvironmentsPage extends Page<null, State> {
       <EnvironmentsWidget environments={this.environments}
                           agents={this.agents}
                           onSuccessfulSave={vnode.state.onSuccessfulSave}
-                          onDelete={vnode.state.onDelete.bind(vnode.state)}/>
+                          onDelete={vnode.state.onDelete}/>
     ];
   }
 
@@ -112,7 +112,7 @@ export class NewEnvironmentsPage extends Page<null, State> {
 
   headerPanel(vnode: m.Vnode<null, State>): any {
     const headerButtons = [];
-    headerButtons.push(<Primary onclick={vnode.state.onAdd.bind(vnode.state)}>Add
+    headerButtons.push(<Primary onclick={vnode.state.onAdd}>Add
       Environment</Primary>);
     return <HeaderPanel title="Environments" buttons={headerButtons}/>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
@@ -40,7 +40,7 @@ export class EnvironmentsWidget extends MithrilViewComponent<Attrs> {
                                warning={isEnvEmpty}
                                actions={[
                                  <Icons.Delete iconOnly={true}
-                                               onclick={vnode.attrs.onDelete.bind(vnode.attrs, environment)}/>
+                                               onclick={(e) => vnode.attrs.onDelete(environment, e)}/>
                                ]}
                                dataTestId={`collapsible-panel-for-env-${environment.name()}`}>
         <EnvironmentBody environment={environment}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_agent.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_agent.tsx
@@ -91,12 +91,12 @@ export class NewAgentPage extends Page<null, State> {
   componentToDisplay(vnode: m.Vnode<null, State>): m.Children {
     return <AgentsWidget staticAgentsVM={vnode.state.staticAgentsVM}
                          elasticAgentsVM={vnode.state.elasticAgentsVM}
-                         onEnable={vnode.state.onEnable.bind(vnode.state)}
-                         onDisable={vnode.state.onDisable.bind(vnode.state)}
-                         onDelete={vnode.state.onDelete.bind(vnode.state)}
+                         onEnable={vnode.state.onEnable}
+                         onDisable={vnode.state.onDisable}
+                         onDelete={vnode.state.onDelete}
                          flashMessage={this.flashMessage}
-                         updateEnvironments={vnode.state.updateEnvironments.bind(vnode.state)}
-                         updateResources={vnode.state.updateResources.bind(vnode.state)}
+                         updateEnvironments={vnode.state.updateEnvironments}
+                         updateResources={vnode.state.updateResources}
                          showAnalyticsIcon={this.showAnalyticsIcon()}
                          pluginInfos={vnode.state.pluginInfos}
                          isUserAdmin={Page.isUserAnAdmin()}/>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_agents/agents_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_agents/agents_widget.tsx
@@ -45,7 +45,7 @@ export class AgentsWidget extends MithrilViewComponent<AgentsWidgetAttrs> {
                           onDisable={vnode.attrs.onDisable}
                           onDelete={vnode.attrs.onDelete}
                           flashMessage={vnode.attrs.flashMessage}
-                          updateEnvironments={vnode.attrs.updateEnvironments.bind(vnode.attrs)}
+                          updateEnvironments={vnode.attrs.updateEnvironments}
                           updateResources={vnode.attrs.updateResources}
                           showAnalyticsIcon={vnode.attrs.showAnalyticsIcon}
                           pluginInfos={vnode.attrs.pluginInfos}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles.tsx
@@ -121,7 +121,7 @@ export class RolesPage extends Page<null, State> {
 
   headerPanel(vnode: m.Vnode<null, State>) {
     const headerButtons = [(<Buttons.Primary data-test-id="role-add-button"
-                                             onclick={vnode.state.onAdd.bind(vnode.state)}>Add</Buttons.Primary>)];
+                                             onclick={vnode.state.onAdd}>Add</Buttons.Primary>)];
 
     return <HeaderPanel title={this.pageName()} buttons={headerButtons}/>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/roles_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/roles_widget.tsx
@@ -129,11 +129,11 @@ abstract class RoleWidget extends MithrilViewComponent<RoleAttrs | PluginRoleAtt
     const actionButtons = [
       <IconGroup>
         <Edit data-test-id="role-edit" disabled={isDisabled}
-              onclick={vnode.attrs.onEdit.bind(vnode.attrs, vnode.attrs.role)}/>
+              onclick={(e) => vnode.attrs.onEdit(vnode.attrs.role, e)}/>
         <Clone data-test-id="role-clone" disabled={isDisabled}
-               onclick={vnode.attrs.onClone.bind(vnode.attrs, vnode.attrs.role)}/>
+               onclick={(e) => vnode.attrs.onClone(vnode.attrs.role, e)}/>
         <Delete data-test-id="role-delete"
-                onclick={vnode.attrs.onDelete.bind(vnode.attrs, vnode.attrs.role)}/>
+                onclick={(e) => vnode.attrs.onDelete(vnode.attrs.role, e)}/>
       </IconGroup>];
 
     return (<CollapsiblePanel header={header} actions={actionButtons}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/secret_configs.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/secret_configs.tsx
@@ -165,6 +165,6 @@ export class SecretConfigsPage extends Page<null, State> {
     return <HeaderPanel title={this.pageName()}
                         buttons={<Buttons.Primary data-test-id="add-secret-config"
                                                   disabled={disabled}
-                                                  onclick={vnode.state.onAdd.bind(this)}>Add</Buttons.Primary>}/>;
+                                                  onclick={vnode.state.onAdd}>Add</Buttons.Primary>}/>;
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/users.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/users.tsx
@@ -183,7 +183,7 @@ export class UsersPage extends Page<null, State> {
 
   headerPanel(vnode: m.Vnode<null, State>) {
     const headerButtons = [];
-    headerButtons.push(<Buttons.Primary onclick={vnode.state.onAdd.bind(vnode.state)}>Import User</Buttons.Primary>);
+    headerButtons.push(<Buttons.Primary onclick={vnode.state.onAdd}>Import User</Buttons.Primary>);
 
     return <div>
       <HeaderPanel title="Users Management" buttons={headerButtons}/>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/users/user_actions_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/users/user_actions_widget.tsx
@@ -176,13 +176,13 @@ class RolesDropdown extends Dropdown<RolesViewAttrs> {
         </div>
         <Form compactForm={true}>
           <QuickAddField property={vnode.attrs.roleNameToAdd} placeholder="Add role"
-                         onclick={vnode.attrs.onRolesAdd.bind(this, vnode.attrs.roleNameToAdd(), vnode.attrs.users())}
+                         onclick={() => vnode.attrs.onRolesAdd(vnode.attrs.roleNameToAdd(), vnode.attrs.users())}
                          buttonDisableReason={"Please type the role name to add."}
           />
         </Form>
-        <Primary onclick={vnode.attrs.onRolesUpdate.bind(this,
-                                                         vnode.attrs.rolesSelection(),
-                                                         vnode.attrs.users())}>Apply</Primary>
+        <Primary onclick={() => vnode.attrs.onRolesUpdate(vnode.attrs.rolesSelection(), vnode.attrs.users())}>
+          Apply
+        </Primary>
       </div>
     );
   }
@@ -221,11 +221,11 @@ export class UsersActionsWidget extends MithrilViewComponent<State> {
       <div class={classnames(styles.userActionsAndCounts)}>
         <div class={classnames(styles.userActions)}>
           <ButtonGroup>
-            <Secondary onclick={vnode.attrs.onEnable.bind(vnode.attrs, vnode.attrs.users())}
+            <Secondary onclick={(e) => vnode.attrs.onEnable(vnode.attrs.users(), e)}
                        disabled={!vnode.attrs.users().anyUserSelected()}>Enable</Secondary>
-            <Secondary onclick={vnode.attrs.onDisable.bind(vnode.attrs, vnode.attrs.users())}
+            <Secondary onclick={(e) => vnode.attrs.onDisable(vnode.attrs.users(), e)}
                        disabled={!vnode.attrs.users().anyUserSelected()}>Disable</Secondary>
-            <Secondary onclick={vnode.attrs.onDelete.bind(vnode.attrs, vnode.attrs.users())}
+            <Secondary onclick={(e) => vnode.attrs.onDelete(vnode.attrs.users(), e)}
                        disabled={!vnode.attrs.users().anyUserSelected()}>Delete</Secondary>
             <RolesDropdown {...vnode.attrs} show={vnode.attrs.showRoles}/>
           </ButtonGroup>


### PR DESCRIPTION
Description:

Context cannot be passed to arrow functions.
`this` always represents the context in which the arrow function is defined.
So binding arrow function does not make any sense.

In reference with https://github.com/gocd/gocd/pull/7115#discussion_r344556165