### PR TITLE
Fix inconsistent ordering when ordering by `lastTransitionTime`

### DIFF
--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/JobInstance.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/JobInstance.xml
@@ -307,7 +307,6 @@
         joined.pipelineCounter,
         joined.stageCounter,
         joined.rerunOfCounter,
-        joined.duration,
 
         buildstatetransitions.id AS stateId,
         buildstatetransitions.buildid AS buildid,
@@ -324,10 +323,7 @@
             stages.name AS stageName,
             pipelines.counter AS pipelineCounter,
             stages.counter AS stageCounter,
-            stages.rerunOfCounter AS rerunOfCounter,
-            (
-                SELECT TIMESTAMPDIFF(MILLISECOND, stateChangeTime, bst.stateChangeTime) FROM buildStateTransitions WHERE buildid = builds.id AND currentState = 'Scheduled'
-            ) as duration
+            stages.rerunOfCounter AS rerunOfCounter
             FROM builds
             INNER JOIN stages on builds.stageid = stages.id
             INNER JOIN pipelines on stages.pipelineid = pipelines.id
@@ -336,6 +332,12 @@
                 (builds.state = 'Completed' OR ignored = true)
                 AND builds.agentUuid = #{uuid}
             ORDER BY ${column} ${order}
+            <if test="order == &quot;ASC&quot;">
+                NULLS FIRST
+            </if>
+            <if test="order == &quot;DESC&quot;">
+                NULLS LAST
+            </if>
             LIMIT #{limit}
             OFFSET #{offset}
         ) AS joined


### PR DESCRIPTION
The `buildStateTransition` table contains a `NULL` transition time for
`completed` state for jobs that are re-scheduled. This behavior by
itself is not a problem as such. However when sorting based on the
`lastTransitionTime`, `NULL` values need to be handled more gracefully
by adding a `NULLS FIRST` or `NULLS LAST` depending on the desired
ordering.

Fixes #7138