### PR TITLE
Fix Pipeline History SPA comment rendering issue

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/comment_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/comment_widget.tsx
@@ -100,7 +100,10 @@ class CommentModal extends Modal {
     return <Secondary dataTestId="edit-comment-button"
                       disabled={!this.canOperatePipeline}
                       title={this.canOperatePipeline ? "Edit comment." : "Requires pipeline operate permission."}
-                      onclick={() => this.mode = Mode.EDIT}>Edit</Secondary>;
+                      onclick={() => {
+                        this.mode = Mode.EDIT;
+                        m.redraw.sync();
+                      }}>Edit</Secondary>;
   }
 
   private updateAndClose() {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/spec/comment_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/spec/comment_widget_spec.tsx
@@ -207,7 +207,7 @@ describe("CommentWidget", () => {
       helper.clickByTestId("edit-comment-button", modal);
 
       expect(helper.byTestId("textarea-to-add-or-edit-comment", modal)).toBeInDOM();
-      expect(helper.byTestId("textarea-to-add-or-edit-comment", modal)).toHaveText(comment());
+      expect(helper.byTestId("textarea-to-add-or-edit-comment", modal)).toHaveValue(comment());
 
       expect(helper.byTestId("close-comment-dropdown-button", modal)).toBeInDOM();
       expect(helper.byTestId("save-comment-button", modal)).toBeInDOM();


### PR DESCRIPTION
##### Bug:
Pipeline comment Textarea gets cleared upon clicking edit of pipeline instance comment.

##### Cause:
Mithril did not detect the bounded data change on clicking edit pipeline instance comment button as the update happens outside of the mithril lifecycle.

##### Fix:
Explicitly call redraw so that the entire view is redrawn appropriately.
