### PR TITLE
Fixing no error on cancel task for tasks

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/update/PipelineConfigErrorCopier.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/PipelineConfigErrorCopier.java
@@ -63,6 +63,7 @@ public class PipelineConfigErrorCopier {
                     Task fromTask = fromTasks.get(i);
                     Task toTask = toTasks.get(i);
                     copy(fromTask, toTask);
+                    copy(fromTask.cancelTask(), toTask.cancelTask());
                     copyCollectionErrors(fromTask.getConditions(), toTask.getConditions());
                     if (toTask instanceof ExecTask) {
                         copyCollectionErrors(((ExecTask) fromTask).getArgList(), ((ExecTask) toTask).getArgList());
@@ -70,7 +71,7 @@ public class PipelineConfigErrorCopier {
                 }
                 List<PluggableArtifactConfig> toPluggableArtifactConfigs = toJob.artifactTypeConfigs().getPluggableArtifactConfigs();
                 List<PluggableArtifactConfig> fromPluggableArtifactConfigs = fromJob.artifactTypeConfigs().getPluggableArtifactConfigs();
-                for(int i = 0; i< toPluggableArtifactConfigs.size(); i++) {
+                for (int i = 0; i < toPluggableArtifactConfigs.size(); i++) {
                     PluggableArtifactConfig fromPluggableArtifactConfig = fromPluggableArtifactConfigs.get(i);
                     PluggableArtifactConfig toPluggableArtifactConfig = toPluggableArtifactConfigs.get(i);
                     copyCollectionErrors(fromPluggableArtifactConfig.getConfiguration(), toPluggableArtifactConfig.getConfiguration());


### PR DESCRIPTION
Issue: #7423 

Description:
 - In PipelineConfigUpdateCommand, the copy error operation was not taking into account the cancel task of the tasks in that pipeline. Fixed the same and added a test



