### PR TITLE
Simplify git log output parsing

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -185,7 +185,8 @@ task verifyJar(type: VerifyJarTask) {
       "spring-tx-${project.versions.spring}.jar",
       "spring-web-${project.versions.spring}.jar",
       "spring-webmvc-${project.versions.spring}.jar",
-      "util-${project.version}.jar"
+      "util-${project.version}.jar",
+      "snakeyaml-${project.versions.snakeYaml}.jar"
     ]
   ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -224,6 +224,7 @@ rootProject.ext.versions = [
   semanticVersion       : '1.2.0',
   servletApi            : '3.1.0',
   slf4j                 : '1.7.26',
+  snakeYaml             : '1.25',
   spark                 : '2.7.2',
   spring                : '4.3.25.RELEASE',
   spring4jUnit5Extension: '1.5.0',
@@ -235,6 +236,8 @@ rootProject.ext.versions = [
   tokenBucket           : '1.7',
   urlrewrite            : '3.2.0',
   velocityToolsView     : '1.4',
+  velocityToolsView     : '1.4',
+  xmlUnitMatchers       : '2.6.3',
   xmlUnitMatchers       : '2.6.3',
   xmlunitassertj        : '2.6.3',
   seleniumDrivers       : [

--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,7 @@ rootProject.ext.versions = [
   semanticVersion       : '1.2.0',
   servletApi            : '3.1.0',
   slf4j                 : '1.7.26',
-  snakeYaml             : '1.25',
+  snakeYaml             : '1.19',
   spark                 : '2.7.2',
   spring                : '4.3.25.RELEASE',
   spring4jUnit5Extension: '1.5.0',

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
@@ -255,9 +255,10 @@ public class GitCommandTest {
     }
 
     @Test
-    void shouldRetrieveLatestModification() throws Exception {
+    void shouldRetrieveLatestModification() {
         Modification mod = git.latestModification().get(0);
-        assertThat(mod.getUserName()).isEqualTo("Chris Turner <cturner@thoughtworks.com>");
+        assertThat(mod.getUserName()).isEqualTo("Chris Turner");
+        assertThat(mod.getEmailAddress()).isEqualTo("cturner@thoughtworks.com");
         assertThat(mod.getComment()).isEqualTo("Added 'run-till-file-exists' ant target");
         assertThat(mod.getModifiedTime()).isEqualTo(parseRFC822("Fri, 12 Feb 2010 16:12:04 -0800"));
         assertThat(mod.getRevision()).isEqualTo("5def073a425dfe239aabd4bf8039ffe3b0e8856b");
@@ -269,10 +270,11 @@ public class GitCommandTest {
     }
 
     @Test
-    void shouldRetrieveLatestModificationWhenColoringIsSetToAlways() throws Exception {
+    void shouldRetrieveLatestModificationWhenColoringIsSetToAlways() {
         setColoring();
         Modification mod = git.latestModification().get(0);
-        assertThat(mod.getUserName()).isEqualTo("Chris Turner <cturner@thoughtworks.com>");
+        assertThat(mod.getUserName()).isEqualTo("Chris Turner");
+        assertThat(mod.getEmailAddress()).isEqualTo("cturner@thoughtworks.com");
         assertThat(mod.getComment()).isEqualTo("Added 'run-till-file-exists' ant target");
         assertThat(mod.getModifiedTime()).isEqualTo(parseRFC822("Fri, 12 Feb 2010 16:12:04 -0800"));
         assertThat(mod.getRevision()).isEqualTo("5def073a425dfe239aabd4bf8039ffe3b0e8856b");
@@ -287,7 +289,8 @@ public class GitCommandTest {
     void shouldRetrieveLatestModificationWhenLogDecorationIsPresent() throws Exception {
         setLogDecoration();
         Modification mod = git.latestModification().get(0);
-        assertThat(mod.getUserName()).isEqualTo("Chris Turner <cturner@thoughtworks.com>");
+        assertThat(mod.getUserName()).isEqualTo("Chris Turner");
+        assertThat(mod.getEmailAddress()).isEqualTo("cturner@thoughtworks.com");
         assertThat(mod.getComment()).isEqualTo("Added 'run-till-file-exists' ant target");
         assertThat(mod.getModifiedTime()).isEqualTo(parseRFC822("Fri, 12 Feb 2010 16:12:04 -0800"));
         assertThat(mod.getRevision()).isEqualTo("5def073a425dfe239aabd4bf8039ffe3b0e8856b");
@@ -299,13 +302,13 @@ public class GitCommandTest {
     }
 
     @Test
-    void retrieveLatestModificationShouldNotResultInWorkingCopyCheckOut() throws Exception {
+    void retrieveLatestModificationShouldNotResultInWorkingCopyCheckOut() {
         git.latestModification();
         assertWorkingCopyNotCheckedOut();
     }
 
     @Test
-    void getModificationsSinceShouldNotResultInWorkingCopyCheckOut() throws Exception {
+    void getModificationsSinceShouldNotResultInWorkingCopyCheckOut() {
         git.modificationsSince(GitTestRepo.REVISION_2);
         assertWorkingCopyNotCheckedOut();
     }
@@ -427,7 +430,8 @@ public class GitCommandTest {
 
         Modification mod = branchedGit.latestModification().get(0);
 
-        assertThat(mod.getUserName()).isEqualTo("Chris Turner <cturner@thoughtworks.com>");
+        assertThat(mod.getUserName()).isEqualTo("Chris Turner");
+        assertThat(mod.getEmailAddress()).isEqualTo("cturner@thoughtworks.com");
         assertThat(mod.getComment()).isEqualTo("Started foo branch");
         assertThat(mod.getModifiedTime()).isEqualTo(parseRFC822("Tue, 05 Feb 2009 14:28:08 -0800"));
         assertThat(mod.getRevision()).isEqualTo("b4fa7271c3cef91822f7fa502b999b2eab2a380d");
@@ -567,32 +571,6 @@ public class GitCommandTest {
             assertThat(e.getMessage()).matches(str -> str.contains("The remote end hung up unexpectedly") ||
                     str.contains("Could not read from remote repository"));
         }
-    }
-
-    @Test
-    void shouldParseGitOutputCorrectly() throws IOException {
-        List<String> stringList;
-        try (InputStream resourceAsStream = getClass().getResourceAsStream("git_sample_output.text")) {
-            stringList = IOUtils.readLines(resourceAsStream, UTF_8);
-        }
-
-        GitModificationParser parser = new GitModificationParser();
-        List<Modification> mods = parser.parse(stringList);
-        assertThat(mods).hasSize(3);
-
-        Modification mod = mods.get(2);
-        assertThat(mod.getRevision()).isEqualTo("46cceff864c830bbeab0a7aaa31707ae2302762f");
-        assertThat(mod.getModifiedTime()).isEqualTo(DateUtils.parseISO8601("2009-08-11 12:37:09 -0700"));
-        assertThat(mod.getUserDisplayName()).isEqualTo("Cruise Developer <cruise@cruise-sf3.(none)>");
-        assertThat(mod.getComment()).isEqualTo("author:cruise <cceuser@CceDev01.(none)>\n"
-                + "node:ecfab84dd4953105e3301c5992528c2d381c1b8a\n"
-                + "date:2008-12-31 14:32:40 +0800\n"
-                + "description:Moving rakefile to build subdirectory for #2266\n"
-                + "\n"
-                + "author:CceUser <cceuser@CceDev01.(none)>\n"
-                + "node:fd16efeb70fcdbe63338c49995ce9ff7659e6e77\n"
-                + "date:2008-12-31 14:17:06 +0800\n"
-                + "description:Adding rakefile");
     }
 
     @Test

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitModificationParserTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitModificationParserTest.java
@@ -61,7 +61,8 @@ class GitModificationParserTest {
                 .containsEntry("signed", "N")
                 .containsEntry("signerName", null)
                 .containsEntry("signingKey", null)
-                .containsEntry("signingMessage", null)
+                .containsEntry("signingMessage", "This is signing message with\n" +
+                        "multiple lines")
                 .containsEntry("committerName", "Chris Turner")
                 .containsEntry("committerEmail", "cturner@thoughtworks.com")
                 .containsEntry("commitDate", "2009-02-11 17:26:36 -0800");

--- a/common/src/test/resources/git/log.yaml
+++ b/common/src/test/resources/git/log.yaml
@@ -12,7 +12,9 @@
     signed: N
     signerName:
     signingKey:
-    signingMessage:
+    signingMessage: |-
+      This is signing message with
+      multiple lines
     committerName: Chris Turner
     committerEmail: cturner@thoughtworks.com
     commitDate: 2009-02-11 17:26:36 -0800

--- a/common/src/test/resources/git/log.yaml
+++ b/common/src/test/resources/git/log.yaml
@@ -1,0 +1,40 @@
+- !!com.thoughtworks.go.domain.materials.git.GitLog
+  commitHash: 9fef97af1cd3a8920fefe5f656cb5795d690ee1b
+  authorName: Chris Turner
+  authorEmail: cturner@thoughtworks.com
+  date: 2009-02-11 17:26:36 -0800
+  subject: |-
+    Added remote file
+  rawBody: |-
+    Added remote file
+
+  additionalInfo:
+    signed: N
+    signerName:
+    signingKey:
+    signingMessage:
+    committerName: Chris Turner
+    committerEmail: cturner@thoughtworks.com
+    commitDate: 2009-02-11 17:26:36 -0800
+
+- !!com.thoughtworks.go.domain.materials.git.GitLog
+  commitHash: ewehsjf232349fef97af1cd3a8920fefe5f656cb57
+  authorName: Bob Ford
+  authorEmail: bford@thoughtworks.com
+  date: 2009-02-11 17:26:36 -0800
+  subject: |-
+    Initial commit
+  rawBody: |-
+    Initial commit
+
+      - Added remote file
+      - Added .gitignore
+
+  additionalInfo:
+    signed: N
+    signerName:
+    signingKey:
+    signingMessage:
+    committerName: Chris Turner
+    committerEmail: cturner@thoughtworks.com
+    commitDate: 2009-02-11 17:26:36 -0800

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -21,6 +21,10 @@ dependencies {
   compile project(':commandline')
   compile group: 'org.springframework', name: 'spring-tx', version: project.versions.spring
   compile group: 'de.skuzzle', name: 'semantic-version', version: project.versions.semanticVersion
+  compile group: 'org.yaml', name: 'snakeyaml', version: project.versions.snakeYaml
+  compileOnly group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+
   testCompile project(path: ':config:config-api', configuration: 'testOutput')
   testCompile project(':test:test-utils')
   testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/Modification.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/Modification.java
@@ -94,7 +94,7 @@ public class Modification extends PersistentObject implements Comparable, Serial
     public Modification(Modification modification, boolean shouldCopyModifiedFiles) {
         this(modification.userName, modification.comment, modification.emailAddress, modification.modifiedTime, modification.getRevision());
         this.id = modification.id;
-        if(shouldCopyModifiedFiles){
+        if (shouldCopyModifiedFiles) {
             this.files = modification.files;
         }
         this.pipelineLabel = modification.pipelineLabel;
@@ -111,13 +111,18 @@ public class Modification extends PersistentObject implements Comparable, Serial
     }
 
     public HashMap<String, String> getAdditionalDataMap() {
-        return additionalDataMap == null ? new HashMap<>(): additionalDataMap;
+        return additionalDataMap == null ? new HashMap<>() : additionalDataMap;
     }
 
 
     public void setAdditionalData(String additionalData) {
         this.additionalData = additionalData;
         this.additionalDataMap = JsonHelper.safeFromJson(this.additionalData, HashMap.class);
+    }
+
+    public void setAdditionalData(HashMap<String, String> additionalDataMap) {
+        this.additionalData = JsonHelper.toJsonString(additionalDataMap);
+        this.additionalDataMap = additionalDataMap;
     }
 
     /**
@@ -166,7 +171,7 @@ public class Modification extends PersistentObject implements Comparable, Serial
      * Returns the list of modified files for this modification set.
      *
      * @return list of {@link ModifiedFile} objects. If there are no files, this returns an empty list
-     *         (<code>null</code> is never returned).
+     * (<code>null</code> is never returned).
      */
     public List<ModifiedFile> getModifiedFiles() {
         return Collections.unmodifiableList(new ArrayList<>(files));
@@ -406,7 +411,7 @@ public class Modification extends PersistentObject implements Comparable, Serial
         if (modifications.isEmpty()) {
             throw new RuntimeException("Cannot find oldest revision.");
         } else {
-            return new StringRevision(modifications.get(modifications.size()-1).getRevision());
+            return new StringRevision(modifications.get(modifications.size() - 1).getRevision());
         }
     }
 

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -19,6 +19,7 @@ import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.Revision;
 import com.thoughtworks.go.domain.materials.SCMCommand;
+import com.thoughtworks.go.domain.materials.git.builder.GitLogCommandBuilder;
 import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
 import com.thoughtworks.go.util.NamedProcessTag;
 import com.thoughtworks.go.util.command.*;
@@ -92,15 +93,30 @@ public class GitCommand extends SCMCommand {
     }
 
     public List<Modification> latestModification() {
-        return gitLog("-1", "--date=iso", "--no-decorate", "--pretty=medium", "--no-color", remoteBranch());
+        CommandLine command = new GitLogCommandBuilder()
+                .latestCommit()
+                .withRemoteBranch(remoteBranch())
+                .withWorkingDir(workingDir)
+                .withNonArgSecrets(secrets)
+                .outputFormatYaml()
+                .build();
+
+        return gitLog(command);
 
     }
 
     public List<Modification> modificationsSince(Revision revision) {
-        return gitLog("--date=iso", "--pretty=medium", "--no-decorate", "--no-color", String.format("%s..%s", revision.getRevision(), remoteBranch()));
+        CommandLine command = new GitLogCommandBuilder()
+                .between(revision.getRevision(), remoteBranch())
+                .withWorkingDir(workingDir)
+                .withNonArgSecrets(secrets)
+                .outputFormatYaml()
+                .build();
+
+        return gitLog(command);
     }
 
-    private List<Modification> gitLog(String... args) {
+    private List<Modification> gitLog(CommandLine gitCmd) {
         // Git log will only show changes before the currently checked out revision
         InMemoryStreamConsumer outputStreamConsumer = inMemoryConsumer();
 
@@ -112,11 +128,9 @@ public class GitCommand extends SCMCommand {
             throw new RuntimeException(String.format("Working directory: %s\n%s", workingDir, outputStreamConsumer.getStdError()), e);
         }
 
-        CommandLine gitCmd = git().withArg("log").withArgs(args).withWorkingDir(workingDir);
         ConsoleResult result = runOrBomb(gitCmd);
-
         GitModificationParser parser = new GitModificationParser();
-        List<Modification> mods = parser.parse(result.output());
+        List<Modification> mods = parser.parse(result.outputAsString());
         for (Modification mod : mods) {
             addModifiedFiles(mod);
         }

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitLog.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitLog.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.materials.git;
+
+import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.util.DateUtils;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.HashMap;
+
+@Getter
+@Setter
+public class GitLog {
+    private String subject;
+    private String commitHash;
+    private String authorName;
+    private String authorEmail;
+    private String date;
+    private String rawBody;
+    private HashMap<String, String> additionalInfo;
+
+    public GitLog() {
+    }
+
+    Modification toModification() {
+        Modification modification = new Modification(
+                StringUtils.stripToNull(authorName),
+                StringUtils.stripToNull(rawBody),
+                StringUtils.stripToNull(authorEmail),
+                DateUtils.parseISO8601(date),
+                StringUtils.stripToNull(commitHash));
+
+        additionalInfo.put("subject", subject);
+        modification.setAdditionalData(additionalInfo);
+        return modification;
+    }
+}

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/builder/Builder.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/builder/Builder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.thoughtworks.go.junit5;
 
-import org.junit.jupiter.params.provider.ArgumentsSource;
+package com.thoughtworks.go.domain.materials.git.builder;
 
-import java.lang.annotation.*;
+import com.thoughtworks.go.util.command.CommandLine;
+import com.thoughtworks.go.util.command.SecretString;
 
-@Documented
-@Target(ElementType.METHOD)
-@Retention(RetentionPolicy.RUNTIME)
-@ArgumentsSource(JsonSourceProvider.class)
-public @interface JsonSource {
-    String[] jsonFiles();
+import java.io.File;
+import java.util.List;
+
+public interface Builder {
+    Builder withWorkingDir(File workingDir);
+
+    Builder outputFormatYaml();
+
+    Builder withNonArgSecrets(List<SecretString> secrets);
+
+    CommandLine build();
 }

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/builder/GitLogCommandBuilder.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/builder/GitLogCommandBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.materials.git.builder;
+
+import com.thoughtworks.go.domain.materials.git.GitLog;
+import com.thoughtworks.go.util.command.CommandLine;
+import com.thoughtworks.go.util.command.SecretString;
+
+import java.io.File;
+import java.util.List;
+
+public class GitLogCommandBuilder implements Builder {
+    private boolean isFormatted = false;
+    private final CommandLine git = CommandLine.createCommandLine("git")
+            .withEncoding("UTF-8")
+            .withArg("log")
+            .withArg("--no-color");
+
+    private static final OutputFormatter FORMATTER = OutputFormatter.newFormatter(GitLog.class)
+            .withCommitHash()
+            .withAuthorName()
+            .withAuthorEmail()
+            .withDate()
+            .withSubject()
+            .withRawBody()
+            .withAdditionalInfo();
+
+    public WithBranchBuilder latestCommit() {
+        git.withArg("-1");
+        return new WithBranchBuilder(this, git);
+    }
+
+    public Builder between(String fromRevision, String toRevision) {
+        git.withArg(String.format("%s..%s", fromRevision, toRevision));
+        return this;
+    }
+
+    public GitLogCommandBuilder withNonArgSecrets(List<SecretString> secrets) {
+        git.withNonArgSecrets(secrets);
+        return this;
+    }
+
+    public Builder outputFormatYaml() {
+        if (isFormatted) {
+            return this;
+        }
+
+        git.withArg(String.format("--pretty=format:%s", FORMATTER.format()));
+        isFormatted = true;
+        return this;
+    }
+
+    @Override
+    public Builder withWorkingDir(File workingDir) {
+        this.git.withWorkingDir(workingDir);
+        return this;
+    }
+
+    @Override
+    public CommandLine build() {
+        return git;
+    }
+
+}
+

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/builder/OutputFormatter.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/builder/OutputFormatter.java
@@ -54,7 +54,7 @@ public class OutputFormatter {
                 .appendWithIndent("signed", "%G?", 4)
                 .appendWithIndent("signerName", "%GS", 4)
                 .appendWithIndent("signingKey", "%GK", 4)
-                .appendWithIndent("signingMessage", "%GG", 4)
+                .appendWithIndent("signingMessage", "|-%n%w(,6,6)%GG", 4)
                 .appendWithIndent("committerName", "%cn", 4)
                 .appendWithIndent("committerEmail", "%ce", 4)
                 .appendWithIndent("commitDate", "%ci", 4);

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/builder/OutputFormatter.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/builder/OutputFormatter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.materials.git.builder;
+
+public class OutputFormatter {
+    private final StringBuilder builder = new StringBuilder();
+
+    public static OutputFormatter newFormatter(Class<?> type) {
+        OutputFormatter formatter = new OutputFormatter();
+        formatter.builder.append(String.format("- !!%s", type.getCanonicalName()));
+        return formatter;
+    }
+
+    public OutputFormatter withCommitHash() {
+        return appendWithIndent("commitHash", "%H", 2);
+    }
+
+    public OutputFormatter withAuthorName() {
+        return appendWithIndent("authorName", "%an", 2);
+    }
+
+    public OutputFormatter withAuthorEmail() {
+        return appendWithIndent("authorEmail", "%ae", 2);
+    }
+
+    public OutputFormatter withDate() {
+        return appendWithIndent("date", "%ai", 2);
+    }
+
+    public OutputFormatter withSubject() {
+        return appendWithIndent("subject", "|-%n%w(,4,4)%s", 2);
+    }
+
+    public OutputFormatter withRawBody() {
+        return appendWithIndent("rawBody", "|-%n%w(,4,4)%B", 2);
+    }
+
+    public OutputFormatter withAdditionalInfo() {
+        return appendWithIndent("additionalInfo:", 2)
+                .appendWithIndent("signed", "%G?", 4)
+                .appendWithIndent("signerName", "%GS", 4)
+                .appendWithIndent("signingKey", "%GK", 4)
+                .appendWithIndent("signingMessage", "%GG", 4)
+                .appendWithIndent("committerName", "%cn", 4)
+                .appendWithIndent("committerEmail", "%ce", 4)
+                .appendWithIndent("commitDate", "%ci", 4);
+    }
+
+    public String format() {
+        return builder.toString();
+    }
+
+    private OutputFormatter appendWithIndent(String fieldName, String selector, int indent) {
+        return appendWithIndent(String.format("%s: %s", fieldName, selector), indent);
+    }
+
+    private OutputFormatter appendWithIndent(String str, int indent) {
+        builder.append("\n").append(indentation(indent)).append(str);
+        return this;
+    }
+
+    private String indentation(int spaceCount) {
+        return String.format("%%w(,%d,%d)", spaceCount, spaceCount);
+    }
+}

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/builder/WithBranchBuilder.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/builder/WithBranchBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.materials.git.builder;
+
+import com.thoughtworks.go.util.command.CommandLine;
+import com.thoughtworks.go.util.command.SecretString;
+
+import java.io.File;
+import java.util.List;
+
+public class WithBranchBuilder implements Builder {
+    private final GitLogCommandBuilder mainBuilder;
+    private CommandLine git;
+
+    WithBranchBuilder(GitLogCommandBuilder mainBuilder, CommandLine git) {
+        this.mainBuilder = mainBuilder;
+        this.git = git;
+    }
+
+    public Builder withRemoteBranch(String remoteBranch) {
+        git.withArg(remoteBranch);
+        return mainBuilder;
+    }
+
+    @Override
+    public Builder withWorkingDir(File workingDir) {
+        return mainBuilder.withWorkingDir(workingDir);
+    }
+
+    @Override
+    public Builder outputFormatYaml() {
+        return mainBuilder.outputFormatYaml();
+    }
+
+    @Override
+    public Builder withNonArgSecrets(List<SecretString> secrets) {
+        return mainBuilder.withNonArgSecrets(secrets);
+    }
+
+    @Override
+    public CommandLine build() {
+        return mainBuilder.build();
+    }
+}

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/PackageMaterialTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/PackageMaterialTest.java
@@ -35,7 +35,7 @@ import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.CachedDigestUtils;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import com.thoughtworks.go.util.json.JsonHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Date;
@@ -44,49 +44,46 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static com.thoughtworks.go.domain.packagerepository.PackageRepositoryMother.create;
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-public class PackageMaterialTest {
+class PackageMaterialTest {
     @Test
-    public void shouldCreatePackageMaterialInstance() {
+    void shouldCreatePackageMaterialInstance() {
         PackageMaterial material = MaterialsMother.packageMaterial();
         PackageMaterialInstance materialInstance = (PackageMaterialInstance) material.createMaterialInstance();
 
-        assertThat(materialInstance, is(notNullValue()));
-        assertThat(materialInstance.getFlyweightName(), is(notNullValue()));
-        assertThat(materialInstance.getConfiguration(), is(JsonHelper.toJsonString(material)));
+        assertThat(materialInstance).isNotNull();
+        assertThat(materialInstance.getFlyweightName()).isNotNull();
+        assertThat(materialInstance.getConfiguration()).isEqualTo(JsonHelper.toJsonString(material));
     }
 
     @Test
-    public void shouldGetMaterialInstanceType() {
-        assertThat(new PackageMaterial().getInstanceType().equals(PackageMaterialInstance.class), is(true));
+    void shouldGetMaterialInstanceType() {
+        assertThat(new PackageMaterial().getInstanceType().equals(PackageMaterialInstance.class)).isTrue();
     }
 
     @Test
-    public void shouldGetSqlCriteria() {
+    void shouldGetSqlCriteria() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
         Map<String, Object> criteria = material.getSqlCriteria();
-        assertThat(criteria.get("type"), is(PackageMaterial.class.getSimpleName()));
-        assertThat(criteria.get("fingerprint"), is(material.getFingerprint()));
+        assertThat(criteria.get("type")).isEqualTo(PackageMaterial.class.getSimpleName());
+        assertThat(criteria.get("fingerprint")).isEqualTo(material.getFingerprint());
     }
 
     @Test
-    public void shouldGetFingerprintForMaterial() {
+    void shouldGetFingerprintForMaterial() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo", "pluginid", "version",
                 new Configuration(ConfigurationPropertyMother.create("k1", false, "v1"), ConfigurationPropertyMother.create("secure-key", true, "secure-value")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
-        assertThat(material.getFingerprint(), is(CachedDigestUtils.sha256Hex("plugin-id=pluginid<|>k2=v2<|>k1=v1<|>secure-key=secure-value")));
+        assertThat(material.getFingerprint()).isEqualTo(CachedDigestUtils.sha256Hex("plugin-id=pluginid<|>k2=v2<|>k1=v1<|>secure-key=secure-value"));
     }
 
     @Test
-    public void shouldGetDifferentFingerprintWhenPluginIdChanges() {
+    void shouldGetDifferentFingerprintWhenPluginIdChanges() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo", "yum-1", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id-1", "name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
@@ -96,44 +93,44 @@ public class PackageMaterialTest {
         PackageRepository anotherRepository = PackageRepositoryMother.create("repo-id", "repo", "yum-2", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         anotherMaterial.setPackageDefinition(PackageDefinitionMother.create("p-id-2", "name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), anotherRepository));
 
-        assertThat(material.getFingerprint().equals(anotherMaterial.getFingerprint()), is(false));
+        assertThat(material.getFingerprint().equals(anotherMaterial.getFingerprint())).isFalse();
     }
 
     @Test
-    public void shouldGetDescription() {
+    void shouldGetDescription() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo-name", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "package-name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
-        assertThat(material.getDescription(), is("repo-name_package-name"));
+        assertThat(material.getDescription()).isEqualTo("repo-name_package-name");
     }
 
     @Test
-    public void shouldGetDisplayName() {
+    void shouldGetDisplayName() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo-name", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "package-name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
-        assertThat(material.getDisplayName(), is("repo-name_package-name"));
+        assertThat(material.getDisplayName()).isEqualTo("repo-name_package-name");
     }
 
     @Test
-    public void shouldTypeForDisplay() {
+    void shouldTypeForDisplay() {
         PackageMaterial material = new PackageMaterial();
-        assertThat(material.getTypeForDisplay(), is("Package"));
+        assertThat(material.getTypeForDisplay()).isEqualTo("Package");
     }
 
     @Test
-    public void shouldGetAttributesForXml() {
+    void shouldGetAttributesForXml() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo-name", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "package-name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
         Map<String, Object> attributesForXml = material.getAttributesForXml();
-        assertThat(attributesForXml.get("type").toString(), is("PackageMaterial"));
-        assertThat(attributesForXml.get("repositoryName").toString(), is("repo-name"));
-        assertThat(attributesForXml.get("packageName").toString(), is("package-name"));
+        assertThat(attributesForXml.get("type").toString()).isEqualTo("PackageMaterial");
+        assertThat(attributesForXml.get("repositoryName").toString()).isEqualTo("repo-name");
+        assertThat(attributesForXml.get("packageName").toString()).isEqualTo("package-name");
     }
 
     @Test
-    public void shouldConvertPackageMaterialToJsonFormatToBeStoredInDb() throws CryptoException {
+    void shouldConvertPackageMaterialToJsonFormatToBeStoredInDb() throws CryptoException {
         GoCipher cipher = new GoCipher();
         String encryptedPassword = cipher.encrypt("password");
         ConfigurationProperty secureRepoProperty = new ConfigurationProperty(new ConfigurationKey("secure-key"), null, new EncryptedConfigurationValue(encryptedPassword), cipher);
@@ -155,26 +152,26 @@ public class PackageMaterialTest {
 
         String expected = "{\"package\":{\"config\":[{\"configKey\":{\"name\":\"secure-key\"},\"encryptedConfigValue\":{\"value\":" + new Gson().toJson(encryptedPassword) + "}},{\"configKey\":{\"name\":\"non-secure-key\"},\"configValue\":{\"value\":\"value\"}}],\"repository\":{\"plugin\":{\"id\":\"plugin-id\",\"version\":\"1.0\"},\"config\":[{\"configKey\":{\"name\":\"secure-key\"},\"encryptedConfigValue\":{\"value\":" + new Gson().toJson(encryptedPassword) + "}},{\"configKey\":{\"name\":\"non-secure-key\"},\"configValue\":{\"value\":\"value\"}}]}}}";
 
-        assertThat(json, is(expected));
-        assertThat(JsonHelper.fromJson(expected, PackageMaterial.class), is(packageMaterial));
+        assertThat(json).isEqualTo(expected);
+        assertThat(JsonHelper.fromJson(expected, PackageMaterial.class)).isEqualTo(packageMaterial);
     }
 
     @Test
-    public void shouldGetJsonRepresentationForPackageMaterial() {
+    void shouldGetJsonRepresentationForPackageMaterial() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = create("repo-id", "repo-name", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "package-name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
         Map<String, String> jsonMap = new LinkedHashMap<>();
         material.toJson(jsonMap, new PackageMaterialRevision("rev123", new Date()));
 
-        assertThat(jsonMap.get("scmType"), is("Package"));
-        assertThat(jsonMap.get("materialName"), is("repo-name_package-name"));
-        assertThat(jsonMap.get("action"), is("Modified"));
-        assertThat(jsonMap.get("location"), is(material.getUriForDisplay()));
+        assertThat(jsonMap.get("scmType")).isEqualTo("Package");
+        assertThat(jsonMap.get("materialName")).isEqualTo("repo-name_package-name");
+        assertThat(jsonMap.get("action")).isEqualTo("Modified");
+        assertThat(jsonMap.get("location")).isEqualTo(material.getUriForDisplay());
     }
 
     @Test
-    public void shouldGetEmailContentForPackageMaterial() {
+    void shouldGetEmailContentForPackageMaterial() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo-name", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "package-name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
@@ -183,40 +180,40 @@ public class PackageMaterialTest {
         Date date = new Date(1367472329111L);
         material.emailContent(content, new Modification(null, null, null, date, "rev123"));
 
-        assertThat(content.toString(), is(String.format("Package : repo-name_package-name\nrevision: rev123, completed on %s", date.toString())));
+        assertThat(content.toString()).isEqualTo(String.format("Package : repo-name_package-name\nrevision: rev123, completed on %s", date.toString()));
     }
 
     @Test
-    public void shouldReturnFalseForIsUsedInFetchArtifact() {
+    void shouldReturnFalseForIsUsedInFetchArtifact() {
         PackageMaterial material = new PackageMaterial();
-        assertThat(material.isUsedInFetchArtifact(new PipelineConfig()), is(false));
+        assertThat(material.isUsedInFetchArtifact(new PipelineConfig())).isFalse();
     }
 
     @Test
-    public void shouldReturnMatchedRevisionForPackageMaterial() {
+    void shouldReturnMatchedRevisionForPackageMaterial() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo-name", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "package-name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
 
         Date timestamp = new Date();
         MatchedRevision matchedRevision = material.createMatchedRevision(new Modification("go", "comment", null, timestamp, "rev123"), "rev");
-        assertThat(matchedRevision.getShortRevision(), is("rev123"));
-        assertThat(matchedRevision.getLongRevision(), is("rev123"));
-        assertThat(matchedRevision.getCheckinTime(), is(timestamp));
-        assertThat(matchedRevision.getUser(), is("go"));
-        assertThat(matchedRevision.getComment(), is("comment"));
+        assertThat(matchedRevision.getShortRevision()).isEqualTo("rev123");
+        assertThat(matchedRevision.getLongRevision()).isEqualTo("rev123");
+        assertThat(matchedRevision.getCheckinTime()).isEqualTo(timestamp);
+        assertThat(matchedRevision.getUser()).isEqualTo("go");
+        assertThat(matchedRevision.getComment()).isEqualTo("comment");
     }
 
     @Test
-    public void shouldGetNameFromRepoNameAndPackageName() {
+    void shouldGetNameFromRepoNameAndPackageName() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo-name", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "package-name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
-        assertThat(material.getName().toString(), is("repo-name_package-name"));
+        assertThat(material.getName().toString()).isEqualTo("repo-name_package-name");
     }
 
     @Test
-    public void shouldPopulateEnvironmentContext() {
+    void shouldPopulateEnvironmentContext() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "tw-dev", "pluginid", "version",
                 new Configuration(ConfigurationPropertyMother.create("k1", false, "v1"), ConfigurationPropertyMother.create("repo-secure", true, "value")));
@@ -226,17 +223,17 @@ public class PackageMaterialTest {
         Modifications modifications = new Modifications(new Modification(null, null, null, new Date(), "revision-123"));
         EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
         material.populateEnvironmentContext(environmentVariableContext, new MaterialRevision(material, modifications), null);
-        assertThat(environmentVariableContext.getProperty("GO_REPO_TW_DEV_GO_AGENT_K1"), is("v1"));
-        assertThat(environmentVariableContext.getProperty("GO_REPO_TW_DEV_GO_AGENT_REPO_SECURE"), is("value"));
-        assertThat(environmentVariableContext.getPropertyForDisplay("GO_REPO_TW_DEV_GO_AGENT_REPO_SECURE"), is(EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE));
-        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_K2"), is("v2"));
-        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_PKG_SECURE"), is("value"));
-        assertThat(environmentVariableContext.getPropertyForDisplay("GO_PACKAGE_TW_DEV_GO_AGENT_PKG_SECURE"), is(EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE));
-        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_LABEL"), is("revision-123"));
+        assertThat(environmentVariableContext.getProperty("GO_REPO_TW_DEV_GO_AGENT_K1")).isEqualTo("v1");
+        assertThat(environmentVariableContext.getProperty("GO_REPO_TW_DEV_GO_AGENT_REPO_SECURE")).isEqualTo("value");
+        assertThat(environmentVariableContext.getPropertyForDisplay("GO_REPO_TW_DEV_GO_AGENT_REPO_SECURE")).isEqualTo(EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE);
+        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_K2")).isEqualTo("v2");
+        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_PKG_SECURE")).isEqualTo("value");
+        assertThat(environmentVariableContext.getPropertyForDisplay("GO_PACKAGE_TW_DEV_GO_AGENT_PKG_SECURE")).isEqualTo(EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE);
+        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_LABEL")).isEqualTo("revision-123");
     }
 
     @Test
-    public void shouldPopulateEnvironmentContextWithEnvironmentVariablesCreatedOutOfAdditionalDataFromModification() {
+    void shouldPopulateEnvironmentContextWithEnvironmentVariablesCreatedOutOfAdditionalDataFromModification() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "tw-dev", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "go-agent", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
@@ -250,14 +247,14 @@ public class PackageMaterialTest {
 
         material.populateEnvironmentContext(environmentVariableContext, new MaterialRevision(material, modifications), null);
 
-        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_LABEL"), is("revision-123"));
-        assertThat(environmentVariableContext.getProperty("GO_REPO_TW_DEV_GO_AGENT_K1"), is("v1"));
-        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_K2"), is("v2"));
-        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_MY_NEW_KEY"), is("my_value"));
+        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_LABEL")).isEqualTo("revision-123");
+        assertThat(environmentVariableContext.getProperty("GO_REPO_TW_DEV_GO_AGENT_K1")).isEqualTo("v1");
+        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_K2")).isEqualTo("v2");
+        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_MY_NEW_KEY")).isEqualTo("my_value");
     }
 
     @Test
-    public void shouldMarkEnvironmentContextCreatedForAdditionalDataAsSecureIfTheValueContainsAnySpecialCharacters() throws UnsupportedEncodingException {
+    void shouldMarkEnvironmentContextCreatedForAdditionalDataAsSecureIfTheValueContainsAnySpecialCharacters() throws UnsupportedEncodingException {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "tw-dev", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "go-agent", new Configuration(ConfigurationPropertyMother.create("k2", true, "!secure_value:with_special_chars"),
@@ -274,20 +271,20 @@ public class PackageMaterialTest {
 
         material.populateEnvironmentContext(environmentVariableContext, new MaterialRevision(material, modifications), null);
 
-        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_LABEL"), is("revision-123"));
-        assertThat(environmentVariableContext.getProperty("GO_REPO_TW_DEV_GO_AGENT_K1"), is("v1"));
-        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_K2"), is("!secure_value:with_special_chars"));
-        assertThat(environmentVariableContext.getPropertyForDisplay("GO_PACKAGE_TW_DEV_GO_AGENT_K2"), is("********"));
-        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_ADDITIONAL_DATA_ONE"), is("foobar:!secure_value:with_special_chars"));
+        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_LABEL")).isEqualTo("revision-123");
+        assertThat(environmentVariableContext.getProperty("GO_REPO_TW_DEV_GO_AGENT_K1")).isEqualTo("v1");
+        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_K2")).isEqualTo("!secure_value:with_special_chars");
+        assertThat(environmentVariableContext.getPropertyForDisplay("GO_PACKAGE_TW_DEV_GO_AGENT_K2")).isEqualTo("********");
+        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_ADDITIONAL_DATA_ONE")).isEqualTo("foobar:!secure_value:with_special_chars");
 
-        assertThat(environmentVariableContext.getPropertyForDisplay("GO_PACKAGE_TW_DEV_GO_AGENT_ADDITIONAL_DATA_ONE"), is("foobar:!secure_value:with_special_chars"));
-        assertThat(environmentVariableContext.getPropertyForDisplay("GO_PACKAGE_TW_DEV_GO_AGENT_ADDITIONAL_DATA_TWO"), is("foobar:secure_value_with_regular_chars"));
-        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_ADDITIONAL_DATA_URL_ENCODED"), is("something:%21secure_value%3Awith_special_chars"));
-        assertThat(environmentVariableContext.getPropertyForDisplay("GO_PACKAGE_TW_DEV_GO_AGENT_ADDITIONAL_DATA_URL_ENCODED"), is("********"));
+        assertThat(environmentVariableContext.getPropertyForDisplay("GO_PACKAGE_TW_DEV_GO_AGENT_ADDITIONAL_DATA_ONE")).isEqualTo("foobar:!secure_value:with_special_chars");
+        assertThat(environmentVariableContext.getPropertyForDisplay("GO_PACKAGE_TW_DEV_GO_AGENT_ADDITIONAL_DATA_TWO")).isEqualTo("foobar:secure_value_with_regular_chars");
+        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_ADDITIONAL_DATA_URL_ENCODED")).isEqualTo("something:%21secure_value%3Awith_special_chars");
+        assertThat(environmentVariableContext.getPropertyForDisplay("GO_PACKAGE_TW_DEV_GO_AGENT_ADDITIONAL_DATA_URL_ENCODED")).isEqualTo("********");
     }
 
     @Test
-    public void shouldNotThrowUpWhenAdditionalDataIsNull() {
+    void shouldNotThrowUpWhenAdditionalDataIsNull() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "tw-dev", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "go-agent", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
@@ -297,13 +294,13 @@ public class PackageMaterialTest {
 
         material.populateEnvironmentContext(environmentVariableContext, new MaterialRevision(material, modifications), null);
 
-        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_LABEL"), is("revision-123"));
-        assertThat(environmentVariableContext.getProperty("GO_REPO_TW_DEV_GO_AGENT_K1"), is("v1"));
-        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_K2"), is("v2"));
+        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_LABEL")).isEqualTo("revision-123");
+        assertThat(environmentVariableContext.getProperty("GO_REPO_TW_DEV_GO_AGENT_K1")).isEqualTo("v1");
+        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_K2")).isEqualTo("v2");
     }
 
     @Test
-    public void shouldNotThrowUpWhenAdditionalDataIsRandomJunkAndNotJSON() {
+    void shouldNotThrowUpWhenAdditionalDataIsRandomJunkAndNotJSON() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "tw-dev", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "go-agent", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
@@ -313,13 +310,13 @@ public class PackageMaterialTest {
 
         material.populateEnvironmentContext(environmentVariableContext, new MaterialRevision(material, modifications), null);
 
-        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_LABEL"), is("revision-123"));
-        assertThat(environmentVariableContext.getProperty("GO_REPO_TW_DEV_GO_AGENT_K1"), is("v1"));
-        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_K2"), is("v2"));
+        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_LABEL")).isEqualTo("revision-123");
+        assertThat(environmentVariableContext.getProperty("GO_REPO_TW_DEV_GO_AGENT_K1")).isEqualTo("v1");
+        assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_K2")).isEqualTo("v2");
     }
 
     @Test
-    public void shouldGetUriForDisplay() {
+    void shouldGetUriForDisplay() {
         RepositoryMetadataStore.getInstance().addMetadataFor("some-plugin", new PackageConfigurations());
         PackageMetadataStore.getInstance().addMetadataFor("some-plugin", new PackageConfigurations());
 
@@ -328,112 +325,112 @@ public class PackageMaterialTest {
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo-name", "some-plugin", "version", configuration);
         PackageDefinition packageDefinition = PackageDefinitionMother.create("p-id", "package-name", new Configuration(ConfigurationPropertyMother.create("k3", false, "package-v1")), repository);
         material.setPackageDefinition(packageDefinition);
-        assertThat(material.getUriForDisplay(), is("Repository: [k1=repo-v1, k2=repo-v2] - Package: [k3=package-v1]"));
+        assertThat(material.getUriForDisplay()).isEqualTo("Repository: [k1=repo-v1, k2=repo-v2] - Package: [k3=package-v1]");
     }
 
     @Test
-    public void shouldGetUriForDisplayNameIfNameIsNull() {
+    void shouldGetUriForDisplayNameIfNameIsNull() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", null, "pluginid", "version",
                 new Configuration(ConfigurationPropertyMother.create("k1", false, "repo-v1"), ConfigurationPropertyMother.create("k2", false, "repo-v2")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", null, new Configuration(ConfigurationPropertyMother.create("k3", false, "package-v1")), repository));
-        assertThat(material.getDisplayName(), is(material.getUriForDisplay()));
+        assertThat(material.getDisplayName()).isEqualTo(material.getUriForDisplay());
     }
 
     @Test
-    public void shouldGetLongDescription() {
+    void shouldGetLongDescription() {
         PackageMaterial material = new PackageMaterial();
         Configuration configuration = new Configuration(ConfigurationPropertyMother.create("k1", false, "repo-v1"), ConfigurationPropertyMother.create("k2", false, "repo-v2"));
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo-name", "pluginid", "version", configuration);
         PackageDefinition packageDefinition = PackageDefinitionMother.create("p-id", "package-name", new Configuration(ConfigurationPropertyMother.create("k3", false, "package-v1")), repository);
         material.setPackageDefinition(packageDefinition);
-        assertThat(material.getLongDescription(), is(material.getUriForDisplay()));
+        assertThat(material.getLongDescription()).isEqualTo(material.getUriForDisplay());
     }
 
     @Test
-    public void shouldPassEqualsCheckIfFingerprintIsSame() {
+    void shouldPassEqualsCheckIfFingerprintIsSame() {
         PackageMaterial material1 = MaterialsMother.packageMaterial();
         material1.setName(new CaseInsensitiveString("name1"));
         PackageMaterial material2 = MaterialsMother.packageMaterial();
         material2.setName(new CaseInsensitiveString("name2"));
 
-        assertThat(material1.equals(material2), is(true));
+        assertThat(material1.equals(material2)).isTrue();
     }
 
     @Test
-    public void shouldFailEqualsCheckIfFingerprintDiffers() {
+    void shouldFailEqualsCheckIfFingerprintDiffers() {
         PackageMaterial material1 = MaterialsMother.packageMaterial();
         material1.getPackageDefinition().getConfiguration().first().setConfigurationValue(new ConfigurationValue("new-url"));
         PackageMaterial material2 = MaterialsMother.packageMaterial();
 
-        assertThat(material1.equals(material2), is(false));
+        assertThat(material1.equals(material2)).isFalse();
     }
 
     @Test
-    public void shouldReturnSomethingMoreSaneForToString() throws Exception {
+    void shouldReturnSomethingMoreSaneForToString() throws Exception {
         PackageMaterial material = MaterialsMother.packageMaterial();
 
         RepositoryMetadataStore.getInstance().addMetadataFor(material.getPluginId(), new PackageConfigurations());
         PackageMetadataStore.getInstance().addMetadataFor(material.getPluginId(), new PackageConfigurations());
 
-        assertThat(material.toString(), is("'PackageMaterial{Repository: [k1=repo-v1, k2=repo-v2] - Package: [k3=package-v1]}'"));
+        assertThat(material.toString()).isEqualTo("'PackageMaterial{Repository: [k1=repo-v1, k2=repo-v2] - Package: [k3=package-v1]}'");
     }
 
     @Test
-    public void shouldReturnNameAsNullIfPackageDefinitionIsNotSet() {
-        assertThat(new PackageMaterial().getName(), is(nullValue()));
+    void shouldReturnNameAsNullIfPackageDefinitionIsNotSet() {
+        assertThat(new PackageMaterial().getName()).isNull();
     }
 
     @Test
-    public void shouldNotCalculateFingerprintWhenAvailable() {
+    void shouldNotCalculateFingerprintWhenAvailable() {
         String fingerprint = "fingerprint";
         PackageDefinition packageDefinition = mock(PackageDefinition.class);
         PackageMaterial packageMaterial = new PackageMaterial();
         packageMaterial.setPackageDefinition(packageDefinition);
         packageMaterial.setFingerprint(fingerprint);
-        assertThat(packageMaterial.getFingerprint(),is(fingerprint));
+        assertThat(packageMaterial.getFingerprint()).isEqualTo(fingerprint);
         verify(packageDefinition,never()).getFingerprint(anyString());
     }
 
     @Test
-    public void shouldTakeValueOfIsAutoUpdateFromPackageDefinition() throws Exception {
+    void shouldTakeValueOfIsAutoUpdateFromPackageDefinition() throws Exception {
         PackageMaterial material = MaterialsMother.packageMaterial();
 
         material.getPackageDefinition().setAutoUpdate(true);
-        assertThat(material.isAutoUpdate(), is(true));
+        assertThat(material.isAutoUpdate()).isTrue();
 
         material.getPackageDefinition().setAutoUpdate(false);
-        assertThat(material.isAutoUpdate(), is(false));
+        assertThat(material.isAutoUpdate()).isFalse();
     }
 
     @Test
-    public void shouldGetAttributesWithSecureFields() {
+    void shouldGetAttributesWithSecureFields() {
         PackageMaterial material = createPackageMaterialWithSecureConfiguration();
         Map<String, Object> attributes = material.getAttributes(true);
 
-        assertThat(attributes.get("type"), is("package"));
-        assertThat(attributes.get("plugin-id"), is("pluginid"));
+        assertThat(attributes.get("type")).isEqualTo("package");
+        assertThat(attributes.get("plugin-id")).isEqualTo("pluginid");
         Map<String, Object> repositoryConfiguration = (Map<String, Object>) attributes.get("repository-configuration");
-        assertThat(repositoryConfiguration.get("k1"), is("repo-v1"));
-        assertThat(repositoryConfiguration.get("k2"), is("repo-v2"));
+        assertThat(repositoryConfiguration.get("k1")).isEqualTo("repo-v1");
+        assertThat(repositoryConfiguration.get("k2")).isEqualTo("repo-v2");
         Map<String, Object> packageConfiguration = (Map<String, Object>) attributes.get("package-configuration");
-        assertThat(packageConfiguration.get("k3"), is("package-v1"));
-        assertThat(packageConfiguration.get("k4"), is("package-v2"));
+        assertThat(packageConfiguration.get("k3")).isEqualTo("package-v1");
+        assertThat(packageConfiguration.get("k4")).isEqualTo("package-v2");
     }
 
     @Test
-    public void shouldGetAttributesWithoutSecureFields() {
+    void shouldGetAttributesWithoutSecureFields() {
         PackageMaterial material = createPackageMaterialWithSecureConfiguration();
         Map<String, Object> attributes = material.getAttributes(false);
 
-        assertThat(attributes.get("type"), is("package"));
-        assertThat(attributes.get("plugin-id"), is("pluginid"));
+        assertThat(attributes.get("type")).isEqualTo("package");
+        assertThat(attributes.get("plugin-id")).isEqualTo("pluginid");
         Map<String, Object> repositoryConfiguration = (Map<String, Object>) attributes.get("repository-configuration");
-        assertThat(repositoryConfiguration.get("k1"), is("repo-v1"));
-        assertThat(repositoryConfiguration.get("k2"), is(nullValue()));
+        assertThat(repositoryConfiguration.get("k1")).isEqualTo("repo-v1");
+        assertThat(repositoryConfiguration.get("k2")).isNull();
         Map<String, Object> packageConfiguration = (Map<String, Object>) attributes.get("package-configuration");
-        assertThat(packageConfiguration.get("k3"), is("package-v1"));
-        assertThat(packageConfiguration.get("k4"), is(nullValue()));
+        assertThat(packageConfiguration.get("k3")).isEqualTo("package-v1");
+        assertThat(packageConfiguration.get("k4")).isNull();
     }
 
     private PackageMaterial createPackageMaterialWithSecureConfiguration() {
@@ -445,8 +442,8 @@ public class PackageMaterialTest {
     }
 
     @Test
-    public void shouldReturnFalseForPackageMaterial_supportsDestinationFolder() throws Exception {
+    void shouldReturnFalseForPackageMaterial_supportsDestinationFolder() throws Exception {
         PackageMaterial material = new PackageMaterial();
-        assertThat(material.supportsDestinationFolder(), is(false));
+        assertThat(material.supportsDestinationFolder()).isFalse();
     }
 }

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/dependency/DependencyMaterialTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/dependency/DependencyMaterialTest.java
@@ -22,140 +22,146 @@ import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.Modifications;
 import com.thoughtworks.go.domain.materials.dependency.DependencyMaterialRevision;
 import com.thoughtworks.go.helper.GoConfigMother;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
 import static com.thoughtworks.go.domain.materials.dependency.DependencyMaterialRevision.create;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class DependencyMaterialTest {
+class DependencyMaterialTest {
     private DependencyMaterial dependencyMaterial;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         dependencyMaterial = new DependencyMaterial(new CaseInsensitiveString("pipeline"), new CaseInsensitiveString("stage"));
     }
 
     @Test
-    public void shouldReturnCruiseAsUser() {
-        assertThat(dependencyMaterial.getUserName(), is("cruise"));
+    void shouldReturnCruiseAsUser() {
+        assertThat(dependencyMaterial.getUserName()).isEqualTo("cruise");
     }
 
     @Test
-    public void shouldReturnJson() {
+    void shouldReturnJson() {
         Map<String, String> json = new LinkedHashMap<>();
         dependencyMaterial.toJson(json, create("pipeline", 10, "1.0.123", "stage", 1));
 
-        assertThat(json.get("location"), is("pipeline/stage"));
-        assertThat(json.get("scmType"), is("Dependency"));
-        assertThat(json.get("folder"), is(""));
-        assertThat(json.get("action"), is("Completed"));
+        assertThat(json.get("location")).isEqualTo("pipeline/stage");
+        assertThat(json.get("scmType")).isEqualTo("Dependency");
+        assertThat(json.get("folder")).isEqualTo("");
+        assertThat(json.get("action")).isEqualTo("Completed");
     }
 
     @Test
-    public void shouldDifferIfStageCounterHasChanged() {
+    void shouldDifferIfStageCounterHasChanged() {
         DependencyMaterialRevision rev1 = create("pipeline", 10, "1.0.123", "stage", 1);
         DependencyMaterialRevision rev2 = create("pipeline", 10, "1.0.123", "stage", 2);
         DependencyMaterialRevision rev3 = create("pipeline", 11, "1.0.123", "stage", 1);
-        assertThat(rev1, is(not(rev2)));
-        assertThat(rev2, is(not(rev3)));
-        assertThat(rev3, is(not(rev1)));
+        assertThat(rev1).isNotEqualTo(rev2);
+        assertThat(rev2).isNotEqualTo(rev3);
+        assertThat(rev3).isNotEqualTo(rev1);
     }
 
     @Test
-    public void shouldParseMaterialRevisionWithPipelineLabel() {
+    void shouldParseMaterialRevisionWithPipelineLabel() {
         ArrayList<Modification> mods = new ArrayList<>();
         Modification mod = new Modification(new Date(), "pipelineName/123/stageName/2", "pipeline-label-123", null);
         mods.add(mod);
         DependencyMaterialRevision revision = (DependencyMaterialRevision) new Modifications(mods).latestRevision(dependencyMaterial);
-        assertThat(revision.getRevision(), is("pipelineName/123/stageName/2"));
-        assertThat(revision.getPipelineLabel(), is("pipeline-label-123"));
-        assertThat(revision.getPipelineCounter(), is(123));
-        assertThat(revision.getPipelineName(), is("pipelineName"));
-        assertThat(revision.getStageName(), is("stageName"));
-        assertThat(revision.getStageCounter(), is(2));
+        assertThat(revision.getRevision()).isEqualTo("pipelineName/123/stageName/2");
+        assertThat(revision.getPipelineLabel()).isEqualTo("pipeline-label-123");
+        assertThat(revision.getPipelineCounter()).isEqualTo(123);
+        assertThat(revision.getPipelineName()).isEqualTo("pipelineName");
+        assertThat(revision.getStageName()).isEqualTo("stageName");
+        assertThat(revision.getStageCounter()).isEqualTo(2);
 
     }
 
-    @Test public void shouldBeUniqueBasedOnpipelineAndStageName() throws Exception {
+    @Test
+    void shouldBeUniqueBasedOnpipelineAndStageName() throws Exception {
         DependencyMaterial material1 = new DependencyMaterial(new CaseInsensitiveString("pipeline1"), new CaseInsensitiveString("stage1"));
         Map<String, Object> map = new HashMap<>();
         material1.appendCriteria(map);
-        assertThat(map, hasEntry("pipelineName", "pipeline1"));
-        assertThat(map, hasEntry("stageName", "stage1"));
-        assertThat(map.size(), is(2));
+        assertThat(map).containsEntry("pipelineName", "pipeline1");
+        assertThat(map).containsEntry("stageName", "stage1");
+        assertThat(map.size()).isEqualTo(2);
     }
 
-    @Test public void shouldUsePipelineNameAsMaterialNameIfItIsNotSet() throws Exception {
-        assertThat(new DependencyMaterial(new CaseInsensitiveString("pipeline1"), new CaseInsensitiveString("stage1")).getName(), is(new CaseInsensitiveString("pipeline1")));
+    @Test
+    void shouldUsePipelineNameAsMaterialNameIfItIsNotSet() throws Exception {
+        assertThat(new DependencyMaterial(new CaseInsensitiveString("pipeline1"), new CaseInsensitiveString("stage1")).getName()).isEqualTo(new CaseInsensitiveString("pipeline1"));
     }
 
-    @Test public void shouldUseMaterialNameAsMaterialNameIfItIsSet() throws Exception {
+    @Test
+    void shouldUseMaterialNameAsMaterialNameIfItIsSet() throws Exception {
         DependencyMaterial material = new DependencyMaterial(new CaseInsensitiveString("pipeline1"), new CaseInsensitiveString("stage1"));
         material.setName(new CaseInsensitiveString("my-material-name"));
-        assertThat(material.getName(), is(new CaseInsensitiveString("my-material-name")));
+        assertThat(material.getName()).isEqualTo(new CaseInsensitiveString("my-material-name"));
     }
 
-    @Test public void shouldGenerateSqlCriteriaMapInSpecificOrder() throws Exception {
+    @Test
+    void shouldGenerateSqlCriteriaMapInSpecificOrder() throws Exception {
         Map<String, Object> map = dependencyMaterial.getSqlCriteria();
-        assertThat(map.size(), is(3));
+        assertThat(map.size()).isEqualTo(3);
         Iterator<Map.Entry<String, Object>> iter = map.entrySet().iterator();
-        assertThat(iter.next().getKey(), is("type"));
-        assertThat(iter.next().getKey(), is("pipelineName"));
-        assertThat(iter.next().getKey(), is("stageName"));
+        assertThat(iter.next().getKey()).isEqualTo("type");
+        assertThat(iter.next().getKey()).isEqualTo("pipelineName");
+        assertThat(iter.next().getKey()).isEqualTo("stageName");
     }
 
-    @Test public void equalsImplementation() throws Exception {
+    @Test
+    void equalsImplementation() throws Exception {
         DependencyMaterial one = new DependencyMaterial(new CaseInsensitiveString("pipelineName"), new CaseInsensitiveString("stage"));
         DependencyMaterial two = new DependencyMaterial(new CaseInsensitiveString("pipelineName"), new CaseInsensitiveString("stage"));
         two.setName(new CaseInsensitiveString("other-name-that-should-be-ignored-in-equals-comparison"));
-        assertEquals(two, one);
+        assertThat(one).isEqualTo(two);
 
         DependencyMaterial three = new DependencyMaterial(new CaseInsensitiveString("otherPipelineName"), new CaseInsensitiveString("stage"));
-        assertNotEquals(one, three);
+        assertThat(three).isNotEqualTo(one);
     }
 
-    @Test public void hashCodeImplementation() throws Exception {
+    @Test
+    void hashCodeImplementation() throws Exception {
         DependencyMaterial one = new DependencyMaterial(new CaseInsensitiveString("pipelineName"), new CaseInsensitiveString("stage"));
         DependencyMaterial two = new DependencyMaterial(new CaseInsensitiveString("pipelineName"), new CaseInsensitiveString("stage"));
         two.setName(new CaseInsensitiveString("other-name-that-should-be-ignored-in-hashcode-generation"));
-        assertEquals(two.hashCode(), one.hashCode());
+        assertThat(one.hashCode()).isEqualTo(two.hashCode());
 
         DependencyMaterial three = new DependencyMaterial(new CaseInsensitiveString("otherPipelineName"), new CaseInsensitiveString("stage"));
-        assertNotEquals(one.hashCode(), three.hashCode());
+        assertThat(three.hashCode()).isNotEqualTo(one.hashCode());
     }
 
-    @Test public void shouldReturnUpstreamPipelineNameAsDisplayNameIfMaterialNameIsNotDefined() throws Exception {
+    @Test
+    void shouldReturnUpstreamPipelineNameAsDisplayNameIfMaterialNameIsNotDefined() throws Exception {
         DependencyMaterial material = new DependencyMaterial(new CaseInsensitiveString("upstream"), new CaseInsensitiveString("first"));
-        assertThat(material.getDisplayName(), is("upstream"));
+        assertThat(material.getDisplayName()).isEqualTo("upstream");
     }
 
-    @Test public void shouldReturnMaterialNameIfDefined() throws Exception {
+    @Test
+    void shouldReturnMaterialNameIfDefined() throws Exception {
         DependencyMaterial material = new DependencyMaterial(new CaseInsensitiveString("upstream"), new CaseInsensitiveString("first"));
         material.setName(new CaseInsensitiveString("my_name"));
-        assertThat(material.getDisplayName(), is("my_name"));
+        assertThat(material.getDisplayName()).isEqualTo("my_name");
     }
 
-    @Test public void shouldNotTruncateshortRevision() throws Exception {
+    @Test
+    void shouldNotTruncateshortRevision() throws Exception {
         Material material = new DependencyMaterial(new CaseInsensitiveString("upstream"), new CaseInsensitiveString("first"));
-        assertThat(material.getShortRevision("pipeline-name/1/stage-name/5"), is("pipeline-name/1/stage-name/5"));
+        assertThat(material.getShortRevision("pipeline-name/1/stage-name/5")).isEqualTo("pipeline-name/1/stage-name/5");
     }
 
     @Test
-    public void shouldUseACombinationOfPipelineAndStageNameAsURI() {
+    void shouldUseACombinationOfPipelineAndStageNameAsURI() {
         Material material = new DependencyMaterial(new CaseInsensitiveString("pipeline-foo"), new CaseInsensitiveString("stage-bar"));
-        assertThat(material.getUriForDisplay(), is("pipeline-foo / stage-bar"));
+        assertThat(material.getUriForDisplay()).isEqualTo("pipeline-foo / stage-bar");
     }
 
     @Test
-    public void shouldDetectDependencyMaterialUsedInFetchArtifact() {
+    void shouldDetectDependencyMaterialUsedInFetchArtifact() {
         DependencyMaterial material = new DependencyMaterial(new CaseInsensitiveString("pipeline-foo"), new CaseInsensitiveString("stage-bar"));
         PipelineConfig pipelineConfig = mock(PipelineConfig.class);
         ArrayList<FetchTask> fetchTasks = new ArrayList<>();
@@ -163,34 +169,34 @@ public class DependencyMaterialTest {
         fetchTasks.add(new FetchTask(new CaseInsensitiveString("pipeline-foo"), new CaseInsensitiveString("stage-bar"), new CaseInsensitiveString("job"), "src", "dest"));
         when(pipelineConfig.getFetchTasks()).thenReturn(fetchTasks);
 
-        assertThat(material.isUsedInFetchArtifact(pipelineConfig), is(true));
+        assertThat(material.isUsedInFetchArtifact(pipelineConfig)).isTrue();
     }
 
     @Test
-    public void shouldDetectDependencyMaterialUsedInFetchArtifactFromAncestor() {
+    void shouldDetectDependencyMaterialUsedInFetchArtifactFromAncestor() {
         DependencyMaterial material = new DependencyMaterial(new CaseInsensitiveString("parent-pipeline"), new CaseInsensitiveString("stage-bar"));
         PipelineConfig pipelineConfig = mock(PipelineConfig.class);
         ArrayList<FetchTask> fetchTasks = new ArrayList<>();
         fetchTasks.add(new FetchTask(new CaseInsensitiveString("grandparent-pipeline/parent-pipeline"), new CaseInsensitiveString("grandparent-stage"), new CaseInsensitiveString("grandparent-job"), "src", "dest"));
         when(pipelineConfig.getFetchTasks()).thenReturn(fetchTasks);
 
-        assertThat(material.isUsedInFetchArtifact(pipelineConfig), is(true));
+        assertThat(material.isUsedInFetchArtifact(pipelineConfig)).isTrue();
     }
 
     @Test
-    public void shouldDetectDependencyMaterialNotUsedInFetchArtifact() {
+    void shouldDetectDependencyMaterialNotUsedInFetchArtifact() {
         DependencyMaterial material = new DependencyMaterial(new CaseInsensitiveString("pipeline-foo"), new CaseInsensitiveString("stage-bar"));
         PipelineConfig pipelineConfig = mock(PipelineConfig.class);
         ArrayList<FetchTask> fetchTasks = new ArrayList<>();
         fetchTasks.add(new FetchTask(new CaseInsensitiveString("something"), new CaseInsensitiveString("new"), "src", "dest"));
-        fetchTasks.add(new FetchTask(new CaseInsensitiveString("another"), new CaseInsensitiveString("boo"),new CaseInsensitiveString("foo"), "src", "dest"));
+        fetchTasks.add(new FetchTask(new CaseInsensitiveString("another"), new CaseInsensitiveString("boo"), new CaseInsensitiveString("foo"), "src", "dest"));
         when(pipelineConfig.getFetchTasks()).thenReturn(fetchTasks);
 
-        assertThat(material.isUsedInFetchArtifact(pipelineConfig), is(false));
+        assertThat(material.isUsedInFetchArtifact(pipelineConfig)).isFalse();
     }
 
     @Test
-    public void shouldGetAttributesAllFields() {
+    void shouldGetAttributesAllFields() {
         DependencyMaterial material = new DependencyMaterial(new CaseInsensitiveString("pipeline-name"), new CaseInsensitiveString("stage-name"));
 
         Map<String, Object> attributesWithSecureFields = material.getAttributes(true);
@@ -202,35 +208,35 @@ public class DependencyMaterialTest {
 
 
     @Test
-    public void shouldHandleNullOriginDuringValidationWhenUpstreamPipelineDoesNotExist() {
+    void shouldHandleNullOriginDuringValidationWhenUpstreamPipelineDoesNotExist() {
         DependencyMaterialConfig dependencyMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString("upstream_stage"), new CaseInsensitiveString("upstream_pipeline"), new CaseInsensitiveString("stage"));
         PipelineConfig pipeline = new PipelineConfig(new CaseInsensitiveString("p"), new MaterialConfigs());
         pipeline.setOrigin(null);
         dependencyMaterialConfig.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", new BasicCruiseConfig(), pipeline));
-        assertThat(dependencyMaterialConfig.errors().on(DependencyMaterialConfig.PIPELINE_STAGE_NAME), is("Pipeline with name 'upstream_pipeline' does not exist, it is defined as a dependency for pipeline 'p' (cruise-config.xml)"));
+        assertThat(dependencyMaterialConfig.errors().on(DependencyMaterialConfig.PIPELINE_STAGE_NAME)).isEqualTo("Pipeline with name 'upstream_pipeline' does not exist, it is defined as a dependency for pipeline 'p' (cruise-config.xml)");
     }
 
     @Test
-    public void shouldHandleNullOriginDuringValidationWhenUpstreamStageDoesNotExist() {
+    void shouldHandleNullOriginDuringValidationWhenUpstreamStageDoesNotExist() {
         CruiseConfig cruiseConfig = GoConfigMother.pipelineHavingJob("upstream_pipeline", "upstream_stage", "j1", null, null);
         DependencyMaterialConfig dependencyMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString("upstream_pipeline"), new CaseInsensitiveString("does_not_exist"));
         PipelineConfig pipeline = new PipelineConfig(new CaseInsensitiveString("downstream"), new MaterialConfigs());
         pipeline.setOrigin(null);
         dependencyMaterialConfig.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", cruiseConfig, pipeline));
-        assertThat(dependencyMaterialConfig.errors().on(DependencyMaterialConfig.PIPELINE_STAGE_NAME), is("Stage with name 'does_not_exist' does not exist on pipeline 'upstream_pipeline', it is being referred to from pipeline 'downstream' (cruise-config.xml)"));
+        assertThat(dependencyMaterialConfig.errors().on(DependencyMaterialConfig.PIPELINE_STAGE_NAME)).isEqualTo("Stage with name 'does_not_exist' does not exist on pipeline 'upstream_pipeline', it is being referred to from pipeline 'downstream' (cruise-config.xml)");
     }
 
 
     private void assertAttributes(Map<String, Object> attributes) {
-        assertThat(attributes.get("type"), is("pipeline"));
+        assertThat(attributes.get("type")).isEqualTo("pipeline");
         Map<String, Object> configuration = (Map<String, Object>) attributes.get("pipeline-configuration");
-        assertThat(configuration.get("pipeline-name"), is("pipeline-name"));
-        assertThat(configuration.get("stage-name"), is("stage-name"));
+        assertThat(configuration.get("pipeline-name")).isEqualTo("pipeline-name");
+        assertThat(configuration.get("stage-name")).isEqualTo("stage-name");
     }
 
     @Test
-    public void shouldReturnFalseForDependencyMaterial_supportsDestinationFolder() throws Exception {
+    void shouldReturnFalseForDependencyMaterial_supportsDestinationFolder() throws Exception {
         DependencyMaterial material = new DependencyMaterial();
-        assertThat(material.supportsDestinationFolder(), is(false));
+        assertThat(material.supportsDestinationFolder()).isFalse();
     }
 }

--- a/domain/src/test/java/com/thoughtworks/go/domain/ArtifactPlanTypeTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/ArtifactPlanTypeTest.java
@@ -15,16 +15,16 @@
  */
 package com.thoughtworks.go.domain;
 
-import org.junit.Test;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import org.junit.jupiter.api.Test;
 
-public class ArtifactPlanTypeTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ArtifactPlanTypeTest {
     @Test
-    public void shouldConvertArtifactTypeToArtifactPlanType() {
-        assertThat(ArtifactPlanType.fromArtifactType(ArtifactType.external), is(ArtifactPlanType.external));
-        assertThat(ArtifactPlanType.fromArtifactType(ArtifactType.test), is(ArtifactPlanType.unit));
-        assertThat(ArtifactPlanType.fromArtifactType(ArtifactType.build), is(ArtifactPlanType.file));
+    void shouldConvertArtifactTypeToArtifactPlanType() {
+        assertThat(ArtifactPlanType.fromArtifactType(ArtifactType.external)).isEqualTo(ArtifactPlanType.external);
+        assertThat(ArtifactPlanType.fromArtifactType(ArtifactType.test)).isEqualTo(ArtifactPlanType.unit);
+        assertThat(ArtifactPlanType.fromArtifactType(ArtifactType.build)).isEqualTo(ArtifactPlanType.file);
     }
 }

--- a/domain/src/test/java/com/thoughtworks/go/domain/MatcherTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/MatcherTest.java
@@ -15,116 +15,113 @@
  */
 package com.thoughtworks.go.domain;
 
+import com.thoughtworks.go.validation.Validator;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import com.thoughtworks.go.validation.Validator;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-
-public class MatcherTest {
+class MatcherTest {
     @Test
-    public void shouldRemoveTheLastEmptyMatcher() {
-        assertThat(new Matcher("JH,Pavan,"), is(new Matcher("JH,Pavan")));
+    void shouldRemoveTheLastEmptyMatcher() {
+        assertThat(new Matcher("JH,Pavan,")).isEqualTo(new Matcher("JH,Pavan"));
     }
 
     @Test
-    public void shouldAllowWhiteSpace() {
-        assertThat(new Matcher("JH Pavan").toCollection().size(), is(1));
+    void shouldAllowWhiteSpace() {
+        assertThat(new Matcher("JH Pavan").toCollection().size()).isEqualTo(1);
     }
 
     @Test
-    public void shouldRemoveDuplication() {
-        assertThat(new Matcher("JH,JH"), is(new Matcher("JH")));
+    void shouldRemoveDuplication() {
+        assertThat(new Matcher("JH,JH")).isEqualTo(new Matcher("JH"));
     }
 
     @Test
-    public void shouldRemoveTheFirstEmptyMatcher() {
-        assertThat(new Matcher(",JH,Pavan"), is(new Matcher("JH,Pavan")));
+    void shouldRemoveTheFirstEmptyMatcher() {
+        assertThat(new Matcher(",JH,Pavan")).isEqualTo(new Matcher("JH,Pavan"));
     }
 
     @Test
-    public void shouldRemoveTheEmptyMatcherInTheMiddle() {
-        assertThat(new Matcher("JH,,Pavan"), is(new Matcher("JH,Pavan")));
+    void shouldRemoveTheEmptyMatcherInTheMiddle() {
+        assertThat(new Matcher("JH,,Pavan")).isEqualTo(new Matcher("JH,Pavan"));
     }
 
     @Test
-    public void shouldReturnCommaSplittedString() {
-        assertThat(new Matcher("JH,Pavan").toString(), is("JH,Pavan"));
+    void shouldReturnCommaSplittedString() {
+        assertThat(new Matcher("JH,Pavan").toString()).isEqualTo("JH,Pavan");
     }
 
     @Test
-    public void shouldSplitEachElement() {
+    void shouldSplitEachElement() {
         String[] array = new String[]{"JH", "Pavan,Jez", "HK"};
-        assertThat(new Matcher(array), is(new Matcher("JH,Pavan,Jez,HK")));
+        assertThat(new Matcher(array)).isEqualTo(new Matcher("JH,Pavan,Jez,HK"));
     }
 
     @Test
-    public void shouldRemoveTheDuplicationFromEachElement() {
+    void shouldRemoveTheDuplicationFromEachElement() {
         String[] array = new String[]{"JH", "Pavan,Jez", "Pavan"};
-        assertThat(new Matcher(array), is(new Matcher("JH,Pavan,Jez")));
+        assertThat(new Matcher(array)).isEqualTo(new Matcher("JH,Pavan,Jez"));
     }
 
     @Test
-    public void shouldReturnMatchersAsArray() {
-        assertThat(new Matcher("JH,Pavan").toCollection(), is(Arrays.asList("JH", "Pavan")));
+    void shouldReturnMatchersAsArray() {
+        assertThat(new Matcher("JH,Pavan").toCollection()).isEqualTo(Arrays.asList("JH", "Pavan"));
     }
 
     @Test
-    public void shouldTrim() {
-        assertThat(new Matcher("  JH   , Pavan "), is(new Matcher("JH,Pavan")));
+    void shouldTrim() {
+        assertThat(new Matcher("  JH   , Pavan ")).isEqualTo(new Matcher("JH,Pavan"));
     }
 
     @Test
-    public void shouldMatchWordBoundaries() throws Exception {
-        assertThat(new Matcher("!!").matches("!!"), is(true));
-        assertThat(new Matcher("ja").matches(" ja"), is(true));
-        assertThat(new Matcher("ja").matches("ja "), is(true));
-        assertThat(new Matcher("ja").matches(" ja"), is(true));
-        assertThat(new Matcher("ja").matches("ja:"), is(true));
-        assertThat(new Matcher("jez.humble@thoughtworks.com").matches("[jez.humble@thoughtworks.com] i checkin"),
-                is(true));
-        assertThat(new Matcher("ja").matches("ja&jh"), is(true));
+    void shouldMatchWordBoundaries() throws Exception {
+        assertThat(new Matcher("!!").matches("!!")).isTrue();
+        assertThat(new Matcher("ja").matches(" ja")).isTrue();
+        assertThat(new Matcher("ja").matches("ja ")).isTrue();
+        assertThat(new Matcher("ja").matches(" ja")).isTrue();
+        assertThat(new Matcher("ja").matches("ja:")).isTrue();
+        assertThat(new Matcher("jez.humble@thoughtworks.com").matches("[jez.humble@thoughtworks.com] i checkin")).isTrue();
+        assertThat(new Matcher("ja").matches("ja&jh")).isTrue();
     }
 
     @Test
-    public void shouldNotMatchWordContainsMatcher() throws Exception {
-        assertThat(new Matcher("ja").matches("javascript"), is(false));
-        assertThat(new Matcher("ja").matches("kaja"), is(false));
-        assertThat(new Matcher("jez.humble@thoughtworks.com").matches("jez.humble"), is(false));
+    void shouldNotMatchWordContainsMatcher() throws Exception {
+        assertThat(new Matcher("ja").matches("javascript")).isFalse();
+        assertThat(new Matcher("ja").matches("kaja")).isFalse();
+        assertThat(new Matcher("jez.humble@thoughtworks.com").matches("jez.humble")).isFalse();
     }
 
     @Test
-    public void shouldEscapeRegexes() throws Exception {
-        assertThat(new Matcher("[").matches("["), is(true));
-        assertThat(new Matcher("]").matches("]]"), is(true));
-        assertThat(new Matcher("\\").matches("\\\\"), is(true));
-        assertThat(new Matcher("^^").matches("^^"), is(true));
-        assertThat(new Matcher("$").matches("$$"), is(true));
-        assertThat(new Matcher("..").matches("..."), is(true));
-        assertThat(new Matcher("|||").matches("||||"), is(true));
-        assertThat(new Matcher("??").matches("???"), is(true));
-        assertThat(new Matcher("**").matches("**"), is(true));
-        assertThat(new Matcher("++").matches("++"), is(true));
-        assertThat(new Matcher("((").matches("((("), is(true));
-        assertThat(new Matcher("))").matches(")))"), is(true));
+    void shouldEscapeRegexes() throws Exception {
+        assertThat(new Matcher("[").matches("[")).isTrue();
+        assertThat(new Matcher("]").matches("]]")).isTrue();
+        assertThat(new Matcher("\\").matches("\\\\")).isTrue();
+        assertThat(new Matcher("^^").matches("^^")).isTrue();
+        assertThat(new Matcher("$").matches("$$")).isTrue();
+        assertThat(new Matcher("..").matches("...")).isTrue();
+        assertThat(new Matcher("|||").matches("||||")).isTrue();
+        assertThat(new Matcher("??").matches("???")).isTrue();
+        assertThat(new Matcher("**").matches("**")).isTrue();
+        assertThat(new Matcher("++").matches("++")).isTrue();
+        assertThat(new Matcher("((").matches("(((")).isTrue();
+        assertThat(new Matcher("))").matches(")))")).isTrue();
     }
 
     @Test
-    public void shouldNotMatchAnyThing() throws Exception {
-        assertThat(new Matcher("").matches("ja"), is(false));
+    void shouldNotMatchAnyThing() throws Exception {
+        assertThat(new Matcher("").matches("ja")).isFalse();
     }
 
     @Test
-    public void shouldValidateAllMatchersUsingAValidator() throws Exception {
+    void shouldValidateAllMatchersUsingAValidator() throws Exception {
         new Matcher(new String[]{"aaa,a"}).validateUsing(Validator.lengthValidator(200));
     }
 
     @Test
-    public void shouldMatchInMultiLineText() throws Exception {
-        assertThat(new Matcher("abc").matches("abc def\nghi jkl"), is(true));
-        assertThat(new Matcher("ghi").matches("abc def\nghi jkl"), is(true));
+    void shouldMatchInMultiLineText() throws Exception {
+        assertThat(new Matcher("abc").matches("abc def\nghi jkl")).isTrue();
+        assertThat(new Matcher("ghi").matches("abc def\nghi jkl")).isTrue();
     }
 }

--- a/domain/src/test/java/com/thoughtworks/go/domain/PipelineStateTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/PipelineStateTest.java
@@ -15,53 +15,53 @@
  */
 package com.thoughtworks.go.domain;
 
-import org.junit.Test;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
-public class PipelineStateTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PipelineStateTest {
     @Test
-    public void shouldBeEqualToAnotherPipelineStateIfAllAttributesMatch() {
+    void shouldBeEqualToAnotherPipelineStateIfAllAttributesMatch() {
         PipelineState pipelineState1 = new PipelineState("p", new StageIdentifier("p", 1, "1", 1L, "s", "1"));
         PipelineState pipelineState2 = new PipelineState("p", new StageIdentifier("p", 1, "1", 1L, "s", "1"));
         pipelineState1.lock(1);
         pipelineState2.lock(1);
-        assertEquals(pipelineState1, pipelineState2);
+        assertThat(pipelineState2).isEqualTo(pipelineState1);
     }
 
     @Test
-    public void shouldBeEqualToAnotherPipelineStateIfBothDoNotHaveLockedBy() {
+    void shouldBeEqualToAnotherPipelineStateIfBothDoNotHaveLockedBy() {
         PipelineState pipelineState1 = new PipelineState("p");
         PipelineState pipelineState2 = new PipelineState("p");
         pipelineState1.lock(1);
         pipelineState2.lock(1);
-        assertEquals(pipelineState1, pipelineState2);
+        assertThat(pipelineState2).isEqualTo(pipelineState1);
     }
 
     @Test
-    public void shouldNotBeEqualToAnotherPipelineStateIfAllAttributesDoNotMatch() {
+    void shouldNotBeEqualToAnotherPipelineStateIfAllAttributesDoNotMatch() {
         PipelineState pipelineState1 = new PipelineState("p", new StageIdentifier("p", 1, "1", 1L, "s", "1"));
         PipelineState pipelineState2 = new PipelineState("p", new StageIdentifier("p", 1, "1", 1L, "s", "1"));
         pipelineState1.lock(1);
-        assertNotEquals(pipelineState1, pipelineState2);
+        assertThat(pipelineState2).isNotEqualTo(pipelineState1);
     }
 
     @Test
-    public void shouldSetLockedByPipelineIdWhileLockingAPipeline() {
+    void shouldSetLockedByPipelineIdWhileLockingAPipeline() {
         PipelineState pipelineState = new PipelineState("p");
         pipelineState.lock(100);
-        assertThat(pipelineState.isLocked(), is(true));
-        assertThat(pipelineState.getLockedByPipelineId(), is(100L));
+        assertThat(pipelineState.isLocked()).isTrue();
+        assertThat(pipelineState.getLockedByPipelineId()).isEqualTo(100L);
     }
 
     @Test
-    public void shouldUnsetLockedByPipelineIdWhileUnlockingAPipeline() {
+    void shouldUnsetLockedByPipelineIdWhileUnlockingAPipeline() {
         PipelineState pipelineState = new PipelineState("p");
         pipelineState.lock(100);
 
         pipelineState.unlock();
-        assertThat(pipelineState.isLocked(), is(false));
-        assertThat(pipelineState.getLockedByPipelineId(), is(0L));
+        assertThat(pipelineState.isLocked()).isFalse();
+        assertThat(pipelineState.getLockedByPipelineId()).isEqualTo(0L);
     }
 }

--- a/domain/src/test/java/com/thoughtworks/go/domain/ResourceTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/ResourceTest.java
@@ -16,19 +16,18 @@
 package com.thoughtworks.go.domain;
 
 import com.rits.cloning.Cloner;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class ResourceTest {
+class ResourceTest {
     @Test
-    public void shouldBeAbleToCreateACopyOfItself() {
+    void shouldBeAbleToCreateACopyOfItself() {
         Resource existingResource = new Resource("some-name");
         existingResource.setId(2);
         existingResource.setBuildId(10);
 
-        assertThat(existingResource, equalTo(new Resource(existingResource)));
-        assertThat(existingResource, equalTo(new Cloner().deepClone(existingResource)));
+        assertThat(existingResource).isEqualTo(new Resource(existingResource));
+        assertThat(existingResource).isEqualTo(new Cloner().deepClone(existingResource));
     }
 }

--- a/domain/src/test/java/com/thoughtworks/go/domain/ResourcesTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/ResourcesTest.java
@@ -17,36 +17,35 @@ package com.thoughtworks.go.domain;
 
 import com.thoughtworks.go.config.ResourceConfig;
 import com.thoughtworks.go.config.ResourceConfigs;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class ResourcesTest {
+class ResourcesTest {
     @Test
-    public void shouldConvertResourceConfigsToListOfResource() {
+    void shouldConvertResourceConfigsToListOfResource() {
         final Resources resources = new Resources(new ResourceConfigs("foo,bar"));
 
-        assertThat(resources, hasSize(2));
-        assertThat(resources, contains(new Resource("foo"), new Resource("bar")));
+        assertThat(resources).hasSize(2);
+        assertThat(resources).containsExactly(new Resource("foo"), new Resource("bar"));
     }
 
     @Test
-    public void shouldConvertResourceListToResourceConfigs() {
+    void shouldConvertResourceListToResourceConfigs() {
         final Resources resources = new Resources(new Resource("foo"), new Resource("bar"));
 
         final ResourceConfigs resourceConfigs = resources.toResourceConfigs();
 
-        assertThat(resourceConfigs, hasSize(2));
-        assertThat(resourceConfigs, contains(new ResourceConfig("foo"), new ResourceConfig("bar")));
+        assertThat(resourceConfigs.size()).isEqualTo(2);
+        assertThat(resourceConfigs.get(0)).isEqualTo(new ResourceConfig("foo"));
+        assertThat(resourceConfigs.get(1)).isEqualTo(new ResourceConfig("bar"));
     }
 
     @Test
-    public void shouldConvertCommaSeparatedResourcesStringToResources() {
+    void shouldConvertCommaSeparatedResourcesStringToResources() {
         final Resources resources = new Resources("foo,bar,baz");
 
-        assertThat(resources, hasSize(3));
-        assertThat(resources, contains(new Resource("foo"), new Resource("bar"), new Resource("baz")));
+        assertThat(resources).hasSize(3);
+        assertThat(resources).containsExactly(new Resource("foo"), new Resource("bar"), new Resource("baz"));
     }
 }

--- a/domain/src/test/java/com/thoughtworks/go/domain/StageConfigIdentifierTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/StageConfigIdentifierTest.java
@@ -15,24 +15,23 @@
  */
 package com.thoughtworks.go.domain;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class StageConfigIdentifierTest {
+class StageConfigIdentifierTest {
 
     @Test
-    public void shouldUseCaseInsensitiveStringForPipelineName() {
+    void shouldUseCaseInsensitiveStringForPipelineName() {
         StageConfigIdentifier stageConfigIdentifier1 = new StageConfigIdentifier("pipelineName", "stageName");
         StageConfigIdentifier stageConfigIdentifier2 = new StageConfigIdentifier("pipelinename", "stageName");
-        assertThat(stageConfigIdentifier1, is(stageConfigIdentifier2));
+        assertThat(stageConfigIdentifier1).isEqualTo(stageConfigIdentifier2);
     }
 
     @Test
-    public void shouldUseCaseInsensitiveStringForStageName() {
+    void shouldUseCaseInsensitiveStringForStageName() {
         StageConfigIdentifier stageConfigIdentifier1 = new StageConfigIdentifier("pipelineName", "stageName");
         StageConfigIdentifier stageConfigIdentifier2 = new StageConfigIdentifier("pipelineName", "Stagename");
-        assertThat(stageConfigIdentifier1, is(stageConfigIdentifier2));
+        assertThat(stageConfigIdentifier1).isEqualTo(stageConfigIdentifier2);
     }
 }

--- a/domain/src/test/java/com/thoughtworks/go/domain/materials/git/GitLogCommandBuilderTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/materials/git/GitLogCommandBuilderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.materials.git;
+
+import com.thoughtworks.go.domain.materials.git.builder.GitLogCommandBuilder;
+import com.thoughtworks.go.util.command.CommandLine;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitLogCommandBuilderTest {
+
+    @Test
+    void shouldBuildGitLogCommandToGetLatestModification() {
+        CommandLine command = new GitLogCommandBuilder()
+                .latestCommit()
+                .build();
+
+        assertThat(command.toString()).isEqualTo("git log --no-color -1");
+    }
+
+    @Test
+    void shouldBuildGitLogCommandToGetLastModificationWithRemoteBranch() {
+        CommandLine command = new GitLogCommandBuilder()
+                .latestCommit()
+                .withRemoteBranch("origin/SomeBranch")
+                .build();
+
+        assertThat(command.toString()).isEqualTo("git log --no-color -1 origin/SomeBranch");
+    }
+
+    @Test
+    void shouldBuildGitLogCommandToGetModificationSinceRevision() {
+        CommandLine command = new GitLogCommandBuilder()
+                .between("45a76368ed", "origin/SomeBranch")
+                .build();
+
+        assertThat(command.toString()).isEqualTo("git log --no-color 45a76368ed..origin/SomeBranch");
+    }
+
+    @Test
+    void shouldBuildGitLogCommandWithWorkingDirectory(@TempDir File workingDir) {
+        CommandLine command = new GitLogCommandBuilder()
+                .between("45a76368ed", "origin/SomeBranch")
+                .withWorkingDir(workingDir)
+                .build();
+
+        assertThat(command.getWorkingDirectory()).isEqualTo(workingDir);
+    }
+
+    @Test
+    void shouldSetFormatArg() {
+        CommandLine command = new GitLogCommandBuilder()
+                .latestCommit()
+                .outputFormatYaml()
+                .build();
+
+        assertThat(command.toString()).contains("--pretty=format:");
+    }
+}

--- a/domain/src/test/java/com/thoughtworks/go/domain/materials/git/GitLogTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/materials/git/GitLogTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.materials.git;
+
+import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.util.DateUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitLogTest {
+    @Test
+    void shouldConvertGitLogToModificationObject() {
+        GitLog gitLog = new GitLog();
+        gitLog.setSubject("Subject");
+        gitLog.setDate("2009-02-11 17:26:36 -0800");
+        gitLog.setAuthorEmail("bob@thoughtworks.com");
+        gitLog.setAuthorName("Bob Ford");
+        gitLog.setCommitHash("dklsjfhjksdhfjks34u283ryifdshfbs");
+        gitLog.setRawBody("Something \n kjsdfsd \n");
+        gitLog.setAdditionalInfo(new HashMap<>() {{
+            put("Foo", "Bar");
+        }});
+
+        Modification modification = gitLog.toModification();
+
+        assertThat(modification.getModifiedTime()).isEqualTo(DateUtils.parseISO8601("2009-02-11 17:26:36 -0800"));
+        assertThat(modification.getUserName()).isEqualTo("Bob Ford");
+        assertThat(modification.getEmailAddress()).isEqualTo("bob@thoughtworks.com");
+        assertThat(modification.getRevision()).isEqualTo("dklsjfhjksdhfjks34u283ryifdshfbs");
+        assertThat(modification.getComment()).isEqualTo("Something \n kjsdfsd");
+        assertThat(modification.getAdditionalDataMap())
+                .hasSize(2)
+                .containsEntry("Foo", "Bar")
+                .containsEntry("subject", "Subject");
+    }
+}

--- a/domain/src/test/java/com/thoughtworks/go/domain/materials/git/builder/OutputFormatterTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/materials/git/builder/OutputFormatterTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.materials.git.builder;
+
+import com.thoughtworks.go.junit5.FileSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OutputFormatterTest {
+    @Test
+    void shouldAddOutputTypeInfo() {
+        String format = OutputFormatter
+                .newFormatter(DummyOutputType.class)
+                .format();
+
+        assertThat(format).isEqualTo("- !!com.thoughtworks.go.domain.materials.git.builder.DummyOutputType");
+    }
+
+    @ParameterizedTest
+    @FileSource(files = "/git/formatter/with-commit-hash.txt")
+    void shouldSelectCommitHash(String expected) {
+        String format = OutputFormatter
+                .newFormatter(DummyOutputType.class)
+                .withCommitHash()
+                .format();
+
+        assertThat(format).isEqualTo(expected.trim());
+    }
+
+    @ParameterizedTest
+    @FileSource(files = "/git/formatter/with-author-name-and-email.txt")
+    void shouldSelectAuthorName(String expected) {
+        String format = OutputFormatter
+                .newFormatter(DummyOutputType.class)
+                .withAuthorName()
+                .withAuthorEmail()
+                .format();
+
+        assertThat(format).isEqualTo(expected.trim());
+    }
+
+    @ParameterizedTest
+    @FileSource(files = "/git/formatter/with-commit-date.txt")
+    void shouldSelectCommitDate(String expected) {
+        String format = OutputFormatter
+                .newFormatter(DummyOutputType.class)
+                .withDate()
+                .format();
+
+        assertThat(format).isEqualTo(expected.trim());
+    }
+
+    @ParameterizedTest
+    @FileSource(files = "/git/formatter/with-commit-subject-and-body.txt")
+    void shouldSelectSubjectAndRawBody(String expected) {
+        String format = OutputFormatter
+                .newFormatter(DummyOutputType.class)
+                .withSubject()
+                .withRawBody()
+                .format();
+
+        assertThat(format).isEqualTo(expected.trim());
+    }
+
+    @ParameterizedTest
+    @FileSource(files = "/git/formatter/with-additional-info.txt")
+    void shouldSelectAdditionalInformation(String expected) {
+        String format = OutputFormatter
+                .newFormatter(DummyOutputType.class)
+                .withAdditionalInfo()
+                .format();
+
+        assertThat(format).isEqualTo(expected.trim());
+    }
+}
+
+class DummyOutputType {
+
+}

--- a/domain/src/test/java/com/thoughtworks/go/domain/materials/perforce/P4OutputParserTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/materials/perforce/P4OutputParserTest.java
@@ -22,10 +22,11 @@ import com.thoughtworks.go.domain.materials.ModifiedFile;
 import com.thoughtworks.go.util.LogFixture;
 import com.thoughtworks.go.util.command.ConsoleResult;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.text.ParseException;
@@ -35,47 +36,44 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.thoughtworks.go.util.LogFixture.logFixtureFor;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class P4OutputParserTest {
+class P4OutputParserTest {
     private P4OutputParser parser;
     private static final SimpleDateFormat DESCRIPTION_FORMAT = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
     private P4Client p4Client;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() {
         p4Client = mock(P4Client.class);
         parser = new P4OutputParser(p4Client);
     }
 
     @Test
-    public void shouldRetrieveRevisionFromChangesOutput() throws Exception {
+    void shouldRetrieveRevisionFromChangesOutput() {
         String output = "Change 2 on 2008/08/19 by cceuser@connect4 'some modification message'";
         long revision = parser.revisionFromChange(output);
-        assertThat(revision, is(2L));
+        assertThat(revision).isEqualTo(2L);
     }
 
     @Test
-    public void shouldThrowExceptionIfP4ReturnDifferentDateFormatWhenCannotParseFistLineOfP4Describe()
-            throws Exception {
+    void shouldThrowExceptionIfP4ReturnDifferentDateFormatWhenCannotParseFistLineOfP4Describe() {
         String output = "Change 2 on 08/08/19 by cceuser@connect4 'some modification message'";
         Modification modification = new Modification();
         try {
             parser.parseFistline(modification, output, new ConsoleResult(0, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
         } catch (P4OutputParseException e) {
-            assertThat(e.getMessage(), containsString("Could not parse P4 describe:"));
+            assertThat(e.getMessage()).contains("Could not parse P4 describe:");
 
         }
     }
 
     @Test
-    public void shouldRetrieveModificationFromDescription() throws Exception {
+    void shouldRetrieveModificationFromDescription() throws P4OutputParseException, ParseException {
         String output =
                 "Change 2 by cce123user@connect4_10.18.2.31 on 2008/08/19 15:04:43\n"
                         + "\n"
@@ -88,17 +86,17 @@ public class P4OutputParserTest {
                         + "... //depot/cruise-output/log.xml#1 delete\n"
                         + "";
         Modification mod = parser.modificationFromDescription(output, new ConsoleResult(0, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
-        assertThat(mod.getRevision(), is("2"));
-        assertThat(mod.getUserName(), is("cce123user@connect4_10.18.2.31"));
-        assertThat(mod.getModifiedTime(), is(DESCRIPTION_FORMAT.parse("2008/08/19 15:04:43")));
-        assertThat(mod.getComment(), is("Added config file"));
+        assertThat(mod.getRevision()).isEqualTo("2");
+        assertThat(mod.getUserName()).isEqualTo("cce123user@connect4_10.18.2.31");
+        assertThat(mod.getModifiedTime()).isEqualTo(DESCRIPTION_FORMAT.parse("2008/08/19 15:04:43"));
+        assertThat(mod.getComment()).isEqualTo("Added config file");
         List<ModifiedFile> files = mod.getModifiedFiles();
-        assertThat(files.size(), is(3));
-        assertThat(files.get(0).getAction(), is(ModifiedAction.added));
-        assertThat(files.get(0).getFileName(), is("cruise-config.xml"));
-        assertThat(files.get(1).getAction(), is(ModifiedAction.modified));
-        assertThat(files.get(2).getAction(), is(ModifiedAction.deleted));
-        assertThat(files.get(2).getFileName(), is("cruise-output/log.xml"));
+        assertThat(files.size()).isEqualTo(3);
+        assertThat(files.get(0).getAction()).isEqualTo(ModifiedAction.added);
+        assertThat(files.get(0).getFileName()).isEqualTo("cruise-config.xml");
+        assertThat(files.get(1).getAction()).isEqualTo(ModifiedAction.modified);
+        assertThat(files.get(2).getAction()).isEqualTo(ModifiedAction.deleted);
+        assertThat(files.get(2).getFileName()).isEqualTo("cruise-output/log.xml");
     }
 
     /*
@@ -106,30 +104,29 @@ public class P4OutputParserTest {
      * It caused a frequent StackOverflow in the java regex library.
      */
     @Test
-    public void shouldParseChangesWithLotsOfFilesWithoutError() throws Exception {
+    void shouldParseChangesWithLotsOfFilesWithoutError() throws IOException, P4OutputParseException {
         final StringWriter writer = new StringWriter();
         IOUtils.copy(new ClassPathResource("/BIG_P4_OUTPUT.txt").getInputStream(), writer, Charset.defaultCharset());
         String output = writer.toString();
         Modification modification = parser.modificationFromDescription(output, new ConsoleResult(0, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
-        assertThat(modification.getModifiedFiles().size(), is(1304));
-        assertThat(modification.getModifiedFiles().get(0).getFileName(),
-                is("Internal Projects/ABC/Customers3/ABC/RIP/SomeProject/data/main/config/lib/java/AdvJDBCColumnHandler.jar"));
+        assertThat(modification.getModifiedFiles().size()).isEqualTo(1304);
+        assertThat(modification.getModifiedFiles().get(0).getFileName()).isEqualTo("Internal Projects/ABC/Customers3/ABC/RIP/SomeProject/data/main/config/lib/java/AdvJDBCColumnHandler.jar");
     }
 
 
     @Test
-    public void shouldThrowExceptionWhenCannotParseChanges() {
+    void shouldThrowExceptionWhenCannotParseChanges() {
         String line = "Some line I don't understand";
         try {
             parser.modificationFromDescription(line, new ConsoleResult(0, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
             fail("Should throw exception if can't parse the description");
         } catch (P4OutputParseException expected) {
-            assertThat(expected.getMessage(), containsString(line));
+            assertThat(expected.getMessage()).contains(line);
         }
     }
 
     @Test
-    public void shouldParseDescriptionProperly_Bug2456() throws P4OutputParseException {
+    void shouldParseDescriptionProperly_Bug2456() throws P4OutputParseException {
         String description =
                 "Change 570548 by michael@michael_AB2-ENV-WXP-000_ABcore on 2009/01/12 14:47:04\n"
                         + "\n"
@@ -159,15 +156,14 @@ public class P4OutputParserTest {
                         + "";
 
         Modification modification = parser.modificationFromDescription(description, new ConsoleResult(0, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
-        assertThat(modification.getComment(), is(
-                "Add a WCF CrossDomainPolicyService and CrossDomain.xml.\n"
-                        + "Update service reference.\n"
-                        + "Update app.config and template config files."));
+        assertThat(modification.getComment()).isEqualTo("Add a WCF CrossDomainPolicyService and CrossDomain.xml.\n"
+                + "Update service reference.\n"
+                + "Update app.config and template config files.");
 
     }
 
     @Test
-    public void shouldParseCommentWithAffectedFilesCorrectly() throws P4OutputParseException {
+    void shouldParseCommentWithAffectedFilesCorrectly() throws P4OutputParseException {
         String description =
                 "Change 5 by cceuser@CceDev01 on 2009/08/06 14:21:30\n"
                         + "\n"
@@ -180,15 +176,14 @@ public class P4OutputParserTest {
                         + "... //depot/file#5 edit";
 
         Modification modification = parser.modificationFromDescription(description, new ConsoleResult(0, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
-        assertThat(modification.getComment(), is(
-                "Affected files ...\n"
-                        + "\n"
-                        + "... //DEPOT/FILE#943 edit"));
+        assertThat(modification.getComment()).isEqualTo("Affected files ...\n"
+                + "\n"
+                + "... //DEPOT/FILE#943 edit");
 
     }
 
     @Test
-    public void shouldParseCorrectlyWhenCommentIsEmpty() throws P4OutputParseException {
+    void shouldParseCorrectlyWhenCommentIsEmpty() throws P4OutputParseException {
         String description =
                 "Change 102 by godev@blrstdcrspair03 on 2013/06/04 12:00:35\n"
                         + "\n"
@@ -198,7 +193,7 @@ public class P4OutputParserTest {
                         + "... //another_depot/1.txt#6 edit";
 
         Modification modification = parser.modificationFromDescription(description, new ConsoleResult(0, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
-        assertThat(modification.getComment(), is(""));
+        assertThat(modification.getComment()).isEqualTo("");
     }
 
     private static final String BUG_2503_OUTPUT = "Change 122636 by ipaipa@ipaipa-STANDARD-DHTML on 2009/02/06 17:53:57\n"
@@ -218,17 +213,17 @@ public class P4OutputParserTest {
             + "... //APP/RF/Core/Somemv.Core/Somemv.Core#1 add\n";
 
     @Test
-    public void shouldMatchWhenCommentsAreMultipleLines() throws Exception {
+    void shouldMatchWhenCommentsAreMultipleLines() throws P4OutputParseException, ParseException {
         Modification modification = parser.modificationFromDescription(BUG_2503_OUTPUT, new ConsoleResult(0, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
 
-        assertThat(parser.revisionFromChange(BUG_2503_OUTPUT), is(122636L));
-        assertThat(modification.getModifiedTime(), is(DESCRIPTION_FORMAT.parse("2009/02/06 17:53:57")));
-        assertThat(modification.getModifiedFiles().size(), is(1));
-        assertThat(modification.getUserName(), is("ipaipa@ipaipa-STANDARD-DHTML"));
+        assertThat(parser.revisionFromChange(BUG_2503_OUTPUT)).isEqualTo(122636L);
+        assertThat(modification.getModifiedTime()).isEqualTo(DESCRIPTION_FORMAT.parse("2009/02/06 17:53:57"));
+        assertThat(modification.getModifiedFiles().size()).isEqualTo(1);
+        assertThat(modification.getUserName()).isEqualTo("ipaipa@ipaipa-STANDARD-DHTML");
     }
 
     @Test
-    public void shouldIgnoreEmptyLinesInChanges() throws ParseException {
+    void shouldIgnoreEmptyLinesInChanges() {
         final String output =
                 "Change 539921 on 2008/09/24 by abc@SomeRefinery_abc_sa1-sgr-xyz-001 'more work in progress on ABC un'\n"
                         + "Change 539920 on 2008/09/24 by "
@@ -264,11 +259,11 @@ public class P4OutputParserTest {
                 + "");
 
         List<Modification> modifications = parser.modifications(new ConsoleResult(0, Arrays.asList(output.split("\n")), new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
-        assertThat(modifications.size(), is(20));
+        assertThat(modifications.size()).isEqualTo(20);
     }
 
     @Test
-    public void shouldIgnoreBadLinesAndLogThem() throws ParseException {
+    void shouldIgnoreBadLinesAndLogThem() {
         try (LogFixture logging = logFixtureFor(P4OutputParser.class, Level.DEBUG)) {
             final String output = "Change 539921 on 2008/09/24 "
                     + "by abc@SomeRefinery_abc_sa1-sgr-xyz-001 'more work in progress on MDC un'\n";
@@ -277,8 +272,8 @@ public class P4OutputParserTest {
             when(p4Client.describe(any(Long.class))).thenReturn(description);
 
             List<Modification> modifications = parser.modifications(new ConsoleResult(0, Arrays.asList(output.split("\n")), new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
-            assertThat(modifications.size(), is(0));
-            assertThat(logging.getLog(), containsString(description));
+            assertThat(modifications.size()).isEqualTo(0);
+            assertThat(logging.getLog()).contains(description);
         }
     }
 }

--- a/domain/src/test/resources/git/formatter/with-additional-info.txt
+++ b/domain/src/test/resources/git/formatter/with-additional-info.txt
@@ -3,7 +3,7 @@
 %w(,4,4)signed: %G?
 %w(,4,4)signerName: %GS
 %w(,4,4)signingKey: %GK
-%w(,4,4)signingMessage: %GG
+%w(,4,4)signingMessage: |-%n%w(,6,6)%GG
 %w(,4,4)committerName: %cn
 %w(,4,4)committerEmail: %ce
 %w(,4,4)commitDate: %ci

--- a/domain/src/test/resources/git/formatter/with-additional-info.txt
+++ b/domain/src/test/resources/git/formatter/with-additional-info.txt
@@ -1,0 +1,9 @@
+- !!com.thoughtworks.go.domain.materials.git.builder.DummyOutputType
+%w(,2,2)additionalInfo:
+%w(,4,4)signed: %G?
+%w(,4,4)signerName: %GS
+%w(,4,4)signingKey: %GK
+%w(,4,4)signingMessage: %GG
+%w(,4,4)committerName: %cn
+%w(,4,4)committerEmail: %ce
+%w(,4,4)commitDate: %ci

--- a/domain/src/test/resources/git/formatter/with-author-name-and-email.txt
+++ b/domain/src/test/resources/git/formatter/with-author-name-and-email.txt
@@ -1,0 +1,3 @@
+- !!com.thoughtworks.go.domain.materials.git.builder.DummyOutputType
+%w(,2,2)authorName: %an
+%w(,2,2)authorEmail: %ae

--- a/domain/src/test/resources/git/formatter/with-commit-date.txt
+++ b/domain/src/test/resources/git/formatter/with-commit-date.txt
@@ -1,0 +1,2 @@
+- !!com.thoughtworks.go.domain.materials.git.builder.DummyOutputType
+%w(,2,2)date: %ai

--- a/domain/src/test/resources/git/formatter/with-commit-hash.txt
+++ b/domain/src/test/resources/git/formatter/with-commit-hash.txt
@@ -1,0 +1,2 @@
+- !!com.thoughtworks.go.domain.materials.git.builder.DummyOutputType
+%w(,2,2)commitHash: %H

--- a/domain/src/test/resources/git/formatter/with-commit-subject-and-body.txt
+++ b/domain/src/test/resources/git/formatter/with-commit-subject-and-body.txt
@@ -1,0 +1,3 @@
+- !!com.thoughtworks.go.domain.materials.git.builder.DummyOutputType
+%w(,2,2)subject: |-%n%w(,4,4)%s
+%w(,2,2)rawBody: |-%n%w(,4,4)%B

--- a/server-launcher/build.gradle
+++ b/server-launcher/build.gradle
@@ -297,6 +297,7 @@ task verifyFatJar(type: VerifyJarTask) {
       "websocket-common-${versions.jetty}.jar",
       "websocket-server-${versions.jetty}.jar",
       "websocket-servlet-${versions.jetty}.jar",
+      "snakeyaml-${project.versions.snakeYaml}.jar"
     ]
   ]
 }

--- a/server-launcher/build.gradle
+++ b/server-launcher/build.gradle
@@ -296,8 +296,7 @@ task verifyFatJar(type: VerifyJarTask) {
       "websocket-client-${versions.jetty}.jar",
       "websocket-common-${versions.jetty}.jar",
       "websocket-server-${versions.jetty}.jar",
-      "websocket-servlet-${versions.jetty}.jar",
-      "snakeyaml-${project.versions.snakeYaml}.jar"
+      "websocket-servlet-${versions.jetty}.jar"
     ]
   ]
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -886,6 +886,7 @@ task verifyWar(type: VerifyJarTask) {
         "semantic-version-${project.versions.semanticVersion}.jar",
         "slf4j-api-${project.versions.slf4j}.jar",
         "smtp-${project.versions.mail}.jar",
+        "snakeyaml-${project.versions.snakeYaml}.jar",
         "spark-core-${project.versions.spark}.jar",
         "spring-aop-${project.versions.spring}.jar",
         "spring-beans-${project.versions.spring}.jar",
@@ -905,7 +906,7 @@ task verifyWar(type: VerifyJarTask) {
         "urlrewritefilter-${project.versions.urlrewrite}.jar",
         "util-${project.version}.jar",
         "velocity-1.7.jar",
-        "velocity-tools-view-${project.versions.velocityToolsView}.jar",
+        "velocity-tools-view-${project.versions.velocityToolsView}.jar"
       ])
   ]
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/FeedEntriesRepresenterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/FeedEntriesRepresenterTest.java
@@ -21,7 +21,7 @@ import com.thoughtworks.go.domain.XmlWriterContext;
 import com.thoughtworks.go.domain.feed.Author;
 import com.thoughtworks.go.domain.feed.FeedEntries;
 import com.thoughtworks.go.domain.feed.stage.StageFeedEntry;
-import com.thoughtworks.go.junit5.JsonSource;
+import com.thoughtworks.go.junit5.FileSource;
 import com.thoughtworks.go.util.DateUtils;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.dom4j.Document;
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
 
 public class FeedEntriesRepresenterTest {
     @ParameterizedTest
-    @JsonSource(jsonFiles = "/feeds/stages-with-entries.xml")
+    @FileSource(files = "/feeds/stages-with-entries.xml")
     void shouldGenerateFeedXml(String expectedXML) {
         String pipelineName = "up42";
         StageFeedEntry entryOne = cancelled();
@@ -53,7 +53,7 @@ public class FeedEntriesRepresenterTest {
     }
 
     @ParameterizedTest
-    @JsonSource(jsonFiles = "/feeds/stages-with-no-entries.xml")
+    @FileSource(files = "/feeds/stages-with-no-entries.xml")
     void shouldGenerateXmlWithoutEntryWhenEmpty(String expectedXML) {
         String pipelineName = "up42";
         XmlWriterContext context = new XmlWriterContext("https://go-server/go", null, null, null, new SystemEnvironment());

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/JobPlanXmlRepresenterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/JobPlanXmlRepresenterTest.java
@@ -18,7 +18,7 @@ package com.thoughtworks.go.server.domain.xml;
 
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.helper.JobInstanceMother;
-import com.thoughtworks.go.junit5.JsonSource;
+import com.thoughtworks.go.junit5.FileSource;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.dom4j.Document;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,7 +29,7 @@ import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class JobPlanXmlRepresenterTest {
     @ParameterizedTest
-    @JsonSource(jsonFiles = "/feeds/job-plan.xml")
+    @FileSource(files = "/feeds/job-plan.xml")
     void shouldGenerateDocumentForJobPlan(String expectedXML) {
         EnvironmentVariable secureEnvVariable = new EnvironmentVariable("secureVariable", "value2", true);
         DefaultJobPlan jobPlan1 = JobInstanceMother.jobPlan("job-1", 1);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/JobPlanXmlViewModelTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/JobPlanXmlViewModelTest.java
@@ -45,20 +45,20 @@ public class JobPlanXmlViewModelTest {
         JobPlanXmlViewModel jobPlanXmlViewModel = new JobPlanXmlViewModel(new ArrayList<>(Arrays.asList(new WaitingJobPlan(jobPlan1, "envName"), new WaitingJobPlan(jobPlan2, null))));
 
         String expectedXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-                + "<scheduledJobs>"
-                + "<job name=\"job-1\" id=\"10\">"
-                + "<link rel=\"self\" href=\"http://baseurl/go/tab/build/detail/pipeline/1/stage/1/job-1\"/>"
-                + "<buildLocator>pipeline/1/stage/1/job-1</buildLocator>"
-                + "<environment>envName</environment>"
-                + "<resources><resource><![CDATA[foo]]></resource><resource><![CDATA[bar]]></resource></resources>"
-                + "<environmentVariables><variable name=\"some_var\">blah</variable><variable name=\"secureVariable\">****</variable></environmentVariables>"
-                + "</job>"
-                + "<job name=\"job-2\" id=\"11\">"
-                + "<link rel=\"self\" href=\"http://baseurl/go/tab/build/detail/pipeline/1/stage/1/job-2\"/>"
-                + "<buildLocator>pipeline/1/stage/1/job-2</buildLocator>"
-                + "<resources><resource><![CDATA[foo]]></resource><resource><![CDATA[bar]]></resource></resources>"
-                + "</job>"
-                + "</scheduledJobs>";
+            + "<scheduledJobs>"
+            + "<job name=\"job-1\" id=\"10\">"
+            + "<link rel=\"self\" href=\"http://baseurl/go/tab/build/detail/pipeline/1/stage/1/job-1\"/>"
+            + "<buildLocator>pipeline/1/stage/1/job-1</buildLocator>"
+            + "<environment>envName</environment>"
+            + "<resources><resource><![CDATA[foo]]></resource><resource><![CDATA[bar]]></resource></resources>"
+            + "<environmentVariables><variable name=\"some_var\">blah</variable><variable name=\"secureVariable\">****</variable></environmentVariables>"
+            + "</job>"
+            + "<job name=\"job-2\" id=\"11\">"
+            + "<link rel=\"self\" href=\"http://baseurl/go/tab/build/detail/pipeline/1/stage/1/job-2\"/>"
+            + "<buildLocator>pipeline/1/stage/1/job-2</buildLocator>"
+            + "<resources><resource><![CDATA[foo]]></resource><resource><![CDATA[bar]]></resource></resources>"
+            + "</job>"
+            + "</scheduledJobs>";
 
         Document document = jobPlanXmlViewModel.toXml(new XmlWriterContext("http://baseurl/go", null, null, null, new SystemEnvironment()));
         assertEquals(expectedXml, document.asXML());

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/JobXmlRepresenterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/JobXmlRepresenterTest.java
@@ -19,7 +19,7 @@ package com.thoughtworks.go.server.domain.xml;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.exception.IllegalArtifactLocationException;
 import com.thoughtworks.go.helper.JobInstanceMother;
-import com.thoughtworks.go.junit5.JsonSource;
+import com.thoughtworks.go.junit5.FileSource;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.dom4j.Document;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,7 +32,7 @@ import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class JobXmlRepresenterTest {
     @ParameterizedTest
-    @JsonSource(jsonFiles = "/feeds/job.xml")
+    @FileSource(files = "/feeds/job.xml")
     void shouldGenerateDocumentForJob(String expectedXML) throws IllegalArtifactLocationException {
         ArtifactUrlReader urlReader = mock(ArtifactUrlReader.class);
         JobInstance jobInstance = JobInstanceMother.failed("unit-test");

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/PipelineXmlRepresenterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/PipelineXmlRepresenterTest.java
@@ -24,7 +24,7 @@ import com.thoughtworks.go.domain.XmlWriterContext;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.ModifiedAction;
 import com.thoughtworks.go.helper.PipelineHistoryMother;
-import com.thoughtworks.go.junit5.JsonSource;
+import com.thoughtworks.go.junit5.FileSource;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
 import com.thoughtworks.go.util.DateUtils;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -61,7 +61,7 @@ public class PipelineXmlRepresenterTest {
     }
 
     @ParameterizedTest
-    @JsonSource(jsonFiles = "/feeds/pipeline.xml")
+    @FileSource(files = "/feeds/pipeline.xml")
     void shouldGeneratePipelineXml(String expectedXML) {
         Document document = new PipelineXmlRepresenter(model).toXml(context);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/PipelinesXmlRepresenterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/PipelinesXmlRepresenterTest.java
@@ -16,7 +16,7 @@
 package com.thoughtworks.go.server.domain.xml;
 
 import com.thoughtworks.go.domain.XmlWriterContext;
-import com.thoughtworks.go.junit5.JsonSource;
+import com.thoughtworks.go.junit5.FileSource;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 
 public class PipelinesXmlRepresenterTest {
     @ParameterizedTest
-    @JsonSource(jsonFiles = "/feeds/pipelines.xml")
+    @FileSource(files = "/feeds/pipelines.xml")
     void shouldConvertPipelineInstanceModelsToDocument(String expectedXML) {
         XmlWriterContext context = new XmlWriterContext("https://go-server/go", null, null, null, new SystemEnvironment());
         PipelineInstanceModel up42Model = pipelineInstanceModel("up42");

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/StageXmlRepresenterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/StageXmlRepresenterTest.java
@@ -21,7 +21,7 @@ import com.thoughtworks.go.domain.Stage;
 import com.thoughtworks.go.domain.StageIdentifier;
 import com.thoughtworks.go.domain.XmlWriterContext;
 import com.thoughtworks.go.helper.StageMother;
-import com.thoughtworks.go.junit5.JsonSource;
+import com.thoughtworks.go.junit5.FileSource;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.dom4j.Document;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -31,7 +31,7 @@ import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class StageXmlRepresenterTest {
     @ParameterizedTest
-    @JsonSource(jsonFiles = "/feeds/stage.xml")
+    @FileSource(files = "/feeds/stage.xml")
     void shouldGenerateDocumentForStage(String expectedXML) {
         String pipelineName = "BulletinBoard";
         String stageName = "UnitTest";

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/materials/DependencyMaterialXmlRepresenterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/materials/DependencyMaterialXmlRepresenterTest.java
@@ -19,7 +19,7 @@ import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.helper.MaterialsMother;
-import com.thoughtworks.go.junit5.JsonSource;
+import com.thoughtworks.go.junit5.FileSource;
 import com.thoughtworks.go.server.domain.xml.builder.ElementBuilder;
 import com.thoughtworks.go.util.DateUtils;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -35,7 +35,7 @@ import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class DependencyMaterialXmlRepresenterTest {
     @ParameterizedTest
-    @JsonSource(jsonFiles = "/feeds/materials/dependency-material.xml")
+    @FileSource(files = "/feeds/materials/dependency-material.xml")
     void shouldRepresentDependencyMaterial(String expectedXML) {
         Date date = DateUtils.parseISO8601("2019-12-31T15:31:49+05:30");
         DependencyMaterial material = MaterialsMother.dependencyMaterial();

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/materials/PackageMaterialXmlRepresenterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/materials/PackageMaterialXmlRepresenterTest.java
@@ -20,7 +20,7 @@ import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.XmlWriterContext;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.helper.MaterialsMother;
-import com.thoughtworks.go.junit5.JsonSource;
+import com.thoughtworks.go.junit5.FileSource;
 import com.thoughtworks.go.server.domain.xml.builder.ElementBuilder;
 import com.thoughtworks.go.util.DateUtils;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -33,7 +33,7 @@ import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class PackageMaterialXmlRepresenterTest {
     @ParameterizedTest
-    @JsonSource(jsonFiles = "/feeds/materials/package-material.xml")
+    @FileSource(files = "/feeds/materials/package-material.xml")
     void shouldRepresentDependencyMaterial(String expectedXML) {
         Date date = DateUtils.parseISO8601("2019-12-31T15:31:49+05:30");
         PackageMaterial material = MaterialsMother.packageMaterial();
@@ -50,5 +50,4 @@ public class PackageMaterialXmlRepresenterTest {
             .ignoreWhitespace()
             .areIdentical();
     }
-
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/materials/ScmMaterialXmlRepresenterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/materials/ScmMaterialXmlRepresenterTest.java
@@ -20,7 +20,7 @@ import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.XmlWriterContext;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.ModifiedAction;
-import com.thoughtworks.go.junit5.JsonSource;
+import com.thoughtworks.go.junit5.FileSource;
 import com.thoughtworks.go.server.domain.xml.builder.ElementBuilder;
 import com.thoughtworks.go.util.DateUtils;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -36,7 +36,7 @@ import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 public class ScmMaterialXmlRepresenterTest {
     @ParameterizedTest
-    @JsonSource(jsonFiles = "/feeds/materials/git-material.xml")
+    @FileSource(files = "/feeds/materials/git-material.xml")
     void shouldGenerateXmlFromMaterialRevision(String expectedXML) {
         GitMaterial gitMaterial = gitMaterial("https://material/example.git");
         gitMaterial.setId(100);
@@ -45,19 +45,19 @@ public class ScmMaterialXmlRepresenterTest {
         ElementBuilder builder = new ElementBuilder(root);
         XmlWriterContext context = new XmlWriterContext("https://test.host/go", null, null, null, new SystemEnvironment());
 
-        new ScmMaterialXmlRepresenter("up42", 1,materialRevision).populate(builder, context);
+        new ScmMaterialXmlRepresenter("up42", 1, materialRevision).populate(builder, context);
 
         assertThat(root.asXML()).and(expectedXML)
-                .ignoreWhitespace()
-                .areIdentical();
+            .ignoreWhitespace()
+            .areIdentical();
     }
 
     private List<Modification> modifications() {
         Date date = DateUtils.parseISO8601("2019-12-31T15:31:49+05:30");
         return Arrays.asList(
-                modification(date, "Bob", "Adding build.xml", "3", "build.xml", ModifiedAction.added),
-                modification(date, "Sam", "Fixing the not checked in files", "2", "tools/bin/go.jruby", ModifiedAction.added),
-                modification(date, "Sam", "Adding .gitignore", "1", ".gitignore", ModifiedAction.modified)
+            modification(date, "Bob", "Adding build.xml", "3", "build.xml", ModifiedAction.added),
+            modification(date, "Sam", "Fixing the not checked in files", "2", "tools/bin/go.jruby", ModifiedAction.added),
+            modification(date, "Sam", "Adding .gitignore", "1", ".gitignore", ModifiedAction.modified)
         );
     }
 

--- a/test/test-utils/src/main/java/com/thoughtworks/go/junit5/FileSource.java
+++ b/test/test-utils/src/main/java/com/thoughtworks/go/junit5/FileSource.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.junit5;
+
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.lang.annotation.*;
+
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ArgumentsSource(FileSourceProvider.class)
+public @interface FileSource {
+    String[] files();
+}

--- a/test/test-utils/src/main/java/com/thoughtworks/go/junit5/FileSourceProvider.java
+++ b/test/test-utils/src/main/java/com/thoughtworks/go/junit5/FileSourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.thoughtworks.go.junit5;
 
 import org.apache.commons.io.FileUtils;
@@ -24,50 +25,47 @@ import org.junit.platform.commons.util.Preconditions;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
-public class JsonSourceProvider implements ArgumentsProvider, AnnotationConsumer<JsonSource> {
-    private final BiFunction<Class<?>, String, File> inputStreamProvider;
+public class FileSourceProvider implements ArgumentsProvider, AnnotationConsumer<FileSource> {
     private String[] jsonFiles;
+    private final BiFunction<Class<?>, String, InputStream> inputStreamProvider;
 
-    JsonSourceProvider() {
-        this((clazz, s) -> new File(clazz.getResource(s).getFile()));
+    FileSourceProvider() {
+        this(Class::getResourceAsStream);
     }
 
-    JsonSourceProvider(BiFunction<Class<?>, String, File> inputStreamProvider) {
+    private FileSourceProvider(BiFunction<Class<?>, String, InputStream> inputStreamProvider) {
         this.inputStreamProvider = inputStreamProvider;
     }
 
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
         Object[] files = Arrays.stream(jsonFiles)
-                .map(resource -> openInputStream(context, resource))
-                .map(this::readFile)
+                .filter(Objects::nonNull)
+                .map(file -> this.readFile(file, context))
                 .toArray();
 
         return Stream.of(Arguments.of(files));
     }
 
-    private String readFile(File file) {
+    private String readFile(String file, ExtensionContext context) {
+        Preconditions.notBlank(file, "Classpath resource [" + file + "] must not be null or blank");
         try {
-            return FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+            Class<?> testClass = context.getRequiredTestClass();
+            return FileUtils.readFileToString(new File(testClass.getResource(file).getFile()), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private File openInputStream(ExtensionContext context, String resource) {
-        Preconditions.notBlank(resource, "Classpath resource [" + resource + "] must not be null or blank");
-        Class<?> testClass = context.getRequiredTestClass();
-        return Preconditions.notNull(inputStreamProvider.apply(testClass, resource),
-                () -> "Classpath resource [" + resource + "] does not exist");
-    }
-
     @Override
-    public void accept(JsonSource jsonSource) {
-        jsonFiles = jsonSource.jsonFiles();
+    public void accept(FileSource fileSource) {
+        jsonFiles = fileSource.files();
     }
 }


### PR DESCRIPTION
- Now git log generates the output in yaml format.
  Yaml generation is done using --pretty option

- Git documentation:
   * [Pretty format - git v1.9.5](https://git-scm.com/docs/pretty-formats/1.9.5)
   * [Pretty format - git v2.24.0](https://git-scm.com/docs/pretty-formats/2.24.0)


The Git log generates the output in the following format. This makes output parsing easy and simple compared to the regex parsing.

```yaml
- !!com.thoughtworks.go.domain.materials.git.GitLog
  commitHash: 9fef97af1cd3a8920fefe5f656cb5795d690ee1b
  authorName: Chris Turner
  authorEmail: cturner@thoughtworks.com
  date: 2009-02-11 17:26:36 -0800
  subject: |-
    Added remote file
  rawBody: |-
    Added remote file

  additionalInfo:
    signed: N
    signerName:
    signingKey:
    signingMessage:
    committerName: Chris Turner
    committerEmail: cturner@thoughtworks.com
    commitDate: 2009-02-11 17:26:36 -0800

- !!com.thoughtworks.go.domain.materials.git.GitLog
  commitHash: ewehsjf232349fef97af1cd3a8920fefe5f656cb57
  authorName: Bob Ford
  authorEmail: bford@thoughtworks.com
  date: 2009-02-11 17:26:36 -0800
  subject: |-
    Initial commit
  rawBody: |-
    Initial commit

      - Added remote file
      - Added .gitignore

  additionalInfo:
    signed: N
    signerName:
    signingKey:
    signingMessage:
    committerName: Chris Turner
    committerEmail: cturner@thoughtworks.com
    commitDate: 2009-02-11 17:26:36 -0800
```

`rawBody: |-`:  Where `|` is a `Block Style Indicator` and allows multiple lines and also preserves new line literal and `-` means no newline at end (strip)