### PR TITLE
Show old environments page to admins only

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/application_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/application_controller.rb
@@ -202,6 +202,10 @@ class ApplicationController < ActionController::Base
     request.env['java.servlet_request']
   end
 
+  def is_user_an_admin?
+    security_service.isUserAdmin(current_user)
+  end
+
   private
 
   def no_layout?

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/environments_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/environments_controller.rb
@@ -19,6 +19,8 @@ class EnvironmentsController < ApplicationController
   helper SortableTableHelper
   helper AgentsHelper
 
+  before_action :verify_user_permissions
+
   before_action :load_new_environment, :only => [:new, :create]
   before_action :load_existing_environment, :only => [:show, :update, :edit_pipelines, :edit_agents, :edit_variables]
 
@@ -189,4 +191,7 @@ class EnvironmentsController < ApplicationController
     @current_tab_name = "environments"
   end
 
+  def verify_user_permissions
+    render_error_template('You are not authorized to perform this action.', 403) unless is_user_an_admin?
+  end
 end


### PR DESCRIPTION
Description:
* Show a generic error message saying "You are not authorized to perform this action." when non-admin users try to access rails based environments page.

![Screen Shot 2019-11-21 at 4 37 44 PM](https://user-images.githubusercontent.com/15275847/69332864-947eba80-0c7d-11ea-87cd-35371d488c9f.png)

