### PR TITLE
Add a toggle to fall back to rails based test connection API

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/SparkOrRailsToggle.java
+++ b/server/src/main/java/com/thoughtworks/go/server/SparkOrRailsToggle.java
@@ -30,4 +30,8 @@ public class SparkOrRailsToggle {
             request.setAttribute("sparkOrRails", "spark");
         }
     }
+
+    public void testConnectionAPI(HttpServletRequest request, HttpServletResponse response) {
+        basedOnToggle(Toggles.USE_RAILS_BASED_MATERIAL_TEST_CONNECTION_API, request);
+    }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -22,6 +22,7 @@ public class Toggles {
     public static String NEW_PIPELINE_DROPDOWN = "new_pipeline_dropdown";
     public static String ENABLE_PIPELINE_GROUP_CONFIG_LISTING_API = "enable_pipeline_group_config_listing_api";
     public static String FAST_PIPELINE_SAVE = "fast_pipeline_save";
+    public static String USE_RAILS_BASED_MATERIAL_TEST_CONNECTION_API = "use_rails_based_material_test_connection_api";
 
     private static FeatureToggleService service;
 

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -30,6 +30,11 @@
       "key": "fast_pipeline_save",
       "description": "Use the pipeline config service to speed up save, instead of doing a full config save",
       "value": true
+    },
+    {
+      "key": "use_rails_based_material_test_connection_api",
+      "description": "Use the rails based material test connection API. Default: false",
+      "value": false
     }
   ]
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -207,7 +207,7 @@ export class SparkRoutes {
   }
 
   static materialConnectionCheck(): string {
-    return `/go/api/internal/material_test`;
+    return `/go/api/admin/internal/material_test`;
   }
 
   static configRepoRevisionStatusPath(id: string): string {

--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -46,8 +46,9 @@
 
   <rule>
     <name>Material Test API</name>
-    <from>^/api/internal/material_test(/?)$</from>
-    <to last="true">/spark/api/internal/material_test</to>
+    <from>^/api/admin/internal/material_test(/?)$</from>
+    <run class="com.thoughtworks.go.server.SparkOrRailsToggle" method="testConnectionAPI"/>
+    <to last="true">/%{attribute:sparkOrRails}/api/admin/internal/material_test</to>
   </rule>
 
   <rule>

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -821,6 +821,6 @@ public class Routes {
     }
 
     public class InternalMaterialTest {
-        public static final String BASE = "/api/internal/material_test";
+        public static final String BASE = "/api/admin/internal/material_test";
     }
 }


### PR DESCRIPTION
Description:
 - Added `admin` in the spark based API to make it consistent with the rails one.
 - Added a toggle at `urlrewrite` level which based on toggle `use_rails_based_material_test_connection_api` will redirect to spark or rails based API. Default is spark based.

