### PR TITLE
Fixed scrolling issue for `Anchor`

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/anchor/anchor.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/anchor/anchor.tsx
@@ -50,10 +50,16 @@ export class Anchor extends MithrilComponent<Attrs, State> {
 
   oncreate(vnode: m.VnodeDOM<Attrs, State>) {
     vnode.state.dom = vnode.dom;
-    this.inited = true;
+    this.inited     = true;
+    this.scrollToEl(vnode);
   }
 
   view(vnode: m.Vnode<Attrs, State>) {
+    this.scrollToEl(vnode);
+    return vnode.children;
+  }
+
+  scrollToEl(vnode: m.Vnode<Attrs, State>) {
     const {id, sm} = vnode.attrs;
     if (this.inited && sm.shouldScroll(id)) {
       sm.scrollToEl(vnode.state.dom);
@@ -62,7 +68,6 @@ export class Anchor extends MithrilComponent<Attrs, State> {
         vnode.attrs.onnavigate();
       }
     }
-    return vnode.children;
   }
 }
 


### PR DESCRIPTION
Description:

Scrolling of the element is called from `view` method of `Anchor` when the element is attached to dom and is not already scrolled.

When the `view` method is called for the first time, scrolling does not take place as the element is not attached to dom. Scrolling actually takes place in re-render.

To fix this, `scrollToEl` is called from both `onCreate`(callback which gets triggered after the element is attached to dom) and `view` methods so that scroll will happen immediately after the element is attached to dom and on re-render.


