### PR TITLE
Fix inconsistent behaviour for delete group

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/PipelineGroups.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/PipelineGroups.java
@@ -19,7 +19,6 @@ package com.thoughtworks.go.domain;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
-import com.thoughtworks.go.config.exceptions.UnprocessableEntityException;
 import com.thoughtworks.go.config.materials.PackageMaterialConfig;
 import com.thoughtworks.go.config.materials.PluggableSCMMaterialConfig;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
@@ -271,16 +270,6 @@ public class PipelineGroups extends BaseCollection<PipelineConfigs> implements V
     }
 
     public void deleteGroup(String groupName) {
-        Iterator<PipelineConfigs> iterator = this.iterator();
-        while (iterator.hasNext()) {
-            PipelineConfigs currentGroup = iterator.next();
-            if (currentGroup.isNamed(groupName)) {
-                if (!currentGroup.isEmpty()) {
-                    throw new UnprocessableEntityException("Failed to delete group " + groupName + " because it was not empty.");
-                }
-                iterator.remove();
-                break;
-            }
-        }
+        this.removeIf(pipelineGroup -> pipelineGroup.isNamed(groupName));
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/domain/PipelineGroupsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/domain/PipelineGroupsTest.java
@@ -297,7 +297,7 @@ public class PipelineGroupsTest {
     }
 
     @Test
-    public void shouldDeleteGroupWhenEmpty() {
+    public void shouldDeleteGroup() {
         PipelineConfigs group = createGroup("group", new PipelineConfig[] {});
 
         PipelineGroups groups = new PipelineGroups(group);
@@ -307,7 +307,7 @@ public class PipelineGroupsTest {
     }
 
     @Test
-    public void shouldDeleteGroupWithSameNameWhenEmpty() {
+    public void shouldDeleteGroupWithSameName() {
         PipelineConfigs group = createGroup("group", new PipelineConfig[] {});
         group.setAuthorization(new Authorization(new ViewConfig(new AdminUser(new CaseInsensitiveString("user")))));
 
@@ -315,15 +315,5 @@ public class PipelineGroupsTest {
         groups.deleteGroup("group");
 
         assertThat(groups.size(), is(0));
-    }
-
-    @Test(expected = UnprocessableEntityException.class)
-    public void shouldThrowExceptionWhenDeletingGroupWhenNotEmpty() {
-        PipelineConfig p1Config = createPipelineConfig("pipeline1", "stage1");
-
-        PipelineConfigs group = createGroup("group", p1Config);
-
-        PipelineGroups groups = new PipelineGroups(group);
-        groups.deleteGroup("group");
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeletePipelineConfigsCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeletePipelineConfigsCommand.java
@@ -17,7 +17,6 @@ package com.thoughtworks.go.config.update;
 
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.PipelineConfigs;
-import com.thoughtworks.go.config.exceptions.UnprocessableEntityException;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
@@ -34,11 +33,7 @@ public class DeletePipelineConfigsCommand extends PipelineConfigsCommand {
     @Override
     public void update(CruiseConfig preprocessedConfig) throws Exception {
         preprocessedPipelineConfigs = group;
-        try {
-            preprocessedConfig.deletePipelineGroup(group.getGroup());
-        } catch (UnprocessableEntityException e) {
-            result.unprocessableEntity(e.getMessage());
-        }
+        preprocessedConfig.deletePipelineGroup(group.getGroup());
     }
 
     @Override
@@ -48,6 +43,10 @@ public class DeletePipelineConfigsCommand extends PipelineConfigsCommand {
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
+        if (!group.isEmpty()) {
+            result.unprocessableEntity("Failed to delete group " + group.getGroup() + " because it was not empty.");
+            return false;
+        }
         return isUserAdminOfGroup(group.getGroup());
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeletePipelineConfigsCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeletePipelineConfigsCommandTest.java
@@ -63,12 +63,12 @@ public class DeletePipelineConfigsCommandTest {
     }
 
     @Test
-    public void commandShouldReturnUnprocessableEntityResult_whenDeletingNonEmptyPipelineGroup() throws Exception {
+    public void commandShouldNotContinue_whenDeletingNonEmptyPipelineGroup() throws Exception {
         pipelineConfigs.add(new PipelineConfig());
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         DeletePipelineConfigsCommand command = new DeletePipelineConfigsCommand(pipelineConfigs, result, user, securityService);
 
-        command.update(cruiseConfig);
+        command.canContinue(cruiseConfig);
 
         assertThat(result.httpCode(), is(HttpStatus.SC_UNPROCESSABLE_ENTITY));
         assertThat(result.message(), is("Failed to delete group group because it was not empty."));


### PR DESCRIPTION
Issue: #7332

Description: If the group contains only config-repo pipelines, the DeletePipelineCommand would receive any empty group as we send configForEdit to the same which does not contains the PartialConfigs. Hence, delete is successful which leads to errors later on.

Moved the empty check to `canContinue` of the command wherein we get the group from go config service which takes into account the PartialConfigs.



