### PR TITLE
Allow ajax button operation state to be monitored

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/buttons/spec/index_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/buttons/spec/index_spec.tsx
@@ -28,11 +28,13 @@ describe("Button", () => {
 
   describe("Ajax Operation", () => {
 
-    it("should show a spinner icon when ajax request is in progress", (done) => {
+    it("should show a spinner icon and disable button when ajax request is in progress", (done) => {
       const promise = new Promise<ApiResult<any>>((resolve) => {
         resolve();
       }).then(() => {
-        expect(helper.byTestId("ajax-button")).toHaveClass(buttonStyles.iconSpinner);
+        const ajaxButton = helper.byTestId("ajax-button");
+        expect(ajaxButton).toHaveClass(buttonStyles.iconSpinner);
+        expect(ajaxButton).toBeDisabled();
         done();
       });
       helper.mount(() => <Primary dataTestId="ajax-button" ajaxOperation={() => promise}>Save</Primary>);
@@ -62,6 +64,12 @@ describe("Button", () => {
         expect(spy).toHaveBeenCalledTimes(1);
         done();
       });
+    });
+
+    it("should honor disabled attribute when passed externally", () => {
+      const promise = Promise.resolve();
+      helper.mount(() => <Primary disabled={true} dataTestId="ajax-button" ajaxOperation={() => promise}>Save</Primary>);
+      expect(helper.byTestId("ajax-button")).toBeDisabled();
     });
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/delete_confirm_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/delete_confirm_modal.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import m from "mithril";
+import Stream from "mithril/stream";
 import * as Buttons from "views/components/buttons";
-import {ButtonIcon} from "views/components/buttons";
 import {Modal, Size} from "views/components/modal";
 import {OperationState} from "../../pages/page_operations";
 
@@ -23,7 +23,7 @@ export class DeleteConfirmModal extends Modal {
   private readonly message: m.Children;
   private readonly modalTitle: string;
   private readonly ondelete: () => Promise<any>;
-  private operationState: OperationState | undefined;
+  private operationState: Stream<OperationState> = Stream<OperationState>(OperationState.UNKNOWN);
 
   constructor(message: m.Children, ondelete: () => Promise<any>, title = "Are you sure?") {
     super(Size.small);
@@ -43,14 +43,9 @@ export class DeleteConfirmModal extends Modal {
   buttons(): m.ChildArray {
     return [
       <Buttons.Danger data-test-id='button-delete'
-                      disabled={this.operationState === OperationState.IN_PROGRESS}
-                      icon={this.operationState === OperationState.IN_PROGRESS ? ButtonIcon.SPINNER : undefined}
-                      onclick={() => {
-                        this.operationState = OperationState.IN_PROGRESS;
-                        const a = this.ondelete();
-                        a.finally(() => this.operationState = OperationState.DONE);
-                      }}>Yes Delete</Buttons.Danger>,
-      <Buttons.Cancel disabled={this.operationState === OperationState.IN_PROGRESS}
+                      ajaxOperationMonitor={this.operationState}
+                      ajaxOperation={this.ondelete}>Yes Delete</Buttons.Danger>,
+      <Buttons.Cancel ajaxOperationMonitor={this.operationState}
                       data-test-id='button-no-delete' onclick={this.close.bind(this)}
       >No</Buttons.Cancel>
     ];

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/spec/delete_confirm_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/spec/delete_confirm_modal_spec.tsx
@@ -68,6 +68,7 @@ describe("DeleteConfirmModal", () => {
     expect(testHelper.byTestId("button-delete")).toHaveClass(style.iconSpinner);
     expect(testHelper.byTestId("button-delete")).toBeDisabled();
     expect(testHelper.byTestId("button-no-delete")).toBeDisabled();
+    expect(testHelper.byTestId("button-no-delete")).not.toHaveClass(style.iconSpinner);
   });
 
   it("should close the modal and not send delete callback when 'No` button is clicked", () => {


### PR DESCRIPTION
There was a bit of duplication between https://github.com/gocd/gocd/commit/a0146465bd12447221eef6aa8c398cc989079905 and https://github.com/gocd/gocd/commit/c271c57004d3d5a907629a3b43a001e16374c07c

Since the use-case for Delete Confirmation Modal seems to be common, I moved the functionality in the button class itself and added an optional `ajaxOperationMonitor` that can be passed to disable other buttons in the group when the ajax operation is in progress.

