### PR TITLE
Time in milliseconds should not be rendered as string but as number

### DIFF
--- a/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/representers/JobHistoryItemRepresenterTest.groovy
+++ b/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/representers/JobHistoryItemRepresenterTest.groovy
@@ -35,7 +35,7 @@ class JobHistoryItemRepresenterTest {
 
     def expectedJson = [
       "name"          : "jobName",
-      "scheduled_date": date.getTime().toString(),
+      "scheduled_date": date.getTime(),
       "state"         : "Completed",
       "result"        : "Passed"
     ]
@@ -70,7 +70,7 @@ class JobHistoryItemRepresenterTest {
 
     def expectedJson = [
       "name"          : "jobName",
-      "scheduled_date": date.getTime().toString(),
+      "scheduled_date": date.getTime(),
       "result"        : "Passed"
     ]
 
@@ -88,7 +88,7 @@ class JobHistoryItemRepresenterTest {
 
     def expectedJson = [
       "name"          : "jobName",
-      "scheduled_date": date.getTime().toString(),
+      "scheduled_date": date.getTime(),
       "state"         : "Completed"
     ]
 

--- a/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/representers/MaterialRevisionRepresenterTest.groovy
+++ b/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/representers/MaterialRevisionRepresenterTest.groovy
@@ -41,14 +41,14 @@ class MaterialRevisionRepresenterTest {
       "modifications": [
         [
           "revision"     : "9fdcf27f16eadc362733328dd481d8a2c29915e1",
-          "modified_time": materialRevision.getModification(0).modifiedTime.getTime().toString(),
+          "modified_time": materialRevision.getModification(0).modifiedTime.getTime(),
           "user_name"    : "user2",
           "comment"      : "comment2",
           "email_address": "email2"
         ],
         [
           "revision"     : "eef77acd79809fc14ed82b79a312648d4a2801c6",
-          "modified_time": materialRevision.getModification(1).modifiedTime.getTime().toString(),
+          "modified_time": materialRevision.getModification(1).modifiedTime.getTime(),
           "user_name"    : "user1",
           "comment"      : "comment1",
           "email_address": "email1"

--- a/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/representers/ModificationRepresenterTest.groovy
+++ b/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/representers/ModificationRepresenterTest.groovy
@@ -30,7 +30,7 @@ class ModificationRepresenterTest {
 
     def expectedJSON = [
       "revision"     : "rev1",
-      "modified_time": ModificationsMother.TODAY_CHECKIN.getTime().toString(),
+      "modified_time": ModificationsMother.TODAY_CHECKIN.getTime(),
       "user_name"    : "committer",
       "comment"      : "Added the README file",
       "email_address": "foo@bar.com"]

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/api/base/JsonOutputWriter.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/api/base/JsonOutputWriter.java
@@ -220,7 +220,7 @@ public class JsonOutputWriter {
         @Override
         public OutputWriter addInMillis(String key, Date value) {
             return withExceptionHandling((jacksonWriter) -> {
-                jacksonWriter.writeStringField(key, value.getTime() + "");
+                jacksonWriter.writeNumberField(key, value.getTime());
             });
         }
 


### PR DESCRIPTION
The time was rendered in milliseconds but was encoded as string in json. Hence UI was failing. Fixed that.