### PR TITLE
Bringing back the empty check in PipelineGroups

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/PipelineGroups.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/PipelineGroups.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.domain;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
+import com.thoughtworks.go.config.exceptions.UnprocessableEntityException;
 import com.thoughtworks.go.config.materials.PackageMaterialConfig;
 import com.thoughtworks.go.config.materials.PluggableSCMMaterialConfig;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
@@ -270,6 +271,16 @@ public class PipelineGroups extends BaseCollection<PipelineConfigs> implements V
     }
 
     public void deleteGroup(String groupName) {
-        this.removeIf(pipelineGroup -> pipelineGroup.isNamed(groupName));
+        Iterator<PipelineConfigs> iterator = this.iterator();
+        while (iterator.hasNext()) {
+            PipelineConfigs currentGroup = iterator.next();
+            if (currentGroup.isNamed(groupName)) {
+                if (!currentGroup.isEmpty()) {
+                    throw new UnprocessableEntityException("Failed to delete group " + groupName + " because it was not empty.");
+                }
+                iterator.remove();
+                break;
+            }
+        }
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/domain/PipelineGroupsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/domain/PipelineGroupsTest.java
@@ -297,8 +297,8 @@ public class PipelineGroupsTest {
     }
 
     @Test
-    public void shouldDeleteGroup() {
-        PipelineConfigs group = createGroup("group", new PipelineConfig[] {});
+    public void shouldDeleteGroupWhenEmpty() {
+        PipelineConfigs group = createGroup("group", new PipelineConfig[]{});
 
         PipelineGroups groups = new PipelineGroups(group);
         groups.deleteGroup("group");
@@ -307,13 +307,23 @@ public class PipelineGroupsTest {
     }
 
     @Test
-    public void shouldDeleteGroupWithSameName() {
-        PipelineConfigs group = createGroup("group", new PipelineConfig[] {});
+    public void shouldDeleteGroupWithSameNameWhenEmpty() {
+        PipelineConfigs group = createGroup("group", new PipelineConfig[]{});
         group.setAuthorization(new Authorization(new ViewConfig(new AdminUser(new CaseInsensitiveString("user")))));
 
         PipelineGroups groups = new PipelineGroups(group);
         groups.deleteGroup("group");
 
         assertThat(groups.size(), is(0));
+    }
+
+    @Test(expected = UnprocessableEntityException.class)
+    public void shouldThrowExceptionWhenDeletingGroupWhenNotEmpty() {
+        PipelineConfig p1Config = createPipelineConfig("pipeline1", "stage1");
+
+        PipelineConfigs group = createGroup("group", p1Config);
+
+        PipelineGroups groups = new PipelineGroups(group);
+        groups.deleteGroup("group");
     }
 }


### PR DESCRIPTION
 This need to be done as we can still call CruiseConfig.deletePipelineGroup independently.

