### PR TITLE
Fix test failure due to incorrect data setup

### DIFF
--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ElasticProfileServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ElasticProfileServiceIntegrationTest.java
@@ -86,10 +86,12 @@ public class ElasticProfileServiceIntegrationTest {
         newElasticProfile = new ElasticProfile(elasticProfileId, clusterProfileId, new ConfigurationProperty(new ConfigurationKey("key1"), new ConfigurationValue("value1")));
 
         goConfigService.updateConfig(cruiseConfig -> {
+            BasicCruiseConfig basicCruiseConfig = new BasicCruiseConfig();
+            basicCruiseConfig.initializeServer();
             ClusterProfiles clusterProfiles = new ClusterProfiles();
             clusterProfiles.add(clusterProfile);
-            cruiseConfig.getElasticConfig().setClusterProfiles(clusterProfiles);
-            return cruiseConfig;
+            basicCruiseConfig.getElasticConfig().setClusterProfiles(clusterProfiles);
+            return basicCruiseConfig;
         });
         elasticProfileService.setProfileConfigurationValidator(validator);
     }
@@ -97,11 +99,6 @@ public class ElasticProfileServiceIntegrationTest {
     @After
     public void tearDown() throws Exception {
         configHelper.onTearDown();
-        goConfigService.updateConfig(cruiseConfig -> {
-            BasicCruiseConfig basicCruiseConfig = new BasicCruiseConfig();
-            basicCruiseConfig.initializeServer();
-            return basicCruiseConfig;
-        });
     }
 
     @Test


### PR DESCRIPTION
The cruise-config xml was cleaned during teardown. The first test run in this class used the config from whatever was left over previously, so it would sometimes fail. To fix this, moved the clean cruise-config from teardown to setup.

Example failures:
https://build.gocd.org/go/tab/build/detail/build-linux/4594/build-server/1/ServerIntegrationTests-runInstance-5#
https://build.gocd.org/go/tab/build/detail/build-linux-PR/5848/build-server/1/ServerIntegrationTests-runInstance-1#