### PR TITLE
Package Material should generate valid material name when one not specified (#7345)

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/config/materials/PackageMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/PackageMaterial.java
@@ -148,7 +148,7 @@ public class PackageMaterial extends AbstractMaterial {
     @Override
     public CaseInsensitiveString getName() {
         if (((name == null) || isEmpty(name.toString())) && packageDefinition != null) {
-            return new CaseInsensitiveString(getPackageDefinition().getRepository().getName() + ":" + packageDefinition.getName());
+            return new CaseInsensitiveString(getPackageDefinition().getRepository().getName() + "_" + packageDefinition.getName());
         } else {
             return name;
         }

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/PackageMaterialTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/PackageMaterialTest.java
@@ -104,7 +104,7 @@ public class PackageMaterialTest {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo-name", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "package-name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
-        assertThat(material.getDescription(), is("repo-name:package-name"));
+        assertThat(material.getDescription(), is("repo-name_package-name"));
     }
 
     @Test
@@ -112,7 +112,7 @@ public class PackageMaterialTest {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo-name", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "package-name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
-        assertThat(material.getDisplayName(), is("repo-name:package-name"));
+        assertThat(material.getDisplayName(), is("repo-name_package-name"));
     }
 
     @Test
@@ -168,7 +168,7 @@ public class PackageMaterialTest {
         material.toJson(jsonMap, new PackageMaterialRevision("rev123", new Date()));
 
         assertThat(jsonMap.get("scmType"), is("Package"));
-        assertThat(jsonMap.get("materialName"), is("repo-name:package-name"));
+        assertThat(jsonMap.get("materialName"), is("repo-name_package-name"));
         assertThat(jsonMap.get("action"), is("Modified"));
         assertThat(jsonMap.get("location"), is(material.getUriForDisplay()));
     }
@@ -183,7 +183,7 @@ public class PackageMaterialTest {
         Date date = new Date(1367472329111L);
         material.emailContent(content, new Modification(null, null, null, date, "rev123"));
 
-        assertThat(content.toString(), is(String.format("Package : repo-name:package-name\nrevision: rev123, completed on %s", date.toString())));
+        assertThat(content.toString(), is(String.format("Package : repo-name_package-name\nrevision: rev123, completed on %s", date.toString())));
     }
 
     @Test
@@ -212,7 +212,7 @@ public class PackageMaterialTest {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo-name", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "package-name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
-        assertThat(material.getName().toString(), is("repo-name:package-name"));
+        assertThat(material.getName().toString(), is("repo-name_package-name"));
     }
 
     @Test

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/shared/_build_cause_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/shared/_build_cause_html_spec.rb
@@ -183,7 +183,7 @@ describe "/shared/_build_cause.html.erb" do
     render :partial => "shared/build_cause", :locals => {:scope => {:material_revisions => revisions, :show_files => false, :pipeline_name => "foo"}}
 
     Capybara.string(response.body).find(".build_cause #material_#{package_material.getPipelineUniqueFingerprint()}").tap do |material|
-      expect(material).to have_selector(".material_name", :text => "Package - repo-name:package-name")
+      expect(material).to have_selector(".material_name", :text => "Package - repo-name_package-name")
       material.find(".change").tap do |change|
         change.find(".modified_by").tap do |revision|
           expect(revision).to have_selector("dd", :text => "user on #{@date.iso8601}")

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/shared/_build_cause_popup_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/shared/_build_cause_popup_html_spec.rb
@@ -143,7 +143,7 @@ describe "/shared/_build_cause_popup.html.erb" do
 
   describe "package_materials" do
     before do
-      @package_material_name = "repo-name:package-name"
+      @package_material_name = "repo-name_package-name"
       @package_material_id = "material_#{PIPELINE_NAME}_#{REVISION_NUMBER}_#{@package_material_name}"
     end
 


### PR DESCRIPTION
* Use 'repo_package' instead of 'repo:package'

Issue: #7345

Description:

With the above changes, the export pipeline generates the following valid materials configurations:
```yaml
materials:
    npmjs_express:
    package: 738552a3-dec4-4123-8563-73a0b4c1a3fa
```

