### PR TITLE
Add feature toggle to enable pipeline group config listing API

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -21,6 +21,7 @@ public class Toggles {
     public static String ALLOW_EMPTY_PIPELINE_GROUPS_DASHBOARD = "allow_empty_pipeline_groups_dashboard";
     public static String TEST_DRIVE = "test_drive";
     public static String NEW_PIPELINE_DROPDOWN = "new_pipeline_dropdown";
+    public static String ENABLE_PIPELINE_GROUP_CONFIG_LISTING_API = "enable_pipeline_group_config_listing_api";
     public static String FAST_PIPELINE_SAVE = "fast_pipeline_save";
 
     private static FeatureToggleService service;

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -27,6 +27,11 @@
       "value": false
     },
     {
+      "key": "enable_pipeline_group_config_listing_api",
+      "description": "Enables Pipeline Group Config Listing API. Default: disabled",
+      "value": false
+    },
+    {
       "key": "fast_pipeline_save",
       "description": "Use the pipeline config service to speed up save, instead of doing a full config save",
       "value": true

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/api/pipeline_groups_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/api/pipeline_groups_controller.rb
@@ -15,11 +15,21 @@
 #
 
 class Api::PipelineGroupsController < Api::ApiController
+  before_action :check_api_enabled_toggle_and_404
+
   def list_configs
     pipeline_group_configs = pipeline_configs_service.getGroupsForUser(CaseInsensitiveString.str(current_user.getUsername()))
     pipeline_group_config_api_models = pipeline_group_configs.collect do |pipeline_group_config|
       PipelineGroupConfigAPIModel.new(pipeline_group_config)
     end
     render json: pipeline_group_config_api_models
+  end
+
+  private
+
+  def check_api_enabled_toggle_and_404
+    unless feature_toggle_service.isToggleOn(Toggles.ENABLE_PIPELINE_GROUP_CONFIG_LISTING_API)
+      render_not_found_error
+    end
   end
 end

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/application_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/application_controller.rb
@@ -206,6 +206,10 @@ class ApplicationController < ActionController::Base
     security_service.isUserAdmin(current_user)
   end
 
+  def render_not_found_error
+    render json: {message: 'Either the resource you requested was not found, or you are not authorized to perform this action.'}, status: 404
+  end
+
   private
 
   def no_layout?

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/pipeline_groups_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/pipeline_groups_controller_spec.rb
@@ -26,6 +26,9 @@ describe Api::PipelineGroupsController do
   describe "list_pipeline_group_configs" do
     before :each do
       allow(controller).to receive(:pipeline_configs_service).and_return(@pipeline_configs_service = double('pipeline_configs_service'))
+      allow(controller).to receive(:feature_toggle_service).and_return(@feature_toggle_service = double('feature_toggle_service'))
+
+      allow(@feature_toggle_service).to receive(:isToggleOn).with("enable_pipeline_group_config_listing_api").and_return(true)
     end
 
     it "should resolve" do
@@ -40,6 +43,14 @@ describe Api::PipelineGroupsController do
       get :list_configs, params:{:no_layout => true}
 
       expect(response.body).to eq([PipelineGroupConfigAPIModel.new(create_pipeline_group_config_model)].to_json)
+    end
+
+    it "should render not found error when API toggle is turned off" do
+      allow(@feature_toggle_service).to receive(:isToggleOn).with("enable_pipeline_group_config_listing_api").and_return(false)
+
+      get :list_configs, params:{:no_layout => true}
+
+      expect(response.body).to eq({message: 'Either the resource you requested was not found, or you are not authorized to perform this action.'}.to_json)
     end
   end
 end


### PR DESCRIPTION
Description:

* Deprecate and hide pipeline group config listing API
* Users are encouraged to use versioned pipeline group config API

