### PR TITLE
Fix for incorrect icon for cancelled jobs

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/new-theme.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/new-theme.scss
@@ -1642,12 +1642,27 @@ input[type='submit'], input[type='submit']:hover, button.submit, button.submit:h
   }
 
   &.Cancelled {
-    color: $icon-txt;
+    background-image: none;
+    background-color: $building;
+    position:         relative;
+
+    &:after {
+      content:          "";
+      background-image: image_url("building.png");
+      position:         absolute;
+      top:              0;
+      left:             0;
+      bottom:           0;
+      background-size:  40px 16px;
+      right:            0;
+    }
+
+    color:            $icon-txt;
     @include icon-after($cancelled-icon, $margin: 0, $line-height: 1.2em);
   }
 }
 
-.Cancelled, .cancelled-stage {
+li.Cancelled, .cancelled-stage {
   background-image: none;
   background-color: $building;
   position:         relative;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/patterns/_status_visualizations.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/patterns/_status_visualizations.scss
@@ -73,15 +73,6 @@
   background-position: bottom left;
 }
 
-.Cancelled {
-  background-image: image_url('building.png');
-  background-repeat: repeat-x;
-  background-color: #FFC11B;
-  background-position: bottom left;
-  text-align: center;
-}
-
-
 /**
  * ==TABLE OVERRIDES
 **/


### PR DESCRIPTION
Issue: #7472

Description:
 - the changes made for stage animation via gif (PR #6707) rendered the gif in all the places `Cancelled` class was used.
   Moved the relevant code to specific class or removed it if wasn't used.

Preview:
<img width="444" alt="Screen Shot 2020-01-02 at 4 20 30 PM" src="https://user-images.githubusercontent.com/41165891/71663590-d66e4680-2d7b-11ea-9500-4215617b1075.png">


