### PR TITLE
Button behaviour on ajax calls

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/buttons/spec/index_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/buttons/spec/index_spec.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ApiResult} from "helpers/api_request_builder";
+import m from "mithril";
+import {Primary} from "views/components/buttons/index";
+import {TestHelper} from "views/pages/spec/test_helper";
+import * as buttonStyles from "../index.scss";
+
+describe("Button", () => {
+
+  const helper = new TestHelper();
+
+  afterEach(helper.unmount.bind(helper));
+
+  describe("Ajax Operation", () => {
+
+    it("should show a spinner icon when ajax request is in progress", (done) => {
+      const promise = new Promise<ApiResult<any>>((resolve) => {
+        resolve();
+      }).then(() => {
+        expect(helper.byTestId("ajax-button")).toHaveClass(buttonStyles.iconSpinner);
+        done();
+      });
+      helper.mount(() => <Primary dataTestId="ajax-button" ajaxOperation={() => promise}>Save</Primary>);
+      expect(helper.byTestId("ajax-button")).not.toHaveClass(buttonStyles.iconSpinner);
+      helper.clickByTestId("ajax-button");
+    });
+
+    it("should ignore clicks when ajax operation is in progress", (done) => {
+      const spy                           = jasmine.createSpy();
+      const promises: Array<Promise<any>> = [];
+      const simulateRemoteCall            = () => {
+        const promise = new Promise<any>((resolve) => {
+          setTimeout(() => {
+            spy();
+            resolve();
+          });
+        });
+        promises.push(promise);
+        return promise;
+      };
+
+      helper.mount(() => <Primary dataTestId="ajax-button"
+                                  ajaxOperation={simulateRemoteCall}>Save</Primary>);
+      helper.clickByTestId("ajax-button");
+      helper.clickByTestId("ajax-button");
+      Promise.all(promises).finally(() => {
+        expect(spy).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+});

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/modals.tsx
@@ -330,12 +330,12 @@ export abstract class ConfigRepoModal extends Modal {
 
   buttons(): m.ChildArray {
     return [
-      <Buttons.Primary data-test-id="button-ok" onclick={this.performSave.bind(this)}>Save</Buttons.Primary>,
+      <Buttons.Primary data-test-id="button-ok" ajaxOperation={this.performSave.bind(this)}>Save</Buttons.Primary>,
       <Buttons.Cancel data-test-id="button-cancel" onclick={this.close.bind(this)}>Cancel</Buttons.Cancel>
     ];
   }
 
-  abstract performSave(): void;
+  abstract performSave(): Promise<any>;
 
   protected handleAutoUpdateError() {
     const errors = this.getRepo().material()!.attributes()!.errors();
@@ -372,9 +372,9 @@ export class NewConfigRepoModal extends ConfigRepoModal {
 
   performSave() {
     if (!this.repo().isValid()) {
-      return;
+      return Promise.resolve();
     }
-    ConfigReposCRUD.create(this.repo())
+    return ConfigReposCRUD.create(this.repo())
                    .then((result) => result.do(this.onSuccess.bind(this),
                                                (errorResponse) => this.handleError(result, errorResponse)));
   }
@@ -421,11 +421,11 @@ export class EditConfigRepoModal extends ConfigRepoModal {
     return `Edit configuration repository ${this.repoId}`;
   }
 
-  performSave(): void {
+  performSave(): Promise<any> {
     if (!this.repoWithEtag().object.isValid()) {
-      return;
+      return Promise.resolve();
     }
-    ConfigReposCRUD.update(this.repoWithEtag())
+    return ConfigReposCRUD.update(this.repoWithEtag())
                    .then((apiResult) => apiResult.do(this.onSuccess.bind(this),
                                                      (errorResponse) => this.handleError(apiResult, errorResponse)));
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/modals_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/modals_spec.tsx
@@ -36,8 +36,8 @@ class TestConfigRepoModal extends ConfigRepoModal {
     this.error = errorMsg;
   }
 
-  performSave(): void {
-    //do nothing
+  performSave(): Promise<any> {
+    return Promise.resolve();
   }
 
   title(): string {


### PR DESCRIPTION
If a button click invokes a server call, the current UI doesn't show any feedback until the request is completed. The user can also click the button multiple times and many server calls will be made with the same request. This can be a problem on slow networks or slow server operations.

With this change, buttons will show a spinner (similar to "Test Connection") while the server call is made, and ignore any more clicks from the user until the operation is done.

To implement this, I've added an `ajaxOperation` attribute to buttons, which should be used instead of `onclick`. This will also need a change in the contract of the event handler - it needs to return a `Promise` instead of `void`. Otherwise, the button wouldn't know when the ajax operation has ended.

As an example, I've implemented the change in the Save button on the  Config Repo modal. Unless there's any feedback, I can go ahead and make the change everywhere else.