### PR TITLE
Fixed tooltip positioning issue

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/tooltip/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/tooltip/index.scss
@@ -15,19 +15,26 @@
  */
 @import "../../global/common";
 
-$tooltip-min-width: 300px;
+$tooltip-min-width:    300px;
 $tooltip-medium-width: 500px;
-$tooltip-large-width: 700px;
+$tooltip-large-width:  700px;
 
 .tooltip-wrapper {
   position: static;
   display:  inline-block;
   cursor:   help;
+
   &:hover {
     .tooltip-content {
       display: block;
     }
   }
+}
+
+.tooltip-content-wrapper {
+  position: relative;
+  top:      0;
+  left:     0;
 }
 
 .tooltip-content {
@@ -43,6 +50,7 @@ $tooltip-large-width: 700px;
   padding:       10px 20px 0;
   box-shadow:    0 2px 4px $box-shadow-color;
   z-index:       map_get($zindex, submenu);
+
   &:before {
     content:          "";
     position:         absolute;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/tooltip/index.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/tooltip/index.scss.d.ts
@@ -3,4 +3,5 @@ export const large: string;
 export const medium: string;
 export const small: string;
 export const tooltipContent: string;
+export const tooltipContentWrapper: string;
 export const tooltipWrapper: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/tooltip/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/tooltip/index.tsx
@@ -18,8 +18,8 @@ import {MithrilViewComponent} from "jsx/mithril-component";
 import m from "mithril";
 
 import {bind} from "classnames/bind";
-import {InfoCircle, QuestionCircle} from "views/components/icons";
 import * as Icons from "views/components/icons";
+import {InfoCircle, QuestionCircle} from "views/components/icons";
 import styles from "./index.scss";
 
 const classnames = bind(styles);
@@ -44,20 +44,22 @@ class Tooltip extends MithrilViewComponent<Attrs> {
   constructor(tooltipType: any) {
     super();
     this.tooltipType = tooltipType;
-    this.id = Tooltip.currentId++; // added to support accessibility
+    this.id          = Tooltip.currentId++; // added to support accessibility
   }
 
   view(vnode: m.Vnode<Attrs>) {
     // @ts-ignore
-    const size = styles[TooltipSize[vnode.attrs.size || TooltipSize.small]];
+    const size   = styles[TooltipSize[vnode.attrs.size || TooltipSize.small]];
     const a11yId = `tooltip-desc-${this.id}`;
 
     return (
       <div data-test-id="tooltip-wrapper" class={styles.tooltipWrapper}>
         {m(this.tooltipType, {iconOnly: true, title: "", describedBy: a11yId})}
-        <div data-test-id="tooltip-content"
-             class={classnames(styles.tooltipContent, size)}>
-          <p role="tooltip" id={a11yId}>{vnode.attrs.content}</p>
+        <div class={styles.tooltipContentWrapper}>
+          <div data-test-id="tooltip-content"
+               class={classnames(styles.tooltipContent, size)}>
+            <p role="tooltip" id={a11yId}>{vnode.attrs.content}</p>
+          </div>
         </div>
       </div>);
   }


### PR DESCRIPTION
Fixes the issue #7442 

- The issue was there because of tooltip content was given the absolute position in relation to where it was rendered initially. Hence once a page is scrolled the content of the page was rendered out of the viewport

- Fix: Render content in relation to the current position of the tooltip icon instead of the absolute position.
