### PR TITLE
Minor ui fixes

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/agent-job-run-history/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/agent-job-run-history/index.scss
@@ -29,8 +29,8 @@
 }
 
 .key-value-pair {
-  height:  35px;
-  display: flex;
+  display:       flex;
+  margin-bottom: 10px;
 }
 
 .key {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
@@ -194,7 +194,8 @@ class ConfigRepoWidget extends MithrilComponent<SingleAttrs> {
     const maybeWarning = <MaybeWarning parseInfo={parseInfo} pluginInfo={pluginInfo}/>;
     const configRepoHasErrors = !pluginInfo || _.isEmpty(parseInfo) || !!parseInfo!.error();
 
-    const title = repo.canAdminister ? "You are not authorised to perform this action!" : "";
+    const title = !repo.canAdminister() ? "You are not authorised to perform this action!" : "";
+
     return <Anchor id={repo.id()!} sm={sm} onnavigate={() => this.expanded(true)}>
       <CollapsiblePanel error={configRepoHasErrors}
                         header={<HeaderWidget {...vnode.attrs}/>}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_widget_spec.tsx
@@ -360,6 +360,23 @@ describe("ConfigReposWidget", () => {
     expect(helper.byTestId("config-repo-delete").title).toBe(title);
   });
 
+  it("should not disable the action buttons and add titles when user has admin permissions", () => {
+    const configRepo = createConfigRepoParsed();
+    configRepo.canAdminister(true);
+    models([vm(configRepo)]);
+    helper.redraw();
+
+    expect(helper.byTestId("config-repo-refresh")).toBeInDOM();
+    expect(helper.byTestId("config-repo-refresh")).not.toBeDisabled();
+    expect(helper.byTestId("config-repo-refresh").title).toBeFalsy();
+    expect(helper.byTestId("config-repo-edit")).toBeInDOM();
+    expect(helper.byTestId("config-repo-edit")).not.toBeDisabled();
+    expect(helper.byTestId("config-repo-edit").title).toBeFalsy();
+    expect(helper.byTestId("config-repo-delete")).toBeInDOM();
+    expect(helper.byTestId("config-repo-delete")).not.toBeDisabled();
+    expect(helper.byTestId("config-repo-delete").title).toBeFalsy();
+  });
+
   it('should render error msg when the anchor element is not present', () => {
     let scrollManager: ScrollManager;
     scrollManager = {


### PR DESCRIPTION
#### Description:
1. Show appropriate tooltip title message for config repository action icons>
2. Fix cluttered job state transition information

##### Before
<img width="550" alt="Screen Shot 2019-12-18 at 12 53 11 PM" src="https://user-images.githubusercontent.com/15275847/71064875-19ce8f80-2196-11ea-9637-96eaee8c59e0.png">

##### After
<img width="547" alt="Screen Shot 2019-12-18 at 12 54 16 PM" src="https://user-images.githubusercontent.com/15275847/71064872-1804cc00-2196-11ea-8b76-40bf0fd1c56c.png">



