### PR TITLE
Do not fail if directories already exist

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-server/docker-entrypoint.sh
+++ b/buildSrc/src/main/resources/gocd-docker-server/docker-entrypoint.sh
@@ -40,7 +40,7 @@ if [ "$1" = "${SERVER_WORK_DIR}/bin/go-server" ]; then
 
   for each_dir in "${server_data_dirs[@]}"; do
     if [ ! -e "${VOLUME_DIR}/${each_dir}" ]; then
-      try mkdir -v "${VOLUME_DIR}/${each_dir}"
+      try mkdir -v -p "${VOLUME_DIR}/${each_dir}"
     fi
 
     if [ ! -e "${SERVER_WORK_DIR}/${each_dir}" ]; then


### PR DESCRIPTION
Issue: #

Description: When mounting directories as docker volume the entrypoint fails with the following error:
`/docker-entrypoint.sh: cannot mkdir -v /godata/`

