### PR TITLE
Bump up stage history api

### DIFF
--- a/api/api-stage-operations-v2/src/main/java/com/thoughtworks/go/apiv2/stageoperations/representers/JobHistoryItemRepresenter.java
+++ b/api/api-stage-operations-v2/src/main/java/com/thoughtworks/go/apiv2/stageoperations/representers/JobHistoryItemRepresenter.java
@@ -20,7 +20,6 @@ import com.thoughtworks.go.presentation.pipelinehistory.JobHistoryItem;
 
 public class JobHistoryItemRepresenter {
     public static void toJSON(OutputWriter jsonWriter, JobHistoryItem jobHistoryItem) {
-        jsonWriter.add("id", jobHistoryItem.getId());
         jsonWriter.add("name", jobHistoryItem.getName());
         if (jobHistoryItem.getState() != null) {
             jsonWriter.add("state", jobHistoryItem.getState().toString());

--- a/api/api-stage-operations-v2/src/main/java/com/thoughtworks/go/apiv2/stageoperations/representers/StageInstanceRepresenter.java
+++ b/api/api-stage-operations-v2/src/main/java/com/thoughtworks/go/apiv2/stageoperations/representers/StageInstanceRepresenter.java
@@ -21,7 +21,6 @@ import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModel;
 
 public class StageInstanceRepresenter {
     public static void toJSON(OutputWriter jsonWriter, StageInstanceModel stageInstanceModel) {
-        jsonWriter.add("id", stageInstanceModel.getId());
         jsonWriter.add("name", stageInstanceModel.getName());
         jsonWriter.add("counter", stageInstanceModel.getCounter());
         jsonWriter.add("approval_type", stageInstanceModel.getApprovalType());

--- a/api/api-stage-operations-v2/src/test/groovy/com/thoughtworks/go/apiv2/stageoperations/representers/JobHistoryItemRepresenterTest.groovy
+++ b/api/api-stage-operations-v2/src/test/groovy/com/thoughtworks/go/apiv2/stageoperations/representers/JobHistoryItemRepresenterTest.groovy
@@ -36,7 +36,6 @@ class JobHistoryItemRepresenterTest {
   }
 
   def jobHash = [
-    id: 34,
     name: 'job',
     state: 'Completed',
     result: 'Passed',

--- a/api/api-stage-operations-v2/src/test/groovy/com/thoughtworks/go/apiv2/stageoperations/representers/StageInstanceRepresenterTest.groovy
+++ b/api/api-stage-operations-v2/src/test/groovy/com/thoughtworks/go/apiv2/stageoperations/representers/StageInstanceRepresenterTest.groovy
@@ -41,7 +41,6 @@ class StageInstanceRepresenterTest {
   }
 
   def stageHash = [
-    id:21,
     name:'stage',
     counter:'3',
     approval_type:null,
@@ -49,7 +48,6 @@ class StageInstanceRepresenterTest {
     rerun_of_counter:null,
     jobs:[
       [
-        id:34,
         name:'job',
         state:'Completed',
         result:'Passed',

--- a/api/api-stage-operations-v2/src/test/groovy/com/thoughtworks/go/apiv2/stageoperations/representers/StageInstancesRepresenterTest.groovy
+++ b/api/api-stage-operations-v2/src/test/groovy/com/thoughtworks/go/apiv2/stageoperations/representers/StageInstancesRepresenterTest.groovy
@@ -49,7 +49,6 @@ class StageInstancesRepresenterTest {
   def stageHash = [
     stages: [
       [
-        id:21,
         name:'stage',
         counter:'3',
         approval_type:null,
@@ -57,7 +56,6 @@ class StageInstancesRepresenterTest {
         rerun_of_counter:null,
         jobs:[
           [
-            id:34,
             name:'job',
             state:'Completed',
             result:'Passed',


### PR DESCRIPTION
Issue: #3326, #7360 

Description:
Updated stage operations api to v2
 - the stage history api will now support `page_size` and `offset` as query params
Format: `/api/stages/:pipeline_name/:stage_name/history?page_size=25&offset=10`

 - default values of `page_size: 10` and `offset: 0`
 - the `page_size` can be an integer between 10 and 100
 - also, removed all the `id`s from the json output
