### PR TITLE
Fixes: new environments SPA

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/environment_variables/spec/types_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/environment_variables/spec/types_spec.ts
@@ -74,7 +74,7 @@ describe("Environment Variables Model", () => {
 
 describe("Environment Variable Model", () => {
   describe("Validations", () => {
-    it("should validate presence of name", () => {
+    it("should validate presence of name if both value and encrypted value are present", () => {
       const envVar = EnvironmentVariable.fromJSON(plainTextEnvVar1);
 
       expect(envVar.isValid()).toBe(true);
@@ -85,28 +85,10 @@ describe("Environment Variable Model", () => {
       expect(envVar.errors().errors("name")).toContain("Name must be present");
     });
 
-    it("should validate presence of either value or encryptedValue", () => {
-      const envVar = EnvironmentVariable.fromJSON(plainTextEnvVar1);
-
+    it("should not validate presence of name if value is empty", () => {
+      const envVar = new EnvironmentVariable("");
       expect(envVar.isValid()).toBe(true);
-
-      envVar.value("");
-
-      expect(envVar.isValid()).toBe(false);
-      expect(envVar.errors().keys()).toEqual(["value"]);
-      const errMsg = "Either 'Value' or 'Encrypted value' must be present. Both 'Value' and 'Encrypted value' cannot be defined at the same time.";
-      expect(envVar.errors().errors("value")).toContain(errMsg);
-    });
-
-    it("should validate mutual exclusivity of value and encryptedValue", () => {
-      const envVar = EnvironmentVariable.fromJSON(plainTextEnvVar1);
-      expect(envVar.isValid()).toBe(true);
-
-      envVar.encryptedValue("some-encrypted-value");
-      expect(envVar.isValid()).toBe(false);
-      expect(envVar.errors().keys()).toEqual(["value"]);
-      const errMsg = "Either 'Value' or 'Encrypted value' must be present. Both 'Value' and 'Encrypted value' cannot be defined at the same time.";
-      expect(envVar.errors().errors("value")).toContain(errMsg);
+      expect(envVar.errors().hasErrors()).toBe(false);
     });
   });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/environment_variables/types.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/environment_variables/types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import _ from "lodash";
 import Stream from "mithril/stream";
 import {applyMixins} from "models/mixins/mixins";
 import {ValidatableMixin} from "models/mixins/new_validatable_mixin";
@@ -38,10 +39,7 @@ export class EnvironmentVariable extends ValidatableMixin {
     this.value          = Stream(value);
     this.encryptedValue = Stream(encryptedValue);
     ValidatableMixin.call(this);
-    this.validatePresenceOf("name");
-    this.validateMutualExclusivityOf("value",
-                                     "encryptedValue",
-                                     {message: "Either 'Value' or 'Encrypted value' must be present. Both 'Value' and 'Encrypted value' cannot be defined at the same time."});
+    this.validatePresenceOf("name", {condition: () => !_.isEmpty(this.value()) || !_.isEmpty(this.encryptedValue())});
   }
 
   static fromJSON(data: EnvironmentVariableJSON) {
@@ -93,12 +91,6 @@ export class EnvironmentVariables<T extends EnvironmentVariable = EnvironmentVar
 
   remove(envVar: T) {
     this.splice(this.indexOf(envVar), 1);
-  }
-
-  isValid() {
-    let valid = true;
-    this.forEach((environment) => valid = valid && environment.isValid());
-    return valid;
   }
 
   toJSON() {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/spec/environments_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/spec/environments_spec.ts
@@ -18,7 +18,8 @@ import {PipelineWithOrigin} from "models/internal_pipeline_structure/pipeline_st
 import {AgentWithOrigin} from "models/new-environments/environment_agents";
 import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
 import data from "models/new-environments/spec/test_data";
-import {OriginType} from "models/origin";
+import {Origin, OriginType} from "models/origin";
+import {EnvironmentVariableWithOrigin} from "../environment_environment_variables";
 
 const envJSON          = data.environment_json();
 const environmentsJSON = {
@@ -222,5 +223,21 @@ describe("Environment Model - Environment", () => {
     };
 
     expect(env.toJSON()).toEqual(expectedJSON);
+  });
+
+  it('should not give uniqueness error for environment variables if environment variable name is blank', () => {
+    const env = EnvironmentWithOrigin.fromJSON(envJSON);
+    env.environmentVariables().push(new EnvironmentVariableWithOrigin("", new Origin(OriginType.GoCD)));
+    env.environmentVariables().push(new EnvironmentVariableWithOrigin("", new Origin(OriginType.GoCD)));
+    expect(env.isValid()).toBe(true);
+  });
+
+  it('should give error for environment variables with same name', () => {
+    const env = EnvironmentWithOrigin.fromJSON(envJSON);
+    env.environmentVariables().push(new EnvironmentVariableWithOrigin("foo", new Origin(OriginType.GoCD)));
+    env.environmentVariables().push(new EnvironmentVariableWithOrigin("foo", new Origin(OriginType.GoCD)));
+    expect(env.isValid()).toBe(false);
+    expect(env.environmentVariables()[4].errors().errors("name")).toEqual(["Name is a duplicate"]);
+    expect(env.environmentVariables()[5].errors().errors("name")).toEqual(["Name is a duplicate"]);
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/new_environments.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/new_environments.tsx
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
-import {SinglePageAppBase} from "helpers/spa_base";
+import {RoutedSinglePageApp} from "helpers/spa_base";
 import {NewEnvironmentsPage} from "views/pages/new-environments";
 
-export class NewEnvironmentsSPA extends SinglePageAppBase {
+export class NewEnvironmentsSPA extends RoutedSinglePageApp {
   constructor() {
-    super(NewEnvironmentsPage);
+    super({
+            "/": NewEnvironmentsPage,
+            "/:name": NewEnvironmentsPage
+          });
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/delete_confirm_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/delete_confirm_modal.tsx
@@ -15,16 +15,17 @@
  */
 import m from "mithril";
 import * as Buttons from "views/components/buttons";
+import {ButtonIcon} from "views/components/buttons";
 import {Modal, Size} from "views/components/modal";
+import {OperationState} from "../../pages/page_operations";
 
 export class DeleteConfirmModal extends Modal {
   private readonly message: m.Children;
   private readonly modalTitle: string;
-  private ondelete: () => any;
+  private readonly ondelete: () => Promise<any>;
+  private operationState: OperationState | undefined;
 
-  constructor(message: m.Children,
-              ondelete: () => any,
-              title = "Are you sure?") {
+  constructor(message: m.Children, ondelete: () => Promise<any>, title = "Are you sure?") {
     super(Size.small);
     this.message    = message;
     this.modalTitle = title;
@@ -41,8 +42,17 @@ export class DeleteConfirmModal extends Modal {
 
   buttons(): m.ChildArray {
     return [
-      <Buttons.Danger data-test-id='button-delete' onclick={this.ondelete.bind(this)}>Yes Delete</Buttons.Danger>,
-      <Buttons.Cancel data-test-id='button-no-delete' onclick={this.close.bind(this)}>No</Buttons.Cancel>
+      <Buttons.Danger data-test-id='button-delete'
+                      disabled={this.operationState === OperationState.IN_PROGRESS}
+                      icon={this.operationState === OperationState.IN_PROGRESS ? ButtonIcon.SPINNER : undefined}
+                      onclick={() => {
+                        this.operationState = OperationState.IN_PROGRESS;
+                        const a = this.ondelete();
+                        a.finally(() => this.operationState = OperationState.DONE);
+                      }}>Yes Delete</Buttons.Danger>,
+      <Buttons.Cancel disabled={this.operationState === OperationState.IN_PROGRESS}
+                      data-test-id='button-no-delete' onclick={this.close.bind(this)}
+      >No</Buttons.Cancel>
     ];
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/spec/delete_confirm_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/spec/delete_confirm_modal_spec.tsx
@@ -17,11 +17,11 @@
 import _ from "lodash";
 import m from "mithril";
 import * as simulateEvent from "simulate-event";
+import style from "views/components/buttons/index.scss";
 import {DeleteConfirmModal} from "views/components/modal/delete_confirm_modal";
 import {ModalManager} from "views/components/modal/modal_manager";
 import "views/components/modal/spec/modal_matchers";
-import style from "../../../components/buttons/index.scss";
-import {TestHelper} from "../../../pages/spec/test_helper";
+import {TestHelper} from "views/pages/spec/test_helper";
 
 describe("DeleteConfirmModal", () => {
   let modal: DeleteConfirmModal;
@@ -31,7 +31,6 @@ describe("DeleteConfirmModal", () => {
   beforeEach(() => {
     spy        = jasmine.createSpy("delete callback").and.returnValue(new Promise(_.noop));
     modal      = new DeleteConfirmModal("You will no longer be able to time travel!", spy, "Delete flux capacitor?");
-    testHelper = new TestHelper();
     modal.render();
     m.redraw.sync();
     testHelper = new TestHelper().forModal();
@@ -62,14 +61,6 @@ describe("DeleteConfirmModal", () => {
     m.redraw.sync();
     // @ts-ignore
     expect(document.querySelector(".component-modal-container").children.length).toBe(0);
-  });
-
-  it("should send callback on clicking delete button", () => {
-    expect(spy).not.toHaveBeenCalled();
-
-    testHelper.clickByTestId('button-delete');
-
-    expect(spy).toHaveBeenCalled();
   });
 
   it('should disable the No and Yes delete button when operation state is in progress', () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines.tsx
@@ -157,18 +157,18 @@ export class AdminPipelinesPage extends Page<null, State> {
     vnode.state.doDeleteGroup = (group) => {
       const message = <span>Are you sure you want to delete the pipeline group <em>{group.name()}</em>?</span>;
 
-      const modal = new DeleteConfirmModal(message, () => {
-        ApiRequestBuilder.DELETE(SparkRoutes.pipelineGroupsPath(group.name()), ApiVersion.latest)
-                         .then((result) => {
-                           result.do(
-                             () => vnode.state.onSuccessfulSave(
-                               <span>The pipeline group <em>{group.name()}</em> was deleted successfully!</span>
-                             ),
-                             onOperationError
-                           );
+      const modal: DeleteConfirmModal = new DeleteConfirmModal(message, () => {
+        return ApiRequestBuilder.DELETE(SparkRoutes.pipelineGroupsPath(group.name()), ApiVersion.latest)
+                                .then((result) => {
+                                  result.do(
+                                    () => vnode.state.onSuccessfulSave(
+                                      <span>The pipeline group <em>{group.name()}</em> was deleted successfully!</span>
+                                    ),
+                                    onOperationError
+                                  );
 
-                         })
-                         .finally(modal.close.bind(modal));
+                                })
+                                .finally(modal.close.bind(modal));
       });
       modal.render();
 
@@ -177,18 +177,18 @@ export class AdminPipelinesPage extends Page<null, State> {
     vnode.state.doDeletePipeline = (pipeline) => {
       const message = <span>Are you sure you want to delete the pipeline <em>{pipeline.name()}</em>?</span>;
 
-      const modal = new DeleteConfirmModal(message, () => {
-        ApiRequestBuilder.DELETE(SparkRoutes.adminPipelineConfigPath(pipeline.name()), ApiVersion.latest)
-                         .then((result) => {
-                           result.do(
-                             () => vnode.state.onSuccessfulSave(
-                               <span>The pipeline group <em>{pipeline.name()}</em> was deleted successfully!</span>
-                             ),
-                             onOperationError
-                           );
+      const modal: DeleteConfirmModal = new DeleteConfirmModal(message, () => {
+        return ApiRequestBuilder.DELETE(SparkRoutes.adminPipelineConfigPath(pipeline.name()), ApiVersion.latest)
+                                .then((result) => {
+                                  result.do(
+                                    () => vnode.state.onSuccessfulSave(
+                                      <span>The pipeline group <em>{pipeline.name()}</em> was deleted successfully!</span>
+                                    ),
+                                    onOperationError
+                                  );
 
-                         })
-                         .finally(modal.close.bind(modal));
+                                })
+                                .finally(modal.close.bind(modal));
       });
 
       modal.render();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_templates.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_templates.tsx
@@ -117,23 +117,24 @@ export class AdminTemplatesPage extends Page<null, State> {
     };
 
     vnode.state.onDelete = (template, e) => {
-      const message = <span>Are you sure you want to delete the template <em>{template.name}</em>?</span>;
-      const modal   = new DeleteConfirmModal(message, () => {
-        ApiRequestBuilder.DELETE(SparkRoutes.templatesPath(template.name), ApiVersion.latest)
-                         .then((apiResponse) => {
-                                 apiResponse.do(
-                                   (successResponse) => {
-                                     vnode.state.onSuccessfulSave(
-                                       <span>The template <em>{template.name}</em> was deleted successfully!</span>
-                                     );
-                                   },
-                                   (errorResponse) => {
-                                     onOperationError(errorResponse);
-                                   }
-                                 );
-                               }
-                         )
-                         .finally(modal.close.bind(modal));
+      const message                   =
+              <span>Are you sure you want to delete the template <em>{template.name}</em>?</span>;
+      const modal: DeleteConfirmModal = new DeleteConfirmModal(message, () => {
+        return ApiRequestBuilder.DELETE(SparkRoutes.templatesPath(template.name), ApiVersion.latest)
+                                .then((apiResponse) => {
+                                        apiResponse.do(
+                                          (successResponse) => {
+                                            vnode.state.onSuccessfulSave(
+                                              <span>The template <em>{template.name}</em> was deleted successfully!</span>
+                                            );
+                                          },
+                                          (errorResponse) => {
+                                            onOperationError(errorResponse);
+                                          }
+                                        );
+                                      }
+                                )
+                                .finally(modal.close.bind(modal));
       });
       modal.render();
     };

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repo_view_model.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repo_view_model.ts
@@ -117,9 +117,9 @@ export class ConfigRepoVM {
       e.stopPropagation();
       page.flash.clear();
 
-      const message = ["Are you sure you want to delete the config repository ", m("strong", this.repo.id()), "?"];
-      const modal   = new DeleteConfirmModal(message, () => {
-        ConfigReposCRUD.delete(this.repo).then((resp) => {
+      const message                   = ["Are you sure you want to delete the config repository ", m("strong", this.repo.id()), "?"];
+      const modal: DeleteConfirmModal = new DeleteConfirmModal(message, () => {
+        return ConfigReposCRUD.delete(this.repo).then((resp) => {
           resp.do(
             (resp) => page.onSuccessfulSave(resp.body.message),
             (err) => page.onError(err.message));

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations.tsx
@@ -101,19 +101,19 @@ export class ElasticProfilesPage extends Page<null, State> {
         </span>
         );
 
-        const modal = new DeleteConfirmModal(
+        const modal: DeleteConfirmModal = new DeleteConfirmModal(
           deleteConfirmMsg,
           () => {
-            ElasticAgentProfilesCRUD.delete(id)
-                                    .then((result) => {
-                                      result.do(
-                                        () => vnode.state.onSuccessfulSave(
-                                          <span>The elastic agent profile <em>{id}</em> was deleted successfully!</span>
-                                        ),
-                                        onOperationError
-                                      );
-                                    })
-                                    .finally(modal.close.bind(modal));
+            return ElasticAgentProfilesCRUD.delete(id)
+                                           .then((result) => {
+                                             result.do(
+                                               () => vnode.state.onSuccessfulSave(
+                                                 <span>The elastic agent profile <em>{id}</em> was deleted successfully!</span>
+                                               ),
+                                               onOperationError
+                                             );
+                                           })
+                                           .finally(modal.close.bind(modal));
           });
         modal.render();
       },
@@ -149,19 +149,19 @@ export class ElasticProfilesPage extends Page<null, State> {
         </span>
         );
 
-        const modal = new DeleteConfirmModal(
+        const modal: DeleteConfirmModal = new DeleteConfirmModal(
           deleteConfirmMsg,
           () => {
-            ClusterProfilesCRUD.delete(clusterProfileId)
-                               .then((result) => {
-                                 result.do(
-                                   () => vnode.state.onSuccessfulSave(
-                                     <span>The cluster profile <em>{clusterProfileId}</em> was deleted successfully!</span>
-                                   ),
-                                   onOperationError
-                                 );
-                               })
-                               .finally(modal.close.bind(modal));
+            return ClusterProfilesCRUD.delete(clusterProfileId)
+                                      .then((result) => {
+                                        result.do(
+                                          () => vnode.state.onSuccessfulSave(
+                                            <span>The cluster profile <em>{clusterProfileId}</em> was deleted successfully!</span>
+                                          ),
+                                          onOperationError
+                                        );
+                                      })
+                                      .finally(modal.close.bind(modal));
           });
         modal.render();
       },

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments.tsx
@@ -117,7 +117,7 @@ export class NewEnvironmentsPage extends Page<null, State> {
 
   headerPanel(vnode: m.Vnode<null, State>): any {
     const headerButtons = [];
-    headerButtons.push(<Primary onclick={vnode.state.onAdd}>Add
+    headerButtons.push(<Primary dataTestId="add-environment-button" onclick={vnode.state.onAdd}>Add
       Environment</Primary>);
     return <HeaderPanel title="Environments" buttons={headerButtons}/>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments.tsx
@@ -21,14 +21,17 @@ import {Agents} from "models/agents/agents";
 import {AgentsCRUD} from "models/agents/agents_crud";
 import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
 import {EnvironmentsAPIs} from "models/new-environments/environments_apis";
+import {AnchorVM, ScrollManager} from "views/components/anchor/anchor";
 import {Primary} from "views/components/buttons";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {HeaderPanel} from "views/components/header_panel";
+import {DeleteConfirmModal} from "views/components/modal/delete_confirm_modal";
 import {CreateEnvModal} from "views/pages/new-environments/create_env_modal";
 import {EnvironmentsWidget} from "views/pages/new-environments/environments_widget";
 import {Page, PageState} from "views/pages/page";
 import {AddOperation, DeleteOperation, SaveOperation} from "views/pages/page_operations";
-import {DeleteConfirmModal} from "../components/modal/delete_confirm_modal";
+
+const sm: ScrollManager = new AnchorVM();
 
 interface State extends AddOperation<EnvironmentWithOrigin>, SaveOperation, DeleteOperation<EnvironmentWithOrigin> {
 }
@@ -81,6 +84,7 @@ export class NewEnvironmentsPage extends Page<null, State> {
   }
 
   componentToDisplay(vnode: m.Vnode<null, State>): m.Children {
+    this.parseEnvironmentLink(sm);
     const flashMessage = this.flashMessage.hasMessage() ?
       <FlashMessage type={this.flashMessage.type} message={this.flashMessage.message}/>
       : null;
@@ -89,7 +93,8 @@ export class NewEnvironmentsPage extends Page<null, State> {
       <EnvironmentsWidget environments={this.environments}
                           agents={this.agents}
                           onSuccessfulSave={vnode.state.onSuccessfulSave}
-                          onDelete={vnode.state.onDelete.bind(vnode.state)}/>
+                          onDelete={vnode.state.onDelete.bind(vnode.state)}
+                          sm={sm}/>
     ];
   }
 
@@ -115,5 +120,9 @@ export class NewEnvironmentsPage extends Page<null, State> {
     headerButtons.push(<Primary onclick={vnode.state.onAdd}>Add
       Environment</Primary>);
     return <HeaderPanel title="Environments" buttons={headerButtons}/>;
+  }
+
+  private parseEnvironmentLink(sm: ScrollManager) {
+    sm.setTarget(m.route.param().name || "");
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments.tsx
@@ -59,22 +59,22 @@ export class NewEnvironmentsPage extends Page<null, State> {
       e.stopPropagation();
       this.flashMessage.clear();
 
-      const message = <span>Are you sure you want to delete environment <em>{env.name()}</em>?</span>;
-      const modal   = new DeleteConfirmModal(message, () => {
+      const message                   = <span>Are you sure you want to delete environment <em>{env.name()}</em>?</span>;
+      const modal: DeleteConfirmModal = new DeleteConfirmModal(message, () => {
         const self = this;
-        env.delete()
-           .then((result: ApiResult<any>) => {
-             result.do(
-               () => {
-                 self.flashMessage.setMessage(MessageType.success,
-                                              `The environment '${env.name()}' was deleted successfully!`);
-               }, (errorResponse: ErrorResponse) => {
-                 self.flashMessage.setMessage(MessageType.alert, JSON.parse(errorResponse.body!).message);
-               }
-             );
-             //@ts-ignore
-           }).then(self.fetchData.bind(self))
-           .finally(modal.close.bind(modal));
+        return env.delete()
+                  .then((result: ApiResult<any>) => {
+                    result.do(
+                      () => {
+                        self.flashMessage.setMessage(MessageType.success,
+                                                     `The environment '${env.name()}' was deleted successfully!`);
+                      }, (errorResponse: ErrorResponse) => {
+                        self.flashMessage.setMessage(MessageType.alert, JSON.parse(errorResponse.body!).message);
+                      }
+                    );
+                    //@ts-ignore
+                  }).then(self.fetchData.bind(self))
+                  .finally(modal.close.bind(modal));
       });
       modal.render();
     };

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments.tsx
@@ -59,7 +59,7 @@ export class NewEnvironmentsPage extends Page<null, State> {
       e.stopPropagation();
       this.flashMessage.clear();
 
-      const message = ["Are you sure you want to delete environment ", m("strong", env.name()), "?"];
+      const message = <span>Are you sure you want to delete environment <em>{env.name()}</em>?</span>;
       const modal   = new DeleteConfirmModal(message, () => {
         const self = this;
         env.delete()

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/create_env_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/create_env_modal.tsx
@@ -25,7 +25,7 @@ import {ButtonGroup, Cancel, Primary} from "views/components/buttons";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {Form} from "views/components/forms/form";
 import {TextField} from "views/components/forms/input_fields";
-import {Modal} from "views/components/modal";
+import {Modal, ModalState} from "views/components/modal";
 import styles from "views/pages/new-environments/index.scss";
 
 export class CreateEnvModal extends Modal {
@@ -68,8 +68,8 @@ export class CreateEnvModal extends Modal {
 
   buttons() {
     return [<ButtonGroup>
-      <Cancel data-test-id="button-cancel" onclick={() => this.close()}>Cancel</Cancel>
-      <Primary data-test-id="button-save" onclick={this.validateAndPerformSave.bind(this)}>Save</Primary>
+      <Cancel data-test-id="button-cancel" onclick={() => this.close()} disabled={this.isLoading()}>Cancel</Cancel>
+      <Primary data-test-id="button-save" onclick={this.validateAndPerformSave.bind(this)} disabled={this.isLoading()}>Save</Primary>
     </ButtonGroup>];
   }
 
@@ -77,8 +77,10 @@ export class CreateEnvModal extends Modal {
     if (!this.environment.isValid()) {
       return;
     }
+    this.modalState = ModalState.LOADING;
     EnvironmentsAPIs.create(this.environment)
                     .then((result) => {
+                      this.modalState = ModalState.OK;
                       result.do(
                         (successResponse: SuccessResponse<ObjectWithEtag<EnvironmentWithOrigin>>) => {
                           this.onSuccessfulSave(<span>Environment <em>{this.environment.name()}</em> created successfully. Now pipelines, agents and environment variables can be added to the same.</span>);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_agents_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_agents_modal.tsx
@@ -24,7 +24,7 @@ import s from "underscore.string";
 import {Cancel, Primary} from "views/components/buttons";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {CheckboxField, SearchField} from "views/components/forms/input_fields";
-import {Modal, Size} from "views/components/modal";
+import {Modal, ModalState, Size} from "views/components/modal";
 import styles from "views/pages/new-environments/edit_pipelines.scss";
 import {AgentsViewModel} from "views/pages/new-environments/models/agents_view_model";
 
@@ -144,16 +144,21 @@ export class EditAgentsModal extends Modal {
   }
 
   buttons(): m.ChildArray {
-    return [<Primary data-test-id="save-button" onclick={this.performSave.bind(this)}>Save</Primary>,
-      <Cancel data-test-id="cancel-button" onclick={this.close.bind(this)}>Cancel</Cancel>];
+    return [
+      <Primary data-test-id="save-button" onclick={this.performSave.bind(this)}
+               disabled={this.isLoading()}>Save</Primary>,
+      <Cancel data-test-id="cancel-button" onclick={this.close.bind(this)} disabled={this.isLoading()}>Cancel</Cancel>
+    ];
   }
 
   performSave() {
     const environment = this.agentsVM.environment;
     if (environment.isValid()) {
       const agentUuids = environment.agents().map((agent) => agent.uuid());
+      this.modalState  = ModalState.LOADING;
       EnvironmentsAPIs.updateAgentAssociation(environment.name(), agentUuids)
                       .then((result) => {
+                        this.modalState = ModalState.OK;
                         result.do((successResponse) => {
                           this.onSuccessfulSave(<span>Environment <em>{environment.name()}</em> was updated successfully!</span>);
                           this.close();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_agents_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_agents_modal.tsx
@@ -127,18 +127,24 @@ export class EditAgentsModal extends Modal {
       return;
     }
 
-    const noAgentsMsg: m.Child = <FlashMessage type={MessageType.info}
-                                               message={`No agents matching search text '${this.agentsVM.searchText()}' found!`}/>;
+    let noAgentsMsg: m.Child;
+    if (this.agentsVM.agents().length === 0) {
+      noAgentsMsg = <FlashMessage type={MessageType.info}
+                                  message={'There are no agents available!'}/>;
+    } else if (this.agentsVM.filteredAgents().length === 0) {
+      noAgentsMsg = <FlashMessage type={MessageType.info}
+                                  message={`No agents matching search text '${this.agentsVM.searchText()}' found!`}/>;
+    }
 
     return <div>
       <AgentFilterWidget agentsVM={this.agentsVM}/>
       <FlashMessage type={MessageType.alert} message={this.errorMessage()}/>
-      {this.agentsVM.filteredAgents().length === 0 ? noAgentsMsg : this.agentsHtml()}
+      {noAgentsMsg ? noAgentsMsg : this.agentsHtml()}
     </div>;
   }
 
   buttons(): m.ChildArray {
-    return [<Primary data-test-id="button-ok" onclick={this.performSave.bind(this)}>Save</Primary>,
+    return [<Primary data-test-id="save-button" onclick={this.performSave.bind(this)}>Save</Primary>,
       <Cancel data-test-id="cancel-button" onclick={this.close.bind(this)}>Cancel</Cancel>];
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_environment_variables_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_environment_variables_modal.tsx
@@ -22,7 +22,7 @@ import {EnvironmentsAPIs} from "models/new-environments/environments_apis";
 import {Cancel, Primary} from "views/components/buttons";
 import {EnvironmentVariablesWidget} from "views/components/environment_variables";
 import {FlashMessage, MessageType} from "views/components/flash_message";
-import {Modal, Size} from "views/components/modal";
+import {Modal, ModalState, Size} from "views/components/modal";
 
 export class EditEnvironmentVariablesModal extends Modal {
   private _environment: EnvironmentWithOrigin;
@@ -55,8 +55,10 @@ export class EditEnvironmentVariablesModal extends Modal {
   }
 
   buttons(): m.ChildArray {
-    return [<Primary data-test-id="save-button" onclick={this.performSave.bind(this)}>Save</Primary>,
-            <Cancel data-test-id="cancel-button" onclick={this.close.bind(this)}>Cancel</Cancel>
+    return [
+      <Primary data-test-id="save-button" onclick={this.performSave.bind(this)}
+               disabled={this.isLoading()}>Save</Primary>,
+      <Cancel data-test-id="cancel-button" onclick={this.close.bind(this)} disabled={this.isLoading()}>Cancel</Cancel>
     ];
   }
 
@@ -64,12 +66,14 @@ export class EditEnvironmentVariablesModal extends Modal {
     if (this.environmentToUpdate.isValid()) {
       const envToAdd    = this.environmentVariablesToAdd().map((envVar) => envVar.toJSON());
       const envToRemove = this.environmentVariablesToRemove().map((envVar) => envVar.name());
+      this.modalState   = ModalState.LOADING;
       EnvironmentsAPIs.patch(this.environmentToUpdate.name(), {
         environment_variables: {
           add: envToAdd,
           remove: envToRemove
         }
       }).then((result) => {
+        this.modalState = ModalState.OK;
         result.do(
           () => {
             this.onSuccessfulSave("Environment variables updated successfully");

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_environment_variables_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_environment_variables_modal.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import _ from "lodash";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {EnvironmentWithOrigin} from "models/new-environments/environments";
@@ -54,7 +55,7 @@ export class EditEnvironmentVariablesModal extends Modal {
   }
 
   buttons(): m.ChildArray {
-    return [<Primary data-test-id="button-ok" onclick={this.performSave.bind(this)}>Save</Primary>,
+    return [<Primary data-test-id="save-button" onclick={this.performSave.bind(this)}>Save</Primary>,
             <Cancel data-test-id="cancel-button" onclick={this.close.bind(this)}>Cancel</Cancel>
     ];
   }
@@ -86,6 +87,11 @@ export class EditEnvironmentVariablesModal extends Modal {
 
   environmentVariablesToAdd() {
     return this.environmentToUpdate.environmentVariables().filter((envVar) => {
+      const isBlankEnvVar = _.isEmpty(envVar.name()) && (_.isEmpty(envVar.value()) && _.isEmpty(envVar.encryptedValue()));
+      if (isBlankEnvVar) {
+        return false;
+      }
+
       const oldEnvVar = this._environment.environmentVariables().find((v) => v.name() === envVar.name());
       // add new and updated variables
       return oldEnvVar === undefined || !oldEnvVar.equals(envVar);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_pipelines_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_pipelines_modal.tsx
@@ -26,6 +26,7 @@ import {CheckboxField, HelpText, SearchField} from "views/components/forms/input
 import {Modal, ModalState, Size} from "views/components/modal";
 import {PipelinesViewModel} from "views/pages/new-environments/models/pipelines_view_model";
 import styles from "./edit_pipelines.scss";
+import _ from "lodash";
 
 interface SelectAllNoneWidgetAttrs {
   pipelinesVM: PipelinesViewModel;
@@ -172,18 +173,24 @@ export class EditPipelinesModal extends Modal {
   }
 
   body(): m.Children {
-    const noPipelinesMsg = <FlashMessage type={MessageType.info}
-                                         message={`No pipelines matching search text '${this.pipelinesVM.searchText()}' found!`}/>;
+    let noPipelinesMsg;
+
+    if (this.pipelinesVM.allPipelines().length === 0) {
+      noPipelinesMsg = <FlashMessage type={MessageType.info} message={'There are no pipelines available!'}/>;
+    } else if (this.pipelinesVM.filteredPipelines().length === 0) {
+      noPipelinesMsg = <FlashMessage type={MessageType.info}
+                                     message={`No pipelines matching search text '${this.pipelinesVM.searchText()}' found!`}/>;
+    }
 
     return <div>
       <FlashMessage type={MessageType.alert} message={this.pipelinesVM.errorMessage()}/>
       <PipelineFilterWidget pipelinesVM={this.pipelinesVM}/>
-      {this.pipelinesVM.filteredPipelines().length === 0 ? noPipelinesMsg : this.pipelinesHtml()}
+      {noPipelinesMsg ? noPipelinesMsg : this.pipelinesHtml()}
     </div>;
   }
 
   buttons(): m.ChildArray {
-    return [<Primary data-test-id="button-ok" onclick={this.performSave.bind(this)}>Save</Primary>,
+    return [<Primary data-test-id="save-button" onclick={this.performSave.bind(this)}>Save</Primary>,
       <Cancel data-test-id="cancel-button" onclick={this.close.bind(this)}>Cancel</Cancel>
     ];
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_pipelines_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_pipelines_modal.tsx
@@ -189,8 +189,10 @@ export class EditPipelinesModal extends Modal {
   }
 
   buttons(): m.ChildArray {
-    return [<Primary data-test-id="save-button" onclick={this.performSave.bind(this)}>Save</Primary>,
-      <Cancel data-test-id="cancel-button" onclick={this.close.bind(this)}>Cancel</Cancel>
+    return [
+      <Primary data-test-id="save-button" onclick={this.performSave.bind(this)}
+               disabled={this.isLoading()}>Save</Primary>,
+      <Cancel data-test-id="cancel-button" onclick={this.close.bind(this)} disabled={this.isLoading()}>Cancel</Cancel>
     ];
   }
 
@@ -198,12 +200,14 @@ export class EditPipelinesModal extends Modal {
     if (this.pipelinesVM.environment.isValid()) {
       const pipelinesToAdd    = this.pipelinesToAdd().map((pipeline) => pipeline.name());
       const pipelinesToRemove = this.pipelinesToRemove().map((pipeline) => pipeline.name());
+      this.modalState         = ModalState.LOADING;
       EnvironmentsAPIs.patch(this.originalEnv.name(), {
         pipelines: {
           add: pipelinesToAdd,
           remove: pipelinesToRemove
         }
       }).then((result) => {
+        this.modalState = ModalState.OK;
         result.do(
           () => {
             this.onSuccessfulSave("Pipelines updated successfully for env " + this.originalEnv.name());

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_pipelines_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_pipelines_modal.tsx
@@ -26,7 +26,6 @@ import {CheckboxField, HelpText, SearchField} from "views/components/forms/input
 import {Modal, ModalState, Size} from "views/components/modal";
 import {PipelinesViewModel} from "views/pages/new-environments/models/pipelines_view_model";
 import styles from "./edit_pipelines.scss";
-import _ from "lodash";
 
 interface SelectAllNoneWidgetAttrs {
   pipelinesVM: PipelinesViewModel;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
@@ -22,9 +22,9 @@ import {Agents} from "models/agents/agents";
 import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
 import {CollapsiblePanel} from "views/components/collapsible_panel";
 import * as Icons from "views/components/icons/index";
-import {IconGroup} from "../../components/icons";
 import {EnvironmentBody} from "views/pages/new-environments/environment_body_widget";
 import {EnvironmentHeader} from "views/pages/new-environments/environment_header_widget";
+import {IconGroup} from "../../components/icons";
 import {DeleteOperation} from "../page_operations";
 
 interface Attrs extends DeleteOperation<EnvironmentWithOrigin> {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
@@ -21,13 +21,13 @@ import m from "mithril";
 import Stream from "mithril/stream";
 import {Agents} from "models/agents/agents";
 import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
+import {Anchor, ScrollManager} from "views/components/anchor/anchor";
 import {CollapsiblePanel} from "views/components/collapsible_panel";
+import {FlashMessage, MessageType} from "views/components/flash_message";
+import {Delete, IconGroup} from "views/components/icons";
+import {Link} from "views/components/link";
 import {EnvironmentBody} from "views/pages/new-environments/environment_body_widget";
 import {EnvironmentHeader} from "views/pages/new-environments/environment_header_widget";
-import {Anchor, ScrollManager} from "../../components/anchor/anchor";
-import {FlashMessage, MessageType} from "../../components/flash_message";
-import {Delete, IconGroup} from "../../components/icons";
-import {Link} from "../../components/link";
 import {DeleteOperation} from "../page_operations";
 
 interface Attrs extends DeleteOperation<EnvironmentWithOrigin> {
@@ -95,13 +95,13 @@ export class EnvironmentsWidget extends MithrilViewComponent<Attrs> {
   noEnvironmentConfiguresMessage() {
     const environmentUrl = "/configuration/managing_environments.html";
     const docLink        = <span data-test-id="doc-link">
-      &nbsp; <Link href={docsUrl(environmentUrl)} target="_blank" externalLinkIcon={true}>
+       <Link href={docsUrl(environmentUrl)} target="_blank" externalLinkIcon={true}>
         Learn More
       </Link>
     </span>;
 
     const noEnvironmentPresentMsg = <span>
-      No environments are displayed because either no environments have been set up or you are not authorized to view the pipelines within any of the environments.{docLink}
+      Either no environments have been set up or you are not authorized to view the environments. {docLink}
     </span>;
 
     return <FlashMessage type={MessageType.info} message={noEnvironmentPresentMsg} dataTestId="no-environment-present-msg"/>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
@@ -22,6 +22,7 @@ import {Agents} from "models/agents/agents";
 import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
 import {CollapsiblePanel} from "views/components/collapsible_panel";
 import * as Icons from "views/components/icons/index";
+import {IconGroup} from "../../components/icons";
 import {EnvironmentBody} from "views/pages/new-environments/environment_body_widget";
 import {EnvironmentHeader} from "views/pages/new-environments/environment_header_widget";
 import {DeleteOperation} from "../page_operations";
@@ -38,12 +39,14 @@ export class EnvironmentsWidget extends MithrilViewComponent<Attrs> {
       const isEnvEmpty = _.isEmpty(environment.pipelines()) && _.isEmpty(environment.agents());
       return <CollapsiblePanel header={<EnvironmentHeader environment={environment}/>}
                                warning={isEnvEmpty}
-                               actions={[
-                                 <Icons.Delete iconOnly={true}
-                                               title={environment.canAdminister() ? undefined : `You are not authorized to delete '${environment.name()}' environment.`}
-                                               disabled={!environment.canAdminister()}
-                                               onclick={vnode.attrs.onDelete.bind(vnode.attrs, environment)}/>
-                               ]}
+                               actions={
+                                 <IconGroup>
+                                   <Icons.Delete
+                                     title={environment.canAdminister() ? undefined : `You are not authorized to delete '${environment.name()}' environment.`}
+                                     disabled={!environment.canAdminister()}
+                                     onclick={vnode.attrs.onDelete.bind(vnode.attrs, environment)}/>
+                                 </IconGroup>
+                               }
                                dataTestId={`collapsible-panel-for-env-${environment.name()}`}>
         <EnvironmentBody environment={environment}
                          environments={vnode.attrs.environments()}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/models/pipelines_view_model.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/models/pipelines_view_model.ts
@@ -46,6 +46,17 @@ export class PipelinesViewModel {
     return new Pipelines(...pipelines);
   }
 
+  allPipelines(): Pipelines {
+    const groups = this.pipelineGroups();
+    if (!groups) {
+      return new Pipelines();
+    }
+
+    const pipelines = _.flatten(groups.map((group) => group.pipelines()));
+
+    return new Pipelines(...pipelines);
+  }
+
   availablePipelines(): Pipelines {
     const repoAssociatedPipelines = this.configRepoEnvironmentPipelines();
     const repoDefinedPipelines    = this.unassociatedPipelinesDefinedInConfigRepository();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/create_env_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/create_env_modal_spec.tsx
@@ -15,9 +15,9 @@
  */
 
 import m from "mithril";
+import {ModalState} from "views/components/modal";
 import {CreateEnvModal} from "views/pages/new-environments/create_env_modal";
 import {TestHelper} from "views/pages/spec/test_helper";
-import {ModalState} from "../../../components/modal";
 
 describe("Create Env Modal", () => {
   const helper = new TestHelper();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/create_env_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/create_env_modal_spec.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+import m from "mithril";
 import {CreateEnvModal} from "views/pages/new-environments/create_env_modal";
 import {TestHelper} from "views/pages/spec/test_helper";
+import {ModalState} from "../../../components/modal";
 
 describe("Create Env Modal", () => {
   const helper = new TestHelper();
@@ -24,7 +26,7 @@ describe("Create Env Modal", () => {
   function mountModal() {
     modal = new CreateEnvModal(jasmine.createSpy("onSuccessfulSave"));
 
-    helper.mount(modal.body.bind(modal));
+    helper.mount(modal.view.bind(modal));
   }
 
   beforeEach(() => {
@@ -46,5 +48,13 @@ describe("Create Env Modal", () => {
     expect(helper.byTestId("flash-message-info")).toContainText(infoMessageText);
     expect(helper.byTestId("form-field-label-environment-name")).toBeInDOM();
     expect(helper.byTestId("form-field-input-environment-name")).toBeInDOM();
+  });
+
+  it('should disable save and cancel button if modal state is loading', () => {
+    modal.modalState = ModalState.LOADING;
+    m.redraw.sync();
+    expect(helper.byTestId("button-save")).toBeDisabled();
+    expect(helper.byTestId("button-cancel")).toBeDisabled();
+    expect(helper.byTestId("spinner")).toBeInDOM();
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_agents_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_agents_modal_spec.tsx
@@ -20,9 +20,9 @@ import {AgentsJSON} from "models/agents/agents_json";
 import {AgentsTestData} from "models/agents/spec/agents_test_data";
 import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
 import test_data from "models/new-environments/spec/test_data";
+import {ModalState} from "views/components/modal";
 import {EditAgentsModal} from "views/pages/new-environments/edit_agents_modal";
 import {TestHelper} from "views/pages/spec/test_helper";
-import {ModalState} from "../../../components/modal";
 
 describe("Edit Agents Modal", () => {
   const helper = new TestHelper();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_agents_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_agents_modal_spec.tsx
@@ -22,6 +22,7 @@ import {Environments, EnvironmentWithOrigin} from "models/new-environments/envir
 import test_data from "models/new-environments/spec/test_data";
 import {EditAgentsModal} from "views/pages/new-environments/edit_agents_modal";
 import {TestHelper} from "views/pages/spec/test_helper";
+import {ModalState} from "../../../components/modal";
 
 describe("Edit Agents Modal", () => {
   const helper = new TestHelper();
@@ -254,4 +255,11 @@ describe("Edit Agents Modal", () => {
     expect(helper.byTestId("save-button")).toHaveText("Save");
   });
 
+  it('should disable save and cancel button if modal state is loading', () => {
+    modal.modalState = ModalState.LOADING;
+    m.redraw.sync();
+    expect(helper.byTestId("save-button")).toBeDisabled();
+    expect(helper.byTestId("cancel-button")).toBeDisabled();
+    expect(helper.byTestId("spinner")).toBeInDOM();
+  });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_agents_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_agents_modal_spec.tsx
@@ -73,7 +73,7 @@ describe("Edit Agents Modal", () => {
                                 Agents.fromJSON(agentsJSON),
                                 jasmine.createSpy("onSuccessfulSave"));
 
-    helper.mount(() => modal.body());
+    helper.mount(() => modal.view());
   });
 
   afterEach(() => {
@@ -214,6 +214,13 @@ describe("Edit Agents Modal", () => {
     expect(helper.byTestId(agent3Selector)).toBeInDOM();
   });
 
+  it("should show no agents available message", () => {
+    modal.agentsVM.agents(new Agents());
+    m.redraw.sync();
+    const expectedMessage = "There are no agents available!";
+    expect(helper.textByTestId("flash-message-info")).toContain(expectedMessage);
+  });
+
   it("should show no agents matching search text message when no agents matched the search text", () => {
     const agent1Selector = `agent-checkbox-for-${normalAgentAssociatedWithEnvInXml}`;
     const agent2Selector = `agent-checkbox-for-${unassociatedStaticAgent}`;
@@ -239,4 +246,12 @@ describe("Edit Agents Modal", () => {
     const expectedMessage = "No agents matching search text 'blah-is-my-agent-hostname' found!";
     expect(helper.textByTestId("flash-message-info")).toContain(expectedMessage);
   });
+
+  it('should render buttons', () => {
+    expect(helper.byTestId("cancel-button")).toBeInDOM();
+    expect(helper.byTestId("cancel-button")).toHaveText("Cancel");
+    expect(helper.byTestId("save-button")).toBeInDOM();
+    expect(helper.byTestId("save-button")).toHaveText("Save");
+  });
+
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_environment_variables_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_environment_variables_modal_spec.tsx
@@ -18,9 +18,9 @@ import _ from "lodash";
 import m from "mithril";
 import {EnvironmentWithOrigin} from "models/new-environments/environments";
 import data from "models/new-environments/spec/test_data";
+import {ModalState} from "views/components/modal";
 import {EditEnvironmentVariablesModal} from "views/pages/new-environments/edit_environment_variables_modal";
 import {TestHelper} from "views/pages/spec/test_helper";
-import {ModalState} from "../../../components/modal";
 
 describe("Edit environment variables modal", () => {
   const helper = new TestHelper();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_environment_variables_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_environment_variables_modal_spec.tsx
@@ -87,7 +87,6 @@ describe("Edit environment variables modal", () => {
   it('should disable save and cancel button if modal state is loading', () => {
     modal.modalState = ModalState.LOADING;
     m.redraw.sync();
-    debugger;
     expect(helper.byTestId("save-button")).toBeDisabled();
     expect(helper.byTestId("cancel-button")).toBeDisabled();
     expect(helper.byTestId("spinner")).toBeInDOM();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_environment_variables_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_environment_variables_modal_spec.tsx
@@ -15,10 +15,12 @@
  */
 
 import _ from "lodash";
+import m from "mithril";
 import {EnvironmentWithOrigin} from "models/new-environments/environments";
 import data from "models/new-environments/spec/test_data";
 import {EditEnvironmentVariablesModal} from "views/pages/new-environments/edit_environment_variables_modal";
 import {TestHelper} from "views/pages/spec/test_helper";
+import {ModalState} from "../../../components/modal";
 
 describe("Edit environment variables modal", () => {
   const helper = new TestHelper();
@@ -82,4 +84,12 @@ describe("Edit environment variables modal", () => {
     expect(helper.byTestId("save-button")).toHaveText("Save");
   });
 
+  it('should disable save and cancel button if modal state is loading', () => {
+    modal.modalState = ModalState.LOADING;
+    m.redraw.sync();
+    debugger;
+    expect(helper.byTestId("save-button")).toBeDisabled();
+    expect(helper.byTestId("cancel-button")).toBeDisabled();
+    expect(helper.byTestId("spinner")).toBeInDOM();
+  });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_environment_variables_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_environment_variables_modal_spec.tsx
@@ -28,7 +28,7 @@ describe("Edit environment variables modal", () => {
   beforeEach(() => {
     environment = EnvironmentWithOrigin.fromJSON(data.xml_environment_json());
     modal       = new EditEnvironmentVariablesModal(environment, _.noop);
-    helper.mount(() => modal.body());
+    helper.mount(() => modal.view());
   });
 
   afterEach(helper.unmount.bind(helper));
@@ -41,6 +41,11 @@ describe("Edit environment variables modal", () => {
     expect(modal.environmentVariablesToAdd().length).toBe(0);
 
     helper.clickByTestId("add-plain-text-variables-btn");
+    // Clicked on add multiple times to check if blank variables not get added
+    helper.clickByTestId("add-plain-text-variables-btn");
+    helper.clickByTestId("add-plain-text-variables-btn");
+    helper.clickByTestId("add-secure-variables-btn");
+
     const newVarName = helper.allByTestId("env-var-name")[1] as HTMLInputElement;
     helper.oninput(newVarName, "new-var");
     const newVarValue = helper.allByTestId("env-var-value")[1] as HTMLInputElement;
@@ -69,4 +74,12 @@ describe("Edit environment variables modal", () => {
     expect(variablesToRemove[0].name()).toBe(oldNameForEnvVar1);
     expect(variablesToRemove[1].name()).toBe(oldNameForEnvVar2);
   });
+
+  it('should render buttons', () => {
+    expect(helper.byTestId("cancel-button")).toBeInDOM();
+    expect(helper.byTestId("cancel-button")).toHaveText("Cancel");
+    expect(helper.byTestId("save-button")).toBeInDOM();
+    expect(helper.byTestId("save-button")).toHaveText("Save");
+  });
+
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_pipelines_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_pipelines_modal_spec.tsx
@@ -54,7 +54,7 @@ describe("Edit Pipelines Modal", () => {
 
     modal = new EditPipelinesModal(environment, environments, jasmine.createSpy("onSuccessfulSave"));
     modal.pipelinesVM.pipelineGroups(PipelineGroups.fromJSON(pipelineGroupsJSON.groups));
-    helper.mount(() => modal.body());
+    helper.mount(() => modal.view());
   });
 
   afterEach(() => {
@@ -193,6 +193,14 @@ describe("Edit Pipelines Modal", () => {
   });
 
   it("should show no pipelines matching search text message when no pipelines matched the search text", () => {
+    modal.pipelinesVM.pipelineGroups(new PipelineGroups());
+    m.redraw.sync();
+
+    const expectedMessage = "There are no pipelines available!";
+    expect(helper.textByTestId("flash-message-info")).toContain(expectedMessage);
+  });
+
+  it("should show no pipelines matching search text message when no pipelines matched the search text", () => {
     const selectorForPipeline1 = `pipeline-checkbox-for-${pipelineGroupsJSON.groups[0].pipelines[0].name}`;
     const selectorForPipeline2 = `pipeline-list-item-for-${pipelineGroupsJSON.groups[0].pipelines[1].name}`;
     const selectorForPipeline3 = `pipeline-list-item-for-${pipelineGroupsJSON.groups[0].pipelines[2].name}`;
@@ -217,5 +225,19 @@ describe("Edit Pipelines Modal", () => {
 
     const expectedMessage = "No pipelines matching search text 'blah-is-my-pipeline-name' found!";
     expect(helper.textByTestId("flash-message-info")).toContain(expectedMessage);
+  });
+
+  it('should render buttons', () => {
+    expect(helper.byTestId("cancel-button")).toBeInDOM();
+    expect(helper.byTestId("cancel-button")).toHaveText("Cancel");
+    expect(helper.byTestId("save-button")).toBeInDOM();
+    expect(helper.byTestId("save-button")).toHaveText("Save");
+  });
+
+  it("should render config repo pipelines with config repo link", () => {
+    const configRepoLink = helper.q("a", helper.byTestId("unavailable-pipelines-defined-in-config-repository"));
+    const configRepoId   = pipelineGroupsJSON.groups[0].pipelines[1].origin.id;
+    expect(configRepoLink).toHaveText(configRepoId!);
+    expect(configRepoLink.getAttribute("href")).toBe(`/go/admin/config_repos/#!${configRepoId}`);
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_pipelines_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_pipelines_modal_spec.tsx
@@ -25,6 +25,7 @@ import {Environments, EnvironmentWithOrigin} from "models/new-environments/envir
 import data from "models/new-environments/spec/test_data";
 import {EditPipelinesModal} from "views/pages/new-environments/edit_pipelines_modal";
 import {TestHelper} from "views/pages/spec/test_helper";
+import {ModalState} from "../../../components/modal";
 
 describe("Edit Pipelines Modal", () => {
   const helper = new TestHelper();
@@ -239,5 +240,13 @@ describe("Edit Pipelines Modal", () => {
     const configRepoId   = pipelineGroupsJSON.groups[0].pipelines[1].origin.id;
     expect(configRepoLink).toHaveText(configRepoId!);
     expect(configRepoLink.getAttribute("href")).toBe(`/go/admin/config_repos/#!${configRepoId}`);
+  });
+
+  it('should disable save and cancel button if modal state is loading', () => {
+    modal.modalState = ModalState.LOADING;
+    m.redraw.sync();
+    expect(helper.byTestId("save-button")).toBeDisabled();
+    expect(helper.byTestId("cancel-button")).toBeDisabled();
+    expect(helper.byTestId("spinner")).toBeInDOM();
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_pipelines_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_pipelines_modal_spec.tsx
@@ -23,9 +23,9 @@ import {
 } from "models/internal_pipeline_structure/pipeline_structure";
 import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
 import data from "models/new-environments/spec/test_data";
+import {ModalState} from "views/components/modal";
 import {EditPipelinesModal} from "views/pages/new-environments/edit_pipelines_modal";
 import {TestHelper} from "views/pages/spec/test_helper";
-import {ModalState} from "../../../components/modal";
 
 describe("Edit Pipelines Modal", () => {
   const helper = new TestHelper();
@@ -193,7 +193,7 @@ describe("Edit Pipelines Modal", () => {
     expect(helper.byTestId(selectorForPipeline5)).toBeInDOM();
   });
 
-  it("should show no pipelines matching search text message when no pipelines matched the search text", () => {
+  it("should show no pipelines text message when no pipelines are available", () => {
     modal.pipelinesVM.pipelineGroups(new PipelineGroups());
     m.redraw.sync();
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environments_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environments_widget_spec.tsx
@@ -23,7 +23,8 @@ import {EnvironmentJSON, Environments} from "models/new-environments/environment
 import data from "models/new-environments/spec/test_data";
 import styles from "views/components/collapsible_panel/index.scss";
 import {EnvironmentsWidget} from "views/pages/new-environments/environments_widget";
-import {TestHelper} from "views/pages/spec/test_helper";
+import {stubAllMethods, TestHelper} from "views/pages/spec/test_helper";
+import {ScrollManager} from "../../../components/anchor/anchor";
 
 describe("Environments Widget", () => {
   const helper = new TestHelper();
@@ -32,13 +33,16 @@ describe("Environments Widget", () => {
   const xmlEnv        = data.xml_environment_json();
   const configRepoEnv = data.config_repo_environment_json();
   const env           = data.environment_json();
+  let sm: ScrollManager;
 
   function mountModal(envs: EnvironmentJSON[] = [xmlEnv, configRepoEnv, env]) {
     environments = Environments.fromJSON({_embedded: {environments: envs}});
+    sm           = stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl"]);
     helper.mount(() => <EnvironmentsWidget environments={Stream(environments)}
                                            agents={Stream(new Agents())}
                                            onDelete={jasmine.createSpy()}
-                                           onSuccessfulSave={_.noop}/>);
+                                           onSuccessfulSave={_.noop}
+                                           sm={sm}/>);
   }
 
   afterEach(helper.unmount.bind(helper));

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environments_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environments_widget_spec.tsx
@@ -21,10 +21,10 @@ import Stream from "mithril/stream";
 import {Agents} from "models/agents/agents";
 import {EnvironmentJSON, Environments} from "models/new-environments/environments";
 import data from "models/new-environments/spec/test_data";
+import {ScrollManager} from "views/components/anchor/anchor";
 import styles from "views/components/collapsible_panel/index.scss";
 import {EnvironmentsWidget} from "views/pages/new-environments/environments_widget";
 import {stubAllMethods, TestHelper} from "views/pages/spec/test_helper";
-import {ScrollManager} from "../../../components/anchor/anchor";
 
 describe("Environments Widget", () => {
   const helper = new TestHelper();
@@ -100,7 +100,7 @@ describe("Environments Widget", () => {
   it('should render info message if there are no environments are available', () => {
     mountModal([]);
     expect(helper.byTestId("no-environment-present-msg")).toBeInDOM();
-    const noEnvPresentText = "No environments are displayed because either no environments have been set up or you are not authorized to view the pipelines within any of the environments.";
+    const noEnvPresentText = "Either no environments have been set up or you are not authorized to view the environments.";
     expect(helper.byTestId("no-environment-present-msg")).toContainText(noEnvPresentText);
     expect(helper.byTestId("doc-link")).toBeInDOM();
     expect(helper.q("a", helper.byTestId("doc-link"))).toHaveAttr("href", docsUrl("configuration/managing_environments.html"));

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environments_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environments_widget_spec.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {docsUrl} from "gen/gocd_version";
 import _ from "lodash";
 import m from "mithril";
 import Stream from "mithril/stream";
@@ -90,5 +91,14 @@ describe("Environments Widget", () => {
     envJson.pipelines = [];
     mountModal([envJson]);
     expect(helper.byTestId("collapsible-panel-for-env-" + envJson.name)).toHaveClass(styles.warning);
+  });
+
+  it('should render info message if there are no environments are available', () => {
+    mountModal([]);
+    expect(helper.byTestId("no-environment-present-msg")).toBeInDOM();
+    const noEnvPresentText = "No environments are displayed because either no environments have been set up or you are not authorized to view the pipelines within any of the environments.";
+    expect(helper.byTestId("no-environment-present-msg")).toContainText(noEnvPresentText);
+    expect(helper.byTestId("doc-link")).toBeInDOM();
+    expect(helper.q("a", helper.byTestId("doc-link"))).toHaveAttr("href", docsUrl("configuration/managing_environments.html"));
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/models/pipelines_view_model_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/models/pipelines_view_model_spec.ts
@@ -58,7 +58,7 @@ describe("Pipelines View Model", () => {
     expect(pipelinesViewModel.errorMessage()).toBe(errorMessage);
   });
 
-  it("should should filter pipelines based on search text", () => {
+  it("should filter pipelines based on search text", () => {
     let filteredPipelines = pipelinesViewModel.filteredPipelines();
 
     expect(filteredPipelines.length).toBe(6);
@@ -78,7 +78,7 @@ describe("Pipelines View Model", () => {
     expect(filteredPipelines[0].name()).toBe(pipelineGroupsJSON.groups[0].pipelines[0].name);
   });
 
-  it("should should filter pipelines based on partial search text match", () => {
+  it("should filter pipelines based on partial search text match", () => {
     let filteredPipelines = pipelinesViewModel.filteredPipelines();
 
     expect(filteredPipelines.length).toBe(6);
@@ -131,5 +131,16 @@ describe("Pipelines View Model", () => {
 
     expect(pipelines.length).toBe(1);
     expect(pipelines[0].name()).toBe(pipeline.name());
+  });
+
+  it('should give all pipelines', () => {
+    const pipelines = pipelinesViewModel.allPipelines();
+    expect(pipelines.length).toBe(6);
+    expect(pipelines[0].name()).toBe(pipelineGroupsJSON.groups[0].pipelines[0].name);
+    expect(pipelines[1].name()).toBe(pipelineGroupsJSON.groups[0].pipelines[1].name);
+    expect(pipelines[2].name()).toBe(pipelineGroupsJSON.groups[0].pipelines[2].name);
+    expect(pipelines[3].name()).toBe(pipelineGroupsJSON.groups[1].pipelines[0].name);
+    expect(pipelines[4].name()).toBe(pipelineGroupsJSON.groups[1].pipelines[1].name);
+    expect(pipelines[5].name()).toBe(pipelineGroupsJSON.groups[1].pipelines[2].name);
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/modals.tsx
@@ -293,7 +293,7 @@ export class DeleteRoleConfirmModal extends DeleteConfirmModal {
   }
 
   private delete(obj: GoCDRole | PluginRole) {
-    RolesCRUD
+    return RolesCRUD
       .delete(obj.name())
       .then((result) => {
         result.do(

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/secret_configs.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/secret_configs.tsx
@@ -87,24 +87,23 @@ export class SecretConfigsPage extends Page<null, State> {
 
     vnode.state.onDelete = (obj, e) => {
       e.stopPropagation();
-      const deleteModal = new DeleteConfirmModal(`Are you sure you want to delete '${obj.id()}' secret configuration?`
-        , () => {
-          SecretConfigsCRUD
-            .delete(obj)
-            .then((response) => {
-              response.do(
-                (successResponse: SuccessResponse<any>) => {
-                  vnode.state.onSuccessfulSave(successResponse.body.message);
-                  const filteredEntities = vnode.state.secretConfigs().filter((entity) => {
-                    return entity().id() !== obj.id();
-                  });
-                  vnode.state.secretConfigs(filteredEntities);
-                },
-                (errorResponse: ErrorResponse) => vnode.state.onError(JSON.parse(errorResponse.body!).message));
-            })
-            .then(deleteModal.close.bind(deleteModal));
-        }
-        , "Delete Secret Configuration");
+      const deleteModal: DeleteConfirmModal = new DeleteConfirmModal(`Are you sure you want to delete '${obj.id()}' secret configuration?`,
+                                                                     () => {
+                                                                       return SecretConfigsCRUD
+                                                                         .delete(obj)
+                                                                         .then((response) => {
+                                                                           response.do(
+                                                                             (successResponse: SuccessResponse<any>) => {
+                                                                               vnode.state.onSuccessfulSave(successResponse.body.message);
+                                                                               const filteredEntities = vnode.state.secretConfigs().filter((entity) => {
+                                                                                 return entity().id() !== obj.id();
+                                                                               });
+                                                                               vnode.state.secretConfigs(filteredEntities);
+                                                                             },
+                                                                             (errorResponse: ErrorResponse) => vnode.state.onError(JSON.parse(errorResponse.body!).message));
+                                                                         })
+                                                                         .then(deleteModal.close.bind(deleteModal));
+                                                                     }, "Delete Secret Configuration");
 
       deleteModal.render();
     };

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/users/delete_user_confirmation_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/users/delete_user_confirmation_modal.tsx
@@ -44,7 +44,7 @@ export class DeleteUserConfirmModal extends DeleteConfirmModal {
   }
 
   private delete(usersToBeDeleted: BulkUserOperationJSON) {
-    UsersCRUD
+    return UsersCRUD
       .bulkUserDelete(usersToBeDeleted)
       .then((apiResult) => {
         apiResult.do(() => {


### PR DESCRIPTION
Issue: #7176 

Description:
- Show message when no environments are configured.
- Add a button group to the delete environment button for consistent styling (across all pages).
- Retain environment variables validation on new environment SPA.
- While the delete operation is in progress, disable Yes Delete and No buttons and showing spinner (to avoid user click Yes Delete option multiple times).
- While the create operation is in progress, disable Save and Cancel buttons and showing spinner (to avoid user click Save option multiple times).
- Added info msg if environments are not available on environments index page.
- Make individual environment linkable.