### PR TITLE
Fix for broken trigger with options

### DIFF
--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/PipelineInstanceRepresenterTest.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/PipelineInstanceRepresenterTest.groovy
@@ -34,7 +34,7 @@ class PipelineInstanceRepresenterTest {
 
     def expectedJson = [
       _links: [
-        self       : [href: 'http://test.host/go/api/pipelines/p1/0']
+        self       : [href: 'http://test.host/go/api/pipelines/p1/0/instance']
       ],
     ]
 

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/PipelineInstanceRepresenterTest.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/PipelineInstanceRepresenterTest.groovy
@@ -34,7 +34,7 @@ class PipelineInstanceRepresenterTest {
 
     def expectedJson = [
       _links: [
-        self: [href: 'http://test.host/go/api/pipelines/p1/0']
+        self: [href: 'http://test.host/go/api/pipelines/p1/0/instance']
       ],
     ]
 

--- a/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1Test.groovy
+++ b/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1Test.groovy
@@ -83,7 +83,7 @@ class PipelineInstanceControllerV1Test implements SecurityServiceTrait, Controll
 
       @Override
       void makeHttpCall() {
-        getWithApiHeader(controller.controllerPath("${pipelineName}/4"))
+        getWithApiHeader(controller.controllerPath("${pipelineName}/4/instance"))
       }
 
       @Override
@@ -106,7 +106,7 @@ class PipelineInstanceControllerV1Test implements SecurityServiceTrait, Controll
 
         when(pipelineHistoryService.findPipelineInstance(eq(pipelineName), eq(4), any(Username.class), any(HttpOperationResult.class))).thenReturn(pipelineInstanceModel)
 
-        getWithApiHeader(controller.controllerPath(pipelineName, "4"))
+        getWithApiHeader(controller.controllerPath(pipelineName, "4", "instance"))
 
         def expectedJson = toObjectString({ PipelineInstanceModelRepresenter.toJSON(it, pipelineInstanceModel) })
 
@@ -119,7 +119,7 @@ class PipelineInstanceControllerV1Test implements SecurityServiceTrait, Controll
       void 'should throw 404 if the pipeline does not exist'() {
         when(goConfigService.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(false)
 
-        getWithApiHeader(controller.controllerPath(pipelineName, "4"))
+        getWithApiHeader(controller.controllerPath(pipelineName, "4", "instance"))
 
         assertThatResponse()
           .isNotFound()
@@ -128,7 +128,7 @@ class PipelineInstanceControllerV1Test implements SecurityServiceTrait, Controll
 
       @Test
       void 'should throw 404 if the counter specified is less than 1'() {
-        getWithApiHeader(controller.controllerPath(pipelineName, "0"))
+        getWithApiHeader(controller.controllerPath(pipelineName, "0", "instance"))
 
         assertThatResponse()
           .isUnprocessableEntity()
@@ -137,7 +137,7 @@ class PipelineInstanceControllerV1Test implements SecurityServiceTrait, Controll
 
       @Test
       void 'should throw 404 if the counter specified is not a valid integer'() {
-        getWithApiHeader(controller.controllerPath(pipelineName, "abc"))
+        getWithApiHeader(controller.controllerPath(pipelineName, "abc", "instance"))
 
         assertThatResponse()
           .isUnprocessableEntity()

--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -116,6 +116,12 @@
   </rule>
 
   <rule>
+    <name>Spark pipeline pause/unpause/unlock/trigger_view API/schedule API</name>
+    <from>^/api/pipelines/([^/]+)/(pause|unpause|unlock|trigger_options|schedule)</from>
+    <to last="true">/spark/api/pipelines/${escape:$1}/${escape:$2}</to>
+  </rule>
+
+  <rule>
       <name>Spark Job Instance API</name>
       <condition name="Accept">application\/vnd\.go\.cd(.v*)*\+json</condition>
       <from>^/api/jobs/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)(/?)</from>
@@ -139,7 +145,7 @@
     <name>Pipeline Instance API V1 and latest</name>
     <condition name="Accept">application\/vnd\.go\.cd(.v*)*\+json</condition>
     <from>^/api/pipelines/([^/]+)/([^/]+)(/?)$</from>
-    <to last="true">/spark/api/pipelines/${escape:$1}/${escape:$2}</to>
+    <to last="true">/spark/api/pipelines/${escape:$1}/${escape:$2}/instance</to>
   </rule>
 
   <rule>
@@ -717,12 +723,6 @@
     <name>Spark Config Repos API</name>
     <from>^/api/admin/config_repos(?:(/)([^/]+))?(?:/?)</from>
     <to last="true">/spark/api/admin/config_repos$1${escape:$2}</to>
-  </rule>
-
-  <rule>
-    <name>Spark pipeline pause/unpause/unlock/trigger_view API/schedule API</name>
-    <from>^/api/pipelines/([^/]+)/(pause|unpause|unlock|trigger_options|schedule)</from>
-    <to last="true">/spark/api/pipelines/${escape:$1}/${escape:$2}</to>
   </rule>
 
   <rule>

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -296,7 +296,7 @@ public class Routes {
         }
 
         public static final String BASE = "/api/pipelines";
-        public static final String INSTANCE_PATH = "/:pipeline_name/:pipeline_counter";
+        public static final String INSTANCE_PATH = "/:pipeline_name/:pipeline_counter/instance";
         public static final String HISTORY_PATH = "/:pipeline_name/history";
         public static final String COMMENT_PATH = "/:pipeline_name/instance/:pipeline_counter/comment";
 


### PR DESCRIPTION
Description: 
 the Pipeline Instance and trigger options API was almost similar causing it parse trigger_options into integer which was throwing an error.
 Fixed the same by changing the internal api for pipeline instance

