### PR TITLE
Build script fix: Updating version of asm jar for server module in verify task

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -799,7 +799,7 @@ task verifyWar(type: VerifyJarTask) {
         "ant-${project.versions.apacheAnt}.jar",
         "antlr-2.7.6.jar",
         "aopalliance-1.0.jar",
-        "asm-3.3.1.jar",
+        "asm-7.1.jar",
         "aspectjrt-${project.versions.aspectj}.jar",
         "aspectjweaver-${project.versions.aspectj}.jar",
         "base-${project.version}.jar",


### PR DESCRIPTION
- This is started failing after updating cglib dependency. New version of
  cglib is now depended on the asm-7.1 instead of 3.3.1



