### PR TITLE
Handle policy evaluation when dealing with multiple roles (#7222)

### DIFF
--- a/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/ApiAuthenticationHelperTest.java
+++ b/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/ApiAuthenticationHelperTest.java
@@ -227,5 +227,79 @@ class ApiAuthenticationHelperTest {
             assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, null));
             assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, "env_1"));
         }
+
+        @Test
+        /*
+        <role name="deny-permissions">
+            <policy>
+                <deny action="administer" type="environment">*</deny>
+            </policy>
+            <users>
+                <user>Bob</user>
+            </users>
+        </role>
+        <role name="allow-permissions">
+            <policy>
+                <allow action="administer" type="environment">*</allow>
+            </policy>
+            <users>
+                <user>Bob</user>
+            </users>
+        </role>
+        */
+        void shouldNotAllowNormalUserAccessToEnvironmentWhenOnOfTheRoleHasAnExplicitDeny_WithFirstRoleAsDeny() {
+            Policy directives = new Policy();
+            directives.add(new Deny("administer", "environment", "*"));
+            RoleConfig denyRoleConfig = new RoleConfig(new CaseInsensitiveString("deny-permissions"), new Users(), directives);
+
+            Policy directives2 = new Policy();
+            directives2.add(new Allow("administer", "environment", "*"));
+            RoleConfig allowRoleConfig = new RoleConfig(new CaseInsensitiveString("allow-permissions"), new Users(), directives2);
+
+            when(goConfigService.rolesForUser(BOB.getUsername())).thenReturn(Arrays.asList(denyRoleConfig, allowRoleConfig));
+
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, null));
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, "env_1"));
+
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, null));
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, "env_1"));
+        }
+
+        @Test
+        /*
+        <role name="allow-permissions">
+            <policy>
+                <allow action="administer" type="environment">*</allow>
+            </policy>
+            <users>
+                <user>Bob</user>
+            </users>
+        </role>
+        <role name="deny-permissions">
+            <policy>
+                <deny action="administer" type="environment">*</deny>
+            </policy>
+            <users>
+                <user>Bob</user>
+            </users>
+        </role>
+        */
+        void shouldNotAllowNormalUserAccessToEnvironmentWhenOnOfTheRoleHasAnExplicitDeny_WithFirstRoleAsAllow() {
+            Policy directives = new Policy();
+            directives.add(new Deny("administer", "environment", "*"));
+            RoleConfig denyRoleConfig = new RoleConfig(new CaseInsensitiveString("deny-permissions"), new Users(), directives);
+
+            Policy directives2 = new Policy();
+            directives2.add(new Allow("administer", "environment", "*"));
+            RoleConfig allowRoleConfig = new RoleConfig(new CaseInsensitiveString("allow-permissions"), new Users(), directives2);
+
+            when(goConfigService.rolesForUser(BOB.getUsername())).thenReturn(Arrays.asList(allowRoleConfig, denyRoleConfig));
+
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, null));
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, "env_1"));
+
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, null));
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, "env_1"));
+        }
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/PolicyAware.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/PolicyAware.java
@@ -40,4 +40,18 @@ public interface PolicyAware {
                 .findFirst()
                 .orElse(false);
     }
+
+    default boolean hasExplicitDenyPermissionsFor(SupportedAction action, Class<? extends Validatable> entityType, String resource) {
+        Policy policy = getPolicy();
+        if (policy == null || policy.isEmpty()) {
+            return false;
+        }
+
+        return policy.stream()
+                .map(directive -> directive.apply(action.getAction(), entityType, resource))
+                .filter(result -> result != Result.SKIP)
+                .map(result -> result == Result.DENY)
+                .findFirst()
+                .orElse(false);
+    }
 }

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/AbstractAuthenticationHelper.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/AbstractAuthenticationHelper.java
@@ -78,13 +78,19 @@ public abstract class AbstractAuthenticationHelper {
         }
 
         List<Role> roles = goConfigService.rolesForUser(username.getUsername());
+
+        boolean hasPermission = false;
         for (Role role : roles) {
+            if (role.hasExplicitDenyPermissionsFor(action, entity.getEntityType(), resource)) {
+                return false;
+            }
+
             if (role.hasPermissionsFor(action, entity.getEntityType(), resource)) {
-                return true;
+                hasPermission = true;
             }
         }
 
-        return false;
+        return hasPermission;
     }
 
     public void checkUserHasPermissions(Username username, SupportedAction action, SupportedEntity entity, String resource) {


### PR DESCRIPTION
##### Issue: #7222

##### Description:

* Do not allow access to user when one of the policy definition from
  multiple roles has an explicit deny access to the resource.

Example:

* User Bob belongs to following two roles:
	- allow-env-role: Allows 'All' access to 'All' environments
	- deny-env-role: Denies 'All' access to 'All' environments
  In the above mentioned case, User bob will not have access to any of
  the environments, as 'deny-env-role' specifies a policy with explicit
  deny permission.
