### PR TITLE
Update APIs

### DIFF
--- a/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/PipelineInstanceModelRepresenter.java
+++ b/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/PipelineInstanceModelRepresenter.java
@@ -27,6 +27,7 @@ public class PipelineInstanceModelRepresenter {
                 .add("label", pipelineInstance.getLabel())
                 .add("natural_order", pipelineInstance.getNaturalOrder())
                 .add("comment", pipelineInstance.getComment())
+                .addInMillisIfNotNull("scheduled_date", pipelineInstance.getScheduledDate())
                 .addChild("build_cause", causeWriter -> BuildCauseRepresenter.toJSON(causeWriter, pipelineInstance.getBuildCause()))
                 .addChildList("stages", stagesWriter -> pipelineInstance.getStageHistory()
                         .forEach(stageInstanceModel -> stagesWriter.addChild(stageWriter -> StageInstanceModelRepresenter.toJSON(stageWriter, stageInstanceModel))));

--- a/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/StageInstanceModelRepresenter.java
+++ b/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/representers/StageInstanceModelRepresenter.java
@@ -24,6 +24,7 @@ public class StageInstanceModelRepresenter {
         if (stageInstanceModel.getResult() != null) {
             outputWriter.add("result", stageInstanceModel.getResult().toString());
         }
+        outputWriter.add("status", stageInstanceModel.getState().toString());
         if (stageInstanceModel.getRerunOfCounter() == null) {
             outputWriter.renderNull("rerun_of_counter");
         } else {

--- a/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/PipelineInstanceModelRepresenterTest.groovy
+++ b/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/PipelineInstanceModelRepresenterTest.groovy
@@ -45,13 +45,14 @@ class PipelineInstanceModelRepresenterTest {
     def actualJson = toObjectString({ PipelineInstanceModelRepresenter.toJSON(it, pipelineInstanceModel) })
 
     def expectedJson = [
-      "name"                 : "pipelineName",
-      "counter"              : 4,
-      "label"                : "label",
-      "natural_order"        : pipelineInstanceModel.getNaturalOrder(),
-      "comment"              : null,
-      "build_cause"          : buildCauseJson,
-      "stages"               : pipelineInstanceModel.getStageHistory().collect { eachItem ->
+      "name"          : "pipelineName",
+      "counter"       : 4,
+      "label"         : "label",
+      "natural_order" : pipelineInstanceModel.getNaturalOrder(),
+      "comment"       : null,
+      "scheduled_date": pipelineInstanceModel.getScheduledDate().getTime(),
+      "build_cause"   : buildCauseJson,
+      "stages"        : pipelineInstanceModel.getStageHistory().collect { eachItem ->
         toObject({
           StageInstanceModelRepresenter.toJSON(it, eachItem)
         })

--- a/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/StageInstanceModelRepresenterTest.groovy
+++ b/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/representers/StageInstanceModelRepresenterTest.groovy
@@ -33,6 +33,7 @@ class StageInstanceModelRepresenterTest {
 
     def expectedJson = [
       "result"            : "Passed",
+      "status"            : "Passed",
       "rerun_of_counter"  : null,
       "name"              : "stageName",
       "counter"           : "4",
@@ -55,6 +56,7 @@ class StageInstanceModelRepresenterTest {
     def actualJson = toObjectString({ StageInstanceModelRepresenter.toJSON(it, stageInstanceModel) })
 
     def expectedJson = [
+      "status"            : "Passed",
       "rerun_of_counter"  : null,
       "name"              : "stageName",
       "counter"           : "4",
@@ -78,6 +80,7 @@ class StageInstanceModelRepresenterTest {
 
     def expectedJson = [
       "result"            : "Passed",
+      "status"            : "Passed",
       "rerun_of_counter"  : 3,
       "name"              : "stageName",
       "counter"           : "4",

--- a/api/api-pipeline-instance-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineinstance/representers/PipelineInstanceModelRepresenter.java
+++ b/api/api-pipeline-instance-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineinstance/representers/PipelineInstanceModelRepresenter.java
@@ -29,6 +29,7 @@ public class PipelineInstanceModelRepresenter {
                 .add("can_run", pipelineInstance.getCanRun())
                 .add("preparing_to_schedule", pipelineInstance.isPreparingToSchedule())
                 .add("comment", pipelineInstance.getComment())
+                .addInMillisIfNotNull("scheduled_date", pipelineInstance.getScheduledDate())
                 .addChild("build_cause", causeWriter -> BuildCauseRepresenter.toJSON(causeWriter, pipelineInstance.getBuildCause()))
                 .addChildList("stages", stagesWriter -> pipelineInstance.getStageHistory()
                         .forEach(stageInstanceModel -> stagesWriter.addChild(stageWriter -> StageInstanceModelRepresenter.toJSON(stageWriter, stageInstanceModel))));

--- a/api/api-pipeline-instance-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineinstance/representers/StageInstanceModelRepresenter.java
+++ b/api/api-pipeline-instance-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineinstance/representers/StageInstanceModelRepresenter.java
@@ -24,6 +24,7 @@ public class StageInstanceModelRepresenter {
         if (stageInstanceModel.getResult() != null) {
             outputWriter.add("result", stageInstanceModel.getResult().toString());
         }
+        outputWriter.add("status", stageInstanceModel.getState().toString());
         if (stageInstanceModel.getRerunOfCounter() == null) {
             outputWriter.renderNull("rerun_of_counter");
         } else {

--- a/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/representers/PipelineInstanceModelRepresenterTest.groovy
+++ b/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/representers/PipelineInstanceModelRepresenterTest.groovy
@@ -52,6 +52,7 @@ class PipelineInstanceModelRepresenterTest {
       "can_run"              : false,
       "preparing_to_schedule": false,
       "comment"              : null,
+      "scheduled_date"       : pipelineInstanceModel.getScheduledDate().getTime(),
       "build_cause"          : buildCauseJson,
       "stages"               : pipelineInstanceModel.getStageHistory().collect { eachItem ->
         toObject({

--- a/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/representers/StageInstanceModelRepresenterTest.groovy
+++ b/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/representers/StageInstanceModelRepresenterTest.groovy
@@ -34,6 +34,7 @@ class StageInstanceModelRepresenterTest {
 
     def expectedJson = [
       "result"            : "Passed",
+      "status"            : "Passed",
       "rerun_of_counter"  : null,
       "name"              : "stageName",
       "counter"           : "4",
@@ -63,6 +64,7 @@ class StageInstanceModelRepresenterTest {
     def actualJson = toObjectString({ StageInstanceModelRepresenter.toJSON(it, stageInstanceModel) })
 
     def expectedJson = [
+      "status"            : "Passed",
       "rerun_of_counter"  : null,
       "name"              : "stageName",
       "counter"           : "4",
@@ -93,6 +95,7 @@ class StageInstanceModelRepresenterTest {
 
     def expectedJson = [
       "result"            : "Passed",
+      "status"            : "Passed",
       "rerun_of_counter"  : 3,
       "name"              : "stageName",
       "counter"           : "4",


### PR DESCRIPTION
Description:
Updated Pipeline Instance API v1 and internal compare APIs to get:
 - `scheduled_date` for a pipeline instance
 - `status` of a stage for a particular pipeline instance
