### PR TITLE
Pipeline tracking tool fix

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
@@ -790,7 +790,9 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
         if (attributeMap.containsKey(LOCK_BEHAVIOR)) {
             setLockBehaviorIfNecessary((String) attributeMap.get(LOCK_BEHAVIOR));
         }
-        setIntegrationType(attributeMap);
+        if (attributeMap.containsKey(TRACKING_TOOL)) {
+            setIntegrationType(attributeMap);
+        }
 
         if (attributeMap.containsKey(CONFIGURATION_TYPE)) {
             setConfigurationType(attributeMap);

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigTest.java
@@ -405,6 +405,21 @@ public class PipelineConfigTest {
     }
 
     @Test
+    public void shouldNotResetTrackingToolWhenNotSpecifiedInConfigAttributes() {
+        PipelineConfig pipelineConfig = new PipelineConfig();
+        TrackingTool trackingTool = new TrackingTool("link", "regex");
+        pipelineConfig.setTrackingTool(trackingTool);
+
+        Map configMap = new HashMap();
+        configMap.put(PipelineConfig.LABEL_TEMPLATE, "LABEL123-${COUNT}");
+
+        pipelineConfig.setConfigAttributes(configMap);
+
+        assertThat(pipelineConfig.getLabelTemplate(), is("LABEL123-${COUNT}"));
+        assertThat(pipelineConfig.getTrackingTool(), is(trackingTool));
+    }
+
+    @Test
     public void isNotLockableWhenLockValueHasNotBeenSet() {
         PipelineConfig pipelineConfig = new PipelineConfig();
 
@@ -508,17 +523,6 @@ public class PipelineConfigTest {
 
         pipelineConfig.setConfigAttributes(map);
         assertThat(pipelineConfig.getTrackingTool(), is(new TrackingTool("GoleyLink", "GoleyRegex")));
-    }
-
-    @Test
-    public void shouldResetTrackingToolWhenTrackingToolIsNone() {
-        PipelineConfig pipelineConfig = new PipelineConfig();
-        pipelineConfig.setTrackingTool(new TrackingTool("link", "regex"));
-
-        Map map = new HashMap();
-
-        pipelineConfig.setConfigAttributes(map);
-        assertThat(pipelineConfig.getTrackingTool(), is(nullValue()));
     }
 
     @Test

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
@@ -181,6 +181,7 @@ module Admin
     def save_tab(error_rendering_options_or_proc)
       if Toggles.isToggleOff(Toggles.FAST_PIPELINE_SAVE)
         save_tab_old(error_rendering_options_or_proc)
+        return
       end
       pipeline_name = params[:pipeline_name]
       @original_params = Struct.new(:params).new


### PR DESCRIPTION
Issue: #7373

Description: Set the tracking tool information only when receiving it from the client.
Verified that we can still remove the tracking tool info from the UI.

This changes some behaviour that has been around for >6 years. What could possibly go wrong?

