### PR TITLE
Fix read only templates page on pipeline config page (#7352)

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/config_view/config_view_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/config_view/config_view_controller.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2019 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module ConfigView
+  class ConfigViewController < ::ApplicationController
+    before_action :enable_admin_error_template
+
+    def enable_admin_error_template
+      self.error_template_for_request = 'shared/config_error'
+    end
+  end
+end

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/config_view/templates_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/config_view/templates_controller.rb
@@ -1,0 +1,28 @@
+#
+# Copyright 2019 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module ConfigView
+  class TemplatesController < ConfigView::ConfigViewController
+    include Admin::AuthorizationHelper
+    before_action :check_view_access_to_template_and_403
+
+    def show
+      result = HttpLocalizedOperationResult.new
+      @template_config = template_config_service.loadForView(params[:name], result)
+      render_localized_operation_result(result) unless result.isSuccessful()
+    end
+  end
+end

--- a/server/src/main/webapp/WEB-INF/rails/app/helpers/config_view/config_view_helper.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/helpers/config_view/config_view_helper.rb
@@ -1,0 +1,35 @@
+#
+# Copyright 2019 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module ConfigView
+  module ConfigViewHelper
+    def plugin_task_type task
+      task_view_service.getViewModel(task, "new").getTypeForDisplay()
+    end
+
+    def plugin_properties task
+      props = task.getPropertiesForDisplay().collect do |property|
+        [property.getName(), property.getValue()]
+      end
+
+      Hash[props]
+    end
+
+    def is_a_pluggable_task task
+      task.getTaskType().start_with?(com.thoughtworks.go.config.pluggabletask.PluggableTask::PLUGGABLE_TASK_PREFIX)
+    end
+  end
+end

--- a/server/src/main/webapp/WEB-INF/rails/app/views/config_view/templates/_job_view.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/config_view/templates/_job_view.html.erb
@@ -1,0 +1,234 @@
+<div id="<%= scope[:stage_id] %>_job_<%= scope[:index] %>" class="definition_view job">
+<h3 class="entity_title">
+    <ul>
+        <li><a href="#<%= scope[:stage_id] %>" title="<%= scope[:stage_name] %>"><%= scope[:stage_name] %> </a></li>
+        <li><%= scope[:job].name() %></li>
+    </ul>
+</h3>
+<div class="section summary">
+    <fieldset class="job_summary">
+        <ul>
+            <li class="field resources">
+                <label>
+                    <span class="key">Resources</span>
+                    <span class="hint">Agent resources that this job requires to run</span>
+                </label>
+                <span class="input value"><%= scope[:job].resourceConfigs().isEmpty() ? 'None' : scope[:job].resourceConfigs() %></span>
+            </li>
+            <li class="field job_timeout">
+                <label>
+                    <span class="key">Job Timeout</span>
+                    <span class="hint">If this job is inactive for more than the specified period (in minutes), Go will cancel it.</span>
+                </label>
+                <% timeoutType = scope[:job].getTimeoutType() %>
+                <% timeoutValue = timeoutType == com.thoughtworks.go.config.JobConfig::DEFAULT_TIMEOUT ? 'Use default' : timeoutType == com.thoughtworks.go.config.JobConfig::OVERRIDE_TIMEOUT ? "Cancel after '#{scope[:job].getTimeout()}' minute(s) of inactivity" : 'Never' %>
+                <span class="input value"><%= timeoutValue %></span>
+            </li>
+            <li class="field run_on_all_agents">
+                <label>
+                    <span class="key">Run on all agents</span>
+                </label>
+                <span class="input value"><%= scope[:job].isRunOnAllAgents() ? 'Yes' : 'No' %></span>
+            </li>
+            <li class="field run_multiple_instances">
+                <label>
+                    <span class="key">Run multiple instances</span>
+                </label>
+                <span class="input value"><%= scope[:job].isRunMultipleInstanceType() ? 'Yes' : 'No' %></span>
+            </li>
+        </ul>
+    </fieldset>
+</div>
+<ul class="nav nav-tabs">
+    <li class="active"><a href="#tasks_<%= scope[:stage_id] %>_job_<%= scope[:index] %>" data-toggle="tab">Tasks</a></li>
+    <li><a href="#artifacts_<%= scope[:stage_id] %>_job_<%= scope[:index] %>" data-toggle="tab">Artifacts</a></li>
+    <li><a href="#environment_variables_<%= scope[:stage_id] %>_job_<%= scope[:index] %>" data-toggle="tab">Environment Variables</a></li>
+    <li><a href="#custom_tabs_<%= scope[:stage_id] %>_job_<%= scope[:index] %>" data-toggle="tab">Custom Tabs</a></li>
+</ul>
+<div class='tab-content'>
+    <div id='artifacts_<%= scope[:stage_id] %>_job_<%= scope[:index] %>' class='tab-pane'>
+      <% artifacts_by_type = scope[:job].artifactTypeConfigs().group_by(&:artifactType) %>
+      <label class="artifact_title build_artifact">Build Artifact</label>
+      <% if artifacts_by_type[com.thoughtworks.go.domain.ArtifactType::build].nil? %>
+        <span class="no_build_artifact">No build artifacts have been configured</span>
+      <% else %>
+        <ul class="artifact_key_value_pair build_artifact">
+          <% Array.wrap(artifacts_by_type[com.thoughtworks.go.domain.ArtifactType::build]).each do |build_artifact| %>
+            <li>
+              <label>
+                <span class="key">Source</span>
+                <span class="value"><%= build_artifact.getSource() %></span>
+              </label>
+
+              <label>
+                <span class="key">Destination</span>
+                <span class="value"><%= build_artifact.getDestination() %></span>
+              </label>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+
+      <label class="artifact_title test_artifact">Test Artifact</label>
+      <% if artifacts_by_type[com.thoughtworks.go.domain.ArtifactType::test].nil? %>
+        <span class="no_test_artifact">No test artifacts have been configured</span>
+      <% else %>
+        <ul class="artifact_key_value_pair test_artifact">
+          <% Array.wrap(artifacts_by_type[com.thoughtworks.go.domain.ArtifactType::test]).each do |build_artifact| %>
+            <li>
+              <label>
+                <span class="key">Source</span>
+                <span class="value"><%= build_artifact.getSource() %></span>
+              </label>
+
+              <label>
+                <span class="key">Destination</span>
+                <span class="value"><%= build_artifact.getDestination() %></span>
+              </label>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+
+      <label class="artifact_title external_artifact">External Artifact</label>
+      <% if artifacts_by_type[com.thoughtworks.go.domain.ArtifactType::external].nil? %>
+        <span class="no_external_artifact">No external artifacts have been configured</span>
+      <% else %>
+        <ul class="artifact_key_value_pair external_artifact">
+          <% Array.wrap(artifacts_by_type[com.thoughtworks.go.domain.ArtifactType::external]).each do |build_artifact| %>
+            <li>
+              <label>
+                <span class="key">Artifact ID</span>
+                <span class="value"><%= build_artifact.getId() %></span>
+              </label>
+
+              <label>
+                <span class="key">Store ID</span>
+                <span class="value"><%= build_artifact.getStoreId() %></span>
+              </label>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+      <div id="environment_variables_<%= scope[:stage_id] %>_job_<%= scope[:index] %>" class="tab-pane">
+        <table class="variables list_table">
+          <thead>
+          <tr>
+            <th>Name</th>
+            <th>Value</th>
+          </tr>
+          </thead>
+          <tbody>
+          <% if scope[:job].getVariables().isEmpty() %>
+            <tr>
+              <td align='center' colspan="2" class="name_value_cell">No environment variables have been configured</td>
+            </tr>
+          <% end %>
+          <% scope[:job].getVariables().each do |environment_variable| %>
+            <tr>
+              <td class="name_value_cell">
+                <%= environment_variable.getName() %>
+              </td>
+              <td class="name_value_cell">
+                <%= environment_variable.getDisplayValue() %>
+              </td>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div id="custom_tabs_<%= scope[:stage_id] %>_job_<%= scope[:index] %>" class="tab-pane">
+        <table class="custom_tabs list_table">
+            <thead>
+            <tr>
+                <th>Tab Name</th>
+                <th>Path</th>
+            </tr>
+            </thead>
+            <tbody>
+            <% if scope[:job].getTabs().isEmpty() %>
+                <tr>
+                    <td align='center' colspan="2" class="name_value_cell">No custom tabs have been configured</td>
+                </tr>
+            <% end %>
+            <% scope[:job].getTabs().each do |tab| %>
+                <tr>
+                    <td class="name_value_cell">
+                        <%= tab.getName() %>
+                    </td>
+                    <td class="name_value_cell">
+                        <%= tab.getPath() %>
+                    </td>
+                </tr>
+            <% end %>
+            </tbody>
+        </table>
+    </div>
+    <div id="tasks_<%= scope[:stage_id] %>_job_<%= scope[:index] %>" class='tab-pane active'>
+        <% if scope[:job].getTasks().isEmpty() %>
+            <span>No tasks have been configured</span>
+        <% else %>
+            <ul class="tasks_view_list">
+                <% scope[:job].getTasks().each do |task| %>
+                    <li class="<%= task.getTaskType() %>">
+                        <span class="condition">Run if <%= task.runIfConfigsAny() ? "#{'Failed'}, #{'Passed'}" : task.getConditionsForDisplay() %></span>
+                        <% if task.getTaskType() == "fetch" %>
+                            <code>
+                                <span><%=task.getTypeForDisplay()%> - </span>
+                                <span title="Pipeline Name" class="pipeline"><%= task.getPipelineName().blank? ? "[#{'Current pipeline'}]" : task.getPipelineName() %></span>
+                                <span class='path_separator'>&gt;</span>
+                                <span title="Stage Name" class="stage"><%= task.getStage() %></span>
+                                <span class='path_separator'>&gt;</span>
+                                <span title="Job Name" class="job"><%= task.getJob() %></span>
+                                <% if task.getTypeForDisplay() == "Fetch Artifact" %>
+                                  <span class='delimiter'>:</span>
+                                  <span title="Source" class="source"><%= task.getSrc() %></span>
+                                  <span class="direction_arrow">-&gt;</span>
+                                  <span title="Destination" class="destination"><%= task.getDest() %></span>
+                                <% else %>
+                                  <span class="path_separator">-&gt;</span>
+                                  <span>ArtifactID</span>
+                                  <span class='delimiter'>:</span>
+                                  <span title="Artifact ID"><%= task.getArtifactId() %></span>
+                                <% end %>
+                            </code>
+                        <% elsif is_a_pluggable_task(task) %>
+                          <code>
+                            <%= render :partial => "config_view/templates/plugin_view.html", :locals => {:scope => {:task => task}} -%>
+                          </code>
+                        <% else %>
+                            <code>
+                                <% working_dir_title = (task.workingDirectory()==nil || task.workingDirectory() == '') ? "Working Directory": "Working Directory: " + task.workingDirectory()  %>
+                                <span class="working_dir" title="<%= working_dir_title %>"><%= "#{task.workingDirectory()}$" %></span>
+                                <span class="command"><%= task.command() %></span>
+                                <span class="arguments"><%= task.arguments() %></span>
+                            </code>
+                        <% end %>
+                        <% if task.hasCancelTask() %>
+                            <ul>
+                                <li>
+                                  <% if is_a_pluggable_task(task.cancelTask()) %>
+                                      <code>
+                                        <span class="on_cancel"> On Cancel</span>
+                                        <%= render :partial => "config_view/templates/plugin_view.html", :locals => {:scope => {:task => task.cancelTask()}} -%>
+                                      </code>
+                                  <% else %>
+                                      <code>
+                                        <% working_dir_title = (task.cancelTask().getTypeForDisplay() == "Fetch Artifact" || task.cancelTask().workingDirectory()==nil || task.cancelTask().workingDirectory() == '') ? "Working Directory": "Working Directory: " + task.cancelTask().workingDirectory() %>
+                                        <span class="on_cancel"> On Cancel</span>
+                                        <span class="working_dir" title="<%= working_dir_title %>"><%= "#{task.cancelTask().workingDirectory()}$" %></span>
+                                        <span class="command"><%= task.cancelTask().command() %></span>
+                                        <span class="arguments"><%= task.cancelTask().arguments() %></span>
+                                      </code>
+                                  <% end %>
+                                </li>
+                            </ul>
+                        <% end %>
+                    </li>
+                <% end %>
+            </ul>
+        <% end %>
+    </div>
+</div>
+</div>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/config_view/templates/_plugin_view.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/config_view/templates/_plugin_view.html.erb
@@ -1,0 +1,13 @@
+<div class="plugin-task">
+  <h5>
+    Plugin: <span class="plugin-name"><%= plugin_task_type(scope[:task]) %></span>
+  </h5>
+  <div class="plugin-task-properties">
+    <% plugin_properties(scope[:task]).each do |key, value| %>
+        <div class="plugin-task-property">
+          <dt class="plugin-task-key">Property: <span class="plugin-task-key-name"><%= key %></span></dt>
+          <dd class="plugin-task-value"><%= value %></dd>
+        </div>
+    <% end %>
+  </div>
+</div>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/config_view/templates/show.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/config_view/templates/show.html.erb
@@ -1,0 +1,185 @@
+<div class="andare">
+    <div id="templates" class="view layout admin-entity">
+        <div class="navigation">
+            <ul class="stages treenav">
+                <% for i in 1..@template_config.size() %>
+                    <% stage = @template_config.get(i-1) %>
+                    <li>
+                        <a href="#definition_view_stage_<%= i %>" title="<%= stage.name %>"><span><%= stage.name %></span></a>
+                        <ul class="jobs">
+                            <% for j in 1..stage.getJobs().size() %>
+                                <% job = stage.getJobs().get(j-1) %>
+                                <li>
+                                    <a href="#definition_view_stage_<%= i %>_job_<%= j %>" title="<%= job.name %>"><span><%= job.name %></span></a>
+                                </li>
+                            <% end %>
+                        </ul>
+                    </li>
+                <% end %>
+            </ul>
+        </div>
+        <div class="content">
+        <% for i in 1..@template_config.size() %>
+            <% stage = @template_config.get(i-1) %>
+            <div id="definition_view_stage_<%= i %>" class="definition_view stage">
+                <h3 class="entity_title">
+                    <ul><li><%= stage.name %></li></ul>
+                </h3>
+                <div class="section summary">
+                    <fieldset class="stage_summary">
+                        <ul>
+                            <li class="field stage_type">
+                                <label>
+                                    <span class="key">Stage Type</span>
+                                    <span class="hint"><%= "'On Success' option will automatically schedule the stage after the preceding stage completes successfully. The 'Manual' option will require a user to manually trigger the stage. For the first stage in a pipeline, setting type to 'on success' is the same as checking 'Automatic Pipeline Scheduling' on the pipeline config.".html_safe %></span>
+                                </label>
+                                <span class="input value"><%= stage.getApproval().isManual() ? 'Manual' : 'On Success' %></span>
+                            </li>
+                            <li class="field fetch_materials">
+                                <label>
+                                    <span class="key">Fetch Materials</span>
+                                    <span class="hint">Perform material updates or checkouts</span>
+                                </label>
+                                <span class="input value"><%= stage.isFetchMaterials() ? 'Yes' : 'No' %></span>
+                            </li>
+                            <li class="field never_cleanup_artifacts">
+                                <label>
+                                    <span class="key">Never Cleanup Artifacts</span>
+                                    <span class="hint">Never cleanup artifacts for this stage, if purging artifacts is configured at the Server Level</span>
+                                </label>
+                                <span class="input value"><%= stage.isArtifactCleanupProhibited() ? 'Yes' : 'No' %></span>
+                            </li>
+                            <li class="field clean_working_directory">
+                                <label>
+                                    <span class="key">Clean Working Directory</span>
+                                    <span class="hint">Remove all files/directories in the working directory on the agent</span>
+                                </label>
+                                <span class="input value"><%= stage.isCleanWorkingDir() ? 'Yes' : 'No' %></span>
+                            </li>
+                        </ul>
+                    </fieldset>
+                </div>
+                <ul class="nav nav-tabs">
+                    <li class="active"><a href="#environment_variables_stage_<%= i %>" data-toggle="tab" class="active">Environment Variables</a></li>
+                    <li><a href="#permissions_stage_<%= i %>" data-toggle="tab">Permissions</a></li>
+                </ul>
+                <div class="tab-content">
+                    <div id="environment_variables_stage_<%= i %>" class="tab-pane active">
+                        <table class="variables list_table">
+                            <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Value</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <% if stage.getVariables().isEmpty() %>
+                                <tr>
+                                    <td align='center' colspan="2" class="name_value_cell">No environment variables have been configured</td>
+                                </tr>
+                            <% end %>
+                            <% stage.getVariables().each do |environment_variable| %>
+                                <tr>
+                                    <td class="name_value_cell">
+                                        <%= environment_variable.getName() %>
+                                    </td>
+                                    <td class="name_value_cell">
+                                        <%= environment_variable.getDisplayValue() %>
+                                    </td>
+                                </tr>
+                            <% end %>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div id="permissions_stage_<%= i %>" class="tab-pane">
+                        <% if !stage.hasOperatePermissionDefined() %>
+                            <div class="information">
+                                There are no operate permissions configured for this stage nor its pipeline group. All Go users can operate on this stage.
+                            </div>
+                        <% else %>
+                            <% if !stage.getOperateUsers().isEmpty() %>
+                                <table class="stage_operate_users list_table">
+                                    <thead>
+                                    <tr>
+                                        <th>Users</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <% stage.getOperateUsers().each do |user| %>
+                                        <tr>
+                                            <td class="name_value_cell">
+                                                <%= user.getName() %>
+                                            </td>
+                                        </tr>
+                                    <% end %>
+                                    </tbody>
+                                </table>
+                            <% end %>
+                            <% if !stage.getOperateRoles().isEmpty() %>
+                                <table class="stage_operate_roles list_table">
+                                    <thead>
+                                    <tr>
+                                        <th>Roles</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <% stage.getOperateRoles().each do |roles| %>
+                                        <tr>
+                                            <td class="name_value_cell">
+                                                <%= roles.getName() %>
+                                            </td>
+                                        </tr>
+                                    <% end %>
+                                    </tbody>
+                                </table>
+                            <% end %>
+                        <% end %>
+                    </div>
+                </div>
+            </div>
+            <% stage.getJobs().each_with_index do |job, j| %>
+                <%= render :partial => "config_view/templates/job_view.html", :locals => {:scope => {:job => job, :index => j+1, :stage_id => "definition_view_stage_#{i}", :stage_name => stage.name()}} -%>
+            <% end %>
+        <% end %>
+
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    Util.on_load(function() {
+        jQuery(".definition_view").hide();
+        jQuery(".definition_view")[0].show();
+
+        jQuery('.stages a, .jobs a').click(function() {
+            showEntity(jQuery(this));
+            return false;
+        });
+
+        jQuery('.entity_title a').click(function() {
+            showEntity(jQuery(this));
+            top = jQuery('.navigation .stages .selected').removeClass('selected').parents('li').addClass('selected').position().top;
+            jQuery('.navigation').scrollTop(top);
+            return false;
+        });
+
+        function showEntity(entity) {
+            jQuery('#templates.view .content').scrollTop('0');
+            jQuery(".definition_view").hide();
+            jQuery(entity.attr("href")).show();
+        }
+
+        jQuery('.treenav li:has(ul)').addClass('has-children collapsed');
+        jQuery('.treenav li:has(ul) a').click(function(event) {
+            jQuery('.treenav li').removeClass('selected');
+            jQuery(this).closest('li').addClass('selected').removeClass('collapsed');
+        });
+
+        jQuery('.treenav li:has(ul)').click(function() {
+            jQuery(this).closest('li').toggleClass('collapsed');
+            jQuery(this).find('ul li:last-child').addClass('last')
+        });
+
+        jQuery('.stages > li:first-child').addClass('selected');
+    })
+</script>

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/config_view/templates_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/config_view/templates_controller_spec.rb
@@ -1,0 +1,105 @@
+#
+# Copyright 2019 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'rails_helper'
+
+describe ConfigView::TemplatesController do
+
+  describe "routes" do
+    it "should resolve & generate route for viewing templates" do
+      expect(:get => "/config_view/templates/template.name").to route_to(:controller => "config_view/templates", :action => "show", :name => "template.name")
+      expect(config_view_templates_show_path(:name => "template.name")).to eq("/config_view/templates/template.name")
+    end
+  end
+
+  describe 'security' do
+
+    it 'should allow anyone, with security disabled' do
+      disable_security
+
+      expect(controller).to allow_action(:get, :show, params: {name: 'template'})
+    end
+
+    it 'should disallow anonymous users, with security enabled' do
+      enable_security
+      login_as_anonymous
+
+      expect(controller).to disallow_action(:get, :show, params: {name: 'template'})
+    end
+
+    it 'should disallow normal users, with security enabled' do
+      enable_security
+      login_as_user
+
+      expect(controller).to disallow_action(:get, :show, params: {name: 'template'})
+    end
+
+    it 'should allow admin, with security enabled' do
+      enable_security
+      login_as_admin
+
+      expect(controller).to allow_action(:get, :show)
+    end
+
+    it 'should allow template admin, with security enabled' do
+      login_as_template_admin
+
+      expect(controller).to allow_action(:get, :show)
+    end
+
+    it 'should allow template view users, with security enabled' do
+      enable_security
+      allow(@security_service).to receive(:isAuthorizedToViewTemplate).with(anything, anything).and_return(true)
+
+      expect(controller).to allow_action(:get, :show)
+    end
+  end
+
+  describe "show" do
+    before :each do
+      login_as_admin
+      @template_config_service = double('template config service')
+      allow(controller).to receive(:template_config_service).and_return(@template_config_service)
+    end
+
+    it "should return a template object of the given name" do
+      template_config = 'template config'
+      expect(@template_config_service).to receive(:loadForView).with('template.name', an_instance_of(HttpLocalizedOperationResult)).and_return(template_config)
+      get :show, params: {:name => 'template.name'}
+      expect(assigns[:template_config]).to eq(template_config)
+    end
+
+    it "should return nil for template config when template name does not exist" do
+      expect(@template_config_service).to receive(:loadForView).with('template.name', an_instance_of(HttpLocalizedOperationResult)).and_return(nil)
+      get :show, params: {:name => 'template.name'}
+      expect(assigns[:template_config]).to eq(nil)
+    end
+
+    it "should render error when template config service returns bad operation result" do
+      result = double(HttpLocalizedOperationResult)
+      expect(result).to receive(:isSuccessful).and_return(false)
+      expect(result).to receive(:httpCode).and_return(404)
+      expect(result).to receive(:message).and_return("Template Not found")
+      allow(HttpLocalizedOperationResult).to receive(:new).and_return(result)
+      template_name = 'template.name'
+      expect(@template_config_service).to receive(:loadForView).with(template_name, result).and_return(nil)
+      get :show, params: {:name => template_name}
+      expect(assigns[:template_config]).to eq(nil)
+      expect(response).to render_template("shared/config_error")
+      expect(response.status).to eq(404)
+    end
+  end
+end

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/config_view/templates/_job_view_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/config_view/templates/_job_view_html_spec.rb
@@ -1,0 +1,575 @@
+#
+# Copyright 2019 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'rails_helper'
+
+describe "config_view/templates/_job_view.html.erb" do
+  include TaskMother
+
+  it "should render job settings" do
+    job = JobConfig.new('build_job')
+    job.addResourceConfig('buildr')
+    job.addResourceConfig('ruby')
+    job.addTask(ant_task)
+    render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+    Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+      job.find(".summary fieldset.job_summary ul").tap do |list|
+        list.find("li.field.resources").tap do |resources|
+          resources.find("label").tap do |label|
+            expect(label).to have_selector("span.key", :text => "Resources")
+            expect(label).to have_selector("span.hint", :text => "Agent resources that this job requires to run")
+          end
+          expect(resources).to have_selector("span.value", :text => "buildr | ruby")
+        end
+        list.find("li.field.job_timeout").tap do |timeout|
+          timeout.find("label").tap do |label|
+            expect(label).to have_selector("span.key", :text => "Job Timeout")
+            expect(label).to have_selector("span.hint", :text => "If this job is inactive for more than the specified period (in minutes), Go will cancel it.")
+          end
+          expect(timeout).to have_selector("span.value", :text => "Use default")
+        end
+        list.find("li.field.run_on_all_agents").tap do |run|
+          run.find("label").tap do |label|
+            expect(label).to have_selector("span.key", :text => "Run on all agents")
+          end
+          expect(run).to have_selector("span.value", :text => "No")
+        end
+        list.find("li.field.run_multiple_instances").tap do |run|
+          run.find("label").tap do |label|
+            expect(label).to have_selector("span.key", :text => "Run multiple instances")
+          end
+          expect(run).to have_selector("span.value", :text => "No")
+        end
+      end
+    end
+  end
+
+  it "should render resources as none when no resources are configured" do
+    job = JobConfig.new('build_job')
+    job.addTask(ant_task)
+    render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+    Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+      job.find(".summary fieldset.job_summary ul").tap do |list|
+        list.find("li.field.resources").tap do |item|
+          item.find("label").tap do |label|
+            expect(label).to have_selector("span.key", :text => "Resources")
+            expect(label).to have_selector("span.hint", :text => "Agent resources that this job requires to run")
+          end
+          expect(item).to have_selector("span.value", :text => "None")
+        end
+      end
+    end
+  end
+
+  it "should render job timeout it is configured to never timeout" do
+    job = JobConfig.new('build_job')
+    job.setTimeout('0')
+    job.addTask(ant_task)
+    render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+    Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+      job.find(".summary fieldset.job_summary ul").tap do |list|
+        list.find("li.field.job_timeout").tap do |item|
+          item.find("label").tap do |label|
+            expect(label).to have_selector("span.key", :text => "Job Timeout")
+            expect(label).to have_selector("span.hint", :text => "If this job is inactive for more than the specified period (in minutes), Go will cancel it.")
+          end
+          expect(item).to have_selector("span.value", :text => "Never")
+        end
+      end
+    end
+  end
+
+  it "should render overridden job timeout" do
+    job = JobConfig.new('build_job')
+    job.setTimeout('30')
+    job.addTask(ant_task)
+    render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+    Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+      job.find(".summary fieldset.job_summary ul").tap do |list|
+        list.find("li.field.job_timeout").tap do |item|
+          item.find("label").tap do |label|
+            expect(label).to have_selector("span.key", :text => "Job Timeout")
+            expect(label).to have_selector("span.hint", :text => "If this job is inactive for more than the specified period (in minutes), Go will cancel it.")
+          end
+          expect(item).to have_selector("span.value", :text => "Cancel after '30' minute(s) of inactivity")
+        end
+      end
+    end
+  end
+
+  it "should render when job is configured to run on all agents" do
+    job = JobConfig.new('build_job')
+    job.setRunOnAllAgents(true)
+    job.addTask(ant_task)
+    render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+    Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+      job.find(".summary fieldset.job_summary ul").tap do |list|
+        list.find("li.field.run_on_all_agents").tap do |item|
+          item.find("label").tap do |label|
+            expect(label).to have_selector("span.key", :text => "Run on all agents")
+          end
+          expect(item).to have_selector("span.value", :text => "Yes")
+        end
+      end
+    end
+  end
+
+  it "should render when job is configured to run multiple instances" do
+    job = JobConfig.new('build_job')
+    job.setRunInstanceCount(2)
+    job.addTask(ant_task)
+    render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+    Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+      job.find(".summary fieldset.job_summary ul").tap do |list|
+        list.find("li.field.run_multiple_instances").tap do |item|
+          item.find("label").tap do |label|
+            expect(label).to have_selector("span.key", :text => "Run multiple instances")
+          end
+          expect(item).to have_selector("span.value", :text => "Yes")
+        end
+      end
+    end
+  end
+
+  it "should render tabs to show job details like tasks, artifacts, environment variables and custom tabs" do
+    job = JobConfig.new('build_job')
+    job.addTask(ant_task)
+    render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+    Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+      job.find("ul.nav.nav-tabs").tap do |list|
+        list.find("li.active").tap do |active_item|
+          expect(active_item).to have_selector("a[href='#tasks_stage_id_job_1'][data-toggle='tab']", :text => "Tasks")
+        end
+        list.all("li:not(.active)").tap do |items|
+          expect(items[0]).to have_selector("a[href='#artifacts_stage_id_job_1'][data-toggle='tab']", :text => "Artifacts")
+          expect(items[1]).to have_selector("a[href='#environment_variables_stage_id_job_1'][data-toggle='tab']", :text => "Environment Variables")
+          expect(items[2]).to have_selector("a[href='#custom_tabs_stage_id_job_1'][data-toggle='tab']", :text => "Custom Tabs")
+        end
+      end
+    end
+  end
+
+  it "should render artifacts tab for a job" do
+    artifact_plans = ArtifactTypeConfigs.new()
+    artifact_plans.add(BuildArtifactConfig.new("build-result", "build-output"))
+    test_artifact = TestArtifactConfig.new('test-result', 'test-output')
+    artifact_plans.add(test_artifact)
+    artifact_plans.add(PluggableArtifactConfig.new("installer","hub.docker"))
+    job = JobConfig.new(CaseInsensitiveString.new("jobName"), ResourceConfigs.new(), artifact_plans)
+    job.addTask(ant_task)
+    render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+    Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+      expect(job).to have_selector(".tab-content #artifacts_stage_id_job_1.tab-pane .artifact_title.build_artifact", count: 1, text: 'Build Artifact')
+      expect(job).to have_selector(".tab-content #artifacts_stage_id_job_1.tab-pane .artifact_title.test_artifact", count: 1, text: 'Test Artifact')
+      expect(job).to have_selector(".tab-content #artifacts_stage_id_job_1.tab-pane .artifact_title.external_artifact", count: 1, text: 'External Artifact')
+
+      expect(job).not_to have_selector(".no_build_artifact")
+      expect(job).not_to have_selector(".no_test_artifact")
+      expect(job).not_to have_selector(".no_external_artifact")
+
+      job.find(".tab-content #artifacts_stage_id_job_1.tab-pane .artifact_key_value_pair.build_artifact li").tap do |li|
+        expect(li).to have_selector("label", count: 2)
+        all_labels = li.all("label")
+        expect(all_labels[0]).to have_selector("span.key", text: 'Source')
+        expect(all_labels[0]).to have_selector("span.value", text: 'build-result')
+
+        expect(all_labels[1]).to have_selector("span.key", text: 'Destination')
+        expect(all_labels[1]).to have_selector("span.value", text: 'build-output')
+      end
+
+      job.find(".tab-content #artifacts_stage_id_job_1.tab-pane .artifact_key_value_pair.test_artifact li").tap do |li|
+        expect(li).to have_selector("label", count: 2)
+        all_labels = li.all("label")
+        expect(all_labels[0]).to have_selector("span.key", text: 'Source')
+        expect(all_labels[0]).to have_selector("span.value", text: 'test-result')
+
+        expect(all_labels[1]).to have_selector("span.key", text: 'Destination')
+        expect(all_labels[1]).to have_selector("span.value", text: 'test-output')
+      end
+
+      job.find(".tab-content #artifacts_stage_id_job_1.tab-pane .artifact_key_value_pair.external_artifact li").tap do |li|
+        expect(li).to have_selector("label", count: 2)
+        all_labels = li.all("label")
+        expect(all_labels[0]).to have_selector("span.key", text: 'Artifact ID')
+        expect(all_labels[0]).to have_selector("span.value", text: 'installer')
+
+        expect(all_labels[1]).to have_selector("span.key", text: 'Store ID')
+        expect(all_labels[1]).to have_selector("span.value", text: 'hub.docker')
+      end
+    end
+  end
+
+  it "should render artifacts tab when not configured for a job" do
+    job = JobConfig.new('job1')
+    job.addTask(ant_task)
+    render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+    Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+      expect(job).to have_selector(".tab-content #artifacts_stage_id_job_1.tab-pane .artifact_title.build_artifact", count: 1, text: 'Build Artifact')
+      expect(job).to have_selector(".tab-content #artifacts_stage_id_job_1.tab-pane .artifact_title.test_artifact", count: 1, text: 'Test Artifact')
+      expect(job).to have_selector(".tab-content #artifacts_stage_id_job_1.tab-pane .artifact_title.external_artifact", count: 1, text: 'External Artifact')
+
+      expect(job).to have_selector(".no_build_artifact", text: 'No build artifacts have been configured')
+      expect(job).to have_selector(".no_test_artifact", text: 'No test artifacts have been configured')
+      expect(job).to have_selector(".no_external_artifact", text: 'No external artifacts have been configured')
+
+      expect(job).not_to have_selector(".tab-content #artifacts_stage_id_job_1.tab-pane .artifact_key_value_pair.build_artifact")
+      expect(job).not_to have_selector(".tab-content #artifacts_stage_id_job_1.tab-pane .artifact_key_value_pair.test_artifact")
+      expect(job).not_to have_selector(".tab-content #artifacts_stage_id_job_1.tab-pane .artifact_key_value_pair.external_artifact")
+    end
+  end
+
+  it "should display environment variables for a job" do
+    job = JobConfig.new('job1')
+    job.addVariable('env1', 'value1')
+    job.addVariable('env2', 'value2')
+    job.addTask(ant_task)
+    render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+    Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+      job.find(".tab-content #environment_variables_stage_id_job_1.tab-pane table.variables.list_table").tap do |table|
+        table.find("thead").tap do |head|
+          head.find("tr").tap do |row|
+            expect(row).to have_selector("th", :text => "Name")
+            expect(row).to have_selector("th", :text => "Value")
+          end
+        end
+        table.find("tbody").tap do |body|
+          body.all("tr").tap do |rows|
+            expect(rows[0]).to have_selector("td.name_value_cell", :text => "env1")
+            expect(rows[0]).to have_selector("td.name_value_cell", :text => "value1")
+            expect(rows[1]).to have_selector("td.name_value_cell", :text => "env2")
+            expect(rows[1]).to have_selector("td.name_value_cell", :text => "value2")
+          end
+        end
+      end
+    end
+  end
+
+  it "should display masked value for secure environment variables for a job" do
+    job = JobConfig.new('job1')
+    environment_variable_config_new = EnvironmentVariableConfig.new("env2", "value2")
+    environment_variable_config_new.setIsSecure(true)
+    job.setVariables(EnvironmentVariablesConfig.new([EnvironmentVariableConfig.new("env1", "value1"), environment_variable_config_new]))
+    job.addTask(ant_task)
+    render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+    Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+      job.find(".tab-content #environment_variables_stage_id_job_1.tab-pane table.variables.list_table").tap do |table|
+        table.find("thead").tap do |head|
+          head.find("tr").tap do |row|
+            expect(row).to have_selector("th", :text => "Name")
+            expect(row).to have_selector("th", :text => "Value")
+          end
+        end
+        table.find("tbody").tap do |body|
+          body.all("tr").tap do |rows|
+            expect(rows[0]).to have_selector("td.name_value_cell", :text => "env1")
+            expect(rows[0]).to have_selector("td.name_value_cell", :text => "value1")
+            expect(rows[1]).to have_selector("td.name_value_cell", :text => "env2")
+            expect(rows[1]).to have_selector("td.name_value_cell", :text => "****")
+          end
+        end
+      end
+    end
+  end
+
+  it "should render environment variables tab when no variables are configured" do
+    job = JobConfig.new('job1')
+    job.addTask(ant_task)
+    render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+    Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+      job.find(".tab-content #environment_variables_stage_id_job_1.tab-pane table.variables.list_table").tap do |table|
+        table.find("thead").tap do |head|
+          head.find("tr").tap do |row|
+            expect(row).to have_selector("th", :text => "Name")
+            expect(row).to have_selector("th", :text => "Value")
+          end
+        end
+        table.find("tbody").tap do |body|
+          body.find("tr").tap do |row|
+            expect(row).to have_selector("td.name_value_cell[align='center'][colspan='2']", :text => "No environment variables have been configured")
+          end
+        end
+      end
+    end
+  end
+
+  it "should display custom tab for a job" do
+    job = JobConfig.new('job1')
+    job.addTab('test-reports', 'reports/rspec')
+    job.addTab('cobertura', 'reports/code-coverage')
+    job.addTask(ant_task)
+    render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+    Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+      job.find(".tab-content #custom_tabs_stage_id_job_1.tab-pane table.custom_tabs.list_table").tap do |table|
+        table.find("thead").tap do |head|
+          head.find("tr").tap do |row|
+            expect(row).to have_selector("th", :text => "Tab Name")
+            expect(row).to have_selector("th", :text => "Path")
+          end
+        end
+        table.find("tbody").tap do |body|
+          body.all("tr").tap do |rows|
+            expect(rows[0]).to have_selector("td.name_value_cell", :text => "test-reports")
+            expect(rows[0]).to have_selector("td.name_value_cell", :text => "reports/rspec")
+            expect(rows[1]).to have_selector("td.name_value_cell", :text => "cobertura")
+            expect(rows[1]).to have_selector("td.name_value_cell", :text => "reports/code-coverage")
+          end
+        end
+      end
+    end
+  end
+
+  it "should render custom tab when no tabs are configured" do
+    job = JobConfig.new('job1')
+    job.addTask(ant_task)
+    render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+    Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+      job.find(".tab-content #custom_tabs_stage_id_job_1.tab-pane table.custom_tabs.list_table").tap do |table|
+        table.find("thead").tap do |head|
+          head.find("tr").tap do |row|
+            expect(row).to have_selector("th", :text => "Tab Name")
+            expect(row).to have_selector("th", :text => "Path")
+          end
+        end
+        table.find("tbody").tap do |body|
+          body.find("tr").tap do |row|
+            expect(row).to have_selector("td.name_value_cell[align='center'][colspan='2']", :text => "No custom tabs have been configured")
+          end
+        end
+      end
+    end
+  end
+
+  describe "render tasks" do
+
+    it "should display tasks of a job" do
+      job = JobConfig.new('job1')
+      job.addTask(ant_task)
+      job.addTask(simple_exec_task)
+      render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+      Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+        job.find(".tab-content #tasks_stage_id_job_1").tap do |tasks|
+          tasks.find("ul.tasks_view_list").tap do |list|
+            list.all("li").tap do |items|
+              items[0].find("code").tap do |code|
+                expect(code).to have_selector("span.working_dir", :text => "default/wd$")
+                expect(code).to have_selector("span.command", :text => "ant")
+                expect(code).to have_selector("span.arguments", :text => "-f \"build.xml\" compile")
+              end
+              expect(items[0]).to have_selector("span.condition", :text => "Run if Passed")
+              expect(items[0]).to_not have_selector("ul li span.on_cancel")
+              items[1].find("code").tap do |code|
+                expect(code).to have_selector("span.working_dir", :text => "hero/ka/directory$")
+                expect(code).to have_selector("span.command", :text => "ls")
+                expect(code).to have_selector("span.arguments", :text => "-la")
+              end
+              expect(items[1]).to have_selector("span.condition", :text => "Run if Passed")
+            end
+          end
+        end
+      end
+    end
+
+    it "should display fetch artifact task of a job" do
+      job = JobConfig.new('job1')
+      job.addTask(fetch_task_with_exec_on_cancel_task)
+      render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+      Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+        job.find(".tab-content #tasks_stage_id_job_1 ul.tasks_view_list").tap do |list|
+          list.all("li.fetch code").tap do |items|
+            item = items[0]
+            expect(item).to have_selector("span", :text => "Fetch Artifact -")
+            expect(item).to have_selector("span[title='Pipeline Name']", :text => "pipeline")
+            expect(item).to have_selector("span.path_separator", :text => ">")
+            expect(item).to have_selector("span[title='Stage Name']", :text => "stage")
+            expect(item).to have_selector("span.path_separator", :text => ">")
+            expect(item).to have_selector("span[title='Job Name']", :text => "job")
+            expect(item).to have_selector("span.delimiter", :text => ":")
+            expect(item).to have_selector("span[title='Source']", :text => "src")
+            expect(item).to have_selector("span.direction_arrow", :text => "->")
+            expect(item).to have_selector("span[title='Destination']", :text => "dest")
+          end
+        end
+      end
+    end
+
+    it "should display fetch artifact task of a job when it fetches from same pipeline" do
+      job = JobConfig.new('job1')
+      task = fetch_task_with_exec_on_cancel_task(nil)
+      job.addTask(task)
+      render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+      Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+        job.find(".tab-content #tasks_stage_id_job_1 ul.tasks_view_list").tap do |list|
+          list.all("li.fetch code").tap do |items|
+            item = items[0]
+            expect(item).to have_selector("span", :text => "Fetch Artifact -")
+            expect(item).to have_selector("span[title='Pipeline Name']", :text => "Current pipeline")
+            expect(item).to have_selector("span.path_separator", :text => ">")
+            expect(item).to have_selector("span[title='Stage Name']", :text => "stage")
+            expect(item).to have_selector("span.path_separator", :text => ">")
+            expect(item).to have_selector("span[title='Job Name']", :text => "job")
+            expect(item).to have_selector("span.delimiter", :text => ":")
+            expect(item).to have_selector("span[title='Source']", :text => "src")
+            expect(item).to have_selector("span.direction_arrow", :text => "->")
+            expect(item).to have_selector("span[title='Destination']", :text => "dest")
+          end
+        end
+      end
+    end
+
+    it "should display fetch external artifact task" do
+      job = JobConfig.new('job1')
+      job.addTask(fetch_external_task(nil))
+      render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+      Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+        job.find(".tab-content #tasks_stage_id_job_1 ul.tasks_view_list").tap do |list|
+          list.all("li.fetch code").tap do |items|
+            item = items[0]
+            expect(item).to have_selector("span", :text => "Fetch External Artifact -")
+            expect(item).to have_selector("span[title='Pipeline Name']", :text => "Current pipeline")
+            expect(item).to have_selector("span.path_separator", :text => ">")
+            expect(item).to have_selector("span[title='Stage Name']", :text => "stage")
+            expect(item).to have_selector("span.path_separator", :text => ">")
+            expect(item).to have_selector("span[title='Job Name']", :text => "job")
+            expect(item).to have_selector("span.delimiter", :text => ":")
+            expect(item).to have_selector("span", :text => "ArtifactID")
+            expect(item).to have_selector("span.delimiter", :text => ":")
+            expect(item).to have_selector("span[title='Artifact ID']", :text => "docker")
+          end
+        end
+      end
+    end
+
+    it "should display multiple run if conditions" do
+      job = JobConfig.new('job1')
+      task = simple_exec_task
+      task.getConditions().add(com.thoughtworks.go.config.RunIfConfig::PASSED)
+      task.getConditions().add(com.thoughtworks.go.config.RunIfConfig::FAILED)
+      job.addTask(task)
+      render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+      Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+        job.find(".tab-content #tasks_stage_id_job_1 ul").tap do |list|
+          list.find("li").tap do |item|
+            expect(item).to have_selector("span.condition", :text => "Run if Passed, Failed")
+          end
+        end
+      end
+    end
+
+    it "should display as run if Passed or failed when run if condition is any" do
+      job = JobConfig.new('job1')
+      task = simple_exec_task
+      task.getConditions().add(com.thoughtworks.go.config.RunIfConfig::ANY)
+      job.addTask(task)
+      render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+      Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+        job.find(".tab-content #tasks_stage_id_job_1 ul").tap do |list|
+          list.find("li").tap do |item|
+            expect(item).to have_selector("span.condition", :text => "Run if Failed, Passed")
+          end
+        end
+      end
+    end
+
+    it "should display on cancel task details of a task" do
+      job = JobConfig.new('job1')
+      task = ant_task
+      task.setCancelTask(nant_task)
+      job.addTask(task)
+      render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+      Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+        job.find(".tab-content #tasks_stage_id_job_1 ul.tasks_view_list").tap do |list|
+          list.find("li.ant").tap do |item|
+            expect(item).to have_selector("span.condition", :text => "Run if Passed")
+            item.all("code").tap do |codes|
+              code = codes[0]
+              expect(code).to have_selector("span.working_dir", :text => "default/wd$")
+              expect(code).to have_selector("span.command", :text => "ant")
+              expect(code).to have_selector("span.arguments", :text => "-f \"build.xml\" compile")
+            end
+            item.find("ul").tap do |list2|
+              list2.find("li").tap do |item2|
+                item2.find("code").tap do |code2|
+                  expect(code2).to have_selector("span.on_cancel", :text => "On Cancel")
+                  expect(code2).to have_selector("span.working_dir", :text => "default/wd$")
+                  expect(code2).to have_selector("span.command", :text => "nant")
+                  expect(code2).to have_selector("span.arguments", :text => "-buildfile:\"default.build\" compile")
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    it "should display message saying that no tasks have been configured when there are none" do
+      job = JobConfig.new('job1')
+      render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+      Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+        job.find(".tab-content #tasks_stage_id_job_1").tap do |tasks|
+          expect(tasks).to have_selector("span", :text => "No tasks have been configured")
+        end
+      end
+    end
+
+    it "should display task details of a plugin task" do
+      pluggable_task = plugin_task "plugin.1", [ConfigurationPropertyMother.create("KEY1", false, "value1"), ConfigurationPropertyMother.create("KEY2", false, "value2")]
+      job = JobConfig.new('job1')
+      job.addTask(pluggable_task)
+      render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+
+      Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+        job.find(".tab-content #tasks_stage_id_job_1 ul.tasks_view_list").tap do |list|
+          list.find("li.pluggable_task_plugin_1 code div.plugin-task").tap do |item|
+            expect(item).to_not have_selector("span.on_cancel", :text => "On Cancel")
+            expect(item).to have_selector("span.plugin-name", :text => "plugin.1")
+
+            item.find("div.plugin-task-properties").tap do |prop|
+              expect(prop).to have_selector(".plugin-task-property dt span.plugin-task-key-name", :text => "KEY1")
+              expect(prop).to have_selector(".plugin-task-property dd.plugin-task-value", :text => "value1")
+              expect(prop).to have_selector(".plugin-task-property dt span.plugin-task-key-name", :text => "KEY2")
+              expect(prop).to have_selector(".plugin-task-property dd.plugin-task-value", :text => "value2")
+            end
+          end
+        end
+      end
+    end
+
+    it "should display cancel task details, even if it's a plugin task" do
+      pluggable_task = plugin_task "plugin.1", [ConfigurationPropertyMother.create("KEY1", false, "value1"), ConfigurationPropertyMother.create("KEY2", false, "value2")]
+      job = JobConfig.new('job1')
+      task = ant_task
+      task.setCancelTask(pluggable_task)
+      job.addTask(task)
+      render :partial => 'config_view/templates/job_view', :locals => {:scope => {:job => job, :index => 1, :stage_id => 'stage_id', :stage_name => "stage_build"}}
+
+      Capybara.string(response.body).find("#stage_id_job_1").tap do |job|
+        job.find(".tab-content #tasks_stage_id_job_1 ul.tasks_view_list").tap do |list|
+          list.find("li.ant ul li code").tap do |code|
+            expect(code).to have_selector("span.on_cancel", :text => "On Cancel")
+            expect(code).to have_selector("span.plugin-name", :text => "plugin.1")
+
+            list.find("div.plugin-task div.plugin-task-properties").tap do |prop|
+              expect(prop).to have_selector(".plugin-task-property dt span.plugin-task-key-name", :text => "KEY1")
+              expect(prop).to have_selector(".plugin-task-property dd.plugin-task-value", :text => "value1")
+              expect(prop).to have_selector(".plugin-task-property dt span.plugin-task-key-name", :text => "KEY2")
+              expect(prop).to have_selector(".plugin-task-property dd.plugin-task-value", :text => "value2")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/config_view/templates/show_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/config_view/templates/show_html_spec.rb
@@ -1,0 +1,295 @@
+#
+# Copyright 2019 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'rails_helper'
+
+describe "config_view/templates/show.html.erb" do
+
+  it "should display tree of stages and jobs to help navigation" do
+    template = com.thoughtworks.go.helper.PipelineTemplateConfigMother.createTemplate("t1")
+    assign(:template_config, template)
+    render
+    Capybara.string(response.body).all(".layout.admin-entity ul.stages li").tap do |stages|
+      stage = stages[0]
+      expect(stage).to have_selector("a[href='#definition_view_stage_1']", :text => "defaultStage")
+      stage.find("ul.jobs li").tap do |job|
+        expect(job).to have_selector("a[href='#definition_view_stage_1_job_1']", :text => "defaultJob")
+      end
+    end
+  end
+
+  it "should display stage heading" do
+    template = PipelineTemplateConfigMother.create_template("t1", [StageConfigMother.stage_config("stage1"), StageConfigMother.manual_stage("stage2")].to_java(StageConfig))
+    assign(:template_config, template)
+    render
+    Capybara.string(response.body).all(".layout.admin-entity div.content div#definition_view_stage_1 h3.entity_title ul li").tap do |item|
+      expect(item[0]).to have_content("stage1")
+    end
+    Capybara.string(response.body).all(".layout.admin-entity div.content div#definition_view_stage_2 h3.entity_title ul li").tap do |item|
+      expect(item[0]).to have_content("stage2")
+    end
+  end
+
+  it "should display stage summary details" do
+    stage2 = StageConfig.new(CaseInsensitiveString.new("stage2"), false, true, Approval.manualApproval(), true, BuildPlanMother.withBuildPlans(["job1"].to_java(java.lang.String)))
+    template = PipelineTemplateConfigMother.create_template("t1", [StageConfigMother.stage_config("stage1"), stage2].to_java(StageConfig))
+    assign(:template_config, template)
+    render
+    expected = [{:stage_name => "stage_1", :stage_type => "On Success", :fetch_materials => "Yes", :cleanup_artifacts => "No", :clean_directory => "No"},
+                {:stage_name => "stage_2", :stage_type => "Manual", :fetch_materials => "No", :cleanup_artifacts => "Yes", :clean_directory => "Yes"}]
+
+    expected.each do |e|
+      Capybara.string(response.body).find(".layout.admin-entity").tap do |stages|
+        stages.find("#definition_view_#{e[:stage_name]}").tap do |stage|
+          stage.find("fieldset.stage_summary").tap do |summary|
+            summary.find("ul").tap do |list|
+              list.find("li.stage_type.field").tap do |field|
+                field.find("label").tap do |label|
+                  expect(label).to have_selector("span.key", :text => "Stage Type")
+                  expect(label).to have_selector("span.hint", :text => "'On Success' option will automatically schedule the stage after the preceding stage completes successfully. The 'Manual' option will require a user to manually trigger the stage. For the first stage in a pipeline, setting type to 'on success' is the same as checking 'Automatic Pipeline Scheduling' on the pipeline config.")
+                end
+                expect(field).to have_selector("span.value", :text => e[:stage_type])
+              end
+              list.find("li.fetch_materials.field").tap do |field|
+                field.find("label").tap do |label|
+                  expect(label).to have_selector("span.key", :text => "Fetch Materials")
+                  expect(label).to have_selector("span.hint", :text => "Perform material updates or checkouts")
+                end
+                expect(field).to have_selector("span.value", :text => e[:fetch_materials])
+              end
+              list.find("li.never_cleanup_artifacts.field").tap do |field|
+                field.find("label").tap do |label|
+                  expect(label).to have_selector("span.key", :text => "Never Cleanup Artifacts")
+                  expect(label).to have_selector("span.hint", :text => "Never cleanup artifacts for this stage, if purging artifacts is configured at the Server Level")
+                end
+                expect(field).to have_selector("span.value", :text => e[:cleanup_artifacts])
+              end
+              list.find("li.clean_working_directory.field").tap do |field|
+                field.find("label").tap do |label|
+                  expect(label).to have_selector("span.key", :text => "Clean Working Directory")
+                  expect(label).to have_selector("span.hint", :text => "Remove all files/directories in the working directory on the agent")
+                end
+                expect(field).to have_selector("span.value", :text => e[:clean_directory])
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  it "should display environment variables and permissions tab for a stage" do
+    stage = StageConfigMother.stage_config("stage1")
+    template = PipelineTemplateConfigMother.create_template("t1", [stage].to_java(StageConfig))
+    assign(:template_config, template)
+    render
+    Capybara.string(response.body).find(".layout.admin-entity").tap do |layout|
+      layout.find("#definition_view_stage_1").tap do |stage|
+        stage.find("ul.nav.nav-tabs").tap do |list|
+          list.all("li").tap do |items|
+            expect(items[0]).to have_selector("a[href='#environment_variables_stage_1'][data-toggle='tab']", :text => "Environment Variables")
+            expect(items[1]).to have_selector("a[href='#permissions_stage_1'][data-toggle='tab']", :text => "Permissions")
+          end
+        end
+      end
+    end
+  end
+
+  it "should display environment variables for a stage" do
+    stage = StageConfigMother.stage_config("stage1")
+    stage.setVariables(EnvironmentVariablesConfig.new([EnvironmentVariableConfig.new("env1", "value1"), EnvironmentVariableConfig.new("env2", "value2")]))
+    template = PipelineTemplateConfigMother.create_template("t1", [stage].to_java(StageConfig))
+    assign(:template_config, template)
+    render
+    Capybara.string(response.body).find("#definition_view_stage_1").tap do |stage|
+      stage.find(".tab-content #environment_variables_stage_1.tab-pane.active table.variables").tap do |table|
+        table.find("thead").tap do |head|
+          head.find("tr").tap do |row|
+            expect(row).to have_selector("th", :text => "Name")
+            expect(row).to have_selector("th", :text => "Value")
+          end
+        end
+        table.find("tbody").tap do |body|
+          body.all("tr").tap do |rows|
+            expect(rows[0]).to have_selector("td.name_value_cell", :text => "env1")
+            expect(rows[0]).to have_selector("td.name_value_cell", :text => "value1")
+            expect(rows[1]).to have_selector("td.name_value_cell", :text => "env2")
+            expect(rows[1]).to have_selector("td.name_value_cell", :text => "value2")
+          end
+        end
+      end
+    end
+  end
+
+  it 'should mask the value of secure environment variable for a stage' do
+    stage = StageConfigMother.stage_config("stage1")
+    environment_variable_config_new = EnvironmentVariableConfig.new("env2", "value2")
+    environment_variable_config_new.setIsSecure(true)
+    stage.setVariables(EnvironmentVariablesConfig.new([EnvironmentVariableConfig.new("env1", "value1"), environment_variable_config_new]))
+    template = PipelineTemplateConfigMother.create_template("t1", [stage].to_java(StageConfig))
+    assign(:template_config, template)
+    render
+    Capybara.string(response.body).find("#definition_view_stage_1").tap do |stage|
+      stage.find(".tab-content #environment_variables_stage_1.tab-pane.active table.variables").tap do |table|
+        table.find("thead").tap do |head|
+          head.find("tr").tap do |row|
+            expect(row).to have_selector("th", :text => "Name")
+            expect(row).to have_selector("th", :text => "Value")
+          end
+        end
+        table.find("tbody").tap do |body|
+          body.all("tr").tap do |rows|
+            expect(rows[0]).to have_selector("td.name_value_cell", :text => "env1")
+            expect(rows[0]).to have_selector("td.name_value_cell", :text => "value1")
+            expect(rows[1]).to have_selector("td.name_value_cell", :text => "env2")
+            expect(rows[1]).to have_selector("td.name_value_cell", :text => "****")
+          end
+        end
+      end
+    end
+  end
+
+  it "should not show environment variables table if none are configured" do
+    template = PipelineTemplateConfigMother.create_template("t1")
+    assign(:template_config, template)
+    render
+    Capybara.string(response.body).find("#definition_view_stage_1") .tap do |stage|
+      stage.find(".tab-content #environment_variables_stage_1.tab-pane.active table.variables").tap do |table|
+        table.find("thead").tap do |head|
+          head.find("tr").tap do |row|
+            expect(row).to have_selector("th", :text => "Name")
+            expect(row).to have_selector("th", :text => "Value")
+          end
+        end
+        table.find("tbody").tap do |body|
+          body.find("tr").tap do |row|
+            expect(row).to have_selector("td.name_value_cell[align='center'][colspan='2']", :text => "No environment variables have been configured")
+          end
+        end
+      end
+    end
+  end
+
+  it "should display permissions for a stage" do
+    stage = StageConfigMother.stage_config("stage1")
+    authConfig = com.thoughtworks.go.config.AuthConfig.new()
+    authConfig.add(com.thoughtworks.go.config.AdminRole.new(CaseInsensitiveString.new("group1_admin")))
+    authConfig.add(com.thoughtworks.go.config.AdminUser.new(CaseInsensitiveString.new("user1")))
+    authConfig.add(com.thoughtworks.go.config.AdminUser.new(CaseInsensitiveString.new("user2")))
+    stage.updateApproval(Approval.new(authConfig))
+    stage.setVariables(EnvironmentVariablesConfig.new([EnvironmentVariableConfig.new("env1", "value1"), EnvironmentVariableConfig.new("env2", "value2")]))
+    template = PipelineTemplateConfigMother.create_template("t1", [stage].to_java(StageConfig))
+    assign(:template_config, template)
+    render
+    Capybara.string(response.body).find("#definition_view_stage_1").tap do |stage|
+      stage.find(".tab-content #permissions_stage_1.tab-pane").tap do |permissions|
+        permissions.find("table.stage_operate_users.list_table").tap do |table|
+          table.find("thead").tap do |head|
+            head.find("tr").tap do |row|
+              expect(row).to have_selector("th", :text => "Users")
+            end
+          end
+          table.find("tbody").tap do |body|
+            body.all("tr").tap do |rows|
+              expect(rows[0]).to have_selector("td.name_value_cell", :text => "user1")
+              expect(rows[1]).to have_selector("td.name_value_cell", :text => "user2")
+            end
+          end
+        end
+        permissions.find("table.stage_operate_roles.list_table").tap do |table|
+          table.find("thead").tap do |head|
+            head.find("tr").tap do |row|
+              expect(row).to have_selector("th", :text => "Roles")
+            end
+          end
+          table.find("tbody").tap do |body|
+            body.find("tr").tap do |row|
+              expect(row).to have_selector("td.name_value_cell", :text => "group1_admin")
+            end
+          end
+        end
+      end
+    end
+  end
+
+  it "should not show permissions table if none are configured" do
+    template = PipelineTemplateConfigMother.create_template("t1")
+    assign(:template_config, template)
+    render
+    Capybara.string(response.body).find("#permissions_stage_1").tap do |stage|
+      stage.find(".information", :text => "There are no operate permissions configured for this stage nor its pipeline group. All Go users can operate on this stage.")
+    end
+  end
+
+  it "should show only users table if only user permissions are defined on stage" do
+    stage = StageConfigMother.stage_config("stage1")
+    authConfig = com.thoughtworks.go.config.AuthConfig.new()
+    authConfig.add(com.thoughtworks.go.config.AdminUser.new(CaseInsensitiveString.new("user1")))
+    stage.updateApproval(Approval.new(authConfig))
+    template = PipelineTemplateConfigMother.create_template("t1", [stage].to_java(StageConfig))
+    assign(:template_config, template)
+    render
+    Capybara.string(response.body).find("#permissions_stage_1").tap do |stage|
+      expect(stage).to have_selector("table.stage_operate_users.list_table")
+      expect(stage).to_not have_selector("table.stage_operate_roles.list_table")
+    end
+  end
+
+  it "should show only roles table if only role permissions are defined on stage" do
+    stage = StageConfigMother.stage_config("stage1")
+    authConfig = com.thoughtworks.go.config.AuthConfig.new()
+    authConfig.add(com.thoughtworks.go.config.AdminRole.new(CaseInsensitiveString.new("role1")))
+    stage.updateApproval(Approval.new(authConfig))
+    template = PipelineTemplateConfigMother.create_template("t1", [stage].to_java(StageConfig))
+    assign(:template_config, template)
+    render
+    Capybara.string(response.body).find("#permissions_stage_1").tap do |stage|
+      expect(stage).to_not have_selector("table.stage_operate_users.list_table")
+      expect(stage).to have_selector("table.stage_operate_roles.list_table")
+    end
+  end
+
+  it "should show breadcrumb for job containing stage it came from" do
+    stage1 = StageConfigMother.custom("stage1", ["j1", "j2"].to_java(java.lang.String))
+    stage2 = StageConfigMother.custom("stage2", ["j1"].to_java(java.lang.String))
+    template = PipelineTemplateConfigMother.create_template("t1", [stage1, stage2].to_java(StageConfig))
+    assign(:template_config, template)
+    render
+    Capybara.string(response.body).find("#templates").tap do |templates|
+      templates.find("#definition_view_stage_1_job_1").tap do |job|
+        job.find("h3.entity_title").tap do |heading|
+          expect(heading).to have_selector("li:first-child a[href='#definition_view_stage_1']", :text => "stage1")
+          expect(heading).to have_selector("li:last-child", "j1")
+        end
+      end
+      templates.find("#definition_view_stage_1_job_2").tap do |job|
+        job.find("h3.entity_title").tap do |heading|
+          expect(heading).to have_selector("li:first-child a[href='#definition_view_stage_1']", :text => "stage1")
+          expect(heading).to have_selector("li:last-child", "j2")
+        end
+      end
+      templates.find("#definition_view_stage_2_job_1").tap do |job|
+        job.find("h3.entity_title").tap do |heading|
+          expect(heading).to have_selector("li:first-child a[href='#definition_view_stage_2']", :text => "stage2")
+          expect(heading).to have_selector("li:last-child", "j1")
+        end
+      end
+    end
+  end
+
+end
+
+


### PR DESCRIPTION
Issue: #7352

Description:
* Bring back templates config_view related files

<img width="1281" alt="Screen Shot 2019-12-02 at 9 35 17 PM" src="https://user-images.githubusercontent.com/15275847/69974672-ba447300-154b-11ea-94c1-601c7edcf637.png">


