### PR TITLE
Fix development environment link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To quickly build your first pipeline while learning key GoCD concepts, visit our
 
 ## Development Setup
 
-This is a Java/JRuby on Rails project. Here is the guide to setup your [development environment](https://developer.gocd.org/current/2/2.1.html).
+This is a Java/JRuby on Rails project. Here is the guide to setup your [development environment](https://developer.gocd.org/current/).
 
 ## Contributing
 


### PR DESCRIPTION
Description: The old link gave a 404

