### PR TITLE
Support for edit action on Policy

### DIFF
--- a/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/ApiAuthenticationHelperTest.java
+++ b/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/ApiAuthenticationHelperTest.java
@@ -109,6 +109,73 @@ class ApiAuthenticationHelperTest {
 
         @Test
         /*
+        <role name="allow-all-environments">
+            <policy>
+                <allow action="edit" type="environment">*</allow>
+            </policy>
+            <users>
+                <user>Bob</user>
+            </users>
+        </role>
+        */
+        void shouldAllowNormalUserWithEditEnvironmentPolicyToViewEnvironments() {
+            Policy directives = new Policy();
+            directives.add(new Allow("edit", "environment", "*"));
+            RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("read-only-environments"), new Users(), directives);
+
+            when(goConfigService.rolesForUser(BOB.getUsername())).thenReturn(Arrays.asList(roleConfig));
+
+            assertDoesNotThrow(() -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, null));
+            assertDoesNotThrow(() -> helper.checkUserHasPermissions(BOB, SupportedAction.VIEW, SupportedEntity.ENVIRONMENT, "foo"));
+        }
+
+
+        @Test
+        /*
+        <role name="allow-all-environments">
+            <policy>
+                <allow action="edit" type="environment">*</allow>
+            </policy>
+            <users>
+                <user>Bob</user>
+            </users>
+        </role>
+        */
+        void shouldAllowNormalUserWithEditEnvironmentPolicyToEditEnvironments() {
+            Policy directives = new Policy();
+            directives.add(new Allow("edit", "environment", "*"));
+            RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("read-only-environments"), new Users(), directives);
+
+            when(goConfigService.rolesForUser(BOB.getUsername())).thenReturn(Arrays.asList(roleConfig));
+
+            assertDoesNotThrow(() -> helper.checkUserHasPermissions(BOB, SupportedAction.EDIT, SupportedEntity.ENVIRONMENT, null));
+            assertDoesNotThrow(() -> helper.checkUserHasPermissions(BOB, SupportedAction.EDIT, SupportedEntity.ENVIRONMENT, "foo"));
+        }
+
+        @Test
+        /*
+        <role name="allow-all-environments">
+            <policy>
+                <allow action="edit" type="environment">*</allow>
+            </policy>
+            <users>
+                <user>Bob</user>
+            </users>
+        </role>
+        */
+        void shouldNotAllowNormalUserWithEditEnvironmentPolicyToAdministerEnvironments() {
+            Policy directives = new Policy();
+            directives.add(new Allow("edit", "environment", "*"));
+            RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("read-only-environments"), new Users(), directives);
+
+            when(goConfigService.rolesForUser(BOB.getUsername())).thenReturn(Arrays.asList(roleConfig));
+
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, null));
+            assertThrows(HaltException.class, () -> helper.checkUserHasPermissions(BOB, SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, "foo"));
+        }
+
+        @Test
+        /*
         <role name="allow-one-environments">
             <policy>
                 <allow action="view" type="environment">env_1</allow>

--- a/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2.java
+++ b/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2.java
@@ -44,7 +44,6 @@ import spark.Response;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.thoughtworks.go.config.policy.SupportedEntity.CONFIG_REPO;
@@ -87,7 +86,7 @@ public class ConfigReposInternalControllerV2 extends ApiController implements Sp
 
             before(ConfigRepos.REPO_PATH, mimeType, this::authorize);
             before(ConfigRepos.STATUS_PATH, mimeType, this::authorize);
-            before(ConfigRepos.TRIGGER_UPDATE_PATH, mimeType, this::authorize);
+            before(ConfigRepos.TRIGGER_UPDATE_PATH, mimeType, this::authorizeForUpdate);
             before(ConfigRepos.DEFINITIONS_PATH, mimeType, this::authorize);
 
             get(ConfigRepos.INDEX_PATH, mimeType, this::listRepos);
@@ -102,6 +101,10 @@ public class ConfigReposInternalControllerV2 extends ApiController implements Sp
         authHelper.checkUserHasPermissions(currentUsername(), getAction(request), CONFIG_REPO, request.params(":id"));
     }
 
+    private void authorizeForUpdate(Request request, Response response) {
+        authHelper.checkUserHasPermissions(currentUsername(), SupportedAction.EDIT, CONFIG_REPO, request.params(":id"));
+    }
+
     String listRepos(Request req, Response res) throws IOException {
         List<ConfigRepoWithResult> userSpecificRepos = allRepos().stream()
                 .filter(repo -> authHelper.doesUserHasPermissions(currentUsername(), getAction(req), CONFIG_REPO, repo.repo().getId()))
@@ -114,8 +117,8 @@ public class ConfigReposInternalControllerV2 extends ApiController implements Sp
         if (fresh(req, etag)) {
             return notModified(res);
         }
-        Function<String, Boolean> canUserAdministerConfigRepo = repoId -> authHelper.doesUserHasPermissions(currentUsername(), SupportedAction.ADMINISTER, CONFIG_REPO, repoId);
-        return writerForTopLevelObject(req, res, w -> ConfigRepoWithResultListRepresenter.toJSON(w, userSpecificRepos, canUserAdministerConfigRepo));
+
+        return writerForTopLevelObject(req, res, w -> ConfigRepoWithResultListRepresenter.toJSON(w, userSpecificRepos, authHelper));
     }
 
     String showRepo(Request req, Response res) throws IOException {
@@ -129,8 +132,7 @@ public class ConfigReposInternalControllerV2 extends ApiController implements Sp
             return notModified(res);
         }
 
-        boolean canAdminister = authHelper.doesUserHasPermissions(currentUsername(), SupportedAction.ADMINISTER, CONFIG_REPO, repo.repo().getId());
-        return writerForTopLevelObject(req, res, w -> ConfigRepoWithResultRepresenter.toJSON(w, repo, canAdminister));
+        return writerForTopLevelObject(req, res, w -> ConfigRepoWithResultRepresenter.toJSON(w, repo, authHelper));
     }
 
     String triggerUpdate(Request req, Response res) {

--- a/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultListRepresenter.java
+++ b/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultListRepresenter.java
@@ -17,23 +17,20 @@
 package com.thoughtworks.go.apiv2.configrepos.representers;
 
 import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv2.configrepos.ConfigRepoWithResult;
 
 import java.util.List;
-import java.util.function.Function;
 
 import static com.thoughtworks.go.spark.Routes.ConfigRepos.BASE;
 
 public class ConfigRepoWithResultListRepresenter {
-    public static void toJSON(OutputWriter json, List<ConfigRepoWithResult> repos, Function<String, Boolean> canUserAdministerConfigRepo) {
+    public static void toJSON(OutputWriter json, List<ConfigRepoWithResult> repos, ApiAuthenticationHelper apiAuthenticationHelper) {
         attachLinks(json);
         json.addChild("_embedded", w -> w.addChildList(
                 "config_repos", all -> repos.forEach(
                         repo -> {
-                            boolean canAdminister = canUserAdministerConfigRepo.apply(repo.repo().getId());
-                            all.addChild(
-                                    el -> ConfigRepoWithResultRepresenter.toJSON(el, repo, canAdminister)
-                            );
+                            all.addChild(el -> ConfigRepoWithResultRepresenter.toJSON(el, repo, apiAuthenticationHelper));
                         }
                 )
         ));

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposControllerV2Test.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposControllerV2Test.groovy
@@ -507,7 +507,7 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
       assertThatResponse().
         isForbidden().
-        hasJsonMessage("User '${currentUsername().getDisplayName()}' does not have permissions to administer 'test-id' config_repo(s).")
+        hasJsonMessage("User '${currentUsername().getDisplayName()}' does not have permissions to edit 'test-id' config_repo(s).")
     }
   }
 

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2Test.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2Test.groovy
@@ -141,16 +141,16 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
       assertThatResponse()
         .isOk()
         .hasJsonBody([
-          _links   : [
-            self: [href: "http://test.host/go$Routes.ConfigRepos.BASE".toString()]
-          ],
-          _embedded: [
-            config_repos: [
-              expectedRepoJson(ID_1, null, null, false),
-              expectedRepoJson(ID_2, "abc", null, false)
-            ]
+        _links   : [
+          self: [href: "http://test.host/go$Routes.ConfigRepos.BASE".toString()]
+        ],
+        _embedded: [
+          config_repos: [
+            expectedRepoJson(ID_1, null, null, false),
+            expectedRepoJson(ID_2, "abc", null, false)
           ]
-        ])
+        ]
+      ])
     }
 
     @Test
@@ -164,13 +164,13 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
         .isOk()
         .hasEtag("\"${new ConfigReposConfig().etag()}\"")
         .hasJsonBody([
-          _links   : [
-            self: [href: "http://test.host/go$Routes.ConfigRepos.BASE".toString()]
-          ],
-          _embedded: [
-            config_repos: []
-          ]
-        ])
+        _links   : [
+          self: [href: "http://test.host/go$Routes.ConfigRepos.BASE".toString()]
+        ],
+        _embedded: [
+          config_repos: []
+        ]
+      ])
     }
   }
 
@@ -238,7 +238,10 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
         ]
       ],
       configuration              : [],
-      can_administer             : true,
+      permissions                : [
+        can_edit      : true,
+        can_administer: true
+      ],
       material_update_in_progress: isInProgress,
       parse_info                 : null == revision ? [:] : [
         error                     : error,
@@ -475,7 +478,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
 
         assertThatResponse()
           .isForbidden()
-          .hasJsonMessage("User '${currentUsername().getDisplayName()}' does not have permissions to administer 'test-id' config_repo(s).")
+          .hasJsonMessage("User '${currentUsername().getDisplayName()}' does not have permissions to edit 'test-id' config_repo(s).")
       }
     }
   }

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultListRepresenterTest.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultListRepresenterTest.groovy
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.apiv2.configrepos.representers
 
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.apiv2.configrepos.ConfigRepoWithResult
 import com.thoughtworks.go.config.PartialConfigParseResult
 import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig
@@ -23,24 +24,32 @@ import com.thoughtworks.go.config.remote.ConfigRepoConfig
 import com.thoughtworks.go.config.remote.PartialConfig
 import com.thoughtworks.go.domain.materials.Modification
 import com.thoughtworks.go.spark.Routes
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-
-import java.util.function.Function
+import org.mockito.Mock
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.helper.MaterialConfigsMother.hg
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+import static org.mockito.MockitoAnnotations.initMocks
 
 class ConfigRepoWithResultListRepresenterTest {
+  @Mock
+  ApiAuthenticationHelper authenticationHelper
+
+  @BeforeEach
+  void setUp() {
+    initMocks(this)
+  }
+
   private static final String TEST_PLUGIN_ID = "test.configrepo.plugin"
   private static final String TEST_REPO_URL = "https://fakeurl.com"
 
   @Test
   void toJSON() {
     List<ConfigRepoWithResult> repos = [repo("foo"), repo("bar")]
-    Function<String, Boolean> canUserAdministerConfigRepo = { name -> true }
 
-    String json = toObjectString({ w -> ConfigRepoWithResultListRepresenter.toJSON(w, repos, canUserAdministerConfigRepo) })
+    String json = toObjectString({ w -> ConfigRepoWithResultListRepresenter.toJSON(w, repos, authenticationHelper) })
 
     assertThatJson(json).isEqualTo([
       _links   : [
@@ -73,7 +82,10 @@ class ConfigRepoWithResultListRepresenterTest {
           auto_update: true
         ]
       ],
-      can_administer             : true,
+      permissions                : [
+        can_edit      : false,
+        can_administer: false
+      ],
       configuration              : [],
       material_update_in_progress: false,
       parse_info                 : [

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultRepresenterTest.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultRepresenterTest.groovy
@@ -16,22 +16,34 @@
 
 package com.thoughtworks.go.apiv2.configrepos.representers
 
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.apiv2.configrepos.ConfigRepoWithResult
 import com.thoughtworks.go.config.PartialConfigParseResult
 import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig
-import static com.thoughtworks.go.helper.MaterialConfigsMother.hg
 import com.thoughtworks.go.config.remote.ConfigRepoConfig
 import com.thoughtworks.go.domain.config.Configuration
 import com.thoughtworks.go.domain.materials.Modification
 import com.thoughtworks.go.helper.ModificationsMother
 import com.thoughtworks.go.spark.Routes
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.Mock
 
 import static com.thoughtworks.go.api.base.JsonOutputWriter.jsonDate
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static com.thoughtworks.go.helper.MaterialConfigsMother.hg
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+import static org.mockito.MockitoAnnotations.initMocks
 
 class ConfigRepoWithResultRepresenterTest {
+  @Mock
+  ApiAuthenticationHelper authenticationHelper
+
+  @BeforeEach
+  void setUp() {
+    initMocks(this)
+  }
+
   private static final String TEST_PLUGIN_ID = "test.configrepo.plugin"
   private static final String TEST_REPO_URL = "https://fakeurl.com"
 
@@ -41,7 +53,7 @@ class ConfigRepoWithResultRepresenterTest {
     ConfigRepoWithResult result = repo(id)
 
     String json = toObjectString({ w ->
-      ConfigRepoWithResultRepresenter.toJSON(w, result, true)
+      ConfigRepoWithResultRepresenter.toJSON(w, result, authenticationHelper)
     })
 
     String self = "http://test.host/go${Routes.ConfigRepos.id(id)}"
@@ -64,7 +76,10 @@ class ConfigRepoWithResultRepresenterTest {
           auto_update: true
         ]
       ],
-      can_administer: true,
+      permissions                : [
+        can_edit      : false,
+        can_administer: false
+      ],
       configuration              : [
         [key: "foo", value: "bar"],
         [key: "baz", value: "quu"]

--- a/api/api-internal-environments-v1/src/main/java/com/thoughtworks/go/apiv1/internalenvironments/InternalEnvironmentsControllerV1.java
+++ b/api/api-internal-environments-v1/src/main/java/com/thoughtworks/go/apiv1/internalenvironments/InternalEnvironmentsControllerV1.java
@@ -25,7 +25,6 @@ import com.thoughtworks.go.api.util.GsonTransformer;
 import com.thoughtworks.go.apiv1.internalenvironments.representers.MergedEnvironmentsRepresenter;
 import com.thoughtworks.go.config.EnvironmentConfig;
 import com.thoughtworks.go.config.exceptions.EntityType;
-import com.thoughtworks.go.config.policy.SupportedAction;
 import com.thoughtworks.go.config.policy.SupportedEntity;
 import com.thoughtworks.go.server.service.AgentService;
 import com.thoughtworks.go.server.service.EnvironmentConfigService;
@@ -40,7 +39,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
 
 import static spark.Spark.*;
 
@@ -76,7 +74,7 @@ public class InternalEnvironmentsControllerV1 extends ApiController implements S
                 if (request.requestMethod().equalsIgnoreCase("GET")) {
                     apiAuthenticationHelper.checkUserAnd403(request, response);
                 } else {    // this is a PATCH request to update agent association
-                    apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, request.params("env_name"));
+                    apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.ENVIRONMENT, request.params("env_name"));
                 }
             });
 
@@ -98,8 +96,7 @@ public class InternalEnvironmentsControllerV1 extends ApiController implements S
             }
         }
 
-        Function<String, Boolean> canUserAdministerEnvironment = envName -> apiAuthenticationHelper.doesUserHasPermissions(currentUsername(), SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, envName);
-        return writerForTopLevelObject(request, response, outputWriter -> MergedEnvironmentsRepresenter.toJSON(outputWriter, userSpecificEnvironments, canUserAdministerEnvironment));
+        return writerForTopLevelObject(request, response, outputWriter -> MergedEnvironmentsRepresenter.toJSON(outputWriter, userSpecificEnvironments, apiAuthenticationHelper));
     }
 
     String updateAgentAssociation(Request request, Response response) {

--- a/api/api-internal-environments-v1/src/main/java/com/thoughtworks/go/apiv1/internalenvironments/representers/MergedEnvironmentRepresenter.java
+++ b/api/api-internal-environments-v1/src/main/java/com/thoughtworks/go/apiv1/internalenvironments/representers/MergedEnvironmentRepresenter.java
@@ -17,18 +17,25 @@
 package com.thoughtworks.go.apiv1.internalenvironments.representers;
 
 import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.config.EnvironmentConfig;
 import com.thoughtworks.go.config.merge.MergeConfigOrigin;
+import com.thoughtworks.go.config.policy.SupportedAction;
+import com.thoughtworks.go.config.policy.SupportedEntity;
 import com.thoughtworks.go.config.remote.ConfigOrigin;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
+
+import static com.thoughtworks.go.server.newsecurity.utils.SessionUtils.currentUsername;
 
 public class MergedEnvironmentRepresenter {
-    public static void toJSON(OutputWriter outputWriter, EnvironmentConfig environmentConfig, Function<String, Boolean> canUserAdministerEnvironment) {
+    public static void toJSON(OutputWriter outputWriter, EnvironmentConfig environmentConfig, ApiAuthenticationHelper apiAuthenticationHelper) {
         outputWriter.add("name", environmentConfig.name());
-        outputWriter.add("can_administer", canUserAdministerEnvironment.apply(environmentConfig.name().toString()));
+        outputWriter.addChild("permissions", permissionsWriter -> {
+            permissionsWriter.add("can_edit", apiAuthenticationHelper.doesUserHasPermissions(currentUsername(), SupportedAction.EDIT, SupportedEntity.ENVIRONMENT, environmentConfig.name().toString()));
+            permissionsWriter.add("can_administer", apiAuthenticationHelper.doesUserHasPermissions(currentUsername(), SupportedAction.ADMINISTER, SupportedEntity.ENVIRONMENT, environmentConfig.name().toString()));
+        });
         addOrigin(outputWriter, environmentConfig.getOrigin());
         outputWriter.addChildList("pipelines", outputListWriter -> {
             environmentConfig.getPipelines().forEach(pipeline -> outputListWriter.addChild(writer -> EnvironmentPipelineRepresenter.toJSON(writer, pipeline, environmentConfig)));

--- a/api/api-internal-environments-v1/src/main/java/com/thoughtworks/go/apiv1/internalenvironments/representers/MergedEnvironmentsRepresenter.java
+++ b/api/api-internal-environments-v1/src/main/java/com/thoughtworks/go/apiv1/internalenvironments/representers/MergedEnvironmentsRepresenter.java
@@ -17,17 +17,17 @@
 package com.thoughtworks.go.apiv1.internalenvironments.representers;
 
 import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.config.EnvironmentConfig;
 
 import java.util.List;
-import java.util.function.Function;
 
 public class MergedEnvironmentsRepresenter {
-    public static void toJSON(OutputWriter outputWriter, List<EnvironmentConfig> allMergedEnvironments, Function<String, Boolean> canUserAdministerEnvironment) {
+    public static void toJSON(OutputWriter outputWriter, List<EnvironmentConfig> allMergedEnvironments, ApiAuthenticationHelper apiAuthenticationHelper) {
         outputWriter.addChild("_embedded", embeddedWriter -> {
             embeddedWriter.addChildList("environments", outputListWriter -> {
                 allMergedEnvironments.forEach(environmentConfig -> {
-                    outputListWriter.addChild(childWriter -> MergedEnvironmentRepresenter.toJSON(childWriter, environmentConfig, canUserAdministerEnvironment));
+                    outputListWriter.addChild(childWriter -> MergedEnvironmentRepresenter.toJSON(childWriter, environmentConfig, apiAuthenticationHelper));
                 });
             });
         });

--- a/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/InternalEnvironmentsControllerV1Test.groovy
+++ b/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/InternalEnvironmentsControllerV1Test.groovy
@@ -55,14 +55,17 @@ class InternalEnvironmentsControllerV1Test implements SecurityServiceTrait, Cont
   @Mock
   private AgentService agentService
 
+  private ApiAuthenticationHelper apiAuthenticationHelper;
+
   @BeforeEach
   void setUp() {
     initMocks(this)
+    apiAuthenticationHelper = new ApiAuthenticationHelper(securityService, goConfigService)
   }
 
   @Override
   InternalEnvironmentsControllerV1 createControllerInstance() {
-    new InternalEnvironmentsControllerV1(new ApiAuthenticationHelper(securityService, goConfigService), environmentConfigService, agentService)
+    new InternalEnvironmentsControllerV1(apiAuthenticationHelper, environmentConfigService, agentService)
   }
 
   @Nested
@@ -150,7 +153,9 @@ class InternalEnvironmentsControllerV1Test implements SecurityServiceTrait, Cont
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJson(toObjectString({ MergedEnvironmentsRepresenter.toJSON(it, [env1, env2], { name -> true }) }))
+          .hasBodyWithJson(toObjectString({
+          MergedEnvironmentsRepresenter.toJSON(it, [env1, env2], apiAuthenticationHelper)
+        }))
       }
 
       @Test
@@ -175,7 +180,9 @@ class InternalEnvironmentsControllerV1Test implements SecurityServiceTrait, Cont
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJson(toObjectString({ MergedEnvironmentsRepresenter.toJSON(it, [env1, env2], { name -> true }) }))
+          .hasBodyWithJson(toObjectString({
+          MergedEnvironmentsRepresenter.toJSON(it, [env1, env2], apiAuthenticationHelper)
+        }))
       }
 
       @Test
@@ -200,7 +207,7 @@ class InternalEnvironmentsControllerV1Test implements SecurityServiceTrait, Cont
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJson(toObjectString({ MergedEnvironmentsRepresenter.toJSON(it, [], { name -> true }) }))
+          .hasBodyWithJson(toObjectString({ MergedEnvironmentsRepresenter.toJSON(it, [], apiAuthenticationHelper) }))
       }
 
       @Test
@@ -217,7 +224,7 @@ class InternalEnvironmentsControllerV1Test implements SecurityServiceTrait, Cont
         assertThatResponse()
           .isOk()
           .hasBodyWithJson(toObjectString({
-          MergedEnvironmentsRepresenter.toJSON(it, [mergeEnvironmentConfig], { name -> true })
+          MergedEnvironmentsRepresenter.toJSON(it, [mergeEnvironmentConfig], apiAuthenticationHelper)
         }))
       }
 
@@ -229,7 +236,7 @@ class InternalEnvironmentsControllerV1Test implements SecurityServiceTrait, Cont
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJson(toObjectString({ MergedEnvironmentsRepresenter.toJSON(it, [], { name -> true }) }))
+          .hasBodyWithJson(toObjectString({ MergedEnvironmentsRepresenter.toJSON(it, [], apiAuthenticationHelper) }))
       }
     }
   }
@@ -340,7 +347,7 @@ class InternalEnvironmentsControllerV1Test implements SecurityServiceTrait, Cont
       }
 
       @Test
-      void 'should throw 403 if the user does not have administer permission on env'() {
+      void 'should throw 403 if the user does not have edit permission on env'() {
         when(goConfigService.rolesForUser(any(CaseInsensitiveString.class))).thenReturn([])
 
         def json = [
@@ -353,7 +360,7 @@ class InternalEnvironmentsControllerV1Test implements SecurityServiceTrait, Cont
 
         assertThatResponse()
           .isForbidden()
-          .hasJsonMessage("User '${currentUsername().displayName}' does not have permissions to administer 'env' environment(s).")
+          .hasJsonMessage("User '${currentUsername().displayName}' does not have permissions to edit 'env' environment(s).")
       }
     }
 

--- a/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/MergedEnvironmentRepresenterTest.groovy
+++ b/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/MergedEnvironmentRepresenterTest.groovy
@@ -16,18 +16,30 @@
 
 package com.thoughtworks.go.apiv1.internalenvironments.representers
 
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.apiv1.internalenvironments.representers.configorigin.ConfigRepoOriginRepresenter
 import com.thoughtworks.go.apiv1.internalenvironments.representers.configorigin.ConfigXmlOriginRepresenter
 import com.thoughtworks.go.config.merge.MergeEnvironmentConfig
 import com.thoughtworks.go.config.remote.RepoConfigOrigin
 import com.thoughtworks.go.helper.EnvironmentConfigMother
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.Mock
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObject
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+import static org.mockito.MockitoAnnotations.initMocks
 
 class MergedEnvironmentRepresenterTest {
+  @Mock
+  ApiAuthenticationHelper apiAuthenticationHelper
+
+  @BeforeEach
+  void setUp() {
+    initMocks(this)
+  }
+
   @Test
   void 'should render merged environment with hal representation'() {
     def environmentName = "env"
@@ -36,7 +48,7 @@ class MergedEnvironmentRepresenterTest {
     def mergeEnvironmentConfig = new MergeEnvironmentConfig(env, remoteEnv)
 
     def actualJson = toObjectString({
-      MergedEnvironmentRepresenter.toJSON(it, mergeEnvironmentConfig, { name -> true })
+      MergedEnvironmentRepresenter.toJSON(it, mergeEnvironmentConfig, apiAuthenticationHelper)
     })
 
     def agentsJSON = mergeEnvironmentConfig.agents.collect { agent ->
@@ -59,7 +71,10 @@ class MergedEnvironmentRepresenterTest {
 
     def expected = [
       "name"                 : environmentName,
-      "can_administer"       : true,
+      "permissions"          : [
+        "can_administer": false,
+        "can_edit"      : false
+      ],
       origins                : [
         toObject({ ConfigXmlOriginRepresenter.toJSON(it, null) }),
         toObject({ ConfigRepoOriginRepresenter.toJSON(it, remoteEnv.getOrigin() as RepoConfigOrigin) })

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Role.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Role.java
@@ -22,14 +22,13 @@ import com.thoughtworks.go.domain.ConfigErrors;
 import java.util.*;
 
 import static com.thoughtworks.go.config.CaseInsensitiveString.isBlank;
-import static com.thoughtworks.go.config.policy.SupportedAction.ADMINISTER;
-import static com.thoughtworks.go.config.policy.SupportedAction.VIEW;
+import static com.thoughtworks.go.config.policy.SupportedAction.*;
 import static com.thoughtworks.go.config.policy.SupportedEntity.CONFIG_REPO;
 import static com.thoughtworks.go.config.policy.SupportedEntity.ENVIRONMENT;
 
 @ConfigInterface
 public interface Role extends Validatable, PolicyAware {
-    List<String> allowedActions = SupportedAction.unmodifiableListOf(VIEW, ADMINISTER);
+    List<String> allowedActions = SupportedAction.unmodifiableListOf(VIEW, EDIT, ADMINISTER);
     List<String> allowedTypes = SupportedEntity.unmodifiableListOf(ENVIRONMENT, CONFIG_REPO);
 
     CaseInsensitiveString getName();

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/AbstractDirective.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/AbstractDirective.java
@@ -86,6 +86,10 @@ public abstract class AbstractDirective implements Directive {
             return true;
         }
 
+        if (equalsIgnoreCase("edit", this.action) && equalsIgnoreCase("view", action)) {
+            return true;
+        }
+
         return equalsIgnoreCase(action, this.action);
     }
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/SupportedAction.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/SupportedAction.java
@@ -24,6 +24,7 @@ import static java.util.Collections.unmodifiableList;
 
 public enum SupportedAction {
     VIEW("view"),
+    EDIT("edit"),
     ADMINISTER("administer"),
     UNKNOWN("unknown");
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/RoleConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/RoleConfigTest.java
@@ -99,12 +99,8 @@ public class RoleConfigTest {
 
     @Test
     void shouldValidatePolicy() {
-        validatePolicyIsInvalid(new Validator() {
-            @Override
-            public void validate(RoleConfig roleConfig, ValidationContext context) {
-                roleConfig.validateTree(context);
-            }
-        });
+        validatePolicyIsInvalid((roleConfig, context) -> roleConfig.validateTree(context));
+        validateEditActionOfAPolicyIsValid((roleConfig, context) -> roleConfig.validateTree(context));
     }
 
     private void validatePresenceOfRoleName(Validator v) {
@@ -153,7 +149,22 @@ public class RoleConfigTest {
         validator.validate(role, validationContext);
 
         assertThat(role.getPolicy().hasErrors()).isTrue();
-        assertThat(role.getPolicy().get(0).errors().on("action")).isEqualTo("Invalid action, must be one of [view, administer].");
+        assertThat(role.getPolicy().get(0).errors().on("action")).isEqualTo("Invalid action, must be one of [view, edit, administer].");
+    }
+
+    @Test
+    private void validateEditActionOfAPolicyIsValid(Validator validator) {
+        SecurityConfig securityConfig = new SecurityConfig();
+        ValidationContext validationContext = ValidationContextMother.validationContext(securityConfig);
+
+        Policy policy = new Policy();
+        policy.add(new Allow("edit", ENVIRONMENT.getType(), "env_1"));
+        RoleConfig role = new RoleConfig(new CaseInsensitiveString("role"), new Users(), policy);
+        securityConfig.getRoles().add(role);
+
+        validator.validate(role, validationContext);
+
+        assertThat(role.getPolicy().hasErrors()).isFalse();
     }
 
     interface Validator {

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/policy/AllowTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/policy/AllowTest.java
@@ -68,6 +68,22 @@ class AllowTest extends AbstractDirectiveTest {
                         .isEqualTo(Result.SKIP);
             }
 
+            @Test
+            void toAdministerConfigIfActionIsEdit() {
+                final Allow allow = new Allow("edit", "environment", "env_1");
+
+                assertThat(allow.apply("administer", EnvironmentConfig.class, "env_1"))
+                        .isEqualTo(Result.SKIP);
+            }
+
+            @Test
+            void toAdministerConfigIfActionIsView() {
+                final Allow allow = new Allow("view", "environment", "env_1");
+
+                assertThat(allow.apply("administer", EnvironmentConfig.class, "env_1"))
+                        .isEqualTo(Result.SKIP);
+            }
+
             @ParameterizedTest
             @ValueSource(strings = {"my_group", "grpoup"})
             void ifResourceDoesNotMatchTheWildCardPatterAndActionAndTypeMatch(String resource) {
@@ -93,6 +109,22 @@ class AllowTest extends AbstractDirectiveTest {
                 final Allow allow = new Allow("administer", "environment", "env_1");
 
                 assertThat(allow.apply("view", EnvironmentConfig.class, "env_1"))
+                        .isEqualTo(Result.ALLOW);
+            }
+
+            @Test
+            void toViewConfigIfActionIsEdit() {
+                final Allow allow = new Allow("edit", "environment", "env_1");
+
+                assertThat(allow.apply("view", EnvironmentConfig.class, "env_1"))
+                        .isEqualTo(Result.ALLOW);
+            }
+
+            @Test
+            void toEditConfigIfActionIsEdit() {
+                final Allow allow = new Allow("edit", "environment", "env_1");
+
+                assertThat(allow.apply("edit", EnvironmentConfig.class, "env_1"))
                         .isEqualTo(Result.ALLOW);
             }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/policy/DenyTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/policy/DenyTest.java
@@ -76,6 +76,23 @@ class DenyTest extends AbstractDirectiveTest {
                         .isEqualTo(Result.SKIP);
             }
 
+
+            @Test
+            void toAdministerConfigIfActionIsEdit() {
+                final Deny deny = new Deny("edit", "environment", "env_1");
+
+                assertThat(deny.apply("administer", EnvironmentConfig.class, "env_1"))
+                        .isEqualTo(Result.SKIP);
+            }
+
+            @Test
+            void toAdministerConfigIfActionIsView() {
+                final Deny deny = new Deny("view", "environment", "env_1");
+
+                assertThat(deny.apply("administer", EnvironmentConfig.class, "env_1"))
+                        .isEqualTo(Result.SKIP);
+            }
+
             @ParameterizedTest
             @ValueSource(strings = {"my_group", "grpoup"})
             void ifResourceDoesNotMatchTheWildCardPatterAndActionAndTypeMatch(String resource) {
@@ -93,6 +110,22 @@ class DenyTest extends AbstractDirectiveTest {
                 final Deny deny = new Deny("view", "environment", "env_1");
 
                 assertThat(deny.apply("view", EnvironmentConfig.class, "env_1"))
+                        .isEqualTo(Result.DENY);
+            }
+
+            @Test
+            void toViewConfigIfActionIsEdit() {
+                final Deny deny = new Deny("edit", "environment", "env_1");
+
+                assertThat(deny.apply("view", EnvironmentConfig.class, "env_1"))
+                        .isEqualTo(Result.DENY);
+            }
+
+            @Test
+            void toEditConfigIfActionIsEdit() {
+                final Deny deny = new Deny("edit", "environment", "env_1");
+
+                assertThat(deny.apply("edit", EnvironmentConfig.class, "env_1"))
                         .isEqualTo(Result.DENY);
             }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/serialization.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/serialization.ts
@@ -24,11 +24,16 @@ export interface EmbeddedJSON {
   config_repos: ConfigRepoJSON[];
 }
 
+export interface PermissionsJSON {
+  can_edit: boolean;
+  can_administer: boolean;
+}
+
 export interface ConfigRepoJSON {
   id: string;
   plugin_id: string;
   material: MaterialJSON;
-  can_administer: boolean;
+  permissions: PermissionsJSON;
   configuration: any[];
   parse_info: ParseInfoJSON;
   errors?: ErrorsJSON;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/spec/config_repos_crud_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/spec/config_repos_crud_spec.ts
@@ -15,6 +15,7 @@
  */
 import {configRepoToSnakeCaseJSON} from "models/config_repos/config_repos_crud";
 import {ConfigRepo} from "models/config_repos/types";
+import {Permissions} from "models/config_repos/types";
 import {GitMaterialAttributes, Material} from "models/materials/types";
 import {Configuration, PlainTextValue} from "models/shared/plugin_infos_new/plugin_settings/plugin_settings";
 
@@ -28,7 +29,7 @@ describe("Config Repo Serialization", () => {
                                                        new GitMaterialAttributes("test",
                                                                                  false,
                                                                                  "https://example.com")),
-                                          false,
+                                          new Permissions(false, false),
                                           [configuration1, configuration2]);
     const json           = configRepoToSnakeCaseJSON(configRepo);
     expect(json.configuration)
@@ -43,7 +44,7 @@ describe("Config Repo Serialization", () => {
                                                        new GitMaterialAttributes("test",
                                                                                  false,
                                                                                  "https://example.com")),
-                                          false,
+                                          new Permissions(false, false),
                                           [configuration1]);
     const json           = configRepoToSnakeCaseJSON(configRepo);
     expect(json.configuration).toEqual([{key: "file_pattern", value: "test-value-1"}]);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/spec/types_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/spec/types_spec.ts
@@ -15,7 +15,7 @@
  */
 import {
   ConfigRepo,
-  MaterialModification, ParseInfo,
+  MaterialModification, ParseInfo, Permissions,
 } from "models/config_repos/types";
 
 import {
@@ -126,7 +126,7 @@ describe("Config Repo Types", () => {
         const latestModification = new MaterialModification("jrDev", "jrDev@github.com", "4926940143a238fefb7566141ba24a96", "My first commit", "19:30");
         const lastParse = new ParseInfo(latestModification, goodModification, null);
 
-        return new ConfigRepo("All_Test_Pipelines", "PluginId", material, false, [], lastParse);
+        return new ConfigRepo("All_Test_Pipelines", "PluginId", material, new Permissions(false, false), [], lastParse);
       }
     });
   });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/environments.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/environments.ts
@@ -113,7 +113,7 @@ export class EnvironmentWithOrigin extends ValidatableMixin {
       origins.push(new Origin(OriginType.GoCD));
     }
     return new EnvironmentWithOrigin(data.name,
-                                     Permissions.fromJSON(data.permissions),
+                                     data.permissions ? Permissions.fromJSON(data.permissions) : new Permissions(false, false),
                                      origins,
                                      Agents.fromJSON(data.agents),
                                      Pipelines.fromJSON(data.pipelines),
@@ -161,7 +161,7 @@ export class EnvironmentWithOrigin extends ValidatableMixin {
 
   clone(): EnvironmentWithOrigin {
     return new EnvironmentWithOrigin(this.name(),
-                                     new Permissions(true, true),
+                                     new Permissions(false, false),
                                      this.origins().map((origin) => origin.clone()),
                                      this.agents().map((agent) => agent.clone()),
                                      this.pipelines().clone(),

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/spec/test_data.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/spec/test_data.ts
@@ -100,8 +100,11 @@ export default {
   agent_association_in_config_repo_json: agentAssociationInConfigRepoJson,
   environment_json: (): EnvironmentJSON => ({
     name: `environment-name-${randomString()}`,
-    can_administer: true,
     origins: [originData.file_origin(), originData.config_repo_origin()],
+    permissions: {
+      can_edit: true,
+      can_administer: true
+    },
     pipelines: [pipelineAssociationInXmlJson(), pipelineAssociationInConfigRepoJson()],
     agents: [agentAssociationInXmlJson(), agentAssociationInConfigRepoJson()],
     environment_variables: [
@@ -113,15 +116,21 @@ export default {
   }),
   xml_environment_json: (): EnvironmentJSON => ({
     name: `xml-environment-name-${randomString()}`,
-    can_administer: true,
     origins: [originData.file_origin()],
+    permissions: {
+      can_edit: true,
+      can_administer: true
+    },
     pipelines: [pipelineAssociationInXmlJson()],
     agents: [agentAssociationInXmlJson()],
     environment_variables: [environmentVariableAssociationInXmlJson(), environmentVariableAssociationInXmlJson(true)]
   }),
   environment_without_pipeline_and_agent_json: (): EnvironmentJSON => ({
     name: `empty-environment-name-${randomString()}`,
-    can_administer: true,
+    permissions: {
+      can_edit: true,
+      can_administer: true
+    },
     origins: [],
     pipelines: [],
     agents: [],
@@ -129,8 +138,11 @@ export default {
   }),
   config_repo_environment_json: (): EnvironmentJSON => ({
     name: `config-repo-environment-name-${randomString()}`,
-    can_administer: true,
     origins: [originData.file_origin(), originData.config_repo_origin()],
+    permissions: {
+      can_edit: true,
+      can_administer: true
+    },
     pipelines: [pipelineAssociationInConfigRepoJson()],
     agents: [agentAssociationInConfigRepoJson()],
     environment_variables: [

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repo_attribute_helper_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repo_attribute_helper_spec.ts
@@ -79,7 +79,10 @@ describe("ConfigRepo attribute util functions", () => {
           destination: ""
         }
       },
-      can_administer: false,
+      permissions: {
+        can_edit: false,
+        can_administer: false
+      },
       configuration: [{
         key: "file_pattern",
         value: "*.json"

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_widget_spec.tsx
@@ -343,7 +343,12 @@ describe("ConfigReposWidget", () => {
   });
 
   it("should disable the action buttons", () => {
-    const configRepo = createConfigRepoParsed();
+    const configRepo = createConfigRepoParsed({
+                                                permissions: {
+                                                  can_administer: false,
+                                                  can_edit: false
+                                                }
+                                              });
     models([vm(configRepo)]);
     helper.redraw();
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/test_data.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/test_data.ts
@@ -77,7 +77,10 @@ export function createConfigRepoParsedWithError(overrides?: any): ConfigRepo {
                                    destination: ""
                                  }
                                },
-                               can_administer: true,
+                               permissions: {
+                                 can_edit: true,
+                                 can_administer: true
+                               },
                                configuration: [{
                                  key: "file_pattern",
                                  value: "*.json"
@@ -129,7 +132,10 @@ export function createConfigRepoParsed(overrides?: any): ConfigRepo {
                                    destination: ""
                                  }
                                },
-                               can_administer: false,
+                               permissions: {
+                                 can_edit: false,
+                                 can_administer: false
+                               },
                                configuration: [{
                                  key: "file_pattern",
                                  value: "*.json"
@@ -169,7 +175,10 @@ export function createConfigRepoWithError(id?: string, repoId?: string): ConfigR
                                    destination: ""
                                  }
                                },
-                               can_administer: false,
+                               permissions: {
+                                 can_edit: false,
+                                 can_administer: false
+                               },
                                configuration: [{
                                  key: "file_pattern",
                                  value: "*.json"

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/create_env_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/create_env_modal.tsx
@@ -18,6 +18,7 @@ import m from "mithril";
 import Stream from "mithril/stream";
 import {EnvironmentVariablesWithOrigin} from "models/environment_variables/types";
 import {Pipelines} from "models/internal_pipeline_structure/pipeline_structure";
+import {Permissions} from "models/new-environments/environments";
 import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
 import {EnvironmentsAPIs} from "models/new-environments/environments_apis";
 import {Origin, OriginType} from "models/origin";
@@ -39,7 +40,7 @@ export class CreateEnvModal extends Modal {
     this.onSuccessfulSave = onSuccessfulSave;
     this.environments     = environments;
     this.environment      = new EnvironmentWithOrigin("",
-                                                      true,
+                                                      new Permissions(true, true),
                                                       [new Origin(OriginType.GoCD)],
                                                       [],
                                                       new Pipelines(),

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environment_body_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environment_body_widget.tsx
@@ -41,8 +41,8 @@ export class ElementListWidget extends MithrilViewComponent<ElementListWidgetAtt
       <div class={styles.envBodyElementHeader} data-test-id={`${s.slugify(vnode.attrs.name)}-header`}>
         <span>{vnode.attrs.name}</span>
         <Icons.Edit iconOnly={true}
-                    title={environment.canAdminister() ? undefined : `You dont have permissions to edit '${environment.name()}' environment.`}
-                    disabled={!environment.canAdminister()}
+                    title={environment.permissions().canEdit() ? undefined : `You dont have permissions to edit '${environment.name()}' environment.`}
+                    disabled={!environment.permissions().canEdit()}
                     onclick={vnode.attrs.modalToRender.bind(vnode.attrs.modalToRender, environment)}/>
       </div>
       {vnode.children}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
@@ -80,7 +80,7 @@ export class EnvironmentWidget extends MithrilViewComponent<EnvAttrs> {
       </div>;
     }
     let deleteTitle;
-    if (!environment.canAdminister()) {
+    if (!environment.permissions().canAdminister()) {
       deleteTitle = `You are not authorized to delete the '${environment.name()}' environment.`;
     } else if (!environment.isLocal()) {
       deleteTitle = `Cannot delete '${environment.name()}' environment as it is partially defined in config repository.`;
@@ -90,7 +90,7 @@ export class EnvironmentWidget extends MithrilViewComponent<EnvAttrs> {
       <IconGroup>
         <Delete
           title={deleteTitle}
-          disabled={!environment.canAdminister() || !environment.isLocal()}
+          disabled={!environment.permissions().canAdminister() || !environment.isLocal()}
           onclick={vnode.attrs.onDelete.bind(vnode.attrs, environment)}/>
       </IconGroup>
     ];
@@ -129,6 +129,7 @@ export class EnvironmentsWidget extends MithrilViewComponent<Attrs> {
       Either no environments have been set up or you are not authorized to view the environments. {docLink}
     </span>;
 
-    return <FlashMessage type={MessageType.info} message={noEnvironmentPresentMsg} dataTestId="no-environment-present-msg"/>;
+    return <FlashMessage type={MessageType.info} message={noEnvironmentPresentMsg}
+                         dataTestId="no-environment-present-msg"/>;
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_pipelines_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_pipelines_modal_spec.tsx
@@ -22,7 +22,7 @@ import {
   PipelineStructureJSON,
   PipelineWithOrigin
 } from "models/internal_pipeline_structure/pipeline_structure";
-import {Permissions, Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
+import {Environments, EnvironmentWithOrigin, Permissions} from "models/new-environments/environments";
 import data from "models/new-environments/spec/test_data";
 import {ModalState} from "views/components/modal";
 import {EditPipelinesModal} from "views/pages/new-environments/edit_pipelines_modal";

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_pipelines_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_pipelines_modal_spec.tsx
@@ -22,7 +22,7 @@ import {
   PipelineStructureJSON,
   PipelineWithOrigin
 } from "models/internal_pipeline_structure/pipeline_structure";
-import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
+import {Permissions, Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
 import data from "models/new-environments/spec/test_data";
 import {ModalState} from "views/components/modal";
 import {EditPipelinesModal} from "views/pages/new-environments/edit_pipelines_modal";
@@ -44,14 +44,14 @@ describe("Edit Pipelines Modal", () => {
 
     const anotherEnvPipelines = new Pipelines(pipelineWithOrigin);
 
-    const anotherEnv = new EnvironmentWithOrigin("another", true, [], [], anotherEnvPipelines, new EnvironmentVariables());
+    const anotherEnv = new EnvironmentWithOrigin("another", new Permissions(true, true), [], [], anotherEnvPipelines, new EnvironmentVariables());
 
     const pipelines = new Pipelines(
       PipelineWithOrigin.fromJSON(pipelineGroupsJSON.groups[0].pipelines[0]),
       PipelineWithOrigin.fromJSON(pipelineGroupsJSON.groups[1].pipelines[1])
     );
 
-    const environment  = new EnvironmentWithOrigin("UAT", true, [], [], pipelines, new EnvironmentVariables());
+    const environment  = new EnvironmentWithOrigin("UAT", new Permissions(true, true), [], [], pipelines, new EnvironmentVariables());
     const environments = new Environments(environment, anotherEnv);
 
     modal = new EditPipelinesModal(environment, environments, jasmine.createSpy("onSuccessfulSave"));

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environment_body_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environment_body_widget_spec.tsx
@@ -75,7 +75,7 @@ describe("Environments Body Widget", () => {
     expect(editIcons[2].title).toBeFalsy();
     expect(editIcons[2]).not.toBeDisabled();
 
-    environment.canAdminister(false);
+    environment.permissions().canEdit(false);
     helper.redraw();
 
     expect(editIcons[0].title).toBe(`You dont have permissions to edit '${environment.name()}' environment.`);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environments_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/environments_widget_spec.tsx
@@ -84,7 +84,7 @@ describe("Environments Widget", () => {
 
   it("should render disabled delete icon for the environments that user can not administer", () => {
     const xmlEnv          = data.xml_environment_json();
-    xmlEnv.can_administer = false;
+    xmlEnv.permissions.can_administer = false;
     mountModal([xmlEnv, data.xml_environment_json()]);
 
     m.redraw.sync();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/models/pipelines_view_model_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/models/pipelines_view_model_spec.ts
@@ -16,7 +16,7 @@
 
 import {EnvironmentVariables} from "models/environment_variables/types";
 import {PipelineGroups, Pipelines, PipelineStructureJSON} from "models/internal_pipeline_structure/pipeline_structure";
-import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
+import {Environments, EnvironmentWithOrigin, Permissions} from "models/new-environments/environments";
 import test_data from "models/new-environments/spec/test_data";
 import {PipelinesViewModel} from "views/pages/new-environments/models/pipelines_view_model";
 
@@ -121,7 +121,7 @@ describe("Pipelines View Model", () => {
   it("should filter pipelines defined in other environment", () => {
     const pipeline = pipelinesViewModel.pipelineGroups()![0].pipelines()[0];
     environments.push(new EnvironmentWithOrigin("another",
-                                                true,
+                                                new Permissions(true, true),
                                                 [],
                                                 [],
                                                 new Pipelines(pipeline),
@@ -133,7 +133,7 @@ describe("Pipelines View Model", () => {
     expect(pipelines[0].name()).toBe(pipeline.name());
   });
 
-  it('should give all pipelines', () => {
+  it("should give all pipelines", () => {
     const pipelines = pipelinesViewModel.allPipelines();
     expect(pipelines.length).toBe(6);
     expect(pipelines[0].name()).toBe(pipelineGroupsJSON.groups[0].pipelines[0].name);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/policy_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/policy_widget.tsx
@@ -171,6 +171,9 @@ export class CreatePolicyWidget extends MithrilViewComponent<AutoCompleteAttrs> 
         id: "view", text: "View"
       },
       {
+        id: "edit", text: "Edit"
+      },
+      {
         id: "administer", text: "Administer"
       }
     ];

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/policy_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/policy_widget_spec.tsx
@@ -59,7 +59,7 @@ describe('PolicyWidgetSpecs', () => {
     expect(helper.byTestId("permission-permission")).toHaveValue("allow");
     expect(helper.textByTestId("permission-permission")).toContain("SelectAllowDeny");
     expect(helper.byTestId("permission-action")).toHaveValue("view");
-    expect(helper.textByTestId("permission-action")).toContain("SelectViewAdminister");
+    expect(helper.textByTestId("permission-action")).toContain("SelectViewEditAdminister");
     expect(helper.byTestId("permission-type")).toHaveValue("*");
     expect(helper.textByTestId("permission-type")).toContain("SelectAllEnvironment");
     expect(helper.byTestId("permission-resource")).toHaveValue("env");
@@ -113,18 +113,20 @@ describe('PolicyWidgetSpecs', () => {
     expect(typeOptions[3]).toHaveValue("config_repo");
   });
 
-  it("should render 4 items in supported actions dropdown", () => {
+  it("should render 3 items in supported actions dropdown", () => {
     const policy = new Policy();
     policy.push(Stream(new Directive("allow", "view", "*", "env")));
     mount(policy);
 
     const actionOptions = helper.qa("option", helper.byTestId("permission-action"));
 
-    expect(actionOptions.length).toBe(3);
+    expect(actionOptions.length).toBe(4);
     expect(actionOptions[1]).toHaveText("View");
     expect(actionOptions[1]).toHaveValue("view");
-    expect(actionOptions[2]).toHaveText("Administer");
-    expect(actionOptions[2]).toHaveValue("administer");
+    expect(actionOptions[2]).toHaveText("Edit");
+    expect(actionOptions[2]).toHaveValue("edit");
+    expect(actionOptions[3]).toHaveText("Administer");
+    expect(actionOptions[3]).toHaveValue("administer");
   });
 
   function mount(policy: Policy = new Policy(), resourceAutoComplete: Map<string, string[]> = new Map()) {

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/SparkController.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/SparkController.java
@@ -64,12 +64,12 @@ public interface SparkController {
                 return SupportedAction.VIEW;
             case "POST":
                 return SupportedAction.ADMINISTER;
-            case "PUT":
-                return SupportedAction.ADMINISTER;
-            case "PATCH":
-                return SupportedAction.ADMINISTER;
             case "DELETE":
                 return SupportedAction.ADMINISTER;
+            case "PUT":
+                return SupportedAction.EDIT;
+            case "PATCH":
+                return SupportedAction.EDIT;
             default:
                 return SupportedAction.UNKNOWN;
         }


### PR DESCRIPTION
##### Issue: ##7390

##### Description:

* Add an ability to define edit action as part of the policy.
* Allow users to define edit action policy on roles SPA.
* Modify Internal Environments API v1 to return user permissions.
* Modify Internal Config Repos API to return user permissions.
* Fix environments SPA to enable/disable action buttons based on permissions.
* Fix config repo SPA to enable/disable action buttons based on permissions.

