### PR TITLE
Allow normal users to access materials check connection internal api endpoint (#7451)

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/api_v1/admin/internal/material_test_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/api_v1/admin/internal/material_test_controller.rb
@@ -22,7 +22,7 @@ module ApiV1
         include_package 'com.thoughtworks.go.config.preprocessor'
         java_import com.thoughtworks.go.config.exceptions.RecordNotFoundException
 
-        before_action :check_admin_user_or_group_admin_user_and_403
+        before_action :check_user_and_403
 
         def test
           material_config = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.get_material_type(params[:type]).new).from_hash(params)

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/internal/material_test_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/internal/material_test_controller_spec.rb
@@ -33,9 +33,9 @@ describe ApiV1::Admin::Internal::MaterialTestController do
         expect(controller).to disallow_action(:post, :test).with(403, 'You are not authorized to perform this action.')
       end
 
-      it 'should disallow normal users, with security enabled' do
+      it 'should allow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:post, :test)
+        expect(controller).to allow_action(:post, :test)
       end
 
       it 'should allow admin users, with security enabled' do


### PR DESCRIPTION
Issue: #7451 (point 1)

Description:

* Users having administer policy permissions are unable to perform material
  check connection on config repo material. Allow all authenticated users to
  access material check connection endpoint.
