### PR TITLE
Fix for constant agents reshuffling on agents SPA

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/agents/agent_comparator.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/agents/agent_comparator.ts
@@ -32,14 +32,20 @@ export class AgentComparator {
     const first = this.getColumnValue(agentOne);
     const other = this.getColumnValue(agentTwo);
 
+    let func;
     switch (this.columnName) {
       case "freeSpace":
-        return this.compareFreespace(first, other);
+        func = this.compareFreespace(first, other);
+        break;
       case "agentState":
-        return this.compareAgentState(first, other);
+        func = this.compareAgentState(first, other);
+        break;
       default:
-        return this.compareString(first, other);
+        func = this.compareString(first, other);
+        break;
     }
+
+    return func || this.compareString(agentOne.uuid, agentTwo.uuid);
   }
 
   private static getAgentStatusRank(status: string): number {


### PR DESCRIPTION
Issue: #7281

Description:  The agents index api returns an unsorted list of agents which is then sorted on the basis of agent status and then displayed.
Since the status and other values such as hostname, OS, etc can have same value, the sort retains the original order in which it was received from the API.

Adding an additional sort on agent uuid as the uuid is unique will render unique value on the sort of similar values which in turn will remove the constant reshuffling on no changes



