### PR TITLE
Move API to list pipeline instance based on search query to spark

### DIFF
--- a/api/api-base/src/main/java/com/thoughtworks/go/api/ApiController.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/ApiController.java
@@ -35,6 +35,7 @@ import static com.thoughtworks.go.api.util.HaltApiResponses.haltBecauseJsonConte
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public abstract class ApiController implements ControllerMethods, SparkController {
+    public static final String BAD_PAGE_SIZE_MSG = "The query parameter 'page_size', if specified must be a number between 10 and 100.";
     private static final Set<String> UPDATE_HTTP_METHODS = new HashSet<>(Arrays.asList("PUT", "POST", "PATCH"));
 
     protected final ApiVersion apiVersion;

--- a/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/CompareControllerV1.java
+++ b/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/CompareControllerV1.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.api.ApiController;
 import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv1.compare.representers.ComparisonRepresenter;
+import com.thoughtworks.go.config.exceptions.BadRequestException;
 import com.thoughtworks.go.config.exceptions.UnprocessableEntityException;
 import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.server.service.ChangesetService;

--- a/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/InternalCompareControllerV1.java
+++ b/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/InternalCompareControllerV1.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare;
+
+import com.thoughtworks.go.api.ApiController;
+import com.thoughtworks.go.api.ApiVersion;
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
+import com.thoughtworks.go.apiv1.compare.representers.PipelineInstanceModelsRepresenter;
+import com.thoughtworks.go.config.exceptions.BadRequestException;
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels;
+import com.thoughtworks.go.server.service.PipelineHistoryService;
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import com.thoughtworks.go.spark.Routes;
+import com.thoughtworks.go.spark.spring.SparkSpringController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import spark.Request;
+import spark.Response;
+
+import java.io.IOException;
+
+import static spark.Spark.*;
+
+@Component
+public class InternalCompareControllerV1 extends ApiController implements SparkSpringController {
+    private final ApiAuthenticationHelper apiAuthenticationHelper;
+    private final PipelineHistoryService pipelineHistoryService;
+
+    @Autowired
+    public InternalCompareControllerV1(ApiAuthenticationHelper apiAuthenticationHelper, PipelineHistoryService pipelineHistoryService) {
+        super(ApiVersion.v1);
+        this.apiAuthenticationHelper = apiAuthenticationHelper;
+        this.pipelineHistoryService = pipelineHistoryService;
+    }
+
+    @Override
+    public String controllerBasePath() {
+        return Routes.CompareAPI.INTERNAL_BASE;
+    }
+
+    @Override
+    public void setupRoutes() {
+        path(controllerBasePath(), () -> {
+            before("/*", mimeType, this::setContentType);
+            before("/*", mimeType, this::verifyContentType);
+
+            before(Routes.CompareAPI.INTERNAL_LIST, mimeType, this.apiAuthenticationHelper::checkPipelineViewPermissionsAnd403);
+
+            get(Routes.CompareAPI.INTERNAL_LIST, mimeType, this::list);
+        });
+    }
+
+    String list(Request request, Response response) throws IOException {
+        String pipelineName = request.params("pipeline_name");
+        Integer pageSize = getPageSize(request);
+        String pattern = request.queryParamOrDefault("pattern", "");
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        PipelineInstanceModels pipelineInstanceModels = pipelineHistoryService.findMatchingPipelineInstances(pipelineName, pattern, pageSize, currentUsername(), result);
+        if (result.isSuccessful()) {
+            return writerForTopLevelObject(request, response, outputWriter -> PipelineInstanceModelsRepresenter.toJSON(outputWriter, pipelineInstanceModels));
+        } else {
+            return renderHTTPOperationResult(result, request, response);
+        }
+    }
+
+    private Integer getPageSize(Request request) {
+        Integer offset;
+        try {
+            offset = Integer.valueOf(request.queryParamOrDefault("page_size", "10"));
+            if (offset < 10 || offset > 100) {
+                throw new BadRequestException(BAD_PAGE_SIZE_MSG);
+            }
+        } catch (NumberFormatException e) {
+            throw new BadRequestException(BAD_PAGE_SIZE_MSG);
+        }
+        return offset;
+    }
+}

--- a/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/BuildCauseRepresenter.java
+++ b/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/BuildCauseRepresenter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.domain.buildcause.BuildCause;
+
+public class BuildCauseRepresenter {
+    public static void toJSON(OutputWriter outputWriter, BuildCause buildCause) {
+        outputWriter
+                .add("trigger_message", buildCause.getBuildCauseMessage())
+                .add("approver", buildCause.getApprover())
+                .add("trigger_forced", buildCause.isForced())
+                .addChildList("material_revisions", listWriter -> buildCause.getMaterialRevisions()
+                        .forEach(revision -> listWriter.addChild(revisionWriter -> MaterialRevisionRepresenter.toJSON(revisionWriter, revision))));
+    }
+}

--- a/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/JobHistoryItemRepresenter.java
+++ b/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/JobHistoryItemRepresenter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.presentation.pipelinehistory.JobHistoryItem;
+
+public class JobHistoryItemRepresenter {
+    public static void toJSON(OutputWriter outputWriter, JobHistoryItem jobHistoryItem) {
+        outputWriter
+                .add("name", jobHistoryItem.getName())
+                .addInMillisIfNotNull("scheduled_date", jobHistoryItem.getScheduledDate());
+        if (jobHistoryItem.getState() != null) {
+            outputWriter.add("state", jobHistoryItem.getState().toString());
+        }
+        if (jobHistoryItem.getResult() != null) {
+            outputWriter.add("result", jobHistoryItem.getResult().toString());
+        }
+    }
+}

--- a/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/MaterialRepresenter.java
+++ b/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/MaterialRepresenter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.domain.materials.Material;
+
+public class MaterialRepresenter {
+    public static void toJSON(OutputWriter outputWriter, Material material) {
+        outputWriter
+                .add("name", material.getDisplayName())
+                .add("fingerprint", material.getFingerprint())
+                .add("type", material.getTypeForDisplay())
+                .add("description", material.getLongDescription());
+    }
+}

--- a/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/MaterialRevisionRepresenter.java
+++ b/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/MaterialRevisionRepresenter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.apiv1.compare.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.domain.MaterialRevision;
+
+public class MaterialRevisionRepresenter {
+    public static void toJSON(OutputWriter outputWriter, MaterialRevision revision) {
+        outputWriter
+                .addChild("material", materialWriter -> MaterialRepresenter.toJSON(outputWriter, revision.getMaterial()))
+                .add("changed", revision.isChanged())
+                .addChildList("modifications", modificationWriter -> revision.getModifications()
+                        .forEach(modification -> modificationWriter.addChild(modWriter -> ModificationRepresenter.toJSON(modWriter, modification))));
+    }
+}

--- a/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/ModificationRepresenter.java
+++ b/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/ModificationRepresenter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.domain.materials.Modification;
+
+public class ModificationRepresenter {
+    public static void toJSON(OutputWriter outputWriter, Modification modification) {
+        outputWriter
+                .add("revision", modification.getRevision())
+                .addIfNotNull("modified_time", modification.getModifiedTime())
+                .add("user_name", modification.getUserName())
+                .add("comment", modification.getComment())
+                .add("email_address", modification.getEmailAddress());
+    }
+}

--- a/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/PipelineInstanceModelRepresenter.java
+++ b/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/PipelineInstanceModelRepresenter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
+
+public class PipelineInstanceModelRepresenter {
+    public static void toJSON(OutputWriter outputWriter, PipelineInstanceModel pipelineInstance) {
+        outputWriter
+                .add("name", pipelineInstance.getName())
+                .add("counter", pipelineInstance.getCounter())
+                .add("label", pipelineInstance.getLabel())
+                .add("natural_order", pipelineInstance.getNaturalOrder())
+                .add("comment", pipelineInstance.getComment())
+                .addChild("build_cause", causeWriter -> BuildCauseRepresenter.toJSON(causeWriter, pipelineInstance.getBuildCause()))
+                .addChildList("stages", stagesWriter -> pipelineInstance.getStageHistory()
+                        .forEach(stageInstanceModel -> stagesWriter.addChild(stageWriter -> StageInstanceModelRepresenter.toJSON(stageWriter, stageInstanceModel))));
+    }
+}

--- a/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/PipelineInstanceModelsRepresenter.java
+++ b/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/PipelineInstanceModelsRepresenter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.domain.PipelineRunIdInfo;
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels;
+
+import static java.util.Collections.emptyList;
+
+public class PipelineInstanceModelsRepresenter {
+    public static void toJSON(OutputWriter outputWriter, PipelineInstanceModels pipelineInstanceModels) {
+        if (pipelineInstanceModels.isEmpty()) {
+            outputWriter.addChildList("pipelines", emptyList());
+            return;
+        }
+        outputWriter.addChildList("pipelines", pipelinesWriter -> pipelineInstanceModels.forEach(pipelineInstanceModel -> pipelinesWriter.addChild(pipelineWriter -> PipelineInstanceModelRepresenter.toJSON(pipelineWriter, pipelineInstanceModel))));
+    }
+}

--- a/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/StageInstanceModelRepresenter.java
+++ b/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/StageInstanceModelRepresenter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModel;
+
+public class StageInstanceModelRepresenter {
+    public static void toJSON(OutputWriter outputWriter, StageInstanceModel stageInstanceModel) {
+        if (stageInstanceModel.getResult() != null) {
+            outputWriter.add("result", stageInstanceModel.getResult().toString());
+        }
+        if (stageInstanceModel.getRerunOfCounter() == null) {
+            outputWriter.renderNull("rerun_of_counter");
+        } else {
+            outputWriter.add("rerun_of_counter", stageInstanceModel.getRerunOfCounter());
+        }
+        outputWriter
+                .add("name", stageInstanceModel.getName())
+                .add("counter", stageInstanceModel.getCounter())
+                .add("scheduled", stageInstanceModel.isScheduled())
+                .add("approval_type", stageInstanceModel.getApprovalType())
+                .add("approved_by", stageInstanceModel.getApprovedBy())
+                .add("operate_permission", stageInstanceModel.hasOperatePermission());
+    }
+}

--- a/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/InternalCompareControllerV1Test.groovy
+++ b/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/InternalCompareControllerV1Test.groovy
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare
+
+import com.thoughtworks.go.api.SecurityTestTrait
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
+import com.thoughtworks.go.apiv1.compare.representers.PipelineInstanceModelsRepresenter
+import com.thoughtworks.go.config.CaseInsensitiveString
+import com.thoughtworks.go.domain.buildcause.BuildCause
+import com.thoughtworks.go.helper.ModificationsMother
+import com.thoughtworks.go.helper.StageMother
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModels
+import com.thoughtworks.go.server.domain.Username
+import com.thoughtworks.go.server.service.PipelineHistoryService
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult
+import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.PipelineAccessSecurity
+import com.thoughtworks.go.spark.SecurityServiceTrait
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.Mock
+
+import java.util.stream.Stream
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static org.mockito.ArgumentMatchers.*
+import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.when
+import static org.mockito.MockitoAnnotations.initMocks
+
+class InternalCompareControllerV1Test implements SecurityServiceTrait, ControllerTrait<InternalCompareControllerV1> {
+  @Mock
+  private PipelineHistoryService pipelineHistoryService
+
+  @Override
+  InternalCompareControllerV1 createControllerInstance() {
+    return new InternalCompareControllerV1(new ApiAuthenticationHelper(securityService, goConfigService), pipelineHistoryService)
+  }
+
+  @BeforeEach
+  void setUp() {
+    initMocks(this)
+  }
+
+  @Nested
+  class List {
+    private pipelineName = "up42"
+    private methodName = "list"
+    private api = getApi(pipelineName, methodName)
+
+    @BeforeEach
+    void setUp() {
+      when(goConfigService.hasPipelineNamed(any(CaseInsensitiveString.class))).thenReturn(true)
+    }
+
+    @Nested
+    class Security implements SecurityTestTrait, PipelineAccessSecurity {
+
+      @Override
+      String getControllerMethodUnderTest() {
+        return methodName
+      }
+
+      @Override
+      void makeHttpCall() {
+        getWithApiHeader(api)
+      }
+
+      @Override
+      String getPipelineName() {
+        return "up42"
+      }
+    }
+
+    @Nested
+    class AsAuthorizedUser {
+      @BeforeEach
+      void setUp() {
+        enableSecurity()
+        loginAsAdmin()
+      }
+
+      @Test
+      void 'should return pipeline instance models'() {
+        def date = new Date()
+        def stage = StageMother.passedStageInstance(pipelineName, "stageName", 2, "buildName", date)
+        def stageInstanceModel = StageMother.toStageInstanceModel(stage)
+        def stageInstanceModels = new StageInstanceModels()
+        stageInstanceModels.add(stageInstanceModel)
+
+        def materialRevisions = ModificationsMother.multipleModifications()
+        def buildCause = BuildCause.createWithModifications(materialRevisions, "approver")
+
+        def pipelineInstanceModel1 = PipelineInstanceModel.createPipeline(pipelineName, 2, "label", buildCause, stageInstanceModels)
+        def pipelineInstanceModel2 = PipelineInstanceModel.createPipeline(pipelineName, 3, "label", buildCause, stageInstanceModels)
+        def pipelineInstanceModels = PipelineInstanceModels.createPipelineInstanceModels(pipelineInstanceModel1, pipelineInstanceModel2)
+
+        when(pipelineHistoryService.findMatchingPipelineInstances(anyString(), anyString(), anyInt(), any(Username.class), any(HttpLocalizedOperationResult.class))).thenReturn(pipelineInstanceModels)
+
+        def expected = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels) })
+
+        getWithApiHeader(api)
+
+        verify(pipelineHistoryService).findMatchingPipelineInstances(eq(pipelineName), eq(""), eq(10), any(Username.class), any(HttpLocalizedOperationResult.class))
+
+        assertThatResponse()
+          .isOk()
+          .hasJsonBody(expected)
+      }
+
+      @ParameterizedTest
+      @MethodSource("pageSizes")
+      void 'should throw error if page_size is not between 10 and 100'(String input) {
+        getWithApiHeader(api + "?page_size=" + input)
+
+        assertThatResponse()
+          .isBadRequest()
+          .hasJsonMessage("The query parameter 'page_size', if specified must be a number between 10 and 100.")
+      }
+
+      static Stream<Arguments> pageSizes() {
+        return Stream.of(
+          Arguments.of("7"),
+          Arguments.of("107"),
+          Arguments.of("-10"),
+          Arguments.of("abc")
+        )
+      }
+    }
+  }
+
+  static String getApi(String pipelineName, String methodName) {
+    return "/api/internal/compare/$pipelineName/$methodName".toString()
+  }
+}

--- a/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/BuildCauseRepresenterTest.groovy
+++ b/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/BuildCauseRepresenterTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers
+
+import com.thoughtworks.go.domain.buildcause.BuildCause
+import com.thoughtworks.go.helper.ModificationsMother
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObject
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class BuildCauseRepresenterTest {
+  @Test
+  void 'should serialize build cause to json'() {
+    def materialRevisions = ModificationsMother.multipleModifications()
+    def buildCause = BuildCause.createWithModifications(materialRevisions, "approver")
+
+    def actualJson = toObjectString({ BuildCauseRepresenter.toJSON(it, buildCause) })
+
+    def expectedJSON = [
+      "trigger_message"   : "modified by committer <html />",
+      "trigger_forced"    : false,
+      "approver"          : "approver",
+      "material_revisions": buildCause.getMaterialRevisions().collect { eachItem ->
+        toObject({
+          MaterialRevisionRepresenter.toJSON(it, eachItem)
+        })
+      }
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
+  }
+}

--- a/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/JobHistoryItemRepresenterTest.groovy
+++ b/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/JobHistoryItemRepresenterTest.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers
+
+import com.thoughtworks.go.domain.JobResult
+import com.thoughtworks.go.domain.JobState
+import com.thoughtworks.go.presentation.pipelinehistory.JobHistoryItem
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class JobHistoryItemRepresenterTest {
+  @Test
+  void 'should deserialize into json'() {
+    Date date = new Date();
+    def jobHistoryItem = new JobHistoryItem("jobName", JobState.Completed, JobResult.Passed, date)
+    jobHistoryItem.setId(5)
+
+    def actualJson = toObjectString({ JobHistoryItemRepresenter.toJSON(it, jobHistoryItem) })
+
+    def expectedJson = [
+      "name"          : "jobName",
+      "scheduled_date": date.getTime().toString(),
+      "state"         : "Completed",
+      "result"        : "Passed"
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should not add scheduled_date if set to null'() {
+    def jobHistoryItem = new JobHistoryItem("jobName", JobState.Completed, JobResult.Passed, new Date())
+    jobHistoryItem.setId(5)
+    jobHistoryItem.setScheduledDate(null)
+
+    def actualJson = toObjectString({ JobHistoryItemRepresenter.toJSON(it, jobHistoryItem) })
+
+    def expectedJson = [
+      "name"  : "jobName",
+      "state" : "Completed",
+      "result": "Passed"
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should not set state if set to null'() {
+    Date date = new Date()
+    def jobHistoryItem = new JobHistoryItem("jobName", null, JobResult.Passed, date)
+    jobHistoryItem.setId(5)
+
+    def actualJson = toObjectString({ JobHistoryItemRepresenter.toJSON(it, jobHistoryItem) })
+
+    def expectedJson = [
+      "name"          : "jobName",
+      "scheduled_date": date.getTime().toString(),
+      "result"        : "Passed"
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+
+  @Test
+  void 'should not set result if set to null'() {
+    Date date = new Date()
+    def jobHistoryItem = new JobHistoryItem("jobName", JobState.Completed, null, date)
+    jobHistoryItem.setId(5)
+
+    def actualJson = toObjectString({ JobHistoryItemRepresenter.toJSON(it, jobHistoryItem) })
+
+    def expectedJson = [
+      "name"          : "jobName",
+      "scheduled_date": date.getTime().toString(),
+      "state"         : "Completed"
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+}

--- a/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/MaterialRepresenterTest.groovy
+++ b/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/MaterialRepresenterTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers
+
+import com.thoughtworks.go.helper.MaterialsMother
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class MaterialRepresenterTest {
+  @Test
+  void 'should render material config properties'() {
+    def material = MaterialsMother.gitMaterial("git1")
+
+    def expectedJSON = [
+      name       : "git1",
+      fingerprint: "2fde537a026695884e2ee13e8f9730eca0610a3e407dbcc6bbce974f595c2f7c",
+      type       : "Git",
+      description: "URL: git1, Branch: master"
+    ]
+
+    def actualJson = toObjectString({ MaterialRepresenter.toJSON(it, material) })
+
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
+  }
+}

--- a/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/MaterialRevisionRepresenterTest.groovy
+++ b/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/MaterialRevisionRepresenterTest.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers
+
+
+import com.thoughtworks.go.helper.ModificationsMother
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonOutputWriter.jsonDate
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class MaterialRevisionRepresenterTest {
+  @Test
+  void 'should render material revision with modifications'() {
+    def materialRevision = ModificationsMother.createHgMaterialRevisions().getMaterialRevision(0)
+
+    def expectedJSON = [
+      "changed"      : false,
+      "material"     : [
+        "name"       : "hg-url",
+        "fingerprint": "4290e91721d0a0be34955725cfd754113588d9c27c39f9bd1a97c15e55832515",
+        "type"       : "Mercurial",
+        "description": "URL: hg-url"
+      ],
+      "modifications": [
+        [
+          "revision"     : "9fdcf27f16eadc362733328dd481d8a2c29915e1",
+          "modified_time": jsonDate(materialRevision.getModification(0).modifiedTime),
+          "user_name"    : "user2",
+          "comment"      : "comment2",
+          "email_address": "email2"
+        ],
+        [
+          "revision"     : "eef77acd79809fc14ed82b79a312648d4a2801c6",
+          "modified_time": jsonDate(materialRevision.getModification(1).modifiedTime),
+          "user_name"    : "user1",
+          "comment"      : "comment1",
+          "email_address": "email1"
+        ]
+      ]
+    ]
+
+    def actualJson = toObjectString({ MaterialRevisionRepresenter.toJSON(it, materialRevision) })
+
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
+  }
+}

--- a/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/ModificationRepresenterTest.groovy
+++ b/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/ModificationRepresenterTest.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers
+
+import com.thoughtworks.go.helper.ModificationsMother
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonOutputWriter.jsonDate
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class ModificationRepresenterTest {
+  @Test
+  void 'should render modified time if not null'() {
+    def modification = ModificationsMother.aCheckIn("rev1", "file1")
+
+    def expectedJSON = [
+      "revision"     : "rev1",
+      "modified_time": jsonDate(ModificationsMother.TODAY_CHECKIN),
+      "user_name"    : "committer",
+      "comment"      : "Added the README file",
+      "email_address": "foo@bar.com"]
+
+    def actualJson = toObjectString({ ModificationRepresenter.toJSON(it, modification) })
+
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
+  }
+
+  @Test
+  void 'should not render modified time if set to null'() {
+    def modification = ModificationsMother.aCheckIn("rev1", "file1")
+    modification.modifiedTime = null
+
+    def expectedJSON = [
+      "revision"     : "rev1",
+      "user_name"    : "committer",
+      "comment"      : "Added the README file",
+      "email_address": "foo@bar.com"]
+
+    def actualJson = toObjectString({ ModificationRepresenter.toJSON(it, modification) })
+
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
+  }
+}

--- a/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/PipelineInstanceModelRepresenterTest.groovy
+++ b/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/PipelineInstanceModelRepresenterTest.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers
+
+import com.thoughtworks.go.domain.buildcause.BuildCause
+import com.thoughtworks.go.helper.ModificationsMother
+import com.thoughtworks.go.helper.StageMother
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModels
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObject
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class PipelineInstanceModelRepresenterTest {
+  @Test
+  void 'should serialize into json'() {
+    def date = new Date()
+    def stage = StageMother.passedStageInstance("pipelineName", "stageName", 4, "buildName", date)
+    def stageInstanceModel = StageMother.toStageInstanceModel(stage)
+    def stageInstanceModels = new StageInstanceModels()
+    stageInstanceModels.add(stageInstanceModel)
+
+    def materialRevisions = ModificationsMother.multipleModifications()
+    def buildCause = BuildCause.createWithModifications(materialRevisions, "approver")
+
+    def pipelineInstanceModel = PipelineInstanceModel.createPipeline("pipelineName", 4, "label", buildCause, stageInstanceModels)
+
+    def buildCauseJson = toObject({ BuildCauseRepresenter.toJSON(it, pipelineInstanceModel.getBuildCause()) })
+    def actualJson = toObjectString({ PipelineInstanceModelRepresenter.toJSON(it, pipelineInstanceModel) })
+
+    def expectedJson = [
+      "name"                 : "pipelineName",
+      "counter"              : 4,
+      "label"                : "label",
+      "natural_order"        : pipelineInstanceModel.getNaturalOrder(),
+      "comment"              : null,
+      "build_cause"          : buildCauseJson,
+      "stages"               : pipelineInstanceModel.getStageHistory().collect { eachItem ->
+        toObject({
+          StageInstanceModelRepresenter.toJSON(it, eachItem)
+        })
+      }
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+}

--- a/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/PipelineInstanceModelsRepresenterTest.groovy
+++ b/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/PipelineInstanceModelsRepresenterTest.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers
+
+import com.thoughtworks.go.domain.PipelineRunIdInfo
+import com.thoughtworks.go.domain.buildcause.BuildCause
+import com.thoughtworks.go.helper.ModificationsMother
+import com.thoughtworks.go.helper.StageMother
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModels
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObject
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class PipelineInstanceModelsRepresenterTest {
+  private PipelineInstanceModels pipelineInstanceModels = PipelineInstanceModels.createPipelineInstanceModels()
+
+  @BeforeEach
+  void setUp() {
+    for (int i = 6; i >= 2; i--) {
+      def pipelineInstanceModel = createPipelineInstance(i + 4)
+      pipelineInstanceModel.id = i
+      pipelineInstanceModels.add(pipelineInstanceModel)
+    }
+  }
+
+  @Test
+  void 'should serializer into json with next and previous links'() {
+    def actualJson = toObjectString({ PipelineInstanceModelsRepresenter.toJSON(it, pipelineInstanceModels) })
+
+    def expectedJson = [
+      "pipelines": pipelineInstanceModels.collect { model ->
+        toObject({ PipelineInstanceModelRepresenter.toJSON(it, model) })
+      }
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  private static def createPipelineInstance(int counter) {
+    def stage = StageMother.passedStageInstance("pipelineName", "stageName", 4, "buildName", new Date())
+    def stageInstanceModel = StageMother.toStageInstanceModel(stage)
+    def stageInstanceModels = new StageInstanceModels()
+    stageInstanceModels.add(stageInstanceModel)
+
+    def materialRevisions = ModificationsMother.multipleModifications()
+    def buildCause = BuildCause.createWithModifications(materialRevisions, "approver")
+    return PipelineInstanceModel.createPipeline("pipelineName", counter, "label", buildCause, stageInstanceModels)
+  }
+}

--- a/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/StageInstanceModelRepresenterTest.groovy
+++ b/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/StageInstanceModelRepresenterTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.compare.representers
+
+import com.thoughtworks.go.helper.StageMother
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class StageInstanceModelRepresenterTest {
+  @Test
+  void 'should deserialize into json'() {
+    def date = new Date()
+    def stage = StageMother.passedStageInstance("pipelineName", "stageName", 4, "buildName", date)
+    def stageInstanceModel = StageMother.toStageInstanceModel(stage)
+
+    def actualJson = toObjectString({ StageInstanceModelRepresenter.toJSON(it, stageInstanceModel) })
+
+    def expectedJson = [
+      "result"            : "Passed",
+      "rerun_of_counter"  : null,
+      "name"              : "stageName",
+      "counter"           : "4",
+      "scheduled"         : true,
+      "approval_type"     : "success",
+      "approved_by"       : "changes",
+      "operate_permission": false
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should not add result if null'() {
+    def date = new Date()
+    def stage = StageMother.passedStageInstance("pipelineName", "stageName", 4, "buildName", date)
+    def stageInstanceModel = StageMother.toStageInstanceModel(stage)
+    stageInstanceModel.result = null
+
+    def actualJson = toObjectString({ StageInstanceModelRepresenter.toJSON(it, stageInstanceModel) })
+
+    def expectedJson = [
+      "rerun_of_counter"  : null,
+      "name"              : "stageName",
+      "counter"           : "4",
+      "scheduled"         : true,
+      "approval_type"     : "success",
+      "approved_by"       : "changes",
+      "operate_permission": false
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should add rerun_of_counter if not null'() {
+    def date = new Date()
+    def stage = StageMother.passedStageInstance("pipelineName", "stageName", 4, "buildName", date)
+    def stageInstanceModel = StageMother.toStageInstanceModel(stage)
+    stageInstanceModel.setRerunOfCounter(3)
+
+    def actualJson = toObjectString({ StageInstanceModelRepresenter.toJSON(it, stageInstanceModel) })
+
+    def expectedJson = [
+      "result"            : "Passed",
+      "rerun_of_counter"  : 3,
+      "name"              : "stageName",
+      "counter"           : "4",
+      "scheduled"         : true,
+      "approval_type"     : "success",
+      "approved_by"       : "changes",
+      "operate_permission": false
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+
+}

--- a/api/api-job-instance-v1/src/main/java/com/thoughtworks/go/apiv1/jobinstance/JobInstanceControllerV1.java
+++ b/api/api-job-instance-v1/src/main/java/com/thoughtworks/go/apiv1/jobinstance/JobInstanceControllerV1.java
@@ -42,7 +42,6 @@ import static spark.Spark.*;
 
 @Component
 public class JobInstanceControllerV1 extends ApiController implements SparkSpringController {
-    static final String BAD_PAGE_SIZE_MSG = "The query parameter `page_size`, if specified must be a number between 10 and 100.";
     static final String BAD_OFFSET_MSG = "The query parameter `offset`, if specified must be a number greater or equal to 0.";
     private final ApiAuthenticationHelper apiAuthenticationHelper;
     private final JobInstanceService jobInstanceService;

--- a/api/api-job-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/jobinstance/JobInstanceControllerV1Test.groovy
+++ b/api/api-job-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/jobinstance/JobInstanceControllerV1Test.groovy
@@ -177,7 +177,7 @@ class JobInstanceControllerV1Test implements SecurityServiceTrait, ControllerTra
 
         assertThatResponse()
           .isBadRequest()
-          .hasJsonMessage("The query parameter `page_size`, if specified must be a number between 10 and 100.")
+          .hasJsonMessage("The query parameter 'page_size', if specified must be a number between 10 and 100.")
       }
 
       @Test
@@ -187,7 +187,7 @@ class JobInstanceControllerV1Test implements SecurityServiceTrait, ControllerTra
 
         assertThatResponse()
           .isBadRequest()
-          .hasJsonMessage("The query parameter `page_size`, if specified must be a number between 10 and 100.")
+          .hasJsonMessage("The query parameter 'page_size', if specified must be a number between 10 and 100.")
       }
 
       @Test
@@ -197,7 +197,7 @@ class JobInstanceControllerV1Test implements SecurityServiceTrait, ControllerTra
 
         assertThatResponse()
           .isBadRequest()
-          .hasJsonMessage("The query parameter `page_size`, if specified must be a number between 10 and 100.")
+          .hasJsonMessage("The query parameter 'page_size', if specified must be a number between 10 and 100.")
       }
 
       def getJobInstances() {

--- a/api/api-pipeline-instance-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1.java
+++ b/api/api-pipeline-instance-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1.java
@@ -44,7 +44,6 @@ import static spark.Spark.*;
 
 @Component
 public class PipelineInstanceControllerV1 extends ApiController implements SparkSpringController {
-    private static final String BAD_PAGE_SIZE_MSG = "The query parameter `page_size`, if specified must be a number between 10 and 100.";
     private final ApiAuthenticationHelper apiAuthenticationHelper;
     private final PipelineHistoryService pipelineHistoryService;
 

--- a/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1Test.groovy
+++ b/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1Test.groovy
@@ -326,7 +326,7 @@ class PipelineInstanceControllerV1Test implements SecurityServiceTrait, Controll
 
         assertThatResponse()
           .isBadRequest()
-          .hasJsonMessage("The query parameter `page_size`, if specified must be a number between 10 and 100.")
+          .hasJsonMessage("The query parameter 'page_size', if specified must be a number between 10 and 100.")
       }
 
       static Stream<Arguments> pageSizes() {

--- a/api/api-stage-instance-v2/src/main/java/com/thoughtworks/go/apiv2/stageinstance/StageInstanceControllerV2.java
+++ b/api/api-stage-instance-v2/src/main/java/com/thoughtworks/go/apiv2/stageinstance/StageInstanceControllerV2.java
@@ -53,7 +53,6 @@ import static spark.Spark.*;
 
 @Component
 public class StageInstanceControllerV2 extends ApiController implements SparkSpringController {
-    static final String BAD_PAGE_SIZE_MSG = "The query parameter `page_size`, if specified must be a number between 10 and 100.";
     static final String BAD_OFFSET_MSG = "The query parameter `offset`, if specified must be a number greater or equal to 0.";
     private final static String JOB_NAMES_PROPERTY = "jobs";
     private final ApiAuthenticationHelper apiAuthenticationHelper;

--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -23,6 +23,13 @@
 -->
 
 <urlrewrite>
+
+  <rule>
+    <name>Internal Compare APIs</name>
+    <from>^/api/internal/compare/([^/]+)/list(/?)$</from>
+    <to last="true">/spark/api/internal/compare/${escape:$1}/list</to>
+  </rule>
+
   <rule>
     <name>Agent Job History API</name>
     <condition name="Accept">application\/vnd\.go\.cd(.v*)*\+json</condition>

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -755,6 +755,9 @@ public class Routes {
     public static class CompareAPI {
         public static final String BASE = "/api/pipelines/:pipeline_name/compare/:from_counter/:to_counter";
         public static final String DOC = apiDocsUrl("#compare");
+
+        public static final String INTERNAL_BASE = "/api/internal/compare";
+        public static final String INTERNAL_LIST = "/:pipeline_name/list";
     }
 
     public static class Packages {


### PR DESCRIPTION
Description: For Comparison SPA, we have an endpoint (`/go/compare/:pipeline_name/list/compare_with/:other_pipeline_counter`) which returns a list of pipeline instances based on the search query. The said API return a HTML based json response. 

This PR moves the same to Spark and returns the list of matched pipeline instances as json.
Endpoint:
`go/api/internal/compare/:pipeline_name/list`

Command: 
```curl
curl 'http://go-server-api/go/api/internal/compare/up42/list?pattern=10&page_size=15' \
      -u 'username:password' \
      -H 'Accept: application/vnd.go.cd.v1+json'
```
Query Params supported:

 - `pattern` : the pattern which needs to be matched
 - `page_size` : the no. of records needed. Can be between 10 and 100
