### PR TITLE
Templates SPA Fixes (#7356)(#7357)

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/admin_templates.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/admin_templates.tsx
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-import {SinglePageAppBase} from "helpers/spa_base";
+import {RoutedSinglePageApp} from "helpers/spa_base";
 import {AdminTemplatesPage} from "views/pages/admin_templates";
 
-export class AdminTemplatesSPA extends SinglePageAppBase {
+export class AdminTemplatesSPA extends RoutedSinglePageApp {
   constructor() {
-    super(AdminTemplatesPage);
+    super({
+            "/": AdminTemplatesPage,
+            "/:name": AdminTemplatesPage,
+            "/:name/:operation": AdminTemplatesPage
+          });
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_templates.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_templates.tsx
@@ -28,15 +28,18 @@ import {EnvironmentsAPIs} from "models/new-environments/environments_apis";
 import {ExtensionTypeString} from "models/shared/plugin_infos_new/extension_type";
 import {PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {PluginInfoCRUD} from "models/shared/plugin_infos_new/plugin_info_crud";
+import {AnchorVM, ScrollManager} from "views/components/anchor/anchor";
 import * as Buttons from "views/components/buttons";
 import {ButtonIcon} from "views/components/buttons";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {HeaderPanel} from "views/components/header_panel";
 import {ModalState} from "views/components/modal";
 import {DeleteConfirmModal} from "views/components/modal/delete_confirm_modal";
-import {AdminTemplatesWidget, Attrs} from "views/pages/admin_templates/admin_templates_widget";
+import {AdminTemplatesWidget, Attrs, TemplatesScrollOptions} from "views/pages/admin_templates/admin_templates_widget";
 import {CreateTemplateModal, ShowTemplateModal} from "views/pages/admin_templates/modals";
 import {Page, PageState} from "views/pages/page";
+
+const sm: ScrollManager = new AnchorVM();
 
 interface State extends Attrs {
   pluginInfos: PluginInfos;
@@ -44,10 +47,16 @@ interface State extends Attrs {
 
 export class AdminTemplatesPage extends Page<null, State> {
   componentToDisplay(vnode: m.Vnode<null, State>): m.Children {
+    this.parseTemplatesLink(sm);
+    const scrollOptions: TemplatesScrollOptions = {
+      sm,
+      shouldOpenReadOnlyView: (m.route.param().operation || "").toLowerCase() === "view"
+    };
+
     return (
       <div>
         <FlashMessage type={this.flashMessage.type} message={this.flashMessage.message}/>
-        <AdminTemplatesWidget {...vnode.state}/>
+        <AdminTemplatesWidget {...vnode.state} scrollOptions={scrollOptions}/>
       </div>
     );
   }
@@ -225,5 +234,9 @@ export class AdminTemplatesPage extends Page<null, State> {
     ];
 
     return <HeaderPanel title={this.pageName()} buttons={headerButtons}/>;
+  }
+
+  private parseTemplatesLink(sm: ScrollManager) {
+    sm.setTarget(m.route.param().name || "");
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_templates/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_templates/modals.tsx
@@ -113,6 +113,7 @@ export class ShowTemplateModal extends Modal {
 
   constructor(template: string, templateConfig: Stream<Template>, pluginInfos: PluginInfos) {
     super(Size.large);
+    this.fixedHeight    = true;
     this.template       = template;
     this.templateConfig = templateConfig;
     this.pluginInfos    = pluginInfos;


### PR DESCRIPTION
#### Issue: #7356 #7357

#### Description:
* Allow linking and opening read only template configurations via url
- '/go/admin/templates' => render templates spa
- '/go/admin/templates#!template1' => render templates spa and scroll to 'template1'
- '/go/admin/templates#!template1/view' => render templates spa, scroll to 'template1' and open read only view for 'template1'

* Show appropriate error message for disabled edit pipeline edit icon

* Render read-only templates view in fixed height modal

