### PR TITLE
Attempt: to render the error response based on the Accept header

### DIFF
--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/PipelineActivityController.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/PipelineActivityController.java
@@ -16,10 +16,8 @@
 
 package com.thoughtworks.go.spark.spa;
 
-import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.SecurityService;
-import com.thoughtworks.go.spark.HtmlErrorPage;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.SparkController;
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper;
@@ -58,13 +56,7 @@ public class PipelineActivityController implements SparkController {
         path(controllerBasePath(), () -> {
             before("", authenticationHelper::checkPipelineViewPermissionsAnd403);
             get("", this::index, engine);
-            exception(RecordNotFoundException.class, this::handleRecordNotFoundException);
         });
-    }
-
-    private void handleRecordNotFoundException(RecordNotFoundException t, Request request, Response response) {
-        response.status(t.getStatus().value());
-        response.body(HtmlErrorPage.errorPage(t.getStatus().value(), t.getMessage()));
     }
 
     public ModelAndView index(Request request, Response response) {

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/PipelineActivityControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/PipelineActivityControllerTest.groovy
@@ -103,16 +103,6 @@ class PipelineActivityControllerTest implements ControllerTrait<PipelineActivity
       String getPipelineName() {
         return "up42"
       }
-
-      @Test
-      void 'should handle record not found'() {
-        enableSecurity()
-        when(goConfigService.hasPipelineNamed(new CaseInsensitiveString(getPipelineName()))).thenReturn(false)
-
-        makeHttpCall()
-
-        assertThatResponse().isNotFound()
-      }
     }
   }
 }


### PR DESCRIPTION
- **Default:** When Accept header is missing then always return JSON response which is same as the existing behavior

- The browser always sends the `text/html` or `application/xhtml+xml` or both(except internet explorer), if any of that value is present render the HTML response

See [this](https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values) for more information