### PR TITLE
Elastic wizard fixes

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agents.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agents.tsx
@@ -286,6 +286,7 @@ export class ElasticAgentsPage extends Page<null, State> {
   }
 
   fetchData(vnode: m.Vnode<null, State>): Promise<any> {
+    this.pageState                        = PageState.LOADING;
     vnode.state.pluginInfos               = Stream(new PluginInfos());
     vnode.state.clusterProfiles           = Stream(new ClusterProfiles([]));
     vnode.state.elasticProfiles           = Stream(new ElasticAgentProfiles([]));

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agents/wizard.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agents/wizard.tsx
@@ -192,11 +192,11 @@ class ElasticProfileWidget extends MithrilViewComponent<Attrs> {
           </div>
         </div>
         <ConceptDiagram image={elasticAgentProfileImg} css={conceptDiagramStyles}>
-            <h2>What is an Elastic Agent Profile?</h2>
-            <p>An Elastic Agent Profile usually contains the configuration for your agent.<br/>
-              Depending on the plugin used, this may contain the machine image (ami, docker image), size of the
-              CPU/memory/disk, network settings among other things.</p>
-          </ConceptDiagram>
+          <h2>What is an Elastic Agent Profile?</h2>
+          <p>An Elastic Agent Profile usually contains the configuration for your agent.<br/>
+            Depending on the plugin used, this may contain the machine image (ami, docker image), size of the
+            CPU/memory/disk, network settings among other things.</p>
+        </ConceptDiagram>
       </div>
     );
   }
@@ -457,13 +457,19 @@ class ElasticProfileStep extends Step {
     }
   }
 
+  protected saveMessage(): m.Children {
+    return <span>The Cluster Profile <em>{this.elasticProfile()
+                                              .clusterProfileId()}</em> and Elastic Agent Profile <em>{this.elasticProfile()
+                                                                                                           .id()}</em> were created successfully!</span>;
+  }
+
   private create(wizard: Wizard) {
     this.elasticProfile().clusterProfileId(this.clusterProfile().id());
     return this.elasticProfile().create()
                .then((result) => {
                  result.do(
                    () => {
-                     this.onSuccessfulSave(<span>The Elastic Agent Profile <em>{this.elasticProfile().id()}</em> was created successfully!</span>);
+                     this.onSuccessfulSave(this.saveMessage());
                      wizard.close();
                    },
                    (errorResponse) => {
@@ -510,6 +516,10 @@ class AddElasticProfileToExistingClusterStep extends ElasticProfileStep {
                          align="right">Show Cluster Profile</Buttons.Secondary>,
       <span class={styles.footerError}>{this.footerError()}</span>
     ];
+  }
+
+  protected saveMessage(): m.Children {
+    return <span>The Elastic Agent Profile <em>{this.elasticProfile().id()}</em> was created successfully!</span>;
   }
 }
 


### PR DESCRIPTION
- Change the message displayed in the Create flow when a Cluster Profile and Elastic Profile are created
- Show a loading spinner when the wizard is closed and the page is being refreshed
