### PR TITLE
Add Granular Auth support for Environments (#7222)

### DIFF
--- a/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/ApiAuthenticationHelperTest.java
+++ b/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/ApiAuthenticationHelperTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.api.spring;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.RoleConfig;
+import com.thoughtworks.go.config.Users;
+import com.thoughtworks.go.config.policy.*;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.SecurityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import spark.HaltException;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+class ApiAuthenticationHelperTest {
+    @Mock
+    private SecurityService securityService;
+    @Mock
+    private GoConfigService goConfigService;
+
+    private ApiAuthenticationHelper helper;
+
+    private final Username ADMIN = new Username("Admin");
+    private final Username BOB = new Username("Bob");
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+
+        when(securityService.isUserAdmin(ADMIN)).thenReturn(true);
+        when(securityService.isUserAdmin(BOB)).thenReturn(false);
+    }
+
+    @Nested
+    class GranularAuth {
+        @BeforeEach
+        void setUp() {
+            helper = new ApiAuthenticationHelper(securityService, goConfigService);
+        }
+
+        @Test
+        void shouldAllowAllAdministratorsToViewAllEnvironments() {
+            assertDoesNotThrow(() -> helper.checkUserHasPermissions(ADMIN, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, null));
+        }
+
+        @Test
+        void shouldAllowAllAdministratorsToViewSingleEnvironments() {
+            assertDoesNotThrow(() -> helper.checkUserHasPermissions(ADMIN, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, "env_1"));
+        }
+
+        @Test
+        void shouldNotAllNormalUsersToViewAllEnvironments() {
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, null));
+        }
+
+        @Test
+        void shouldNotAllNormalUsersToViewSingleEnvironments() {
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, "env_1"));
+        }
+
+        @Test
+        /*
+        <role name="allow-all-environments">
+            <policy>
+                <allow action="view" type="environment">*</allow>
+            </policy>
+            <users>
+                <user>Bob</user>
+            </users>
+        </role>
+        */
+        void shouldAllowNormalUserWithAllowedEnvironmentPolicyToViewEnvironments() {
+            Policy directives = new Policy();
+            directives.add(new Allow("view", "environment", "*"));
+            RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("read-only-environments"), new Users(), directives);
+
+            when(goConfigService.rolesForUser(BOB.getUsername())).thenReturn(Arrays.asList(roleConfig));
+
+            assertDoesNotThrow(() -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, null));
+            assertDoesNotThrow(() -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, "foo"));
+        }
+
+        @Test
+        /*
+        <role name="allow-one-environments">
+            <policy>
+                <allow action="view" type="environment">env_1</allow>
+            </policy>
+            <users>
+                <user>Bob</user>
+            </users>
+        </role>
+        */
+        void shouldAllowNormalUserWithAllowedEnvironmentPolicyToViewSpecificEnvironment() {
+            Policy directives = new Policy();
+            directives.add(new Allow("view", "environment", "env_1"));
+            RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("read-only-environments"), new Users(), directives);
+
+            when(goConfigService.rolesForUser(BOB.getUsername())).thenReturn(Arrays.asList(roleConfig));
+
+            assertDoesNotThrow(() -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, "env_1"));
+
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, null));
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, "env_2"));
+        }
+
+        @Test
+        /*
+        <role name="disallowed-directive-first-environment">
+            <policy>
+                <deny action="view" type="environment">*</deny>
+                <allow action="view" type="environment">env_1</allow>
+            </policy>
+            <users>
+                <user>Bob</user>
+            </users>
+        </role>
+        */
+        void shouldNotAllowNormalUserWithDisallowPolicyFirstToViewEnvironment() {
+            Policy directives = new Policy();
+            directives.add(new Deny("view", "environment", "*"));
+            directives.add(new Allow("view", "environment", "env_1"));
+            RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("read-only-environments"), new Users(), directives);
+
+            when(goConfigService.rolesForUser(BOB.getUsername())).thenReturn(Arrays.asList(roleConfig));
+
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, null));
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, "env_1"));
+        }
+
+        @Test
+        /*
+        <role name="disallowed-directive-first-environment">
+            <policy>
+                <allow action="view" type="environment">env_1</allow>
+                <deny action="view" type="environment">*</deny>
+            </policy>
+            <users>
+                <user>Bob</user>
+            </users>
+        </role>
+        */
+        void shouldAllowNormalUserWithAllowedPolicyFirstToViewEnvironment() {
+            Policy directives = new Policy();
+            directives.add(new Allow("view", "environment", "env_1"));
+            directives.add(new Deny("view", "environment", "*"));
+            RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("read-only-environments"), new Users(), directives);
+
+            when(goConfigService.rolesForUser(BOB.getUsername())).thenReturn(Arrays.asList(roleConfig));
+
+            assertDoesNotThrow(() -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, "env_1"));
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, null));
+        }
+    }
+}

--- a/api/api-environments-v3/src/main/java/com/thoughtworks/go/apiv3/environments/EnvironmentsControllerV3.java
+++ b/api/api-environments-v3/src/main/java/com/thoughtworks/go/apiv3/environments/EnvironmentsControllerV3.java
@@ -29,6 +29,7 @@ import com.thoughtworks.go.apiv3.environments.representers.EnvironmentRepresente
 import com.thoughtworks.go.apiv3.environments.representers.PatchEnvironmentRequestRepresenter;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.exceptions.EntityType;
+import com.thoughtworks.go.config.policy.SupportedEntity;
 import com.thoughtworks.go.domain.ConfigElementForEdit;
 import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.EnvironmentConfigService;
@@ -42,8 +43,6 @@ import spark.Request;
 import spark.Response;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -81,8 +80,14 @@ public class EnvironmentsControllerV3 extends ApiController implements SparkSpri
             before("", mimeType, this::setContentType);
             before("/*", mimeType, this::setContentType);
 
-            before("", mimeType, apiAuthenticationHelper::checkAdminUserAnd403);
-            before("/*", mimeType, apiAuthenticationHelper::checkAdminUserAnd403);
+            before("", mimeType, (request, response) -> {
+                apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.ENVIRONMENT, "*");
+            });
+
+            before(Routes.Environments.NAME, mimeType, (request, response) -> {
+                apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.ENVIRONMENT, request.params("name"));
+            });
+
             get("", mimeType, this::index);
             get(Routes.Environments.NAME, mimeType, this::show);
             post("", mimeType, this::create);

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Role.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Role.java
@@ -17,21 +17,21 @@ package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.config.policy.Policy;
 import com.thoughtworks.go.config.policy.PolicyAware;
+import com.thoughtworks.go.config.policy.SupportedAction;
+import com.thoughtworks.go.config.policy.SupportedEntity;
 import com.thoughtworks.go.config.validation.NameTypeValidator;
 import com.thoughtworks.go.domain.ConfigErrors;
 
 import java.util.*;
 
 import static com.thoughtworks.go.config.CaseInsensitiveString.isBlank;
-import static com.thoughtworks.go.config.rules.SupportedEntity.ENVIRONMENT;
-import static com.thoughtworks.go.config.rules.SupportedEntity.unmodifiableListOf;
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
+import static com.thoughtworks.go.config.policy.SupportedAction.VIEW;
+import static com.thoughtworks.go.config.policy.SupportedEntity.ENVIRONMENT;
 
 @ConfigInterface
 public interface Role extends Validatable, PolicyAware {
-    List<String> allowedActions = unmodifiableList(asList("view"));
-    List<String> allowedTypes = unmodifiableListOf(ENVIRONMENT);
+    List<String> allowedActions = SupportedAction.unmodifiableListOf(VIEW);
+    List<String> allowedTypes = SupportedEntity.unmodifiableListOf(ENVIRONMENT);
 
     CaseInsensitiveString getName();
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/AbstractDirective.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/AbstractDirective.java
@@ -18,12 +18,16 @@ package com.thoughtworks.go.config.policy;
 
 import com.thoughtworks.go.config.ConfigAttribute;
 import com.thoughtworks.go.config.ConfigValue;
+import com.thoughtworks.go.config.Validatable;
 import com.thoughtworks.go.config.ValidationContext;
 import com.thoughtworks.go.domain.ConfigErrors;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOCase;
 
 import java.util.List;
 import java.util.Objects;
 
+import static com.thoughtworks.go.config.policy.SupportedEntity.fromString;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 
@@ -65,12 +69,37 @@ public abstract class AbstractDirective implements Directive {
         }
     }
 
-    private boolean isInvalid(String actionOrType, List<String> allowedTypes) {
+
+    private boolean isInvalid(String actionOrType, List<String> allowedActions) {
         if ("*".equals(actionOrType)) {
             return false;
         }
 
-        return allowedTypes.stream().noneMatch(it -> equalsIgnoreCase(it, actionOrType));
+        return allowedActions.stream().noneMatch(it -> equalsIgnoreCase(it, actionOrType));
+    }
+
+    protected boolean matchesAction(String action) {
+        if (equalsIgnoreCase("*", this.action)) {
+            return true;
+        }
+
+        return equalsIgnoreCase(action, this.action);
+    }
+
+    protected boolean matchesType(Class<? extends Validatable> entityType) {
+        if (equalsIgnoreCase("*", this.type)) {
+            return true;
+        }
+
+        return fromString(this.type).getEntityType().isAssignableFrom(entityType);
+    }
+
+    protected boolean matchesResource(String resource) {
+        if (equalsIgnoreCase("*", this.resource)) {
+            return true;
+        }
+
+        return FilenameUtils.wildcardMatch(resource, this.resource, IOCase.INSENSITIVE);
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/Allow.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/Allow.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.config.policy;
 
 import com.thoughtworks.go.config.ConfigTag;
+import com.thoughtworks.go.config.Validatable;
 
 @ConfigTag("allow")
 public class Allow extends AbstractDirective {
@@ -26,6 +27,15 @@ public class Allow extends AbstractDirective {
 
     public Allow(String action, String type, String resource) {
         super(DirectiveType.ALLOW, action, type, resource);
+    }
+
+    @Override
+    public Result apply(String action, Class<? extends Validatable> entityClass, String resource) {
+        if (matchesAction(action) && matchesType(entityClass) && matchesResource(resource)) {
+            return Result.ALLOW;
+        }
+
+        return Result.SKIP;
     }
 }
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/Deny.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/Deny.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.config.policy;
 
 import com.thoughtworks.go.config.ConfigTag;
+import com.thoughtworks.go.config.Validatable;
 
 @ConfigTag("deny")
 public class Deny extends AbstractDirective {
@@ -27,4 +28,14 @@ public class Deny extends AbstractDirective {
     public Deny(String action, String type, String resource) {
         super(DirectiveType.DENY, action, type, resource);
     }
+
+    @Override
+    public Result apply(String action, Class<? extends Validatable> entityClass, String resource) {
+        if (matchesAction(action) && matchesType(entityClass) && matchesResource(resource)) {
+            return Result.DENY;
+        }
+
+        return Result.SKIP;
+    }
+
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/Result.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/Result.java
@@ -16,22 +16,8 @@
 
 package com.thoughtworks.go.config.policy;
 
-import com.thoughtworks.go.config.ConfigInterface;
-import com.thoughtworks.go.config.Validatable;
-
-import java.io.Serializable;
-
-@ConfigInterface
-public interface Directive extends Validatable, Serializable {
-    boolean hasErrors();
-
-    String action();
-
-    String type();
-
-    String resource();
-
-    DirectiveType getDirectiveType();
-
-    Result apply(String refer, Class<? extends Validatable> aClass, String group);
+public enum Result {
+    ALLOW,
+    DENY,
+    SKIP
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/SupportedAction.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/SupportedAction.java
@@ -16,22 +16,29 @@
 
 package com.thoughtworks.go.config.policy;
 
-import com.thoughtworks.go.config.ConfigInterface;
-import com.thoughtworks.go.config.Validatable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
-import java.io.Serializable;
+import static java.util.Collections.unmodifiableList;
 
-@ConfigInterface
-public interface Directive extends Validatable, Serializable {
-    boolean hasErrors();
+public enum SupportedAction {
+    VIEW("view"),
+    UNKNOWN("unknown");
 
-    String action();
+    private final String action;
 
-    String type();
+    SupportedAction(String action) {
+        this.action = action;
+    }
 
-    String resource();
+    public String getAction() {
+        return action;
+    }
 
-    DirectiveType getDirectiveType();
-
-    Result apply(String refer, Class<? extends Validatable> aClass, String group);
+    public static List<String> unmodifiableListOf(SupportedAction... supportedActions) {
+        return unmodifiableList(Arrays.stream(supportedActions)
+                .map(SupportedAction::getAction)
+                .collect(Collectors.toList()));
+    }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/SupportedEntity.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/SupportedEntity.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.policy;
+
+import com.thoughtworks.go.config.EnvironmentConfig;
+import com.thoughtworks.go.config.PipelineConfigs;
+import com.thoughtworks.go.config.Validatable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.unmodifiableList;
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+
+public enum SupportedEntity {
+    ENVIRONMENT("environment", EnvironmentConfig.class),
+    UNKNOWN(null, null);
+
+    private final String type;
+    private final Class<? extends Validatable> entityType;
+
+    SupportedEntity(String type, Class<? extends Validatable> entityClass) {
+        this.type = type;
+        this.entityType = entityClass;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Class<? extends Validatable> getEntityType() {
+        return entityType;
+    }
+
+    public static SupportedEntity fromString(String type) {
+        return Arrays.stream(values()).filter(t -> equalsIgnoreCase(t.type, type))
+                .findFirst().orElse(UNKNOWN);
+    }
+
+    public static List<String> unmodifiableListOf(SupportedEntity... supportedEntities) {
+        return unmodifiableList(Arrays.stream(supportedEntities)
+                .map(SupportedEntity::getType)
+                .collect(Collectors.toList()));
+    }
+}

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PluginRoleConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PluginRoleConfigTest.java
@@ -16,6 +16,9 @@
 package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.config.helper.ValidationContextMother;
+import com.thoughtworks.go.config.policy.Allow;
+import com.thoughtworks.go.config.policy.Policy;
+import com.thoughtworks.go.config.policy.SupportedAction;
 import com.thoughtworks.go.domain.config.ConfigurationKey;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
 import com.thoughtworks.go.domain.config.ConfigurationValue;
@@ -31,6 +34,7 @@ import com.thoughtworks.go.security.GoCipher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import static com.thoughtworks.go.config.policy.SupportedEntity.ENVIRONMENT;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -165,6 +169,17 @@ public class PluginRoleConfigTest {
 
         assertTrue(roleConfig.hasErrors());
         assertTrue(roleConfig.errors().isEmpty());
+    }
+
+    @Test
+    public void shouldAnswerWhetherItHasPermissionsForGivenEntityOfTypeAndName() {
+        final Policy directives = new Policy();
+        directives.add(new Allow("view", ENVIRONMENT.getType(), "env_1"));
+        RoleConfig role = new RoleConfig(new CaseInsensitiveString(""), new Users(), directives);
+
+        assertTrue(role.hasPermissionsFor(SupportedAction.VIEW, EnvironmentConfig.class, "env_1"));
+        assertFalse(role.hasPermissionsFor(SupportedAction.VIEW, EnvironmentConfig.class, "env_2"));
+        assertFalse(role.hasPermissionsFor(SupportedAction.VIEW, PipelineConfig.class, "*"));
     }
 
     private void validatePresenceOfRoleName(Validator v) {

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/RoleConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/RoleConfigTest.java
@@ -16,16 +16,19 @@
 package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.config.helper.ValidationContextMother;
+import com.thoughtworks.go.config.policy.Allow;
+import com.thoughtworks.go.config.policy.Policy;
+import com.thoughtworks.go.config.policy.SupportedAction;
 import org.junit.Test;
 
+import static com.thoughtworks.go.config.policy.SupportedEntity.ENVIRONMENT;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 public class RoleConfigTest {
 
     @Test
-    public void validate_presenceOfRoleName(){
+    public void validate_presenceOfRoleName() {
         validatePresenceOfRoleName(new Validator() {
             @Override
             public void validate(RoleConfig roleConfig, ValidationContext context) {
@@ -35,7 +38,7 @@ public class RoleConfigTest {
     }
 
     @Test
-    public void validate_nullNameInRole(){
+    public void validate_nullNameInRole() {
         validateNullRoleName(new Validator() {
             @Override
             public void validate(RoleConfig roleConfig, ValidationContext context) {
@@ -55,7 +58,7 @@ public class RoleConfigTest {
     }
 
     @Test
-    public void validateTree_presenceOfRoleName(){
+    public void validateTree_presenceOfRoleName() {
         validatePresenceOfRoleName(new Validator() {
             @Override
             public void validate(RoleConfig roleConfig, ValidationContext context) {
@@ -65,7 +68,7 @@ public class RoleConfigTest {
     }
 
     @Test
-    public void validateTree_nullNameInRole(){
+    public void validateTree_nullNameInRole() {
         validateNullRoleName(new Validator() {
             @Override
             public void validate(RoleConfig roleConfig, ValidationContext context) {
@@ -82,6 +85,17 @@ public class RoleConfigTest {
                 assertFalse(roleConfig.validateTree(context));
             }
         });
+    }
+
+    @Test
+    public void shouldAnswerWhetherItHasPermissionsForGivenEntityOfTypeAndName() {
+        final Policy directives = new Policy();
+        directives.add(new Allow("view", ENVIRONMENT.getType(), "env_1"));
+        RoleConfig role = new RoleConfig(new CaseInsensitiveString(""), new Users(), directives);
+
+        assertTrue(role.hasPermissionsFor(SupportedAction.VIEW, EnvironmentConfig.class, "env_1"));
+        assertFalse(role.hasPermissionsFor(SupportedAction.VIEW, EnvironmentConfig.class, "env_2"));
+        assertFalse(role.hasPermissionsFor(SupportedAction.VIEW, PipelineConfig.class, "*"));
     }
 
     private void validatePresenceOfRoleName(Validator v) {

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/policy/AllowTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/policy/AllowTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.policy;
+
+import com.thoughtworks.go.config.EnvironmentConfig;
+import com.thoughtworks.go.config.StageConfig;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AllowTest extends AbstractDirectiveTest {
+    //runs the test from AbstractDirectiveTest for this Directive
+    @Override
+    Directive getDirective(String action, String type, String resource) {
+        return new Allow(action, type, resource);
+    }
+
+    @Nested
+    class apply {
+        @Nested
+        class shouldSkip {
+            @Test
+            void ifActionDoesNotMatch() {
+                final Allow allow = new Allow("view", null, null);
+
+                assertThat(allow.apply("unknown-action", null, null))
+                        .isEqualTo(Result.SKIP);
+            }
+
+            @Test
+            void ifEntityTypeDoesNotMatch() {
+                final Allow allow = new Allow("view", "environment", null);
+
+                assertThat(allow.apply("view", StageConfig.class, null))
+                        .isEqualTo(Result.SKIP);
+            }
+
+            @Test
+            void ifResourceDoesNotMatch() {
+                final Allow allow = new Allow("view", "environment", "group1");
+
+                assertThat(allow.apply("view", EnvironmentConfig.class, "group2"))
+                        .isEqualTo(Result.SKIP);
+            }
+
+            @Test
+            void ifProvidedResourceDoesNotMatchTheWildcardInDirective() {
+                final Allow allow = new Allow("view", "environment", "group_*");
+
+                assertThat(allow.apply("view", EnvironmentConfig.class, "groupA"))
+                        .isEqualTo(Result.SKIP);
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"my_group", "grpoup"})
+            void ifResourceDoesNotMatchTheWildCardPatterAndActionAndTypeMatch(String resource) {
+                final Allow allow = new Allow("view", "environment", "gro*up*");
+
+                assertThat(allow.apply("view", EnvironmentConfig.class, resource))
+                        .isEqualTo(Result.SKIP);
+            }
+        }
+
+        @Nested
+        class shouldAllow {
+            @Test
+            void ifActionTypeAndResourceMatches() {
+                final Allow allow = new Allow("view", "environment", "env_1");
+
+                assertThat(allow.apply("view", EnvironmentConfig.class, "env_1"))
+                        .isEqualTo(Result.ALLOW);
+            }
+
+            @Test
+            void ifResourceAndTypeMatchesWhenAllActionsAreAllowed() {
+                final Allow allow = new Allow("*", "environment", "env_1");
+
+                assertThat(allow.apply("any-action-is-allowed", EnvironmentConfig.class, "env_1"))
+                        .isEqualTo(Result.ALLOW);
+            }
+
+            @Test
+            void ifResourceAndActionMatchesWhenAllTypesAreAllowed() {
+                final Allow allow = new Allow("view", "*", "env_1");
+
+                assertThat(allow.apply("view", EnvironmentConfig.class, "env_1"))
+                        .isEqualTo(Result.ALLOW);
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"group", "my_group", "group_A", "gro---up", "gro...up"})
+            void ifResourceMatchesTheWildCardAndActionAndTypeMatch(String resource) {
+                final Allow allow = new Allow("view", "environment", "*gro*up*");
+
+                assertThat(allow.apply("view", EnvironmentConfig.class, resource))
+                        .isEqualTo(Result.ALLOW);
+            }
+        }
+    }
+}

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/policy/DenyTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/policy/DenyTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.policy;
+
+import com.thoughtworks.go.config.EnvironmentConfig;
+import com.thoughtworks.go.config.StageConfig;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DenyTest extends AbstractDirectiveTest {
+    //runs the test from AbstractDirectiveTest for this Directive
+    @Override
+    Directive getDirective(String action, String type, String resource) {
+        return new Deny(action, type, resource);
+    }
+
+    @Nested
+    class apply {
+        @Nested
+        class shouldSkip {
+            @Test
+            void ifActionDoesNotMatch() {
+                final Deny deny = new Deny("view", null, null);
+
+                assertThat(deny.apply("unknown-action", null, null))
+                        .isEqualTo(Result.SKIP);
+            }
+
+            @Test
+            void ifEntityTypeDoesNotMatch() {
+                final Deny deny = new Deny("view", "environment", null);
+
+                assertThat(deny.apply("view", StageConfig.class, null))
+                        .isEqualTo(Result.SKIP);
+            }
+
+            @Test
+            void ifResourceDoesNotMatch() {
+                final Deny deny = new Deny("view", "environment", "group1");
+
+                assertThat(deny.apply("view", EnvironmentConfig.class, "group2"))
+                        .isEqualTo(Result.SKIP);
+            }
+
+            @Test
+            void ifProvidedResourceDoesNotMatchTheWildcardInDirective() {
+                final Deny deny = new Deny("view", "environment", "group_*");
+
+                assertThat(deny.apply("view", EnvironmentConfig.class, "groupA"))
+                        .isEqualTo(Result.SKIP);
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"my_group", "grpoup"})
+            void ifResourceDoesNotMatchTheWildCardPatterAndActionAndTypeMatch(String resource) {
+                final Deny deny = new Deny("view", "environment", "gro*up*");
+
+                assertThat(deny.apply("view", EnvironmentConfig.class, resource))
+                        .isEqualTo(Result.SKIP);
+            }
+        }
+
+        @Nested
+        class shouldDeny {
+            @Test
+            void ifActionTypeAndResourceMatches() {
+                final Deny deny = new Deny("view", "environment", "env_1");
+
+                assertThat(deny.apply("view", EnvironmentConfig.class, "env_1"))
+                        .isEqualTo(Result.DENY);
+            }
+
+            @Test
+            void ifResourceAndTypeMatchesWhenAllActionsAreAllowed() {
+                final Deny deny = new Deny("*", "environment", "env_1");
+
+                assertThat(deny.apply("any-action-is-allowed", EnvironmentConfig.class, "env_1"))
+                        .isEqualTo(Result.DENY);
+            }
+
+            @Test
+            void ifResourceAndActionMatchesWhenAllTypesAreAllowed() {
+                final Deny deny = new Deny("view", "*", "env_1");
+
+                assertThat(deny.apply("view", EnvironmentConfig.class, "env_1"))
+                        .isEqualTo(Result.DENY);
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"group", "my_group", "group_A", "gro---up", "gro...up"})
+            void ifResourceMatchesTheWildCardAndActionAndTypeMatch(String resource) {
+                final Deny deny = new Deny("view", "environment", "*gro*up*");
+
+                assertThat(deny.apply("view", EnvironmentConfig.class, resource))
+                        .isEqualTo(Result.DENY);
+            }
+        }
+    }
+}

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/policy/SupportedEntityTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/policy/SupportedEntityTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.policy;
+
+import com.thoughtworks.go.config.BasicEnvironmentConfig;
+import com.thoughtworks.go.config.EnvironmentConfig;
+import com.thoughtworks.go.config.merge.MergeEnvironmentConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.thoughtworks.go.config.policy.SupportedEntity.ENVIRONMENT;
+import static com.thoughtworks.go.config.policy.SupportedEntity.unmodifiableListOf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class SupportedEntityTest {
+    @Test
+    void shouldSupportEnvironment() {
+        assertThat(ENVIRONMENT.getType()).isEqualTo("environment");
+        assertThat(ENVIRONMENT.getEntityType()).isEqualTo(EnvironmentConfig.class);
+
+        assertThat(ENVIRONMENT.getEntityType().isAssignableFrom(BasicEnvironmentConfig.class)).isTrue();
+        assertThat(ENVIRONMENT.getEntityType().isAssignableFrom(MergeEnvironmentConfig.class)).isTrue();
+    }
+
+    @Test
+    void shouldReturnUnmodifiableListOfTheSupportedEntities() {
+        List<String> entities = unmodifiableListOf(ENVIRONMENT);
+
+        assertThat(entities).hasSize(1).contains(ENVIRONMENT.getType());
+        assertThatCode(() -> entities.add("foo"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
@@ -95,6 +95,8 @@ public class AuthorizeFilterChain extends FilterChainProxy {
                 .addAuthorityFilterChain("/api/admin/templates/**", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/elastic/profiles/**", apiAccessDeniedHandler, ROLE_USER)
 
+                .addAuthorityFilterChain("/api/admin/environments/**", apiAccessDeniedHandler, ROLE_USER)
+
                 // blanket role that requires supervisor access, used by old admin apis
                 .addAuthorityFilterChain("/api/admin/**", apiAccessDeniedHandler, ROLE_SUPERVISOR)
 

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/SparkController.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/SparkController.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.spark;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.policy.SupportedAction;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.newsecurity.utils.SessionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -53,6 +54,17 @@ public interface SparkController {
 
     default Username currentUsername() {
         return SessionUtils.currentUsername();
+    }
+
+    default SupportedAction getAction(Request request) {
+        switch (request.requestMethod()) {
+            case "GET":
+                return SupportedAction.VIEW;
+            case "HEAD":
+                return SupportedAction.VIEW;
+            default:
+                return SupportedAction.UNKNOWN;
+        }
     }
 
     default String currentUsernameString() {


### PR DESCRIPTION
Issue: #7222

Description:
* Modify Environments API to perform authorization based on role policy.
* Define 'checkUserHasPermissions' authentication helper method to perform
  user authorization based on the associated role policies.


