### PR TITLE
Show environments link for pipeline group and template admins (#7349)

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.tsx
@@ -187,6 +187,7 @@ export class SiteMenu extends MithrilViewComponent<Attrs> {
           <div class={styles.subNavigation}>
             <SiteSubNav>
               <SiteSubNavItem href="/go/admin/pipelines" text="Pipelines"/>
+              <SiteSubNavItem href="/go/admin/environments" text="Environments"/>
               <SiteSubNavItem href="/go/admin/templates" text="Templates"/>
               <SiteSubNavItem href="/go/admin/elastic_agent_configurations" text="Elastic Agent Configurations"/>
               <SiteSubNavItem href="/go/admin/pipelines/snippet" text="Config XML"/>
@@ -199,6 +200,7 @@ export class SiteMenu extends MithrilViewComponent<Attrs> {
         adminMenu = <SiteNavItem isDropDown={true} text="Admin">
           <div class={styles.subNavigation}>
             <SiteSubNav>
+              <SiteSubNavItem href="/go/admin/environments" text="Environments"/>
               <SiteSubNavItem href="/go/admin/templates" text="Templates"/>
             </SiteSubNav>
           </div>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/spec/index_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/spec/index_spec.tsx
@@ -86,6 +86,7 @@ describe("Site Menu", () => {
     expect(findMenuItem("/go/admin/pipelines")).toBeFalsy();
     expect(findMenuItem("/go/admin/config_repos")).toBeFalsy();
     expect(findMenuItem("/go/admin/templates")).toHaveText("Templates");
+    expect(findMenuItem("/go/admin/environments")).toHaveText("Environments");
     expect(findMenuItem("/go/admin/elastic_agent_configurations")).toBeFalsy();
     expect(findMenuItem("/go/admin/config_xml")).toBeFalsy();
     expect(findMenuItem("/go/admin/config/server")).toBeFalsy();
@@ -96,7 +97,7 @@ describe("Site Menu", () => {
     expect(findMenuItem("/go/admin/security/auth_configs")).toBeFalsy();
     expect(findMenuItem("/go/admin/security/roles")).toBeFalsy();
     expect(helper.qa(`a.${styles.siteNavLink}`)).toHaveLength(4);
-    expect(helper.qa(`a.${styles.siteSubNavLink}`)).toHaveLength(1);
+    expect(helper.qa(`a.${styles.siteSubNavLink}`)).toHaveLength(2);
   });
 
   it("should display the menus for Group Admins", () => {
@@ -119,6 +120,7 @@ describe("Site Menu", () => {
     expect(analytics).toHaveAttr("href", "/go/analytics");
     expect(admin).toHaveText("Admin");
     expect(findMenuItem("/go/admin/pipelines")).toHaveText("Pipelines");
+    expect(findMenuItem("/go/admin/environments")).toHaveText("Environments");
     expect(findMenuItem("/go/admin/config_repos")).toBeFalsy();
     expect(findMenuItem("/go/admin/templates")).toHaveText("Templates");
     expect(findMenuItem("/go/admin/elastic_agent_configurations")).toHaveText("Elastic Agent Configurations");
@@ -131,7 +133,7 @@ describe("Site Menu", () => {
     expect(findMenuItem("/go/admin/security/auth_configs")).toBeFalsy();
     expect(findMenuItem("/go/admin/security/roles")).toBeFalsy();
     expect(helper.qa(`a.${styles.siteNavLink}`)).toHaveLength(4);
-    expect(helper.qa(`a.${styles.siteSubNavLink}`)).toHaveLength(6);
+    expect(helper.qa(`a.${styles.siteSubNavLink}`)).toHaveLength(7);
   });
 
   it("should not show analytics when the attribute is passed as false", () => {


### PR DESCRIPTION
Issue: #7349

Description:

* Show environments link for:
	- pipeline group admin users
	- template admin users