### PR TITLE
Do not fail while loading pipeline config edit page when user does not have permissions to edit the pipeline

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/lib/pipeline_config_loader.rb
+++ b/server/src/main/webapp/WEB-INF/rails/lib/pipeline_config_loader.rb
@@ -40,7 +40,7 @@ module PipelineConfigLoader
       pipeline_for_edit = template_config_service.loadForEdit(params[:pipeline_name], current_user, result)
     else
 
-      unless go_config_service.doesPipelineExist(params[:pipeline_name], result)
+      unless go_config_service.canEditPipeline(params[:pipeline_name], current_user, result)
         render_localized_operation_result result
         return
       end


### PR DESCRIPTION
Description:
* Check whether the specified pipeline exists.
* Check for whether current_user has permissions to edit the pipeline.