### PR TITLE
Fix Pipeline history throwing invalid pipeline counter error

### DIFF
--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -142,17 +142,17 @@
   </rule>
 
   <rule>
-    <name>Pipeline Instance API V1 and latest</name>
-    <condition name="Accept">application\/vnd\.go\.cd(.v*)*\+json</condition>
-    <from>^/api/pipelines/([^/]+)/([^/]+)(/?)$</from>
-    <to last="true">/spark/api/pipelines/${escape:$1}/${escape:$2}/instance</to>
-  </rule>
-
-  <rule>
     <name>Pipeline History API</name>
     <condition name="Accept">application\/vnd\.go\.cd(.v*)*\+json</condition>
     <from>^/api/pipelines/([^/]+)/history$</from>
     <to last="true">/spark/api/pipelines/${escape:$1}/history</to>
+  </rule>
+
+  <rule>
+    <name>Pipeline Instance API V1 and latest</name>
+    <condition name="Accept">application\/vnd\.go\.cd(.v*)*\+json</condition>
+    <from>^/api/pipelines/([^/]+)/([^/]+)(/?)$</from>
+    <to last="true">/spark/api/pipelines/${escape:$1}/${escape:$2}/instance</to>
   </rule>
 
   <rule>


### PR DESCRIPTION
Description: After renaming the Pipeline/Stage/Job Instance and History APIs, the pipeline history api was throwing invalid pipeline counter error. This was becoz the `history` part of the api was getting matched with `:pipeline_counter` of Pipeline Instance API. 


