### PR TITLE
Show user specific environments on environments SPA (#7222)

### DIFF
--- a/api/api-internal-environments-v1/src/main/java/com/thoughtworks/go/apiv1/internalenvironments/representers/MergedEnvironmentRepresenter.java
+++ b/api/api-internal-environments-v1/src/main/java/com/thoughtworks/go/apiv1/internalenvironments/representers/MergedEnvironmentRepresenter.java
@@ -23,10 +23,12 @@ import com.thoughtworks.go.config.remote.ConfigOrigin;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 public class MergedEnvironmentRepresenter {
-    public static void toJSON(OutputWriter outputWriter, EnvironmentConfig environmentConfig) {
+    public static void toJSON(OutputWriter outputWriter, EnvironmentConfig environmentConfig, Function<String, Boolean> canUserAdministerEnvironment) {
         outputWriter.add("name", environmentConfig.name());
+        outputWriter.add("can_administer", canUserAdministerEnvironment.apply(environmentConfig.name().toString()));
         addOrigin(outputWriter, environmentConfig.getOrigin());
         outputWriter.addChildList("pipelines", outputListWriter -> {
             environmentConfig.getPipelines().forEach(pipeline -> outputListWriter.addChild(writer -> EnvironmentPipelineRepresenter.toJSON(writer, pipeline, environmentConfig)));

--- a/api/api-internal-environments-v1/src/main/java/com/thoughtworks/go/apiv1/internalenvironments/representers/MergedEnvironmentsRepresenter.java
+++ b/api/api-internal-environments-v1/src/main/java/com/thoughtworks/go/apiv1/internalenvironments/representers/MergedEnvironmentsRepresenter.java
@@ -20,13 +20,14 @@ import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.config.EnvironmentConfig;
 
 import java.util.List;
+import java.util.function.Function;
 
 public class MergedEnvironmentsRepresenter {
-    public static void toJSON(OutputWriter outputWriter, List<EnvironmentConfig> allMergedEnvironments) {
+    public static void toJSON(OutputWriter outputWriter, List<EnvironmentConfig> allMergedEnvironments, Function<String, Boolean> canUserAdministerEnvironment) {
         outputWriter.addChild("_embedded", embeddedWriter -> {
             embeddedWriter.addChildList("environments", outputListWriter -> {
                 allMergedEnvironments.forEach(environmentConfig -> {
-                    outputListWriter.addChild(childWriter -> MergedEnvironmentRepresenter.toJSON(childWriter, environmentConfig));
+                    outputListWriter.addChild(childWriter -> MergedEnvironmentRepresenter.toJSON(childWriter, environmentConfig, canUserAdministerEnvironment));
                 });
             });
         });

--- a/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/MergedEnvironmentRepresenterTest.groovy
+++ b/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/MergedEnvironmentRepresenterTest.groovy
@@ -35,7 +35,9 @@ class MergedEnvironmentRepresenterTest {
     def remoteEnv = EnvironmentConfigMother.remote(environmentName)
     def mergeEnvironmentConfig = new MergeEnvironmentConfig(env, remoteEnv)
 
-    def actualJson = toObjectString({ MergedEnvironmentRepresenter.toJSON(it, mergeEnvironmentConfig) })
+    def actualJson = toObjectString({
+      MergedEnvironmentRepresenter.toJSON(it, mergeEnvironmentConfig, { name -> true })
+    })
 
     def agentsJSON = mergeEnvironmentConfig.agents.collect { agent ->
       toObject({
@@ -57,6 +59,7 @@ class MergedEnvironmentRepresenterTest {
 
     def expected = [
       "name"                 : environmentName,
+      "can_administer"       : true,
       origins                : [
         toObject({ ConfigXmlOriginRepresenter.toJSON(it, null) }),
         toObject({ ConfigRepoOriginRepresenter.toJSON(it, remoteEnv.getOrigin() as RepoConfigOrigin) })

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
@@ -74,6 +74,8 @@ public class AuthorizeFilterChain extends FilterChainProxy {
                 .addAuthorityFilterChain("/admin/package_repositories/**", genericAccessDeniedHandler, ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR)
                 .addAuthorityFilterChain("/admin/package_definitions/**", genericAccessDeniedHandler, ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR)
                 .addAuthorityFilterChain("/admin/elastic_agent_configurations/**", genericAccessDeniedHandler, ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR)
+                //allow /go/admin/environments page to be accessible by normal users
+                .addAuthorityFilterChain("/admin/environments", genericAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/admin/**", genericAccessDeniedHandler, ROLE_SUPERVISOR)
                 .addAuthorityFilterChain("/agents/*/job_run_history/**", genericAccessDeniedHandler, ROLE_SUPERVISOR)
 
@@ -95,6 +97,7 @@ public class AuthorizeFilterChain extends FilterChainProxy {
                 .addAuthorityFilterChain("/api/elastic/profiles/**", apiAccessDeniedHandler, ROLE_USER)
 
                 .addAuthorityFilterChain("/api/admin/environments/**", apiAccessDeniedHandler, ROLE_USER)
+                .addAuthorityFilterChain("/api/admin/internal/environments/merged", apiAccessDeniedHandler, ROLE_USER)
 
                 // blanket role that requires supervisor access, used by old admin apis
                 .addAuthorityFilterChain("/api/admin/**", apiAccessDeniedHandler, ROLE_SUPERVISOR)

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/environments.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/environments.ts
@@ -28,6 +28,7 @@ import {Origin, OriginJSON, OriginType} from "models/origin";
 
 export interface EnvironmentJSON {
   name: string;
+  can_administer: boolean;
   origins: OriginJSON[];
   pipelines: PipelineJSON[];
   agents: EnvironmentAgentJSON[];
@@ -44,12 +45,14 @@ export interface EnvironmentsJSON {
 
 export class EnvironmentWithOrigin extends ValidatableMixin {
   readonly name: Stream<string>;
+  readonly canAdminister: Stream<boolean>;
   readonly origins: Stream<Origin[]>;
   readonly agents: Stream<Agents>;
   readonly pipelines: Stream<Pipelines>;
   readonly environmentVariables: Stream<EnvironmentVariablesWithOrigin>;
 
   constructor(name: string,
+              canAdminister: boolean,
               origins: Origin[],
               agents: Agents,
               pipelines: Pipelines,
@@ -57,6 +60,7 @@ export class EnvironmentWithOrigin extends ValidatableMixin {
     super();
     ValidatableMixin.call(this);
     this.name                 = Stream(name);
+    this.canAdminister        = Stream(canAdminister);
     this.origins              = Stream(origins);
     this.agents               = Stream(agents);
     this.pipelines            = Stream(pipelines);
@@ -74,6 +78,7 @@ export class EnvironmentWithOrigin extends ValidatableMixin {
       origins.push(new Origin(OriginType.GoCD));
     }
     return new EnvironmentWithOrigin(data.name,
+                                     data.can_administer,
                                      origins,
                                      Agents.fromJSON(data.agents),
                                      Pipelines.fromJSON(data.pipelines),
@@ -121,6 +126,7 @@ export class EnvironmentWithOrigin extends ValidatableMixin {
 
   clone(): EnvironmentWithOrigin {
     return new EnvironmentWithOrigin(this.name(),
+                                     true,
                                      this.origins().map((origin) => origin.clone()),
                                      this.agents().map((agent) => agent.clone()),
                                      this.pipelines().clone(),

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/spec/test_data.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/spec/test_data.ts
@@ -117,6 +117,7 @@ export default {
   environment_variable_association_in_config_repo_json: environmentVariableAssociationInConfigRepoJson,
   environment_json: (): EnvironmentJSON => ({
     name: `environment-name-${randomString()}`,
+    can_administer: true,
     origins: [fileOriginJson(), configRepoOrigin()],
     pipelines: [pipelineAssociationInXmlJson(), pipelineAssociationInConfigRepoJson()],
     agents: [agentAssociationInXmlJson(), agentAssociationInConfigRepoJson()],
@@ -129,6 +130,7 @@ export default {
   }),
   xml_environment_json: (): EnvironmentJSON => ({
     name: `xml-environment-name-${randomString()}`,
+    can_administer: true,
     origins: [fileOriginJson()],
     pipelines: [pipelineAssociationInXmlJson()],
     agents: [agentAssociationInXmlJson()],
@@ -136,6 +138,7 @@ export default {
   }),
   config_repo_environment_json: (): EnvironmentJSON => ({
     name: `config-repo-environment-name-${randomString()}`,
+    can_administer: true,
     origins: [fileOriginJson(), configRepoOrigin()],
     pipelines: [pipelineAssociationInConfigRepoJson()],
     agents: [agentAssociationInConfigRepoJson()],

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.scss
@@ -121,7 +121,6 @@
 //subnavigation
 
 .sub-navigation {
-
   @media(min-width: $screen-md) {
     background:  $sub-navigation-bg;
     position:    absolute;
@@ -133,6 +132,10 @@
     box-shadow:  0 3px 10px $box-shadow-color;
     z-index:     map_get($zindex, submenu);
   }
+}
+
+.has-only-one-option {
+  padding:     10px 20px;
 }
 
 .site-sub-nav {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.scss.d.ts
@@ -2,6 +2,7 @@
 export const active: string;
 export const caretDownIcon: string;
 export const caret_down_icon: string;
+export const hasOnlyOneOption: string;
 export const isDropDown: string;
 export const mainMenu: string;
 export const siteNav: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.tsx
@@ -68,9 +68,9 @@ interface SiteNavItemAttrs extends TextWithLink {
 class SiteNavItem extends MithrilViewComponent<SiteNavItemAttrs> {
   view(vnode: m.Vnode<SiteNavItemAttrs>) {
     const dropDownClass = classnames({
-      [styles.isDropDown]: vnode.attrs.isDropDown,
-      [styles.active]: activeItem(vnode.attrs.href),
-    }, styles.siteNavItem);
+                                       [styles.isDropDown]: vnode.attrs.isDropDown,
+                                       [styles.active]: activeItem(vnode.attrs.href),
+                                     }, styles.siteNavItem);
 
     if (!vnode.attrs.isDropDown) {
       return (
@@ -204,6 +204,17 @@ export class SiteMenu extends MithrilViewComponent<Attrs> {
           </div>
         </SiteNavItem>;
       }
+    } else {
+      //Normal users now too have access to environments!!
+      adminMenu = (
+        <SiteNavItem isDropDown={true} text="Admin">
+          <div class={classnames(styles.subNavigation, styles.hasOnlyOneOption)}>
+            <SiteSubNav>
+              <SiteSubNavItem href="/go/admin/environments" text="Environments"/>
+            </SiteSubNav>
+          </div>
+        </SiteNavItem>
+      );
     }
 
     return <nav class={styles.mainMenu}>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/spec/index_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/spec/index_spec.tsx
@@ -153,7 +153,7 @@ describe("Site Menu", () => {
     expect(findMenuItem("/go/analytics")).toBeFalsy();
   });
 
-  it("should not show Admin link for non-admins", () => {
+  it("should show Admin link with environments tab for non-admins", () => {
     mount({
             canViewTemplates: true,
             isGroupAdmin: false,
@@ -168,7 +168,8 @@ describe("Site Menu", () => {
     expect(dashboard).toHaveAttr("href", "/go/pipelines");
     expect(agents).toHaveText("Agents");
     expect(agents).toHaveAttr("href", "/go/agents");
-    expect(admin).not.toHaveText("Admin");
+    expect(admin).toHaveText("Admin");
+    expect(findMenuItem("/go/admin/environments")).toHaveText("Environments");
   });
 
   function mount(menuAttrs: Attrs) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/create_env_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/create_env_modal.tsx
@@ -36,6 +36,7 @@ export class CreateEnvModal extends Modal {
     super();
     this.onSuccessfulSave = onSuccessfulSave;
     this.environment      = new EnvironmentWithOrigin("",
+                                                      true,
                                                       [new Origin(OriginType.GoCD)],
                                                       [],
                                                       new Pipelines(),

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environment_body_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environment_body_widget.tsx
@@ -36,12 +36,15 @@ export interface ElementListWidgetAttrs {
 
 export class ElementListWidget extends MithrilViewComponent<ElementListWidgetAttrs> {
   view(vnode: m.Vnode<ElementListWidgetAttrs>) {
+    const environment = vnode.attrs.environment;
     return <div class={styles.envBodyElement}
-                data-test-id={`${s.slugify(vnode.attrs.name)}-for-${vnode.attrs.environment.name()}`}>
+                                                            data-test-id={`${s.slugify(vnode.attrs.name)}-for-${environment.name()}`}>
       <div class={styles.envBodyElementHeader} data-test-id={`${s.slugify(vnode.attrs.name)}-header`}>
         <span>{vnode.attrs.name}</span>
         <Icons.Edit iconOnly={true}
-                    onclick={vnode.attrs.modalToRender.bind(vnode.attrs.modalToRender, vnode.attrs.environment)}/>
+                    title={environment.canAdminister() ? undefined : `You are not authorized to modify ${vnode.attrs.name.toLowerCase()} of '${environment.name()}' environment.`}
+                    disabled={!environment.canAdminister()}
+                    onclick={vnode.attrs.modalToRender.bind(vnode.attrs.modalToRender, environment)}/>
       </div>
       {vnode.children}
     </div>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
@@ -40,6 +40,8 @@ export class EnvironmentsWidget extends MithrilViewComponent<Attrs> {
                                warning={isEnvEmpty}
                                actions={[
                                  <Icons.Delete iconOnly={true}
+                                               title={environment.canAdminister() ? undefined : `You are not authorized to delete '${environment.name()}' environment.`}
+                                               disabled={!environment.canAdminister()}
                                                onclick={vnode.attrs.onDelete.bind(vnode.attrs, environment)}/>
                                ]}
                                dataTestId={`collapsible-panel-for-env-${environment.name()}`}>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_pipelines_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_pipelines_modal_spec.tsx
@@ -42,14 +42,14 @@ describe("Edit Pipelines Modal", () => {
 
     const anotherEnvPipelines = new Pipelines(pipelineWithOrigin);
 
-    const anotherEnv = new EnvironmentWithOrigin("another", [], [], anotherEnvPipelines, new EnvironmentVariables());
+    const anotherEnv = new EnvironmentWithOrigin("another", true, [], [], anotherEnvPipelines, new EnvironmentVariables());
 
     const pipelines = new Pipelines(
       PipelineWithOrigin.fromJSON(pipelineGroupsJSON.groups[0].pipelines[0]),
       PipelineWithOrigin.fromJSON(pipelineGroupsJSON.groups[1].pipelines[1])
     );
 
-    const environment  = new EnvironmentWithOrigin("UAT", [], [], pipelines, new EnvironmentVariables());
+    const environment  = new EnvironmentWithOrigin("UAT", true, [], [], pipelines, new EnvironmentVariables());
     const environments = new Environments(environment, anotherEnv);
 
     modal = new EditPipelinesModal(environment, environments, jasmine.createSpy("onSuccessfulSave"));

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environment_body_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environment_body_widget_spec.tsx
@@ -57,6 +57,33 @@ describe("Environments Body Widget", () => {
     expect(helper.byTestId("environment-variables-for-" + environment.name())).toBeInDOM();
   });
 
+  it('should render edit icons', () => {
+    const editIcons = helper.allByTestId("Edit-icon");
+    expect(editIcons).toHaveLength(3);
+  });
+
+  it('should render disabled edit icons when user does not have permissions to administer', () => {
+    const editIcons = helper.allByTestId("Edit-icon");
+    expect(editIcons).toHaveLength(3);
+
+    expect(editIcons[0].title).toBeFalsy();
+    expect(editIcons[0]).not.toBeDisabled();
+    expect(editIcons[1].title).toBeFalsy();
+    expect(editIcons[1]).not.toBeDisabled();
+    expect(editIcons[2].title).toBeFalsy();
+    expect(editIcons[2]).not.toBeDisabled();
+
+    environment.canAdminister(false);
+    helper.redraw();
+
+    expect(editIcons[0].title).toBe(`You are not authorized to modify pipelines of '${environment.name()}' environment.`);
+    expect(editIcons[0]).toBeDisabled();
+    expect(editIcons[1].title).toBe(`You are not authorized to modify agents of '${environment.name()}' environment.`);
+    expect(editIcons[1]).toBeDisabled();
+    expect(editIcons[2].title).toBe(`You are not authorized to modify environment variables of '${environment.name()}' environment.`);
+    expect(editIcons[2]).toBeDisabled();
+  });
+
   describe("Environment Pipelines", () => {
     it("should render pipeline header", () => {
       expect(helper.textByTestId("pipelines-header")).toContain("Pipelines");

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environments_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environments_widget_spec.tsx
@@ -63,6 +63,27 @@ describe("Environments Widget", () => {
     expect(helper.byTestId("environment-body-for-" + env.name)).toBeInDOM();
   });
 
+  it("should render delete icon for all the environments", () => {
+    mountModal([xmlEnv, configRepoEnv, env]);
+    const deleteIcons = helper.allByTestId("Delete-icon");
+    expect(deleteIcons).toHaveLength(3);
+  });
+
+  it("should render disabled delete icon for the environments that user can not administer", () => {
+    xmlEnv.can_administer = false;
+
+    mountModal([xmlEnv, configRepoEnv, env]);
+    const deleteIcons = helper.allByTestId("Delete-icon");
+    expect(deleteIcons).toHaveLength(3);
+
+    expect(deleteIcons[0].title).toBe(`You are not authorized to delete '${xmlEnv.name}' environment.`);
+    expect(deleteIcons[0]).toBeDisabled();
+    expect(deleteIcons[1].title).toBeFalsy();
+    expect(deleteIcons[1]).not.toBeDisabled();
+    expect(deleteIcons[2].title).toBeFalsy();
+    expect(deleteIcons[2]).not.toBeDisabled();
+  });
+
   it("should render warning line if no pipelines and agents assigned to the environment", () => {
     const envJson     = data.environment_json();
     envJson.agents    = [];

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/models/pipelines_view_model_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/models/pipelines_view_model_spec.ts
@@ -121,6 +121,7 @@ describe("Pipelines View Model", () => {
   it("should filter pipelines defined in other environment", () => {
     const pipeline = pipelinesViewModel.pipelineGroups()![0].pipelines()[0];
     environments.push(new EnvironmentWithOrigin("another",
+                                                true,
                                                 [],
                                                 [],
                                                 new Pipelines(pipeline),

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/NewEnvironmentsController.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/NewEnvironmentsController.java
@@ -46,7 +46,7 @@ public class NewEnvironmentsController implements SparkController {
     @Override
     public void setupRoutes() {
         path(controllerBasePath(), () -> {
-            before("", authenticationHelper::checkAdminUserAnd403);
+            before("", authenticationHelper::checkUserAnd403);
             get("", this::index, engine);
         });
     }

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/NewEnvironmentsControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/NewEnvironmentsControllerTest.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.spark.spa
+
+
+import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.NormalUserSecurity
+import com.thoughtworks.go.spark.SecurityServiceTrait
+import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+
+import static org.mockito.MockitoAnnotations.initMocks
+
+class NewEnvironmentsControllerTest implements ControllerTrait<NewEnvironmentsController>, SecurityServiceTrait {
+
+  @Override
+  NewEnvironmentsController createControllerInstance() {
+    return new NewEnvironmentsController(new SPAAuthenticationHelper(securityService, goConfigService), templateEngine)
+  }
+
+  @Nested
+  class Index {
+    @Nested
+    class Security implements SecurityTestTrait, NormalUserSecurity {
+
+      @Override
+      String getControllerMethodUnderTest() {
+        return "index"
+      }
+
+      @Override
+      void makeHttpCall() {
+        get(controller.controllerPath())
+      }
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    initMocks(this)
+  }
+
+}
+


### PR DESCRIPTION
#### Issue: #7222

#### Description:
* Show **Admin => Environments** navigation menu for normal users
* Make `/go/admin/environments` page accessible by normal users
* Fix `/go/api/admin/internal/environments/merged` to be accessible by normal users
* Add `can_administer` flag to internal environments API
* Disable administer action on environments spa when the user does not have permissions

#### Screenshots

1. Admin => Environments navigation

![Screen Shot 2019-11-15 at 2 39 12 PM](https://user-images.githubusercontent.com/15275847/68931686-115df000-07b7-11ea-8b21-9a73cc1aeb24.png)


2. Disable `delete` environment button

<img width="1437" alt="Screen Shot 2019-11-15 at 2 43 46 PM" src="https://user-images.githubusercontent.com/15275847/68931709-1de24880-07b7-11ea-920d-f92017123469.png">

3. Disable edit pipelines, agents and environment variables

![Screen Shot 2019-11-15 at 2 44 24 PM](https://user-images.githubusercontent.com/15275847/68931731-2a66a100-07b7-11ea-8a79-ca66abdfc75c.png)
![Screen Shot 2019-11-15 at 2 44 17 PM](https://user-images.githubusercontent.com/15275847/68931733-2aff3780-07b7-11ea-9050-83ba8095ba67.png)
![Screen Shot 2019-11-15 at 2 44 20 PM](https://user-images.githubusercontent.com/15275847/68931734-2aff3780-07b7-11ea-9a21-4d1ef6fdb23a.png)



