### PR TITLE
Moving comment api for pipeline instance to spark

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/NotImplementedException.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/NotImplementedException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public class NotImplementedException extends HttpException {
+    public NotImplementedException(String message) {
+        super(HttpStatus.NOT_IMPLEMENTED, message);
+    }
+}

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/pipelines_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/pipelines_controller.rb
@@ -32,13 +32,11 @@ class PipelinesController < ApplicationController
   end
 
   def update_comment
-    result = HttpLocalizedOperationResult.new
-
-    pipeline_history_service.updateComment(params[:pipeline_name], params[:pipeline_counter].to_i, params[:comment], current_user, result)
-    if result.isSuccessful()
-      render json: { status: 'success' }
-    else
-      render_localized_operation_result(result)
+    begin
+      pipeline_history_service.updateComment(params[:pipeline_name], params[:pipeline_counter].to_i, params[:comment], current_user)
+      render json: {status: 'success'}
+    rescue com.thoughtworks.go.config.exceptions.HttpException => e
+      render_message(e.message, e.status.value)
     end
   end
 

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/pipelines_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/pipelines_controller_spec.rb
@@ -98,30 +98,28 @@ describe PipelinesController do
   describe 'update_comment' do
     context 'when the update is successful' do
       it 'updates the comment using the pipeline history service' do
-        expect(@pipeline_history_service).to receive(:updateComment).with('pipeline_name', 1, 'test comment', current_user, @localized_result)
+        expect(@pipeline_history_service).to receive(:updateComment).with('pipeline_name', 1, 'test comment', current_user)
 
         post :update_comment, params:{pipeline_name: 'pipeline_name', pipeline_counter: 1, comment: 'test comment', format: :json}
       end
 
       it 'renders success json' do
-        allow(@pipeline_history_service).to receive(:updateComment).with('pipeline_name', 1, 'test comment', current_user, @localized_result)
+        allow(@pipeline_history_service).to receive(:updateComment).with('pipeline_name', 1, 'test comment', current_user)
 
         post :update_comment, params:{pipeline_name: 'pipeline_name', pipeline_counter: 1, comment: 'test comment', format: :json}
 
-        expect(JSON.load(response.body)).to eq({'status' => 'success'})
+        expect(JSON.load(response.body)).to eq({"status" => 'success'})
       end
     end
 
-    context 'when the update is unauthorized' do
-      it 'it returns 403' do
-        allow(@pipeline_history_service).to receive(:updateComment).with('pipeline_name', 1, 'test comment', current_user, @localized_result) do |_, _, _, _, result|
-          result.forbidden('some message', nil)
-        end
-
-        post :update_comment, params:{pipeline_name: 'pipeline_name', pipeline_counter: 1, comment: 'test comment', format: :json}
-        assert_response(403)
+    it 'should render http exceptions as message' do
+      allow(@pipeline_history_service).to receive(:updateComment).with('pipeline_name', 1, 'test comment', current_user) do |_, _, _, _, result|
+        raise com.thoughtworks.go.config.exceptions.RecordNotFoundException.new("Boom!!")
       end
 
+      post :update_comment, params:{pipeline_name: 'pipeline_name', pipeline_counter: 1, comment: 'test comment', format: :json}
+      assert_response(404)
+      expect(JSON.load(response.body)).to eq({"message" => 'Boom!!'})
     end
   end
 end

--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -136,6 +136,13 @@
   </rule>
 
   <rule>
+    <name>Pipeline Instance comment API</name>
+    <condition name="Accept">application\/vnd\.go\.cd(.v*)*\+json</condition>
+    <from>^/api/pipelines/([^/]+)/instance/([^/]+)/comment$</from>
+    <to last="true">/spark/api/pipelines/${escape:$1}/instance/${escape:$2}/comment</to>
+  </rule>
+
+  <rule>
     <name>Feature Toggles Index API</name>
     <from>^/api/admin/feature_toggles(/?)$</from>
     <to last="true">/spark/api/admin/feature_toggles</to>

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineHistoryServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineHistoryServiceIntegrationTest.java
@@ -895,41 +895,6 @@ public class PipelineHistoryServiceIntegrationTest {
     }
 
     @Test
-    public void updateComment_shouldUpdateTheCommentInTheDatabase() throws Exception {
-        PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline_name", "stage", "job");
-        goConfigService.addPipeline(pipelineConfig, "pipeline-group");
-        configHelper.addAuthorizedUserForPipelineGroup("valid-user");
-        configHelper.setAdminPermissionForGroup("pipeline-group", "valid-user");
-
-        dbHelper.newPipelineWithAllStagesPassed(pipelineConfig);
-        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        pipelineHistoryService.updateComment("pipeline_name", 1, "test comment", new Username(new CaseInsensitiveString("valid-user")), result);
-
-        PipelineInstanceModel pim = dbHelper.getPipelineDao().findPipelineHistoryByNameAndCounter("pipeline_name", 1);
-        assertThat(pim.getComment(), is("test comment"));
-    }
-
-    @Test
-    public void updateComment_shouldNotUpdateTheCommentInTheDatabaseIfTheUserIsUnauthorized() throws Exception {
-        PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline_name", "stage", "job");
-        goConfigService.addPipeline(pipelineConfig, "pipeline-group");
-        configHelper.addAuthorizedUserForPipelineGroup("valid-user");
-
-        dbHelper.newPipelineWithAllStagesPassed(pipelineConfig);
-
-        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-
-        pipelineHistoryService.updateComment("pipeline_name", 1, "test comment",
-                new Username(new CaseInsensitiveString("invalid-user")), result);
-
-        PipelineInstanceModel pim = dbHelper.getPipelineDao().findPipelineHistoryByNameAndCounter("pipeline_name", 1);
-
-        assertThat(pim.getComment(), is(nullValue()));
-        assertThat(result.httpCode(), is(403));
-        assertThat(result.message(), is("You do not have operate permissions for pipeline 'pipeline_name'."));
-    }
-
-    @Test
     public void shouldReturnTheLatestAndOldestPipelineRunId() {
         Pipeline pipeline1 = pipelineTwo.createdPipelineWithAllStagesPassed();
         Pipeline pipeline2 = pipelineTwo.createdPipelineWithAllStagesPassed();

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -298,6 +298,7 @@ public class Routes {
         public static final String BASE = "/api/pipelines";
         public static final String INSTANCE_PATH = "/:pipeline_name/instance/:pipeline_counter";
         public static final String HISTORY_PATH = "/:pipeline_name/history";
+        public static final String COMMENT_PATH = "/:pipeline_name/instance/:pipeline_counter/comment";
 
 
         public static String instance(String pipelineName, int pipelineCounter) {


### PR DESCRIPTION
## Update comment

```bash
curl "http://localhost:8153/go/api/pipelines/spaceship/instance/1/comment" \
	-u 'admin:badger' \
	-H 'Accept: application/vnd.go.cd.v1+json' \
	-H 'Content-Type: application/json' \
	-X POST -d '{ "comment": "Failed bacause of flaky tests"}'

//output
{
  "message" : "Comment successfully updated."
}
```

## Non-integer pipeline counter

```bash
curl "http://localhost:8153/go/api/pipelines/spaceship/instance/one/comment" \
	-u 'admin:badger' \
	-H 'Accept: application/vnd.go.cd.v1+json' \
	-H 'Content-Type: application/json' \
	-X POST -d '{ "comment": "Failed bacause of flaky tests"}'

//output
{"message": "Your request could not be processed. The pipeline counter should be an integer."}
```

## Non-existing pipeline run

```bash
curl "http://localhost:8153/go/api/pipelines/spaceship/instance/9999/comment" \
	-u 'admin:badger' \
	-H 'Accept: application/vnd.go.cd.v1+json' \
	-H 'Content-Type: application/json' \
	-X POST -d '{ "comment": "Failed bacause of flaky tests"}'

//output
{"message":"Pipeline instance for 'spaceship' with counter '9999' were not found!"}
```

##  When the feature is turned off

```bash
curl "http://localhost:8153/go/api/pipelines/spaceship/instance/9999/comment" \
	-u 'admin:badger' \
	-H 'Accept: application/vnd.go.cd.v1+json' \
	-H 'Content-Type: application/json' \
	-X POST -d '{ "comment": "Failed bacause of flaky tests"}'

//output
{"message":"'Pipeline Comment' feature is turned off. Please turn it on to use it."}
```