### PR TITLE
Package Material should generate valid material name when one not specified (#7345)

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/PackageMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/PackageMaterialConfig.java
@@ -149,7 +149,7 @@ public class PackageMaterialConfig extends AbstractMaterialConfig {
     @Override
     public CaseInsensitiveString getName() {
         if (((name == null) || StringUtils.isEmpty(name.toString())) && packageDefinition != null) {
-            return new CaseInsensitiveString(getPackageDefinition().getRepository().getName() + ":" + packageDefinition.getName());
+            return new CaseInsensitiveString(getPackageDefinition().getRepository().getName() + "_" + packageDefinition.getName());
         } else {
             return name;
         }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/PackageMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/PackageMaterialConfigTest.java
@@ -146,7 +146,7 @@ public class PackageMaterialConfigTest {
         PackageMaterialConfig materialConfig = new PackageMaterialConfig();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo-name", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         materialConfig.setPackageDefinition(PackageDefinitionMother.create("p-id", "package-name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
-        assertThat(materialConfig.getName().toString(), is("repo-name:package-name"));
+        assertThat(materialConfig.getName().toString(), is("repo-name_package-name"));
         materialConfig.setPackageDefinition(null);
         assertThat(materialConfig.getName(), is(nullValue()));
     }

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
@@ -3184,7 +3184,7 @@ public class MagicalGoConfigXmlLoaderTest {
                 + "    </repository>\n"
                 + "  </repositories>"
                 + "<pipelines group=\"group_name\">\n"
-                + "  <pipeline name=\"new_name\" labeltemplate=\"${COUNT}-${repo_name:pkg_name}\">\n"
+                + "  <pipeline name=\"new_name\" labeltemplate=\"${COUNT}:${repo_name_pkg_name}\">\n"
                 + "    <materials>\n"
                 + "      <package ref='package-id' />\n"
                 + "    </materials>\n"
@@ -3196,7 +3196,7 @@ public class MagicalGoConfigXmlLoaderTest {
                 + "  </pipeline>\n"
                 + "</pipelines></cruise>";
         GoConfigHolder holder = ConfigMigrator.loadWithMigration(xml);
-        assertThat(holder.config.getAllPipelineConfigs().get(0).materialConfigs().get(0).getName().toString()).isEqualTo("repo_name:pkg_name");
+        assertThat(holder.config.getAllPipelineConfigs().get(0).materialConfigs().get(0).getName().toString()).isEqualTo("repo_name_pkg_name");
     }
 
     @Test


### PR DESCRIPTION
Issue: #7345

Description:

* Use 'repo_package' instead of 'repo:package'

Reattempt of: https://github.com/gocd/gocd/pull/7412