### PR TITLE
Guess webhook url without username for gitlab

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/api/web_hooks/guess_url_web_hook_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/api/web_hooks/guess_url_web_hook_controller.rb
@@ -37,6 +37,10 @@ module Api
           git@#{repo_host_name}:#{repo_full_name}/
           git@#{repo_host_name}:#{repo_full_name}.git
           git@#{repo_host_name}:#{repo_full_name}.git/
+          ssh://#{repo_host_name}/#{repo_full_name}
+          ssh://#{repo_host_name}/#{repo_full_name}/
+          ssh://#{repo_host_name}/#{repo_full_name}.git
+          ssh://#{repo_host_name}/#{repo_full_name}.git/
           ssh://git@#{repo_host_name}/#{repo_full_name}
           ssh://git@#{repo_host_name}/#{repo_full_name}/
           ssh://git@#{repo_host_name}/#{repo_full_name}.git

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/web_hooks/bit_bucket_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/web_hooks/bit_bucket_controller_spec.rb
@@ -88,6 +88,10 @@ describe Api::WebHooks::BitBucketController do
                             git@gitlab.example.com:org/repo/
                             git@gitlab.example.com:org/repo.git
                             git@gitlab.example.com:org/repo.git/
+                            ssh://gitlab.example.com/org/repo
+                            ssh://gitlab.example.com/org/repo/
+                            ssh://gitlab.example.com/org/repo.git
+                            ssh://gitlab.example.com/org/repo.git/
                             ssh://git@gitlab.example.com/org/repo
                             ssh://git@gitlab.example.com/org/repo/
                             ssh://git@gitlab.example.com/org/repo.git

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/web_hooks/git_hub_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/web_hooks/git_hub_controller_spec.rb
@@ -75,6 +75,10 @@ describe Api::WebHooks::GitHubController do
                             git@github.com:org/repo/
                             git@github.com:org/repo.git
                             git@github.com:org/repo.git/
+                            ssh://github.com/org/repo
+                            ssh://github.com/org/repo/
+                            ssh://github.com/org/repo.git
+                            ssh://github.com/org/repo.git/
                             ssh://git@github.com/org/repo
                             ssh://git@github.com/org/repo/
                             ssh://git@github.com/org/repo.git
@@ -168,6 +172,10 @@ describe Api::WebHooks::GitHubController do
                             git@github.com:org/repo/
                             git@github.com:org/repo.git
                             git@github.com:org/repo.git/
+                            ssh://github.com/org/repo
+                            ssh://github.com/org/repo/
+                            ssh://github.com/org/repo.git
+                            ssh://github.com/org/repo.git/
                             ssh://git@github.com/org/repo
                             ssh://git@github.com/org/repo/
                             ssh://git@github.com/org/repo.git

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/web_hooks/git_lab_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/web_hooks/git_lab_controller_spec.rb
@@ -74,6 +74,10 @@ describe Api::WebHooks::GitLabController do
                             git@gitlab.example.com:org/repo/
                             git@gitlab.example.com:org/repo.git
                             git@gitlab.example.com:org/repo.git/
+                            ssh://gitlab.example.com/org/repo
+                            ssh://gitlab.example.com/org/repo/
+                            ssh://gitlab.example.com/org/repo.git
+                            ssh://gitlab.example.com/org/repo.git/
                             ssh://git@gitlab.example.com/org/repo
                             ssh://git@gitlab.example.com/org/repo/
                             ssh://git@gitlab.example.com/org/repo.git


### PR DESCRIPTION
Relates issue: #6897

Description:
Guess more ssh based URLs (without user)

