### PR TITLE
Attempt to fix agent fatJar verification

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -128,7 +128,7 @@ task verifyJar(type: VerifyJarTask) {
       "base-${project.version}.jar",
       "bcpkix-jdk15on-${project.versions.bouncyCastle}.jar",
       "bcprov-jdk15on-${project.versions.bouncyCastle}.jar",
-      "cglib-${project.versions.cglib}.jar",
+      "cglib-2.2.2.jar",
       "cloning-${project.versions.cloning}.jar",
       "commandline-${project.version}.jar",
       "common-${project.version}.jar",


### PR DESCRIPTION
cglib(`2.2.2`) is pulled by `org.apache.commons:commons-digester3:3.2`  as transitive dep

```bash
|    +--- project :plugin-infra:go-plugin-access
|    |    +--- project :plugin-infra:go-plugin-config-repo
|    |    |    \--- project :domain (*)
|    |    +--- project :plugin-infra:go-plugin-infra
|    |    |    +--- project :base (*)
|    |    |    +--- project :util (*)
|    |    |    +--- project :plugin-infra:go-plugin-activator
|    |    |    |    +--- project :plugin-infra:go-plugin-api (*)
|    |    |    |    \--- org.apache.felix:org.apache.felix.framework:5.6.10
|    |    |    +--- org.springframework:spring-context:4.3.25.RELEASE (*)
|    |    |    +--- org.apache.commons:commons-collections4:4.4
|    |    |    +--- org.apache.commons:commons-digester3:3.2
|    |    |    |    +--- cglib:cglib:2.2.2
|    |    |    |    |    \--- asm:asm:3.3.1
```

