### PR TITLE
Added policy authorization to internal env controller

### DIFF
--- a/api/api-internal-environments-v1/src/main/java/com/thoughtworks/go/apiv1/internalenvironments/InternalEnvironmentsControllerV1.java
+++ b/api/api-internal-environments-v1/src/main/java/com/thoughtworks/go/apiv1/internalenvironments/InternalEnvironmentsControllerV1.java
@@ -75,11 +75,11 @@ public class InternalEnvironmentsControllerV1 extends ApiController implements S
 
             before("", mimeType, this.apiAuthenticationHelper::checkAdminUserAnd403);
 
-            before("/*", mimeType, (request, response) -> {
+            before(Routes.InternalEnvironments.ENV_NAME, mimeType, (request, response) -> {
                 if (request.requestMethod().equalsIgnoreCase("GET")) {
                     apiAuthenticationHelper.checkUserAnd403(request, response);
-                } else {
-                    apiAuthenticationHelper.checkAdminUserAnd403(request, response);
+                } else {    // this is a PUT request to update agent association
+                    apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, request.params("env_name"));
                 }
             });
 

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
@@ -97,7 +97,7 @@ public class AuthorizeFilterChain extends FilterChainProxy {
                 .addAuthorityFilterChain("/api/elastic/profiles/**", apiAccessDeniedHandler, ROLE_USER)
 
                 .addAuthorityFilterChain("/api/admin/environments/**", apiAccessDeniedHandler, ROLE_USER)
-                .addAuthorityFilterChain("/api/admin/internal/environments/merged", apiAccessDeniedHandler, ROLE_USER)
+                .addAuthorityFilterChain("/api/admin/internal/environments/**", apiAccessDeniedHandler, ROLE_USER)
 
                 // blanket role that requires supervisor access, used by old admin apis
                 .addAuthorityFilterChain("/api/admin/**", apiAccessDeniedHandler, ROLE_SUPERVISOR)


### PR DESCRIPTION
Issue: #7319 

Description:
 - the env-agent association update on env SPA is via the internal controller which had admin user check. Updated the same to check whether the current user has access to the same via policy check

