### PR TITLE
Update Policy to support config repo

### DIFF
--- a/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2.java
+++ b/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2.java
@@ -85,24 +85,21 @@ public class ConfigReposInternalControllerV2 extends ApiController implements Sp
             before("/*", mimeType, this::setContentType);
             before("/*", mimeType, this::verifyContentType);
 
+            before(ConfigRepos.REPO_PATH, mimeType, this::authorize);
+            before(ConfigRepos.STATUS_PATH, mimeType, this::authorize);
+            before(ConfigRepos.TRIGGER_UPDATE_PATH, mimeType, this::authorize);
+            before(ConfigRepos.DEFINITIONS_PATH, mimeType, this::authorize);
+
             get(ConfigRepos.INDEX_PATH, mimeType, this::listRepos);
-            before(ConfigRepos.REPO_PATH, mimeType, (request, response) -> {
-                authHelper.checkUserHasPermissions(currentUsername(), getAction(request), CONFIG_REPO, request.params(":id"));
-            });
             get(ConfigRepos.REPO_PATH, mimeType, this::showRepo);
-            before(ConfigRepos.STATUS_PATH, mimeType, (request, response) -> {
-                authHelper.checkUserHasPermissions(currentUsername(), getAction(request), CONFIG_REPO, request.params(":id"));
-            });
             get(ConfigRepos.STATUS_PATH, mimeType, this::inProgress);
-            before(ConfigRepos.TRIGGER_UPDATE_PATH, mimeType, (request, response) -> {
-                authHelper.checkUserHasPermissions(currentUsername(), getAction(request), CONFIG_REPO, request.params(":id"));
-            });
             post(ConfigRepos.TRIGGER_UPDATE_PATH, mimeType, this::triggerUpdate);
-            before(ConfigRepos.DEFINITIONS_PATH, mimeType, (request, response) -> {
-                authHelper.checkUserHasPermissions(currentUsername(), getAction(request), CONFIG_REPO, request.params(":id"));
-            });
             get(ConfigRepos.DEFINITIONS_PATH, mimeType, this::definedConfigs);
         });
+    }
+
+    private void authorize(Request request, Response response) {
+        authHelper.checkUserHasPermissions(currentUsername(), getAction(request), CONFIG_REPO, request.params(":id"));
     }
 
     String listRepos(Request req, Response res) throws IOException {

--- a/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultListRepresenter.java
+++ b/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultListRepresenter.java
@@ -20,17 +20,21 @@ import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.apiv2.configrepos.ConfigRepoWithResult;
 
 import java.util.List;
+import java.util.function.Function;
 
 import static com.thoughtworks.go.spark.Routes.ConfigRepos.BASE;
 
 public class ConfigRepoWithResultListRepresenter {
-    public static void toJSON(OutputWriter json, List<ConfigRepoWithResult> repos) {
+    public static void toJSON(OutputWriter json, List<ConfigRepoWithResult> repos, Function<String, Boolean> canUserAdministerConfigRepo) {
         attachLinks(json);
         json.addChild("_embedded", w -> w.addChildList(
                 "config_repos", all -> repos.forEach(
-                        repo -> all.addChild(
-                                el -> ConfigRepoWithResultRepresenter.toJSON(el, repo)
-                        )
+                        repo -> {
+                            boolean canAdminister = canUserAdministerConfigRepo.apply(repo.repo().getId());
+                            all.addChild(
+                                    el -> ConfigRepoWithResultRepresenter.toJSON(el, repo, canAdminister)
+                            );
+                        }
                 )
         ));
     }

--- a/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultRepresenter.java
+++ b/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultRepresenter.java
@@ -25,7 +25,7 @@ import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import static com.thoughtworks.go.spark.Routes.ConfigRepos.*;
 
 public class ConfigRepoWithResultRepresenter {
-    public static void toJSON(OutputWriter json, ConfigRepoWithResult crwr) {
+    public static void toJSON(OutputWriter json, ConfigRepoWithResult crwr, boolean canAdminister) {
         ConfigRepoConfig repo = crwr.repo();
         PartialConfigParseResult result = crwr.result();
 
@@ -33,6 +33,7 @@ public class ConfigRepoWithResultRepresenter {
         json.add("id", repo.getId());
         json.add("plugin_id", repo.getPluginId());
         json.addChild("material", w -> MaterialsRepresenter.toJSON(w, repo.getMaterialConfig()));
+        json.add("can_administer", canAdminister);
         attachConfigurations(json, repo);
 
         json.add("material_update_in_progress", crwr.isMaterialUpdateInProgress());

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposControllerV2Test.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposControllerV2Test.groovy
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
 
-import static com.thoughtworks.go.api.util.HaltApiMessages.forbiddenMessage
 import static com.thoughtworks.go.helper.MaterialConfigsMother.hg
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
@@ -265,7 +264,7 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
       assertThatResponse()
         .isForbidden()
-        .hasJsonMessage(forbiddenMessage())
+        .hasJsonMessage("User '${currentUsername().getDisplayName()}' does not have permissions to view 'repo-01' config_repo(s).")
     }
 
     @Test
@@ -389,7 +388,7 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
       assertThatResponse()
         .isForbidden()
-        .hasJsonMessage(forbiddenMessage())
+        .hasJsonMessage("User '${currentUsername().getDisplayName()}' does not have permissions to administer 'test-repo' config_repo(s).")
     }
   }
 
@@ -508,7 +507,7 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
       assertThatResponse().
         isForbidden().
-        hasJsonMessage(forbiddenMessage())
+        hasJsonMessage("User '${currentUsername().getDisplayName()}' does not have permissions to administer 'test-id' config_repo(s).")
     }
   }
 
@@ -556,7 +555,7 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
       assertThatResponse()
         .isForbidden()
-        .hasJsonMessage(forbiddenMessage())
+        .hasJsonMessage("User '${currentUsername().getDisplayName()}' does not have permissions to administer 'repo-02' config_repo(s).")
     }
   }
 

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposControllerV2Test.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposControllerV2Test.groovy
@@ -18,24 +18,31 @@ package com.thoughtworks.go.apiv2.configrepos
 
 import com.thoughtworks.go.api.SecurityTestTrait
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
+import com.thoughtworks.go.config.CaseInsensitiveString
+import com.thoughtworks.go.config.RoleConfig
+import com.thoughtworks.go.config.Users
 import com.thoughtworks.go.config.materials.PasswordDeserializer
-import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig
-import static com.thoughtworks.go.helper.MaterialConfigsMother.hg
+import com.thoughtworks.go.config.policy.Allow
+import com.thoughtworks.go.config.policy.Deny
+import com.thoughtworks.go.config.policy.Policy
 import com.thoughtworks.go.config.remote.ConfigRepoConfig
 import com.thoughtworks.go.config.remote.ConfigReposConfig
 import com.thoughtworks.go.server.domain.Username
 import com.thoughtworks.go.server.service.ConfigRepoService
 import com.thoughtworks.go.server.service.EntityHashingService
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult
-import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.Routes
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.invocation.InvocationOnMock
 
+import static com.thoughtworks.go.api.util.HaltApiMessages.forbiddenMessage
+import static com.thoughtworks.go.helper.MaterialConfigsMother.hg
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
@@ -69,8 +76,23 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
   @Nested
   class Security {
+    @BeforeEach
+    void setUp() {
+      Policy directives = new Policy()
+      directives.add(new Allow("administer", "config_repo", "*"))
+      RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)
+
+      when(goConfigService.rolesForUser(any())).then({ InvocationOnMock invocation ->
+        CaseInsensitiveString username = invocation.getArguments()[0]
+        if (username == Username.ANONYMOUS.username) {
+          return []
+        }
+        return [roleConfig]
+      })
+    }
+
     @Nested
-    class Index implements SecurityTestTrait, AdminUserSecurity {
+    class Index implements SecurityTestTrait, NormalUserSecurity {
       @Override
       String getControllerMethodUnderTest() {
         return "index"
@@ -83,7 +105,7 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
     }
 
     @Nested
-    class Show implements SecurityTestTrait, AdminUserSecurity {
+    class Show implements SecurityTestTrait, NormalUserSecurity {
       @Override
       String getControllerMethodUnderTest() {
         return "showRepo"
@@ -96,7 +118,7 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
     }
 
     @Nested
-    class Create implements SecurityTestTrait, AdminUserSecurity {
+    class Create implements SecurityTestTrait, NormalUserSecurity {
       @Override
       String getControllerMethodUnderTest() {
         return "createRepo"
@@ -104,12 +126,12 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
       @Override
       void makeHttpCall() {
-        postWithApiHeader(controller.controllerBasePath(), [:])
+        postWithApiHeader(controller.controllerBasePath(), [id: 'repo-id'])
       }
     }
 
     @Nested
-    class Update implements SecurityTestTrait, AdminUserSecurity {
+    class Update implements SecurityTestTrait, NormalUserSecurity {
       @Override
       String getControllerMethodUnderTest() {
         return "updateRepo"
@@ -122,7 +144,7 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
     }
 
     @Nested
-    class Delete implements SecurityTestTrait, AdminUserSecurity {
+    class Delete implements SecurityTestTrait, NormalUserSecurity {
       @Override
       String getControllerMethodUnderTest() {
         return "deleteRepo"
@@ -140,11 +162,47 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
     @BeforeEach
     void setup() {
-      loginAsAdmin()
+      loginAsUser()
     }
 
     @Test
-    void 'should list existing config repos'() {
+    void 'should list existing config repos for which user has permissions'() {
+      Policy directives = new Policy()
+      directives.add(new Allow("administer", "config_repo", "repo-01"))
+      RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)
+
+      when(goConfigService.rolesForUser(any())).thenReturn([roleConfig])
+
+      def repoConfig = repo(ID_1)
+      def userSpecificRepos = new ConfigReposConfig(repoConfig)
+      ConfigReposConfig repos = new ConfigReposConfig(repoConfig, repo(ID_2))
+      when(service.getConfigRepos()).thenReturn(repos)
+
+      getWithApiHeader(controller.controllerBasePath())
+
+      assertThatResponse().
+        isOk().
+        hasHeader('ETag', "\"${userSpecificRepos.etag()}\"").
+        hasJsonBody([
+          _links   : [
+            self: [href: "http://test.host/go$Routes.ConfigRepos.BASE".toString()]
+          ],
+          _embedded: [
+            config_repos: [
+              expectedRepoJson(ID_1)
+            ]
+          ]
+        ])
+    }
+
+    @Test
+    void 'should return no config repos when user does not have access to any config repo'() {
+      Policy directives = new Policy()
+      directives.add(new Allow("administer", "config_repo", "blah-*"))
+      RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)
+
+      when(goConfigService.rolesForUser(any())).thenReturn([roleConfig])
+
       ConfigReposConfig repos = new ConfigReposConfig(repo(ID_1), repo(ID_2))
       when(service.getConfigRepos()).thenReturn(repos)
 
@@ -152,16 +210,13 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
       assertThatResponse().
         isOk().
-        hasHeader('ETag', "\"${repos.etag()}\"").
+        hasHeader('ETag', "\"${new ConfigReposConfig().etag()}\"").
         hasJsonBody([
           _links   : [
             self: [href: "http://test.host/go$Routes.ConfigRepos.BASE".toString()]
           ],
           _embedded: [
-            config_repos: [
-              expectedRepoJson(ID_1),
-              expectedRepoJson(ID_2)
-            ]
+            config_repos: []
           ]
         ])
     }
@@ -172,11 +227,17 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
     @BeforeEach
     void setup() {
-      loginAsAdmin()
+      loginAsUser()
     }
 
     @Test
-    void 'fetches a repo'() {
+    void 'fetches a repo if the user has permission'() {
+      Policy directives = new Policy()
+      directives.add(new Allow("administer", "config_repo", "repo-*"))
+      RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)
+
+      when(goConfigService.rolesForUser(any())).thenReturn([roleConfig])
+
       ConfigRepoConfig repo = repo(ID_1)
       when(service.getConfigRepo(ID_1)).thenReturn(repo)
       when(entityHashingService.md5ForEntity(repo)).thenReturn('md5')
@@ -190,7 +251,31 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
     }
 
     @Test
+    void 'returns 403 if the user does not have permission to view it'() {
+      Policy directives = new Policy()
+      directives.add(new Deny("view", "config_repo", "repo-*"))
+      RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)
+
+      when(goConfigService.rolesForUser(any())).thenReturn([roleConfig])
+
+      ConfigRepoConfig repo = repo(ID_1)
+      when(service.getConfigRepo(ID_1)).thenReturn(repo)
+
+      getWithApiHeader(controller.controllerPath(ID_1))
+
+      assertThatResponse()
+        .isForbidden()
+        .hasJsonMessage(forbiddenMessage())
+    }
+
+    @Test
     void 'returns 404 if the repo does not exist'() {
+      Policy directives = new Policy()
+      directives.add(new Allow("administer", "config_repo", "repo-*"))
+      RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)
+
+      when(goConfigService.rolesForUser(any())).thenReturn([roleConfig])
+
       getWithApiHeader(controller.controllerPath(ID_1))
 
       assertThatResponse().isNotFound()
@@ -202,12 +287,18 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
     @BeforeEach
     void setup() {
-      loginAsAdmin()
+      loginAsUser()
     }
 
     @Test
-    void 'creates a new config repo'() {
+    void 'creates a new config repo if the user has access to create one'() {
       String id = "test-repo"
+
+      Policy directives = new Policy()
+      directives.add(new Allow("administer", "config_repo", id))
+      RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)
+
+      when(goConfigService.rolesForUser(any())).thenReturn([roleConfig])
 
       postWithApiHeader(controller.controllerBasePath(), [
         id           : id,
@@ -234,6 +325,12 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
     @Test
     void 'create fails if an existing repo has the same id'() {
       String id = "test-repo"
+
+      Policy directives = new Policy()
+      directives.add(new Allow("administer", "config_repo", id))
+      RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)
+
+      when(goConfigService.rolesForUser(any())).thenReturn([roleConfig])
 
       when(service.getConfigRepo(id)).thenReturn(repo(id))
 
@@ -265,6 +362,35 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
           data   : payload
         ])
     }
+
+    @Test
+    void 'should not allow to create a config repo if the user does not have permissions'() {
+      String id = "test-repo"
+
+      Policy directives = new Policy()
+      directives.add(new Allow("view", "config_repo", id))
+      RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)
+
+      when(goConfigService.rolesForUser(any())).thenReturn([roleConfig])
+
+      postWithApiHeader(controller.controllerBasePath(), [
+        id           : id,
+        plugin_id    : TEST_PLUGIN_ID,
+        material     : [
+          type      : "hg",
+          attributes: [
+            name       : null,
+            url        : "${TEST_REPO_URL}/$id".toString(),
+            auto_update: true
+          ]
+        ],
+        configuration: []
+      ])
+
+      assertThatResponse()
+        .isForbidden()
+        .hasJsonMessage(forbiddenMessage())
+    }
   }
 
   @Nested
@@ -272,7 +398,12 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
     @BeforeEach
     void setup() {
-      loginAsAdmin()
+      loginAsUser()
+      Policy directives = new Policy()
+      directives.add(new Allow("administer", "config_repo", "*repo*"))
+      RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)
+
+      when(goConfigService.rolesForUser(any())).thenReturn([roleConfig])
     }
 
     @Test
@@ -356,6 +487,29 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
         isPreconditionFailed().
         hasJsonMessage("Someone has modified the entity. Please update your copy with the changes and try again.")
     }
+
+    @Test
+    void 'should throw 403 if the user does not have permission to update config-repo'() {
+      String id = "test-id"
+
+      putWithApiHeader(controller.controllerPath(id), ['If-Match': 'md5'], [
+        id           : id,
+        plugin_id    : TEST_PLUGIN_ID,
+        material     : [
+          type      : "hg",
+          attributes: [
+            name       : null,
+            url        : "https://newfakeurl.com",
+            auto_update: true
+          ]
+        ],
+        configuration: []
+      ])
+
+      assertThatResponse().
+        isForbidden().
+        hasJsonMessage(forbiddenMessage())
+    }
   }
 
   @Nested
@@ -363,7 +517,12 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
     @BeforeEach
     void setup() {
-      loginAsAdmin()
+      loginAsUser()
+      Policy directives = new Policy()
+      directives.add(new Allow("administer", "config_repo", ID_1))
+      RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)
+
+      when(goConfigService.rolesForUser(any())).thenReturn([roleConfig])
     }
 
     @Test
@@ -389,6 +548,15 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
       assertThatResponse().
         isNotFound()
+    }
+
+    @Test
+    void 'should throw 403 if the user does not have permission to delete'() {
+      deleteWithApiHeader(controller.controllerPath(ID_2))
+
+      assertThatResponse()
+        .isForbidden()
+        .hasJsonMessage(forbiddenMessage())
     }
   }
 

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2Test.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2Test.groovy
@@ -45,7 +45,6 @@ import org.mockito.invocation.InvocationOnMock
 
 import java.util.stream.Collectors
 
-import static com.thoughtworks.go.api.util.HaltApiMessages.forbiddenMessage
 import static com.thoughtworks.go.helper.MaterialConfigsMother.hg
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.*
@@ -216,7 +215,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
 
       assertThatResponse()
         .isForbidden()
-        .hasJsonMessage(forbiddenMessage())
+        .hasJsonMessage("User '${currentUsername().getDisplayName()}' does not have permissions to view 'test-id' config_repo(s).")
     }
   }
 
@@ -328,7 +327,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
 
         assertThatResponse()
           .isForbidden()
-          .hasJsonMessage(forbiddenMessage())
+          .hasJsonMessage("User '${currentUsername().getDisplayName()}' does not have permissions to view 'test-id' config_repo(s).")
       }
 
       private PipelineConfigs groupWithPipelines(String groupName, String... pipelineNames) {
@@ -407,7 +406,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
 
         assertThatResponse()
           .isForbidden()
-          .hasJsonMessage(forbiddenMessage())
+          .hasJsonMessage("User '${currentUsername().getDisplayName()}' does not have permissions to view 'test-id' config_repo(s).")
       }
     }
   }
@@ -476,7 +475,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
 
         assertThatResponse()
           .isForbidden()
-          .hasJsonMessage(forbiddenMessage())
+          .hasJsonMessage("User '${currentUsername().getDisplayName()}' does not have permissions to administer 'test-id' config_repo(s).")
       }
     }
   }

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2Test.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2Test.groovy
@@ -20,6 +20,8 @@ import com.thoughtworks.go.api.SecurityTestTrait
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.config.*
 import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig
+import com.thoughtworks.go.config.policy.Allow
+import com.thoughtworks.go.config.policy.Policy
 import com.thoughtworks.go.config.remote.ConfigRepoConfig
 import com.thoughtworks.go.config.remote.ConfigReposConfig
 import com.thoughtworks.go.config.remote.PartialConfig
@@ -27,20 +29,23 @@ import com.thoughtworks.go.domain.PipelineGroups
 import com.thoughtworks.go.domain.materials.Material
 import com.thoughtworks.go.domain.materials.MaterialConfig
 import com.thoughtworks.go.domain.materials.Modification
+import com.thoughtworks.go.server.domain.Username
 import com.thoughtworks.go.server.materials.MaterialUpdateService
 import com.thoughtworks.go.server.service.ConfigRepoService
 import com.thoughtworks.go.server.service.MaterialConfigConverter
-import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.Routes
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.invocation.InvocationOnMock
 
 import java.util.stream.Collectors
 
+import static com.thoughtworks.go.api.util.HaltApiMessages.forbiddenMessage
 import static com.thoughtworks.go.helper.MaterialConfigsMother.hg
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.*
@@ -67,6 +72,17 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
   @BeforeEach
   void setUp() {
     initMocks(this)
+    Policy directives = new Policy()
+    directives.add(new Allow("administer", "config_repo", "repo-*"))
+    RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)
+
+    when(goConfigService.rolesForUser(any())).then({ InvocationOnMock invocation ->
+      CaseInsensitiveString username = invocation.getArguments()[0]
+      if (username == Username.ANONYMOUS.username) {
+        return []
+      }
+      return [roleConfig]
+    })
   }
 
   @Override
@@ -75,7 +91,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
   }
 
   @Nested
-  class IndexSecurity implements SecurityTestTrait, AdminUserSecurity {
+  class IndexSecurity implements SecurityTestTrait, NormalUserSecurity {
     @Override
     String getControllerMethodUnderTest() {
       return "listRepos"
@@ -88,7 +104,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
   }
 
   @Nested
-  class GetSecurity implements SecurityTestTrait, AdminUserSecurity {
+  class GetSecurity implements SecurityTestTrait, NormalUserSecurity {
     @Override
     String getControllerMethodUnderTest() {
       return "showRepo"
@@ -105,27 +121,27 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
 
     @BeforeEach
     void setup() {
-      loginAsAdmin()
+      loginAsUser()
     }
 
     @Test
-    void 'should list existing config repos with associated parse results'() {
+    void 'should list only those existing config repos, with associated parse results, for which the user has permission'() {
       Modification modification = new Modification()
       modification.setRevision("abc")
 
       PartialConfig partialConfig = new PartialConfig()
       PartialConfigParseResult result = PartialConfigParseResult.parseSuccess(modification, partialConfig);
 
-      ConfigReposConfig repos = new ConfigReposConfig(repo(ID_1), repo(ID_2))
+      ConfigReposConfig repos = new ConfigReposConfig(repo(ID_1), repo(ID_2), repo("test-id"))
       when(service.getConfigRepos()).thenReturn(repos)
       when(dataSource.getLastParseResult(repos.get(0).getMaterialConfig())).thenReturn(null)
       when(dataSource.getLastParseResult(repos.get(1).getMaterialConfig())).thenReturn(result)
 
       getWithApiHeader(controller.controllerBasePath())
 
-      assertThatResponse().
-        isOk().
-        hasJsonBody([
+      assertThatResponse()
+        .isOk()
+        .hasJsonBody([
           _links   : [
             self: [href: "http://test.host/go$Routes.ConfigRepos.BASE".toString()]
           ],
@@ -137,6 +153,26 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
           ]
         ])
     }
+
+    @Test
+    void 'should return empty list if the user does not have permission to view any config repos'() {
+      ConfigReposConfig repos = new ConfigReposConfig(repo("test-id"), repo("another-id"))
+      when(service.getConfigRepos()).thenReturn(repos)
+
+      getWithApiHeader(controller.controllerBasePath())
+
+      assertThatResponse()
+        .isOk()
+        .hasEtag("\"${new ConfigReposConfig().etag()}\"")
+        .hasJsonBody([
+          _links   : [
+            self: [href: "http://test.host/go$Routes.ConfigRepos.BASE".toString()]
+          ],
+          _embedded: [
+            config_repos: []
+          ]
+        ])
+    }
   }
 
   @Nested
@@ -144,7 +180,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
 
     @BeforeEach
     void setup() {
-      loginAsAdmin()
+      loginAsUser()
     }
 
     @Test
@@ -173,6 +209,15 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
       verify(dataSource, never()).getLastParseResult(any() as MaterialConfig)
       assertThatResponse().isNotFound()
     }
+
+    @Test
+    void 'should throw 403 if user does not have access to the specified config repo'() {
+      getWithApiHeader(controller.controllerPath('test-id'))
+
+      assertThatResponse()
+        .isForbidden()
+        .hasJsonMessage(forbiddenMessage())
+    }
   }
 
   static Map expectedRepoJson(String id, String revision, String error, boolean isInProgress) {
@@ -194,9 +239,8 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
         ]
       ],
       configuration              : [],
-
+      can_administer             : true,
       material_update_in_progress: isInProgress,
-
       parse_info                 : null == revision ? [:] : [
         error                     : error,
         good_modification         : [
@@ -227,7 +271,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
   @Nested
   class Definitions {
     @Nested
-    class Security implements SecurityTestTrait, AdminUserSecurity {
+    class Security implements SecurityTestTrait, NormalUserSecurity {
       @Override
       String getControllerMethodUnderTest() {
         return "definedConfigs"
@@ -243,7 +287,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
     class Requests {
       @BeforeEach
       void setUp() {
-        loginAsAdmin()
+        loginAsUser()
       }
 
       @Test
@@ -278,6 +322,15 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
           ])
       }
 
+      @Test
+      void 'should throw 403 if user does not have access to the specified config repo'() {
+        getWithApiHeader(controller.controllerPath('test-id', 'definitions'), [:])
+
+        assertThatResponse()
+          .isForbidden()
+          .hasJsonMessage(forbiddenMessage())
+      }
+
       private PipelineConfigs groupWithPipelines(String groupName, String... pipelineNames) {
         PipelineConfig[] pipelines = Arrays.stream(pipelineNames).map({ String s ->
           PipelineConfig p = mock(PipelineConfig.class)
@@ -293,7 +346,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
   @Nested
   class Status {
     @Nested
-    class Security implements SecurityTestTrait, AdminUserSecurity {
+    class Security implements SecurityTestTrait, NormalUserSecurity {
       @Override
       String getControllerMethodUnderTest() {
         return "inProgress"
@@ -309,7 +362,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
     class Requests {
       @BeforeEach
       void setUp() {
-        loginAsAdmin()
+        loginAsUser()
       }
 
       @Test
@@ -347,13 +400,22 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
           .hasContentType(controller.mimeType)
           .hasJsonBody([inProgress: false])
       }
+
+      @Test
+      void 'should throw 403 if user does not have access to the specified config repo'() {
+        getWithApiHeader(controller.controllerPath('test-id', 'status'), [:])
+
+        assertThatResponse()
+          .isForbidden()
+          .hasJsonMessage(forbiddenMessage())
+      }
     }
   }
 
   @Nested
   class Trigger {
     @Nested
-    class Security implements SecurityTestTrait, AdminUserSecurity {
+    class Security implements SecurityTestTrait, NormalUserSecurity {
       @Override
       String getControllerMethodUnderTest() {
         return "triggerUpdate"
@@ -369,7 +431,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
     class Requests {
       @BeforeEach
       void setUp() {
-        loginAsAdmin()
+        loginAsUser()
       }
 
       @Test
@@ -406,6 +468,15 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
           .isConflict()
           .hasContentType(controller.mimeType)
           .hasJsonMessage("Update already in progress.")
+      }
+
+      @Test
+      void 'should throw 403 if user does not have access to the specified config repo'() {
+        postWithApiHeader(controller.controllerPath('test-id', 'trigger_update'), [:])
+
+        assertThatResponse()
+          .isForbidden()
+          .hasJsonMessage(forbiddenMessage())
       }
     }
   }

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultListRepresenterTest.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultListRepresenterTest.groovy
@@ -19,14 +19,16 @@ package com.thoughtworks.go.apiv2.configrepos.representers
 import com.thoughtworks.go.apiv2.configrepos.ConfigRepoWithResult
 import com.thoughtworks.go.config.PartialConfigParseResult
 import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig
-import static com.thoughtworks.go.helper.MaterialConfigsMother.hg
 import com.thoughtworks.go.config.remote.ConfigRepoConfig
 import com.thoughtworks.go.config.remote.PartialConfig
 import com.thoughtworks.go.domain.materials.Modification
 import com.thoughtworks.go.spark.Routes
 import org.junit.jupiter.api.Test
 
+import java.util.function.Function
+
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static com.thoughtworks.go.helper.MaterialConfigsMother.hg
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 
 class ConfigRepoWithResultListRepresenterTest {
@@ -36,7 +38,9 @@ class ConfigRepoWithResultListRepresenterTest {
   @Test
   void toJSON() {
     List<ConfigRepoWithResult> repos = [repo("foo"), repo("bar")]
-    String json = toObjectString({ w -> ConfigRepoWithResultListRepresenter.toJSON(w, repos) })
+    Function<String, Boolean> canUserAdministerConfigRepo = { name -> true }
+
+    String json = toObjectString({ w -> ConfigRepoWithResultListRepresenter.toJSON(w, repos, canUserAdministerConfigRepo) })
 
     assertThatJson(json).isEqualTo([
       _links   : [
@@ -69,6 +73,7 @@ class ConfigRepoWithResultListRepresenterTest {
           auto_update: true
         ]
       ],
+      can_administer             : true,
       configuration              : [],
       material_update_in_progress: false,
       parse_info                 : [

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultRepresenterTest.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultRepresenterTest.groovy
@@ -41,7 +41,7 @@ class ConfigRepoWithResultRepresenterTest {
     ConfigRepoWithResult result = repo(id)
 
     String json = toObjectString({ w ->
-      ConfigRepoWithResultRepresenter.toJSON(w, result)
+      ConfigRepoWithResultRepresenter.toJSON(w, result, true)
     })
 
     String self = "http://test.host/go${Routes.ConfigRepos.id(id)}"
@@ -64,6 +64,7 @@ class ConfigRepoWithResultRepresenterTest {
           auto_update: true
         ]
       ],
+      can_administer: true,
       configuration              : [
         [key: "foo", value: "bar"],
         [key: "baz", value: "quu"]

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Role.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Role.java
@@ -24,12 +24,13 @@ import java.util.*;
 import static com.thoughtworks.go.config.CaseInsensitiveString.isBlank;
 import static com.thoughtworks.go.config.policy.SupportedAction.ADMINISTER;
 import static com.thoughtworks.go.config.policy.SupportedAction.VIEW;
+import static com.thoughtworks.go.config.policy.SupportedEntity.CONFIG_REPO;
 import static com.thoughtworks.go.config.policy.SupportedEntity.ENVIRONMENT;
 
 @ConfigInterface
 public interface Role extends Validatable, PolicyAware {
     List<String> allowedActions = SupportedAction.unmodifiableListOf(VIEW, ADMINISTER);
-    List<String> allowedTypes = SupportedEntity.unmodifiableListOf(ENVIRONMENT);
+    List<String> allowedTypes = SupportedEntity.unmodifiableListOf(ENVIRONMENT, CONFIG_REPO);
 
     CaseInsensitiveString getName();
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/SupportedEntity.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/SupportedEntity.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.config.policy;
 import com.thoughtworks.go.config.EnvironmentConfig;
 import com.thoughtworks.go.config.PipelineConfigs;
 import com.thoughtworks.go.config.Validatable;
+import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,6 +30,7 @@ import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 
 public enum SupportedEntity {
     ENVIRONMENT("environment", EnvironmentConfig.class),
+    CONFIG_REPO("config_repo", ConfigRepoConfig.class),
     UNKNOWN(null, null);
 
     private final String type;

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/policy/SupportedEntityTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/policy/SupportedEntityTest.java
@@ -19,12 +19,12 @@ package com.thoughtworks.go.config.policy;
 import com.thoughtworks.go.config.BasicEnvironmentConfig;
 import com.thoughtworks.go.config.EnvironmentConfig;
 import com.thoughtworks.go.config.merge.MergeEnvironmentConfig;
+import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static com.thoughtworks.go.config.policy.SupportedEntity.ENVIRONMENT;
-import static com.thoughtworks.go.config.policy.SupportedEntity.unmodifiableListOf;
+import static com.thoughtworks.go.config.policy.SupportedEntity.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
@@ -36,6 +36,12 @@ class SupportedEntityTest {
 
         assertThat(ENVIRONMENT.getEntityType().isAssignableFrom(BasicEnvironmentConfig.class)).isTrue();
         assertThat(ENVIRONMENT.getEntityType().isAssignableFrom(MergeEnvironmentConfig.class)).isTrue();
+    }
+
+    @Test
+    void shouldSupportConfigRepo() {
+        assertThat(CONFIG_REPO.getType()).isEqualTo("config_repo");
+        assertThat(CONFIG_REPO.getEntityType()).isEqualTo(ConfigRepoConfig.class);
     }
 
     @Test

--- a/server/src/main/java/com/thoughtworks/go/config/update/ConfigRepoCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ConfigRepoCommand.java
@@ -96,14 +96,6 @@ abstract class ConfigRepoCommand implements EntityConfigUpdateCommand<ConfigRepo
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isUserAuthorized();
-    }
-
-    private boolean isUserAuthorized() {
-        if (!securityService.isUserAdmin(username)) {
-            result.forbidden(EntityType.ConfigRepo.forbiddenToEdit(configRepo.getId(), username.getUsername()), forbidden());
-            return false;
-        }
         return true;
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeleteConfigRepoCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeleteConfigRepoCommand.java
@@ -63,18 +63,10 @@ public class DeleteConfigRepoCommand implements EntityConfigUpdateCommand<Config
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return doesConfigRepoExist(cruiseConfig) && isUserAuthorized();
+        return doesConfigRepoExist(cruiseConfig);
     }
 
     private boolean doesConfigRepoExist(CruiseConfig cruiseConfig) {
         return cruiseConfig.getConfigRepos().getConfigRepo(repoId) != null;
-    }
-
-    public boolean isUserAuthorized() {
-        if (!securityService.isUserAdmin(username)) {
-            result.forbidden(EntityType.ConfigRepo.forbiddenToDelete(repoId, username.getUsername()), forbidden());
-            return false;
-        }
-        return true;
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
@@ -97,6 +97,8 @@ public class AuthorizeFilterChain extends FilterChainProxy {
                 .addAuthorityFilterChain("/api/elastic/profiles/**", apiAccessDeniedHandler, ROLE_USER)
 
                 .addAuthorityFilterChain("/api/admin/environments/**", apiAccessDeniedHandler, ROLE_USER)
+                .addAuthorityFilterChain("/api/admin/config_repos/**", apiAccessDeniedHandler, ROLE_USER)
+                .addAuthorityFilterChain("/api/admin/internal/environments/merged", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/admin/internal/environments/**", apiAccessDeniedHandler, ROLE_USER)
 
                 // blanket role that requires supervisor access, used by old admin apis

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
@@ -76,6 +76,7 @@ public class AuthorizeFilterChain extends FilterChainProxy {
                 .addAuthorityFilterChain("/admin/elastic_agent_configurations/**", genericAccessDeniedHandler, ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR)
                 //allow /go/admin/environments page to be accessible by normal users
                 .addAuthorityFilterChain("/admin/environments", genericAccessDeniedHandler, ROLE_USER)
+                .addAuthorityFilterChain("/admin/config_repos", genericAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/admin/**", genericAccessDeniedHandler, ROLE_SUPERVISOR)
                 .addAuthorityFilterChain("/agents/*/job_run_history/**", genericAccessDeniedHandler, ROLE_SUPERVISOR)
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/serialization.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/serialization.ts
@@ -28,6 +28,7 @@ export interface ConfigRepoJSON {
   id: string;
   plugin_id: string;
   material: MaterialJSON;
+  can_administer: boolean;
   configuration: any[];
   parse_info: ParseInfoJSON;
   errors?: ErrorsJSON;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/spec/config_repos_crud_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/spec/config_repos_crud_spec.ts
@@ -28,6 +28,7 @@ describe("Config Repo Serialization", () => {
                                                        new GitMaterialAttributes("test",
                                                                                  false,
                                                                                  "https://example.com")),
+                                          false,
                                           [configuration1, configuration2]);
     const json           = configRepoToSnakeCaseJSON(configRepo);
     expect(json.configuration)
@@ -42,6 +43,7 @@ describe("Config Repo Serialization", () => {
                                                        new GitMaterialAttributes("test",
                                                                                  false,
                                                                                  "https://example.com")),
+                                          false,
                                           [configuration1]);
     const json           = configRepoToSnakeCaseJSON(configRepo);
     expect(json.configuration).toEqual([{key: "file_pattern", value: "test-value-1"}]);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/spec/types_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/spec/types_spec.ts
@@ -126,7 +126,7 @@ describe("Config Repo Types", () => {
         const latestModification = new MaterialModification("jrDev", "jrDev@github.com", "4926940143a238fefb7566141ba24a96", "My first commit", "19:30");
         const lastParse = new ParseInfo(latestModification, goodModification, null);
 
-        return new ConfigRepo("All_Test_Pipelines", "PluginId", material, [], lastParse);
+        return new ConfigRepo("All_Test_Pipelines", "PluginId", material, false, [], lastParse);
       }
     });
   });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/types.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/types.ts
@@ -44,6 +44,7 @@ export class ConfigRepo implements ValidatableMixin {
                   id: Stream<string | undefined>;
                   pluginId: Stream<string | undefined>;
                   material: Stream<Material | undefined>;
+                  canAdminister: Stream<boolean>;
                   configuration: Stream<Configuration[] | undefined>;
                   lastParse: Stream<ParseInfo | null | undefined>;
                   __jsonPluginPipelinesPattern: Stream<string> = Stream("");
@@ -54,12 +55,14 @@ export class ConfigRepo implements ValidatableMixin {
   constructor(id?: string,
               pluginId?: string,
               material?: Material,
+              canAdminister?: boolean,
               configuration?: Configuration[],
               lastParse?: ParseInfo | null,
               materialUpdateInProgress?: boolean) {
     this.id                       = Stream(id);
     this.pluginId                 = Stream(pluginId);
     this.material                 = Stream(material);
+    this.canAdminister            = Stream(canAdminister || false);
     this.configuration            = Stream(configuration);
     this.lastParse                = Stream(lastParse);
     this.materialUpdateInProgress = Stream(materialUpdateInProgress || false);
@@ -90,6 +93,7 @@ export class ConfigRepo implements ValidatableMixin {
     const configRepo = new ConfigRepo(json.id,
                                       json.plugin_id,
                                       Materials.fromJSON(json.material),
+                                      json.can_administer,
                                       configurations,
                                       parseInfo,
                                       json.material_update_in_progress);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.tsx
@@ -213,6 +213,7 @@ export class SiteMenu extends MithrilViewComponent<Attrs> {
           <div class={classnames(styles.subNavigation, styles.hasOnlyOneOption)}>
             <SiteSubNav>
               <SiteSubNavItem href="/go/admin/environments" text="Environments"/>
+              <SiteSubNavItem href="/go/admin/config_repos" text="Config Repositories"/>
             </SiteSubNav>
           </div>
         </SiteNavItem>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/spec/index_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/spec/index_spec.tsx
@@ -155,7 +155,7 @@ describe("Site Menu", () => {
     expect(findMenuItem("/go/analytics")).toBeFalsy();
   });
 
-  it("should show Admin link with environments tab for non-admins", () => {
+  it("should show Admin link for non-admins", () => {
     mount({
             canViewTemplates: true,
             isGroupAdmin: false,
@@ -172,6 +172,7 @@ describe("Site Menu", () => {
     expect(agents).toHaveAttr("href", "/go/agents");
     expect(admin).toHaveText("Admin");
     expect(findMenuItem("/go/admin/environments")).toHaveText("Environments");
+    expect(findMenuItem("/go/admin/config_repos")).toHaveText("Config Repositories");
   });
 
   function mount(menuAttrs: Attrs) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
@@ -113,6 +113,8 @@ class SectionHeader extends MithrilViewComponent<SectionHeaderAttrs> {
 interface ActionsAttrs extends CRVMAware {
   inProgress: boolean;
   configRepoHasErrors: boolean;
+  can_administer: boolean;
+  title: string;
 }
 
 class CRPanelActions extends MithrilViewComponent<ActionsAttrs> {
@@ -129,9 +131,9 @@ class CRPanelActions extends MithrilViewComponent<ActionsAttrs> {
     return [
       statusIcon,
       <IconGroup>
-        <Refresh data-test-id="config-repo-refresh" onclick={vm.reparseRepo}/>
-        <Edit data-test-id="config-repo-edit" onclick={vm.showEditModal}/>
-        <Delete data-test-id="config-repo-delete" onclick={vm.showDeleteModal}/>
+        <Refresh data-test-id="config-repo-refresh" title={vnode.attrs.title} disabled={!vnode.attrs.can_administer} onclick={vm.reparseRepo}/>
+        <Edit data-test-id="config-repo-edit" title={vnode.attrs.title} disabled={!vnode.attrs.can_administer} onclick={vm.showEditModal}/>
+        <Delete data-test-id="config-repo-delete" title={vnode.attrs.title} disabled={!vnode.attrs.can_administer} onclick={vm.showDeleteModal}/>
       </IconGroup>];
   }
 }
@@ -184,11 +186,12 @@ class ConfigRepoWidget extends MithrilComponent<SingleAttrs> {
     const maybeWarning = <MaybeWarning parseInfo={parseInfo} pluginInfo={pluginInfo}/>;
     const configRepoHasErrors = !pluginInfo || _.isEmpty(parseInfo) || !!parseInfo!.error();
 
+    const title = repo.canAdminister ? "You are not authorised to perform this action!" : "";
     return <Anchor id={repo.id()!} sm={sm} onnavigate={() => this.expanded(true)}>
       <CollapsiblePanel error={configRepoHasErrors}
                         header={<HeaderWidget {...vnode.attrs}/>}
                         dataTestId={"config-repo-details-panel"}
-                        actions={<CRPanelActions configRepoHasErrors={configRepoHasErrors} inProgress={repo.materialUpdateInProgress()} vm={vm}/>}
+                        actions={<CRPanelActions configRepoHasErrors={configRepoHasErrors} inProgress={repo.materialUpdateInProgress()} can_administer={repo.canAdminister()} title={title} vm={vm}/>}
                         vm={this}
                         onexpand={() => vm.notify("expand")}>
         {maybeWarning}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repo_attribute_helper_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repo_attribute_helper_spec.ts
@@ -79,6 +79,7 @@ describe("ConfigRepo attribute util functions", () => {
           destination: ""
         }
       },
+      can_administer: false,
       configuration: [{
         key: "file_pattern",
         value: "*.json"

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_widget_spec.tsx
@@ -342,4 +342,20 @@ describe("ConfigReposWidget", () => {
     expect(reparseRepo).toHaveBeenCalledWith(jasmine.any(MouseEvent));
   });
 
+  it("should disable the action buttons", () => {
+    const configRepo = createConfigRepoParsed();
+    models([vm(configRepo)]);
+    helper.redraw();
+
+    const title = "You are not authorised to perform this action!";
+    expect(helper.byTestId("config-repo-refresh")).toBeInDOM();
+    expect(helper.byTestId("config-repo-refresh")).toBeDisabled();
+    expect(helper.byTestId("config-repo-refresh").title).toBe(title);
+    expect(helper.byTestId("config-repo-edit")).toBeInDOM();
+    expect(helper.byTestId("config-repo-edit")).toBeDisabled();
+    expect(helper.byTestId("config-repo-edit").title).toBe(title);
+    expect(helper.byTestId("config-repo-delete")).toBeInDOM();
+    expect(helper.byTestId("config-repo-delete")).toBeDisabled();
+    expect(helper.byTestId("config-repo-delete").title).toBe(title);
+  });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/test_data.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/test_data.ts
@@ -77,6 +77,7 @@ export function createConfigRepoParsedWithError(overrides?: any): ConfigRepo {
                                    destination: ""
                                  }
                                },
+                               can_administer: true,
                                configuration: [{
                                  key: "file_pattern",
                                  value: "*.json"
@@ -128,6 +129,7 @@ export function createConfigRepoParsed(overrides?: any): ConfigRepo {
                                    destination: ""
                                  }
                                },
+                               can_administer: false,
                                configuration: [{
                                  key: "file_pattern",
                                  value: "*.json"
@@ -167,6 +169,7 @@ export function createConfigRepoWithError(id?: string, repoId?: string): ConfigR
                                    destination: ""
                                  }
                                },
+                               can_administer: false,
                                configuration: [{
                                  key: "file_pattern",
                                  value: "*.json"

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/policy_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/policy_widget.tsx
@@ -186,6 +186,8 @@ export class CreatePolicyWidget extends MithrilViewComponent<AutoCompleteAttrs> 
       },
       {
         id: "environment", text: "Environment"
+      }, {
+        id: "config_repo", text: "Config Repository"
       }
     ];
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/policy_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/policy_widget_spec.tsx
@@ -120,13 +120,11 @@ describe('PolicyWidgetSpecs', () => {
 
     const actionOptions = helper.qa("option", helper.byTestId("permission-action"));
 
-    expect(actionOptions.length).toBe(4);
-    expect(actionOptions[1]).toHaveText("All");
-    expect(actionOptions[1]).toHaveValue("*");
-    expect(actionOptions[2]).toHaveText("View");
-    expect(actionOptions[2]).toHaveValue("view");
-    expect(actionOptions[3]).toHaveText("Administer");
-    expect(actionOptions[3]).toHaveValue("administer");
+    expect(actionOptions.length).toBe(3);
+    expect(actionOptions[1]).toHaveText("View");
+    expect(actionOptions[1]).toHaveValue("view");
+    expect(actionOptions[2]).toHaveText("Administer");
+    expect(actionOptions[2]).toHaveValue("administer");
   });
 
   function mount(policy: Policy = new Policy(), resourceAutoComplete: Map<string, string[]> = new Map()) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/policy_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/policy_widget_spec.tsx
@@ -97,6 +97,38 @@ describe('PolicyWidgetSpecs', () => {
 
   });
 
+  it("should render 4 items in supported type dropdown", () => {
+    const policy = new Policy();
+    policy.push(Stream(new Directive("allow", "view", "*", "env")));
+    mount(policy);
+
+    const typeOptions = helper.qa("option", helper.byTestId("permission-type"));
+
+    expect(typeOptions.length).toBe(4);
+    expect(typeOptions[1]).toHaveText("All");
+    expect(typeOptions[1]).toHaveValue("*");
+    expect(typeOptions[2]).toHaveText("Environment");
+    expect(typeOptions[2]).toHaveValue("environment");
+    expect(typeOptions[3]).toHaveText("Config Repository");
+    expect(typeOptions[3]).toHaveValue("config_repo");
+  });
+
+  it("should render 4 items in supported actions dropdown", () => {
+    const policy = new Policy();
+    policy.push(Stream(new Directive("allow", "view", "*", "env")));
+    mount(policy);
+
+    const actionOptions = helper.qa("option", helper.byTestId("permission-action"));
+
+    expect(actionOptions.length).toBe(4);
+    expect(actionOptions[1]).toHaveText("All");
+    expect(actionOptions[1]).toHaveValue("*");
+    expect(actionOptions[2]).toHaveText("View");
+    expect(actionOptions[2]).toHaveValue("view");
+    expect(actionOptions[3]).toHaveText("Administer");
+    expect(actionOptions[3]).toHaveValue("administer");
+  });
+
   function mount(policy: Policy = new Policy(), resourceAutoComplete: Map<string, string[]> = new Map()) {
     helper.mount(() => <CreatePolicyWidget policy={Stream(policy)} resourceAutocompleteHelper={resourceAutoComplete}/>);
   }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateConfigRepoCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateConfigRepoCommandTest.java
@@ -68,17 +68,6 @@ public class CreateConfigRepoCommandTest {
     }
 
     @Test
-    public void shouldNotContinueIfTheUserDontHavePermissionsToOperateOnPackages() throws Exception {
-        CreateConfigRepoCommand command = new CreateConfigRepoCommand(securityService, configRepo, currentUser, result, configRepoExtension);
-        when(securityService.isUserAdmin(currentUser)).thenReturn(false);
-        HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.forbidden(EntityType.ConfigRepo.forbiddenToEdit(configRepo.getId(), currentUser.getUsername()), forbidden());
-
-        assertThat(command.canContinue(cruiseConfig), is(false));
-        assertThat(result, is(expectedResult));
-    }
-
-    @Test
     public void isValid_shouldValidateConfigRepo() {
         GitMaterialConfig material = git("https://foo.git", "master");
         material.setAutoUpdate(false);
@@ -111,12 +100,5 @@ public class CreateConfigRepoCommandTest {
 
         assertFalse(command.isValid(cruiseConfig));
         assertThat(configRepo.errors().on("plugin_id"), is("Invalid plugin id: json-plugin"));
-    }
-
-    @Test
-    public void shouldContinueWithConfigSaveIfUserIsAdmin() {
-        when(securityService.isUserAdmin(currentUser)).thenReturn(true);
-        CreateConfigRepoCommand command = new CreateConfigRepoCommand(securityService, configRepo, currentUser, result, configRepoExtension);
-        assertThat(command.canContinue(cruiseConfig), is(true));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteConfigRepoCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteConfigRepoCommandTest.java
@@ -17,7 +17,6 @@ package com.thoughtworks.go.config.update;
 
 import com.thoughtworks.go.config.BasicCruiseConfig;
 import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.server.domain.Username;
@@ -29,10 +28,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class DeleteConfigRepoCommandTest {
@@ -65,16 +62,6 @@ public class DeleteConfigRepoCommandTest {
         assertNotNull(cruiseConfig.getConfigRepos().getConfigRepo(repoId));
         command.update(cruiseConfig);
         assertNull(cruiseConfig.getConfigRepos().getConfigRepo(repoId));
-    }
-
-    @Test
-    public void shouldNotContinueIfTheUserDontHavePermissionsToOperateOnConfigRepos() throws Exception {
-        DeleteConfigRepoCommand command = new DeleteConfigRepoCommand(securityService, repoId, currentUser, result);
-        when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
-        assertThat(command.canContinue(cruiseConfig), is(false));
-        assertFalse(result.isSuccessful());
-        assertThat(result.httpCode(), is(403));
-        assertThat(result.message(), equalTo(EntityType.ConfigRepo.forbiddenToDelete(repoId, currentUser.getUsername())));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateConfigRepoCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateConfigRepoCommandTest.java
@@ -79,18 +79,6 @@ public class UpdateConfigRepoCommandTest {
     }
 
     @Test
-    public void shouldNotContinueIfTheUserDontHavePermissionsToOperateOnConfigRepos() throws Exception {
-        UpdateConfigRepoCommand command = new UpdateConfigRepoCommand(securityService, entityHashingService, oldConfigRepoId, newConfigRepo, md5, currentUser, result, configRepoExtension);
-        when(securityService.isUserAdmin(currentUser)).thenReturn(false);
-        when(entityHashingService.md5ForEntity(oldConfigRepo)).thenReturn(md5);
-        HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.forbidden(EntityType.ConfigRepo.forbiddenToEdit(newConfigRepoId, currentUser.getUsername()), forbidden());
-
-        assertThat(command.canContinue(cruiseConfig), is(false));
-        assertThat(result, is(expectedResult));
-    }
-
-    @Test
     public void shouldNotContinueIfMD5IsStale() throws Exception {
         UpdateConfigRepoCommand command = new UpdateConfigRepoCommand(securityService, entityHashingService, oldConfigRepoId, newConfigRepo, md5, currentUser, result, configRepoExtension);
         when(securityService.isUserAdmin(currentUser)).thenReturn(true);
@@ -139,14 +127,5 @@ public class UpdateConfigRepoCommandTest {
 
         assertFalse(command.isValid(cruiseConfig));
         assertThat(configRepo.errors().on("plugin_id"), is("Invalid plugin id: invalid_id"));
-    }
-
-    @Test
-    public void shouldContinueWithConfigSaveIfUserIsAdmin() {
-        when(securityService.isUserAdmin(currentUser)).thenReturn(true);
-        when(entityHashingService.md5ForEntity(oldConfigRepo)).thenReturn(md5);
-
-        UpdateConfigRepoCommand command = new UpdateConfigRepoCommand(securityService, entityHashingService, oldConfigRepoId, newConfigRepo, md5, currentUser, result, configRepoExtension);
-        assertThat(command.canContinue(cruiseConfig), is(true));
     }
 }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/ConfigReposController.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/ConfigReposController.java
@@ -44,13 +44,13 @@ public class ConfigReposController implements SparkController {
     @Override
     public void setupRoutes() {
         path(controllerBasePath(), () -> {
-            before("", authenticationHelper::checkAdminUserAnd403);
+            before("", authenticationHelper::checkUserAnd403);
             get("", this::index, engine);
         });
     }
 
     public ModelAndView index(Request request, Response response) {
-        HashMap<Object, Object> object = new HashMap<Object, Object>() {{
+        HashMap<Object, Object> object = new HashMap<>() {{
             put("viewTitle", "Config Repos");
         }};
 

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ConfigReposControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ConfigReposControllerTest.groovy
@@ -15,9 +15,8 @@
  */
 package com.thoughtworks.go.spark.spa
 
-
-import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
 import org.junit.jupiter.api.Nested
@@ -32,7 +31,7 @@ class ConfigReposControllerTest implements ControllerTrait<ConfigReposController
   @Nested
   class Index {
     @Nested
-    class Security implements SecurityTestTrait, AdminUserSecurity {
+    class Security implements SecurityTestTrait, NormalUserSecurity {
 
       @Override
       String getControllerMethodUnderTest() {


### PR DESCRIPTION
Issue: #7222

Description:
- Added support for `config_repo` as type in policy.
- Updated Roles Config SPA to support `config_repo` as supported types.
- Updated Config Repo API v3 to implement policy.
- Show user specific config repos on Config Repositories SPA as per user permissions.