### PR TITLE
Update policy to not accept wildcard as a valid action

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Role.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Role.java
@@ -15,10 +15,7 @@
  */
 package com.thoughtworks.go.config;
 
-import com.thoughtworks.go.config.policy.Policy;
-import com.thoughtworks.go.config.policy.PolicyAware;
-import com.thoughtworks.go.config.policy.SupportedAction;
-import com.thoughtworks.go.config.policy.SupportedEntity;
+import com.thoughtworks.go.config.policy.*;
 import com.thoughtworks.go.config.validation.NameTypeValidator;
 import com.thoughtworks.go.domain.ConfigErrors;
 
@@ -46,6 +43,12 @@ public interface Role extends Validatable, PolicyAware {
 
     default boolean validateTree(ValidationContext validationContext) {
         validate(validationContext);
+        getPolicy().validateTree(new DelegatingValidationContext(validationContext) {
+            @Override
+            public PolicyValidationContext getPolicyValidationContext() {
+                return new PolicyValidationContext(allowedActions(), allowedTypes());
+            }
+        });
         return !hasErrors();
     }
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/AbstractDirective.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/AbstractDirective.java
@@ -60,29 +60,28 @@ public abstract class AbstractDirective implements Directive {
     public void validate(ValidationContext validationContext) {
         PolicyValidationContext policyValidationContext = validationContext.getPolicyValidationContext();
 
-        if (isInvalid(action, policyValidationContext.getAllowedActions())) {
+        if (isInvalidAction(action, policyValidationContext.getAllowedActions())) {
             this.addError("action", format("Invalid action, must be one of %s.", policyValidationContext.getAllowedActions()));
         }
 
-        if (isInvalid(type, policyValidationContext.getAllowedTypes())) {
+        if (isInvalidType(type, policyValidationContext.getAllowedTypes())) {
             this.addError("type", format("Invalid type, must be one of %s.", policyValidationContext.getAllowedTypes()));
         }
     }
 
-
-    private boolean isInvalid(String actionOrType, List<String> allowedActions) {
-        if ("*".equals(actionOrType)) {
+    private boolean isInvalidType(String type, List<String> allowedTypes) {
+        if ("*".equals(type)) {
             return false;
         }
 
-        return allowedActions.stream().noneMatch(it -> equalsIgnoreCase(it, actionOrType));
+        return allowedTypes.stream().noneMatch(it -> equalsIgnoreCase(it, type));
+    }
+
+    private boolean isInvalidAction(String action, List<String> allowedActions) {
+        return allowedActions.stream().noneMatch(it -> equalsIgnoreCase(it, action));
     }
 
     protected boolean matchesAction(String action) {
-        if (equalsIgnoreCase("*", this.action)) {
-            return true;
-        }
-
         if (equalsIgnoreCase("administer", this.action)) {
             return true;
         }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/Policy.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/Policy.java
@@ -16,16 +16,26 @@
 
 package com.thoughtworks.go.config.policy;
 
-import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.ConfigCollection;
+import com.thoughtworks.go.config.ConfigTag;
+import com.thoughtworks.go.config.Validatable;
+import com.thoughtworks.go.config.ValidationContext;
 import com.thoughtworks.go.domain.BaseCollection;
 import com.thoughtworks.go.domain.ConfigErrors;
 
 @ConfigTag("policy")
 @ConfigCollection(Directive.class)
 public class Policy extends BaseCollection<Directive> implements Validatable {
+    public Policy(Directive... items) {
+        super(items);
+    }
 
     @Override
     public void validate(ValidationContext validationContext) {
+    }
+
+    public void validateTree(ValidationContext validationContext) {
+        this.forEach(directive -> directive.validate(validationContext));
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/Policy.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/Policy.java
@@ -30,6 +30,9 @@ public class Policy extends BaseCollection<Directive> implements Validatable {
         super(items);
     }
 
+    public Policy() {
+    }
+
     @Override
     public void validate(ValidationContext validationContext) {
     }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/policy/AbstractDirectiveTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/policy/AbstractDirectiveTest.java
@@ -55,12 +55,13 @@ class AbstractDirectiveTest {
         }
 
         @Test
-        void shouldAllowActionToHaveWildcard() {
+        void shouldNotAllowActionToHaveWildcard() {
             Directive directive = getDirective("*", "environment", "test-resource");
 
             directive.validate(rulesValidationContext(singletonList("view"), singletonList("environment")));
 
-            assertThat(directive.errors()).hasSize(0);
+            assertThat(directive.errors()).hasSize(1);
+            assertThat(directive.errors().on("action")).isEqualTo("Invalid action, must be one of [view].");
         }
 
         @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/policy/AllowTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/policy/AllowTest.java
@@ -97,14 +97,6 @@ class AllowTest extends AbstractDirectiveTest {
             }
 
             @Test
-            void ifResourceAndTypeMatchesWhenAllActionsAreAllowed() {
-                final Allow allow = new Allow("*", "environment", "env_1");
-
-                assertThat(allow.apply("any-action-is-allowed", EnvironmentConfig.class, "env_1"))
-                        .isEqualTo(Result.ALLOW);
-            }
-
-            @Test
             void ifResourceAndActionMatchesWhenAllTypesAreAllowed() {
                 final Allow allow = new Allow("view", "*", "env_1");
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/policy/DenyTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/policy/DenyTest.java
@@ -97,14 +97,6 @@ class DenyTest extends AbstractDirectiveTest {
             }
 
             @Test
-            void ifResourceAndTypeMatchesWhenAllActionsAreAllowed() {
-                final Deny deny = new Deny("*", "environment", "env_1");
-
-                assertThat(deny.apply("any-action-is-allowed", EnvironmentConfig.class, "env_1"))
-                        .isEqualTo(Result.DENY);
-            }
-
-            @Test
             void ifResourceAndActionMatchesWhenAllTypesAreAllowed() {
                 final Deny deny = new Deny("view", "*", "env_1");
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/policy/PolicyTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/policy/PolicyTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.policy;
+
+import com.thoughtworks.go.config.DelegatingValidationContext;
+import com.thoughtworks.go.config.ValidationContext;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class PolicyTest {
+    @Nested
+    class validateTree {
+        @Test
+        void shouldCallValidateOfEachRule() {
+            ValidationContext validationContext = mock(ValidationContext.class);
+            Allow allow = mock(Allow.class);
+            Deny deny = mock(Deny.class);
+            Policy policy = new Policy(allow, deny);
+
+            policy.validateTree(validationContext);
+
+            verify(allow).validate(validationContext);
+            verify(deny).validate(validationContext);
+        }
+
+        @Test
+        void shouldHaveErrorsIfOneOfTheDirectiveHasError() {
+            final Allow invalidDirective = new Allow(null, "environment", null);
+            final Policy policy = new Policy(invalidDirective);
+
+            policy.validateTree(rulesValidationContext(singletonList("view"), singletonList("environment")));
+
+            assertThat(policy.hasErrors()).isTrue();
+        }
+
+        @Test
+        void shouldNotHaveErrorsIfNoneOfTheDirectiveHasErrors() {
+            final Policy policy = new Policy(
+                    new Allow("view", "environment", "env1"),
+                    new Deny("view", "environment", "env2"));
+
+            policy.validateTree(rulesValidationContext(singletonList("view"), singletonList("environment")));
+
+            assertThat(policy.hasErrors()).isFalse();
+        }
+    }
+
+    private ValidationContext rulesValidationContext(List<String> allowedAction, List<String> allowedType) {
+        return new DelegatingValidationContext(null) {
+            @Override
+            public PolicyValidationContext getPolicyValidationContext() {
+                return new PolicyValidationContext(allowedAction, allowedType);
+            }
+        };
+    }
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/policy_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/policy_widget.tsx
@@ -152,10 +152,10 @@ export class CreatePolicyWidget extends MithrilViewComponent<AutoCompleteAttrs> 
         id: "", text: "Select"
       },
       {
-        id: "deny", text: "Deny"
+        id: "allow", text: "Allow"
       },
       {
-        id: "allow", text: "Allow"
+        id: "deny", text: "Deny"
       }
     ];
   }
@@ -164,9 +164,6 @@ export class CreatePolicyWidget extends MithrilViewComponent<AutoCompleteAttrs> 
     return [
       {
         id: "", text: "Select"
-      },
-      {
-        id: "*", text: "All"
       },
       {
         id: "view", text: "View"
@@ -184,7 +181,8 @@ export class CreatePolicyWidget extends MithrilViewComponent<AutoCompleteAttrs> 
       },
       {
         id: "*", text: "All"
-      }, {
+      },
+      {
         id: "environment", text: "Environment"
       }
     ];

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/policy_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/policy_widget_spec.tsx
@@ -55,9 +55,9 @@ describe('PolicyWidgetSpecs', () => {
 
     expect(helper.qa("td", tableRow).length).toBe(6);
     expect(helper.byTestId("permission-permission")).toHaveValue("allow");
-    expect(helper.textByTestId("permission-permission")).toContain("DenyAllow");
+    expect(helper.textByTestId("permission-permission")).toContain("SelectAllowDeny");
     expect(helper.byTestId("permission-action")).toHaveValue("view");
-    expect(helper.textByTestId("permission-action")).toContain("SelectAllViewAdminister");
+    expect(helper.textByTestId("permission-action")).toContain("SelectViewAdminister");
     expect(helper.byTestId("permission-type")).toHaveValue("*");
     expect(helper.textByTestId("permission-type")).toContain("SelectAllEnvironment");
     expect(helper.byTestId("permission-resource")).toHaveValue("env");

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/RoleConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/RoleConfigCommandTest.java
@@ -17,6 +17,8 @@ package com.thoughtworks.go.config.update;
 
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.exceptions.EntityType;
+import com.thoughtworks.go.config.policy.Allow;
+import com.thoughtworks.go.config.policy.Policy;
 import com.thoughtworks.go.domain.config.ConfigurationKey;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
 import com.thoughtworks.go.domain.config.ConfigurationValue;
@@ -209,6 +211,19 @@ public class RoleConfigCommandTest {
         assertThat(role.getProperty("k3").getEncryptedValue(), is(goCipher.encrypt("pub_v3")));
         assertThat(role.getProperty("k3").getConfigValue(), is(nullValue()));
         assertThat(role.getProperty("k3").getValue(), is("pub_v3"));
+    }
+
+    @Test
+    public void shouldNotPassValidationIfPolicyHasAnError() {
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        Policy policy = new Policy();
+        policy.add(new Allow("*", "*", "*"));
+        RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("foo"), new Users(), policy);
+        cruiseConfig.server().security().addRole(roleConfig);
+
+        RoleConfigCommand command = new StubCommand(goConfigService, roleConfig, extension, currentUser, result);
+        boolean isValid = command.isValid(cruiseConfig);
+        assertFalse(isValid);
     }
 
     private void setAuthorizationPluginInfo() {


### PR DESCRIPTION
Issue: #7297 

Description:
 - Removed support of wildcard(`*`) as a valid action in `policy`
 - Added validation to `role` to validate policy during creation/updation
 - updated the roles spa regarding the same

