### PR TITLE
Improve Error Messages for Granular auth

### DIFF
--- a/api/api-base/src/main/java/com/thoughtworks/go/api/spring/ApiAuthenticationHelper.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/spring/ApiAuthenticationHelper.java
@@ -39,6 +39,12 @@ public class ApiAuthenticationHelper extends AbstractAuthenticationHelper {
         return HaltApiResponses.haltBecauseForbidden();
     }
 
+    @Override
+    protected HaltException renderForbiddenResponse(String message) {
+        LOG.info("{}", message);
+        return HaltApiResponses.haltBecauseForbidden(message);
+    }
+
     public void ensureSecurityEnabled(Request request, Response response) {
         if (!securityService.isSecurityEnabled()) {
             throw HaltApiResponses.haltBecauseSecurityIsNotEnabled();

--- a/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/ApiAuthenticationHelperTest.java
+++ b/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/ApiAuthenticationHelperTest.java
@@ -30,7 +30,10 @@ import org.mockito.Mock;
 import spark.HaltException;
 
 import java.util.Arrays;
+import java.util.Map;
 
+import static com.thoughtworks.go.domain.ArtifactPlan.GSON;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
@@ -300,6 +303,20 @@ class ApiAuthenticationHelperTest {
 
             assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, null));
             assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, "env_1"));
+        }
+
+        @Test
+        void shouldRenderAppropriateForbiddenErrorMessageWhenUserDoesNotHaveViewPermissions() {
+            HaltException thrown = assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, "env_1"));
+            String expectedMessage = "User 'Bob' does not have permissions to view 'env_1' environment(s).";
+            assertThat(GSON.fromJson(thrown.body(), Map.class).get("message")).isEqualTo(expectedMessage);
+        }
+
+        @Test
+        void shouldRenderAppropriateForbiddenErrorMessageWhenUserDoesNotHaveAdministerPermissions() {
+            HaltException thrown = assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, "env_1"));
+            String expectedMessage = "User 'Bob' does not have permissions to administer 'env_1' environment(s).";
+            assertThat(GSON.fromJson(thrown.body(), Map.class).get("message")).isEqualTo(expectedMessage);
         }
     }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environment_body_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environment_body_widget.tsx
@@ -42,7 +42,7 @@ export class ElementListWidget extends MithrilViewComponent<ElementListWidgetAtt
       <div class={styles.envBodyElementHeader} data-test-id={`${s.slugify(vnode.attrs.name)}-header`}>
         <span>{vnode.attrs.name}</span>
         <Icons.Edit iconOnly={true}
-                    title={environment.canAdminister() ? undefined : `You are not authorized to modify ${vnode.attrs.name.toLowerCase()} of '${environment.name()}' environment.`}
+                    title={environment.canAdminister() ? undefined : `You dont have permissions to edit '${environment.name()}' environment.`}
                     disabled={!environment.canAdminister()}
                     onclick={vnode.attrs.modalToRender.bind(vnode.attrs.modalToRender, environment)}/>
       </div>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
@@ -61,7 +61,7 @@ export class EnvironmentWidget extends MithrilViewComponent<EnvAttrs> {
                         actions={[
                           <IconGroup>
                             <Delete
-                              title={environment.canAdminister() ? undefined : `You are not authorized to delete '${environment.name()}' environment.`}
+                              title={environment.canAdminister() ? undefined : `You dont have permissions to delete '${environment.name()}' environment.`}
                               disabled={!environment.canAdminister()}
                               onclick={vnode.attrs.onDelete.bind(vnode.attrs, environment)}/>
                           </IconGroup>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environment_body_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environment_body_widget_spec.tsx
@@ -76,11 +76,11 @@ describe("Environments Body Widget", () => {
     environment.canAdminister(false);
     helper.redraw();
 
-    expect(editIcons[0].title).toBe(`You are not authorized to modify pipelines of '${environment.name()}' environment.`);
+    expect(editIcons[0].title).toBe(`You dont have permissions to edit '${environment.name()}' environment.`);
     expect(editIcons[0]).toBeDisabled();
-    expect(editIcons[1].title).toBe(`You are not authorized to modify agents of '${environment.name()}' environment.`);
+    expect(editIcons[1].title).toBe(`You dont have permissions to edit '${environment.name()}' environment.`);
     expect(editIcons[1]).toBeDisabled();
-    expect(editIcons[2].title).toBe(`You are not authorized to modify environment variables of '${environment.name()}' environment.`);
+    expect(editIcons[2].title).toBe(`You dont have permissions to edit '${environment.name()}' environment.`);
     expect(editIcons[2]).toBeDisabled();
   });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environments_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environments_widget_spec.tsx
@@ -81,7 +81,7 @@ describe("Environments Widget", () => {
     const deleteIcons = helper.allByTestId("Delete-icon");
     expect(deleteIcons).toHaveLength(3);
 
-    expect(deleteIcons[0].title).toBe(`You are not authorized to delete '${xmlEnv.name}' environment.`);
+    expect(deleteIcons[0].title).toBe(`You dont have permissions to delete '${xmlEnv.name}' environment.`);
     expect(deleteIcons[0]).toBeDisabled();
     expect(deleteIcons[1].title).toBeFalsy();
     expect(deleteIcons[1]).not.toBeDisabled();

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/AbstractAuthenticationHelper.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/AbstractAuthenticationHelper.java
@@ -51,6 +51,8 @@ public abstract class AbstractAuthenticationHelper {
 
     protected abstract HaltException renderForbiddenResponse();
 
+    protected abstract HaltException renderForbiddenResponse(String message);
+
     public void checkUserAnd403(Request req, Response res) {
         if (!securityService.isSecurityEnabled()) {
             return;
@@ -95,7 +97,8 @@ public abstract class AbstractAuthenticationHelper {
 
     public void checkUserHasPermissions(Username username, SupportedAction action, SupportedEntity entity, String resource) {
         if (!doesUserHasPermissions(username, action, entity, resource)) {
-            throw renderForbiddenResponse();
+            String message = String.format("User '%s' does not have permissions to %s '%s' %s(s).", username.getDisplayName(), action.getAction(), resource, entity.getType());
+            throw renderForbiddenResponse(message);
         }
     }
 

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/SPAAuthenticationHelper.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/SPAAuthenticationHelper.java
@@ -37,6 +37,11 @@ public class SPAAuthenticationHelper extends AbstractAuthenticationHelper {
         return halt(403, HtmlErrorPage.errorPage(403, "Forbidden"));
     }
 
+    @Override
+    protected HaltException renderForbiddenResponse(String message) {
+        return halt(403, HtmlErrorPage.errorPage(403, message));
+    }
+
     public HaltException renderNotFoundResponse() {
         return halt(404, HtmlErrorPage.errorPage(404, "Not Found"));
     }


### PR DESCRIPTION
Issue: #7222

Description:
* Show better error message from API when the user does not have permissions to access a particular resource.
* Show consistent error messages when the user does not have access to administer environments
