### PR TITLE
Updated Stage History API v2 to support cursor-based pagination

### DIFF
--- a/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1Test.groovy
+++ b/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1Test.groovy
@@ -304,7 +304,7 @@ class PipelineInstanceControllerV1Test implements SecurityServiceTrait, Controll
 
         assertThatResponse()
           .isBadRequest()
-          .hasJsonMessage("The query parameter `after`, if specified, must be positive integer.")
+          .hasJsonMessage("The query parameter `after`, if specified, must be a positive integer.")
       }
 
       @Test
@@ -315,7 +315,7 @@ class PipelineInstanceControllerV1Test implements SecurityServiceTrait, Controll
 
         assertThatResponse()
           .isBadRequest()
-          .hasJsonMessage("The query parameter `before`, if specified, must be positive integer.")
+          .hasJsonMessage("The query parameter `before`, if specified, must be a positive integer.")
       }
 
       @ParameterizedTest

--- a/api/api-stage-instance-v2/src/test/groovy/com/thoughtworks/go/apiv2/stageinstance/representers/StageInstancesRepresenterTest.groovy
+++ b/api/api-stage-instance-v2/src/test/groovy/com/thoughtworks/go/apiv2/stageinstance/representers/StageInstancesRepresenterTest.groovy
@@ -17,11 +17,12 @@ package com.thoughtworks.go.apiv2.stageinstance.representers
 
 import com.thoughtworks.go.domain.JobResult
 import com.thoughtworks.go.domain.JobState
+import com.thoughtworks.go.domain.PipelineRunIdInfo
+import com.thoughtworks.go.domain.StageIdentifier
 import com.thoughtworks.go.presentation.pipelinehistory.JobHistory
 import com.thoughtworks.go.presentation.pipelinehistory.JobHistoryItem
 import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModel
 import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModels
-import com.thoughtworks.go.server.util.Pagination
 import org.junit.jupiter.api.Test
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
@@ -30,44 +31,179 @@ import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 class StageInstancesRepresenterTest {
   @Test
   void 'should represent stage history with hal'() {
-
     def jobHistoryItem = new JobHistoryItem("job", JobState.Completed, JobResult.Passed, new Date(12345))
     jobHistoryItem.setId(34)
     def jobHistory = new JobHistory()
     jobHistory.add(jobHistoryItem)
-    def stageInstanceModel = new StageInstanceModel("stage", "3", jobHistory)
+    def identifier = new StageIdentifier("pipeline", 2, "stage", "4")
+    def stageInstanceModel = new StageInstanceModel("stage", "3", jobHistory, identifier)
     stageInstanceModel.setId(21)
     def stageInstances = new StageInstanceModels()
     stageInstances.add(stageInstanceModel)
-    def pagination = new Pagination(1, 20, 10)
+    def runIdInfo = new PipelineRunIdInfo(50, 1)
 
-    def actualJson = toObjectString({StageInstancesRepresenter.toJSON(it, stageInstances, pagination) })
+    def actualJson = toObjectString({ StageInstancesRepresenter.toJSON(it, stageInstances, runIdInfo) })
 
-    assertThatJson(actualJson).isEqualTo(stageHash)
-  }
-
-  def stageHash = [
-    stages: [
-      [
-        name:'stage',
-        counter:'3',
-        approval_type:null,
-        approved_by:null,
-        rerun_of_counter:null,
-        jobs:[
-          [
-            name:'job',
-            state:'Completed',
-            result:'Passed',
-            scheduled_date:12345
+    def expectedJson = [
+      "_links": [
+        "previous": [
+          "href": "http://test.host/go/api/stages/pipeline/stage/history?before=21"
+        ],
+        "next"    : [
+          "href": "http://test.host/go/api/stages/pipeline/stage/history?after=21"
+        ]
+      ],
+      "stages": [
+        [
+          "name"            : "stage",
+          "counter"         : "3",
+          "approval_type"   : null,
+          "approved_by"     : null,
+          "rerun_of_counter": null,
+          "pipeline_name"   : "pipeline",
+          "pipeline_counter": 2,
+          "jobs"            : [
+            [
+              "name"          : "job",
+              "state"         : "Completed",
+              "result"        : "Passed",
+              "scheduled_date": 12345
+            ]
           ]
         ]
       ]
-    ],
-    pagination : [
-      offset: 1,
-      page_size: 10,
-      total: 20
     ]
-  ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should not add previous link if there are no newer records'() {
+    def jobHistoryItem = new JobHistoryItem("job", JobState.Completed, JobResult.Passed, new Date(12345))
+    jobHistoryItem.setId(34)
+    def jobHistory = new JobHistory()
+    jobHistory.add(jobHistoryItem)
+    def identifier = new StageIdentifier("pipeline", 2, "stage", "4")
+    def stageInstanceModel = new StageInstanceModel("stage", "3", jobHistory, identifier)
+    stageInstanceModel.setId(21)
+    def stageInstances = new StageInstanceModels()
+    stageInstances.add(stageInstanceModel)
+    def runIdInfo = new PipelineRunIdInfo(21, 1)
+
+    def actualJson = toObjectString({ StageInstancesRepresenter.toJSON(it, stageInstances, runIdInfo) })
+
+    def expectedJson = [
+      "_links": [
+        "next": [
+          "href": "http://test.host/go/api/stages/pipeline/stage/history?after=21"
+        ]
+      ],
+      "stages": [
+        [
+          "name"            : "stage",
+          "counter"         : "3",
+          "approval_type"   : null,
+          "approved_by"     : null,
+          "rerun_of_counter": null,
+          "pipeline_name"   : "pipeline",
+          "pipeline_counter": 2,
+          "jobs"            : [
+            [
+              "name"          : "job",
+              "state"         : "Completed",
+              "result"        : "Passed",
+              "scheduled_date": 12345
+            ]
+          ]
+        ]
+      ]
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should not add next link if there are no older records'() {
+    def jobHistoryItem = new JobHistoryItem("job", JobState.Completed, JobResult.Passed, new Date(12345))
+    jobHistoryItem.setId(34)
+    def jobHistory = new JobHistory()
+    jobHistory.add(jobHistoryItem)
+    def identifier = new StageIdentifier("pipeline", 2, "stage", "4")
+    def stageInstanceModel = new StageInstanceModel("stage", "3", jobHistory, identifier)
+    stageInstanceModel.setId(21)
+    def stageInstances = new StageInstanceModels()
+    stageInstances.add(stageInstanceModel)
+    def runIdInfo = new PipelineRunIdInfo(44, 21)
+
+    def actualJson = toObjectString({ StageInstancesRepresenter.toJSON(it, stageInstances, runIdInfo) })
+
+    def expectedJson = [
+      "_links": [
+        "previous": [
+          "href": "http://test.host/go/api/stages/pipeline/stage/history?before=21"
+        ]
+      ],
+      "stages": [
+        [
+          "name"            : "stage",
+          "counter"         : "3",
+          "approval_type"   : null,
+          "approved_by"     : null,
+          "rerun_of_counter": null,
+          "pipeline_name"   : "pipeline",
+          "pipeline_counter": 2,
+          "jobs"            : [
+            [
+              "name"          : "job",
+              "state"         : "Completed",
+              "result"        : "Passed",
+              "scheduled_date": 12345
+            ]
+          ]
+        ]
+      ]
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should not add links if only one page is present'() {
+    def jobHistoryItem = new JobHistoryItem("job", JobState.Completed, JobResult.Passed, new Date(12345))
+    jobHistoryItem.setId(34)
+    def jobHistory = new JobHistory()
+    jobHistory.add(jobHistoryItem)
+    def identifier = new StageIdentifier("pipeline", 2, "stage", "4")
+    def stageInstanceModel = new StageInstanceModel("stage", "3", jobHistory, identifier)
+    stageInstanceModel.setId(21)
+    def stageInstances = new StageInstanceModels()
+    stageInstances.add(stageInstanceModel)
+    def runIdInfo = new PipelineRunIdInfo(21, 21)
+
+    def actualJson = toObjectString({ StageInstancesRepresenter.toJSON(it, stageInstances, runIdInfo) })
+
+    def expectedJson = [
+      "stages": [
+        [
+          "name"            : "stage",
+          "counter"         : "3",
+          "approval_type"   : null,
+          "approved_by"     : null,
+          "rerun_of_counter": null,
+          "pipeline_name"   : "pipeline",
+          "pipeline_counter": 2,
+          "jobs"            : [
+            [
+              "name"          : "job",
+              "state"         : "Completed",
+              "result"        : "Passed",
+              "scheduled_date": 12345
+            ]
+          ]
+        ]
+      ]
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/dao/StageDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/StageDao.java
@@ -31,6 +31,7 @@ public interface StageDao extends JobDurationStrategy {
     Stage mostRecentWithBuilds(String pipelineName, StageConfig stageConfig);
 
     Stage save(Pipeline pipeline, Stage stage);
+
     @Deprecated
     // This is only used in test for legacy purpose.
     // Please call pipelineService.save(aPipeline) instead
@@ -84,7 +85,9 @@ public interface StageDao extends JobDurationStrategy {
 
     StageHistoryPage findStageHistoryPageByNumber(String pipelineName, String stageName, int pageNumber, int pageSize);
 
-	StageInstanceModels findDetailedStageHistoryByOffset(String pipelineName, String stageName, Pagination pagination);
+    StageInstanceModels findDetailedStageHistoryByOffset(String pipelineName, String stageName, Pagination pagination);
+
+    StageInstanceModels findDetailedStageHistoryViaCursor(String pipelineName, String stageName, FeedModifier feedModifier, long cursor, Integer pageSize);
 
     List<StageIdentifier> findFailedStagesBetween(String pipelineName, String stageName, double fromNaturalOrder, double toNaturalOrder);
 
@@ -101,4 +104,6 @@ public interface StageDao extends JobDurationStrategy {
     int getTotalStageCountForChart(String pipelineName, String stageName);
 
     List<StageIdentity> findLatestStageInstances();
+
+    PipelineRunIdInfo getOldestAndLatestStageInstanceId(String pipelineName, String stageName);
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
@@ -64,7 +64,7 @@ public class PipelineHistoryService {
     private PipelineLockService pipelineLockService;
     private PipelinePauseService pipelinePauseService;
     private static final String NOT_AUTHORIZED_TO_VIEW_PIPELINE = "Not authorized to view pipeline";
-    public static final String BAD_CURSOR_MSG = "The query parameter `%s`, if specified, must be positive integer.";
+    public static final String BAD_CURSOR_MSG = "The query parameter `%s`, if specified, must be a positive integer.";
 
     @Autowired
     public PipelineHistoryService(PipelineDao pipelineDao,

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml
@@ -109,6 +109,11 @@
         <result property="scheduledDate" column="scheduledDate"/>
     </resultMap>
 
+    <resultMap id="latest-oldest-stage-identifiers" type="com.thoughtworks.go.domain.PipelineRunIdInfo">
+        <result property="oldestRunId" column="oldestRunId"/>
+        <result property="latestRunId" column="latestRunId"/>
+    </resultMap>
+
     <parameterMap id="insert-stage-param" type="com.thoughtworks.go.domain.Stage">
         <parameter property="name"/>
         <parameter property="pipelineId"/>
@@ -430,6 +435,84 @@
           AND id &gt; #{id}
         ORDER BY id
         LIMIT #{limit}
+    </select>
+
+    <!-- Following query returns the lastest and oldest run id for the given pipeline and stage. This helps in identifying the first and last record for the given pipeline and stage.  -->
+    <select id="getOldestAndLatestStageInstanceRun" resultMap="latest-oldest-stage-identifiers">
+        SELECT MAX(_stages.id) as latestRunId, MIN(_stages.id) as oldestRunId
+        FROM _stages
+        WHERE pipelineName = #{pipelineName}
+          AND name = #{stageName}
+    </select>
+
+    <!-- The following query will return the latest #{limit} instances for the given pipeline and stage -->
+    <sql id="selectStageIdsForHistory">
+        SELECT id
+        FROM _stages
+        WHERE name = #{stageName}
+          AND pipelineName = #{pipelineName}
+        ORDER BY id DESC
+        LIMIT #{limit}
+    </sql>
+
+    <!-- The following query will return the #{limit} instances which are older than the given stage instance id for the given pipeline and stage -->
+    <sql id="selectStageIdsForHistoryAfter">
+        SELECT id
+        FROM _stages
+        WHERE name = #{stageName}
+          AND pipelineName = #{pipelineName}
+          AND _stages.id &lt; #{cursor}
+        ORDER BY id DESC
+        LIMIT #{limit}
+    </sql>
+
+    <!-- The following query will return the #{limit} instances which are newer than the given stage instance id for the given pipeline and stage -->
+    <sql id="selectStageIdsForHistoryBefore">
+        SELECT id
+        FROM (SELECT id
+              FROM _stages
+              WHERE name = #{stageName}
+                AND pipelineName = #{pipelineName}
+                AND _stages.id &gt; #{cursor}
+              ORDER BY id ASC
+              LIMIT #{limit}) as StageInstanceIdsBeforeSpecifiedId
+        ORDER BY id DESC
+    </sql>
+
+    <select id="getStageHistoryViaCursor" resultMap="stage-with-job-history">
+        SELECT pipelines.name as pipelineName,
+        pipelines.counter as pipelineCounter,
+        pipelines.label as pipelineLabel,
+        stages.name as stageName,
+        stages.counter as stageCounter,
+        stages.id as stageId,
+        stages.approvedBy as approvedBy,
+        stages.cancelledBy as cancelledBy,
+        stages.approvalType as approvalType,
+        stages.result as stageResult,
+        stages.rerunOfCounter,
+        builds.id as buildId,
+        builds.name as buildName,
+        builds.state as buildState,
+        builds.result as buildResult,
+        builds.scheduledDate as scheduledDate
+        FROM stages
+        JOIN pipelines ON pipelines.id = stages.pipelineId
+        INNER JOIN builds ON stages.id = builds.stageId AND builds.ignored != true
+        WHERE stages.id IN (
+        <choose>
+            <when test="suffix==null or suffix==''">
+                <include refid="selectStageIdsForHistory"/>
+            </when>
+            <when test="suffix=='After'">
+                <include refid="selectStageIdsForHistoryAfter"/>
+            </when>
+            <when test="suffix=='Before'">
+                <include refid="selectStageIdsForHistoryBefore"/>
+            </when>
+        </choose>
+        )
+        ORDER BY stages.id DESC
     </select>
 
     <select id="getDetailedStageHistory" resultMap="stage-with-job-history">

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dao/StageSqlMapDaoTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dao/StageSqlMapDaoTest.java
@@ -260,6 +260,24 @@ class StageSqlMapDaoTest {
     }
 
     @Nested
+    class CacheKeyForStageHistoryViaCursor {
+        @Test
+        void shouldGenerateCacheKey() {
+            Assertions.assertThat(stageSqlMapDao.cacheKeyForStageHistoryViaCursor("foo", "bar_baz"))
+                    .isEqualTo("com.thoughtworks.go.server.dao.StageSqlMapDao.$findDetailedStageHistoryViaCursor.$foo.$bar_baz");
+        }
+
+        @Test
+        void shouldGenerateADifferentCacheKeyWhenPartOfPipelineIsInterchangedWithStageName() {
+            Assertions.assertThat(stageSqlMapDao.cacheKeyForStageHistoryViaCursor("foo", "bar_baz"))
+                    .isNotEqualTo(stageSqlMapDao.cacheKeyForStageHistoryViaCursor("foo_bar", "baz"));
+
+            Assertions.assertThat(stageSqlMapDao.cacheKeyForStageHistoryViaCursor("foo", "bar-baz"))
+                    .isNotEqualTo(stageSqlMapDao.cacheKeyForStageHistoryViaCursor("foo-bar", "baz"));
+        }
+    }
+
+    @Nested
     class CacheKeyForStageOffset {
 
         @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineHistoryServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineHistoryServiceTest.java
@@ -922,7 +922,7 @@ class PipelineHistoryServiceTest {
 
             assertThatCode(() -> pipelineHistoryService.loadPipelineHistoryData(username, pipelineName, -10L, 0, 10))
                     .isInstanceOf(BadRequestException.class)
-                    .hasMessage("The query parameter `after`, if specified, must be positive integer.");
+                    .hasMessage("The query parameter `after`, if specified, must be a positive integer.");
 
             verifyZeroInteractions(pipelineDao);
         }
@@ -939,7 +939,7 @@ class PipelineHistoryServiceTest {
 
             assertThatCode(() -> pipelineHistoryService.loadPipelineHistoryData(username, pipelineName, 0, -10L, 10))
                     .isInstanceOf(BadRequestException.class)
-                    .hasMessage("The query parameter `before`, if specified, must be positive integer.");
+                    .hasMessage("The query parameter `before`, if specified, must be a positive integer.");
 
             verifyZeroInteractions(pipelineDao);
         }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/StageSqlMapDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/StageSqlMapDaoIntegrationTest.java
@@ -1623,43 +1623,43 @@ public class StageSqlMapDaoIntegrationTest {
         );
     }
 
-	@Test
-	public void shouldGetDetailedStageHistory() throws Exception{
-		HgMaterial hg = new HgMaterial("url", null);
-		String[] hg_revs = {"h1", "h2", "h3"};
-		scheduleUtil.checkinInOrder(hg, hg_revs);
+    @Test
+    public void shouldGetDetailedStageHistory() throws Exception {
+        HgMaterial hg = new HgMaterial("url", null);
+        String[] hg_revs = {"h1", "h2", "h3"};
+        scheduleUtil.checkinInOrder(hg, hg_revs);
 
-		String pipelineName = "p1";
-		String stageName = "stage_name";
+        String pipelineName = "p1";
+        String stageName = "stage_name";
 
-		ScheduleTestUtil.AddedPipeline p1 = scheduleUtil.saveConfigWith(pipelineName, stageName, scheduleUtil.m(hg),new String[]{"job1","job2"});
-		scheduleUtil.runAndPass(p1, "h1");
-		scheduleUtil.runAndPass(p1, "h2");
-		scheduleUtil.runAndPass(p1, "h3");
+        ScheduleTestUtil.AddedPipeline p1 = scheduleUtil.saveConfigWith(pipelineName, stageName, scheduleUtil.m(hg), new String[]{"job1", "job2"});
+        scheduleUtil.runAndPass(p1, "h1");
+        scheduleUtil.runAndPass(p1, "h2");
+        scheduleUtil.runAndPass(p1, "h3");
 
-		Pagination pagination = Pagination.pageStartingAt(0, 3, 2);
-		StageInstanceModels stageInstanceModels = stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination);
+        Pagination pagination = Pagination.pageStartingAt(0, 3, 2);
+        StageInstanceModels stageInstanceModels = stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination);
 
-		assertThat(stageInstanceModels.size(), is(2));
+        assertThat(stageInstanceModels.size(), is(2));
 
-		assertThat(stageInstanceModels.get(0).getResult(), is(StageResult.Passed));
-		assertThat(stageInstanceModels.get(0).getIdentifier().getPipelineName(), is(pipelineName));
-		assertThat(stageInstanceModels.get(0).getIdentifier().getPipelineCounter(), is(3));
-		assertThat(stageInstanceModels.get(0).getIdentifier().getStageName(), is(stageName));
-		assertThat(stageInstanceModels.get(0).getIdentifier().getStageCounter(), is("1"));
-		assertJobDetails(stageInstanceModels.get(0).getBuildHistory());
+        assertThat(stageInstanceModels.get(0).getResult(), is(StageResult.Passed));
+        assertThat(stageInstanceModels.get(0).getIdentifier().getPipelineName(), is(pipelineName));
+        assertThat(stageInstanceModels.get(0).getIdentifier().getPipelineCounter(), is(3));
+        assertThat(stageInstanceModels.get(0).getIdentifier().getStageName(), is(stageName));
+        assertThat(stageInstanceModels.get(0).getIdentifier().getStageCounter(), is("1"));
+        assertJobDetails(stageInstanceModels.get(0).getBuildHistory());
 
-		assertThat(stageInstanceModels.get(1).getResult(), is(StageResult.Passed));
-		assertThat(stageInstanceModels.get(1).getIdentifier().getPipelineName(), is(pipelineName));
-		assertThat(stageInstanceModels.get(1).getIdentifier().getPipelineCounter(), is(2));
-		assertThat(stageInstanceModels.get(1).getIdentifier().getStageName(), is(stageName));
-		assertThat(stageInstanceModels.get(1).getIdentifier().getStageCounter(), is("1"));
-		assertJobDetails(stageInstanceModels.get(1).getBuildHistory());
+        assertThat(stageInstanceModels.get(1).getResult(), is(StageResult.Passed));
+        assertThat(stageInstanceModels.get(1).getIdentifier().getPipelineName(), is(pipelineName));
+        assertThat(stageInstanceModels.get(1).getIdentifier().getPipelineCounter(), is(2));
+        assertThat(stageInstanceModels.get(1).getIdentifier().getStageName(), is(stageName));
+        assertThat(stageInstanceModels.get(1).getIdentifier().getStageCounter(), is("1"));
+        assertJobDetails(stageInstanceModels.get(1).getBuildHistory());
 
-		pagination = Pagination.pageStartingAt(2, 3, 2);
-		stageInstanceModels = stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination);
+        pagination = Pagination.pageStartingAt(2, 3, 2);
+        stageInstanceModels = stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination);
 
-		assertThat(stageInstanceModels.size(), is(1));
+        assertThat(stageInstanceModels.size(), is(1));
 
 		assertThat(stageInstanceModels.get(0).getResult(), is(StageResult.Passed));
 		assertThat(stageInstanceModels.get(0).getIdentifier().getPipelineName(), is(pipelineName));
@@ -1669,13 +1669,13 @@ public class StageSqlMapDaoIntegrationTest {
 		assertJobDetails(stageInstanceModels.get(0).getBuildHistory());
 	}
 
-	private void assertJobDetails(JobHistory buildHistory) {
-		assertThat(buildHistory.size(), is(2));
-		Set<String> jobNames = new HashSet<>(Arrays.asList(buildHistory.get(0).getName(), buildHistory.get(1).getName()));
-		assertThat(jobNames, hasItems("job2", "job1"));
-		assertThat(buildHistory.get(0).getResult(), is(JobResult.Passed));
-		assertThat(buildHistory.get(1).getResult(), is(JobResult.Passed));
-	}
+    private void assertJobDetails(JobHistory buildHistory) {
+        assertThat(buildHistory.size(), is(2));
+        Set<String> jobNames = new HashSet<>(Arrays.asList(buildHistory.get(0).getName(), buildHistory.get(1).getName()));
+        assertThat(jobNames, hasItems("job2", "job1"));
+        assertThat(buildHistory.get(0).getResult(), is(JobResult.Passed));
+        assertThat(buildHistory.get(1).getResult(), is(JobResult.Passed));
+    }
 
 	@Test
 	public void shouldCacheDetailedStageHistoryPageAndCountAndOffset() throws Exception{
@@ -1683,57 +1683,57 @@ public class StageSqlMapDaoIntegrationTest {
 		String[] hg_revs = {"h1"};
 		scheduleUtil.checkinInOrder(hg, hg_revs);
 
-		String pipelineName = "p1";
-		String stageName = "stage_name";
-		Pagination pagination = Pagination.pageStartingAt(0, 10, 10);
+        String pipelineName = "p1";
+        String stageName = "stage_name";
+        Pagination pagination = Pagination.pageStartingAt(0, 10, 10);
 
-		ScheduleTestUtil.AddedPipeline p1 = scheduleUtil.saveConfigWith(pipelineName, stageName, scheduleUtil.m(hg));
-		scheduleUtil.runAndPass(p1, "h1");
+        ScheduleTestUtil.AddedPipeline p1 = scheduleUtil.saveConfigWith(pipelineName, stageName, scheduleUtil.m(hg));
+        scheduleUtil.runAndPass(p1, "h1");
 
-		Stage stage = stageDao.mostRecentStage(new StageConfigIdentifier(pipelineName, stageName));
-		stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination); // PRIME CACHE
+        Stage stage = stageDao.mostRecentStage(new StageConfigIdentifier(pipelineName, stageName));
+        stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination); // PRIME CACHE
 
-		Method cacheKeyForDetailedStageHistories = getMethodViaReflection("cacheKeyForDetailedStageHistories", String.class, String.class);
-		Object primedDetailedStageHistoryPage = goCache.get((String) cacheKeyForDetailedStageHistories.invoke(stageDao, pipelineName, stageName));
+        Method cacheKeyForDetailedStageHistories = getMethodViaReflection("cacheKeyForDetailedStageHistories", String.class, String.class);
+        Object primedDetailedStageHistoryPage = goCache.get((String) cacheKeyForDetailedStageHistories.invoke(stageDao, pipelineName, stageName));
 
-		stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination); // SHOULD RETURN FROM CACHE
+        stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination); // SHOULD RETURN FROM CACHE
 
-		Object cachedDetailedStageHistoryPage = goCache.get((String) cacheKeyForDetailedStageHistories.invoke(stageDao, pipelineName, stageName));
+        Object cachedDetailedStageHistoryPage = goCache.get((String) cacheKeyForDetailedStageHistories.invoke(stageDao, pipelineName, stageName));
 
-		assertThat(cachedDetailedStageHistoryPage, is(sameInstance(primedDetailedStageHistoryPage)));
-	}
-
-	@Test
-	public void shouldInvalidateDetailedStageHistoryCachesOnStageSave() throws Exception {
-		HgMaterial hg = new HgMaterial("url", null);
-		String[] hg_revs = {"h1"};
-		scheduleUtil.checkinInOrder(hg, hg_revs);
-
-		String pipelineName = "p1";
-		String stageName = "stage_name";
-		Pagination pagination = Pagination.pageStartingAt(0, 10, 10);
-
-		ScheduleTestUtil.AddedPipeline p1 = scheduleUtil.saveConfigWith(pipelineName, stageName, scheduleUtil.m(hg));
-		scheduleUtil.runAndPass(p1, "h1");
-
-		Stage stage = stageDao.mostRecentStage(new StageConfigIdentifier(pipelineName, stageName));
-		stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination); // PRIME CACHE
-
-		Method cacheKeyForDetailedStageHistories = getMethodViaReflection("cacheKeyForDetailedStageHistories", String.class, String.class);
-		Object primedDetailedStageHistoryPage = goCache.get((String) cacheKeyForDetailedStageHistories.invoke(stageDao, pipelineName, stageName));
-
-		scheduleUtil.runAndPass(p1, "h1"); // NEW RUN OF STAGE, CACHE SHOULD BE INVALIDATED
-
-		stage = stageDao.mostRecentStage(new StageConfigIdentifier(pipelineName, stageName));
-		stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination); // SHOULD QUERY AGAIN
-
-		Object reprimedDetailedStageHistoryPage = goCache.get((String) cacheKeyForDetailedStageHistories.invoke(stageDao, pipelineName, stageName));
-
-		assertThat(reprimedDetailedStageHistoryPage, is(not(sameInstance(primedDetailedStageHistoryPage))));
-	}
+        assertThat(cachedDetailedStageHistoryPage, is(sameInstance(primedDetailedStageHistoryPage)));
+    }
 
     @Test
-    public void shouldPaginateBasedOnOffset() throws Exception{
+    public void shouldInvalidateDetailedStageHistoryCachesOnStageSave() throws Exception {
+        HgMaterial hg = new HgMaterial("url", null);
+        String[] hg_revs = {"h1"};
+        scheduleUtil.checkinInOrder(hg, hg_revs);
+
+        String pipelineName = "p1";
+        String stageName = "stage_name";
+        Pagination pagination = Pagination.pageStartingAt(0, 10, 10);
+
+        ScheduleTestUtil.AddedPipeline p1 = scheduleUtil.saveConfigWith(pipelineName, stageName, scheduleUtil.m(hg));
+        scheduleUtil.runAndPass(p1, "h1");
+
+        Stage stage = stageDao.mostRecentStage(new StageConfigIdentifier(pipelineName, stageName));
+        stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination); // PRIME CACHE
+
+        Method cacheKeyForDetailedStageHistories = getMethodViaReflection("cacheKeyForDetailedStageHistories", String.class, String.class);
+        Object primedDetailedStageHistoryPage = goCache.get((String) cacheKeyForDetailedStageHistories.invoke(stageDao, pipelineName, stageName));
+
+        scheduleUtil.runAndPass(p1, "h1"); // NEW RUN OF STAGE, CACHE SHOULD BE INVALIDATED
+
+        stage = stageDao.mostRecentStage(new StageConfigIdentifier(pipelineName, stageName));
+        stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination); // SHOULD QUERY AGAIN
+
+        Object reprimedDetailedStageHistoryPage = goCache.get((String) cacheKeyForDetailedStageHistories.invoke(stageDao, pipelineName, stageName));
+
+        assertThat(reprimedDetailedStageHistoryPage, is(not(sameInstance(primedDetailedStageHistoryPage))));
+    }
+
+    @Test
+    public void shouldPaginateBasedOnOffset() throws Exception {
         HgMaterial hg = new HgMaterial("url", null);
         String[] hg_revs = {"h1", "h2", "h3"};
         scheduleUtil.checkinInOrder(hg, hg_revs);
@@ -1789,6 +1789,91 @@ public class StageSqlMapDaoIntegrationTest {
         pagination = Pagination.pageStartingAt(1, 7, 4);
         stageInstanceModels = stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination);
         assertStageModels(stageInstanceModels, run6, run5, run4, run3);
+    }
+
+    @Test
+    public void stageHistoryViaCursor_shouldReturnEmptyListIfNoRecordsArePresent() {
+        StageInstanceModels stageHistory = stageDao.findDetailedStageHistoryViaCursor(PIPELINE_NAME, STAGE_DEV, FeedModifier.Latest, 0, 10);
+
+        assertThat(stageHistory, is(empty()));
+    }
+
+    @Test
+    public void stageHistoryViaCursor_shouldReturnListWithTheLatestRecords() {
+        HgMaterial hg = new HgMaterial("url", null);
+        String[] hg_revs = {"h1", "h2", "h3"};
+        scheduleUtil.checkinInOrder(hg, hg_revs);
+
+        ScheduleTestUtil.AddedPipeline p1 = scheduleUtil.saveConfigWith(PIPELINE_NAME, STAGE_DEV, scheduleUtil.m(hg));
+        String run1 = scheduleUtil.runAndPass(p1, "h1");
+        String run2 = scheduleUtil.runAndPass(p1, "h2");
+        String run3 = scheduleUtil.runAndPass(p1, "h3");
+        String run4 = scheduleUtil.runAndPass(p1, "h1", "h2");
+        String run5 = scheduleUtil.runAndPass(p1, "h2", "h3");
+        String run6 = scheduleUtil.runAndPass(p1, "h3", "h1");
+        String run7 = scheduleUtil.runAndPass(p1, "h1", "h2", "h3");
+
+        StageInstanceModels stageHistory = stageDao.findDetailedStageHistoryViaCursor(PIPELINE_NAME, STAGE_DEV, FeedModifier.Latest, 0, 3);
+
+        assertStageModels(stageHistory, run7, run6, run5);
+    }
+
+    @Test
+    public void stageHistoryViaCursor_shouldReturnListWithTheRecordsAfterTheSpecifiedCursor() { //older records
+        HgMaterial hg = new HgMaterial("url", null);
+        String[] hg_revs = {"h1", "h2", "h3"};
+        scheduleUtil.checkinInOrder(hg, hg_revs);
+
+        ScheduleTestUtil.AddedPipeline p1 = scheduleUtil.saveConfigWith(PIPELINE_NAME, STAGE_DEV, scheduleUtil.m(hg));
+        String run1 = scheduleUtil.runAndPass(p1, "h1");
+        String run2 = scheduleUtil.runAndPass(p1, "h2");
+        String run3 = scheduleUtil.runAndPass(p1, "h3");
+        String run4 = scheduleUtil.runAndPass(p1, "h1", "h2");
+        String run5 = scheduleUtil.runAndPass(p1, "h2", "h3");
+        String run6 = scheduleUtil.runAndPass(p1, "h3", "h1");
+        String run7 = scheduleUtil.runAndPass(p1, "h1", "h2", "h3");
+
+        StageInstanceModels stageHistory = stageDao.findDetailedStageHistoryViaCursor(PIPELINE_NAME, STAGE_DEV, FeedModifier.After, 5, 3);
+
+        assertStageModels(stageHistory, run4, run3, run2);
+    }
+
+    @Test
+    public void stageHistoryViaCursor_shouldReturnListWithTheRecordsBeforeTheSpecifiedCursor() { //newer records
+        HgMaterial hg = new HgMaterial("url", null);
+        String[] hg_revs = {"h1", "h2", "h3"};
+        scheduleUtil.checkinInOrder(hg, hg_revs);
+
+        ScheduleTestUtil.AddedPipeline p1 = scheduleUtil.saveConfigWith(PIPELINE_NAME, STAGE_DEV, scheduleUtil.m(hg));
+        String run1 = scheduleUtil.runAndPass(p1, "h1");
+        String run2 = scheduleUtil.runAndPass(p1, "h2");
+        String run3 = scheduleUtil.runAndPass(p1, "h3");
+        String run4 = scheduleUtil.runAndPass(p1, "h1", "h2");
+        String run5 = scheduleUtil.runAndPass(p1, "h2", "h3");
+        String run6 = scheduleUtil.runAndPass(p1, "h3", "h1");
+        String run7 = scheduleUtil.runAndPass(p1, "h1", "h2", "h3");
+
+        StageInstanceModels stageHistory = stageDao.findDetailedStageHistoryViaCursor(PIPELINE_NAME, STAGE_DEV, FeedModifier.Before, 3, 3);
+
+        assertStageModels(stageHistory, run6, run5, run4);
+    }
+
+    @Test
+    public void latestAndOldest_shouldReturnOldestAndLatestStageRun() {
+        HgMaterial hg = new HgMaterial("url", null);
+        String[] hg_revs = {"h1", "h2", "h3"};
+        scheduleUtil.checkinInOrder(hg, hg_revs);
+
+        Date date = new Date();
+        ScheduleTestUtil.AddedPipeline p1 = scheduleUtil.saveConfigWith(PIPELINE_NAME, STAGE_DEV, scheduleUtil.m(hg));
+        Pipeline run1 = scheduleUtil.runAndPassAndReturnPipelineInstance(p1, date, "h1");
+        Pipeline run2 = scheduleUtil.runAndPassAndReturnPipelineInstance(p1, date, "h2");
+        Pipeline run3 = scheduleUtil.runAndPassAndReturnPipelineInstance(p1, date, "h3");
+
+        PipelineRunIdInfo info = stageDao.getOldestAndLatestStageInstanceId(PIPELINE_NAME, STAGE_DEV);
+
+        assertThat(info.getLatestRunId(), is(run3.getId()));
+        assertThat(info.getOldestRunId(), is(run1.getId()));
     }
 
     private void assertStageModels(StageInstanceModels stageInstanceModels, String... runIdentifiers) {

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -349,6 +349,15 @@ public class Routes {
                     "stage_name", stageName,
                     "stage_counter", stageCounter));
         }
+
+
+        public static String previous(String pipelineName, String stageName, long before) {
+            return BASE + STAGE_HISTORY.replaceAll(":pipeline_name", pipelineName).replaceAll(":stage_name", stageName) + "?before=" + before;
+        }
+
+        public static String next(String pipelineName, String stageName, long after) {
+            return BASE + STAGE_HISTORY.replaceAll(":pipeline_name", pipelineName).replaceAll(":stage_name", stageName) + "?after=" + after;
+        }
     }
 
     public static class Job {


### PR DESCRIPTION
Issue:  #1353

Description:
Query params supported:

 - page_size: the end user can specify the number of records they wish to see in a single page. Should be between 10 and 100
 - after: the cursor value for fetching the next set of records
 - before: the cursor value for fetching the previous set of records
