### PR TITLE
Endpoint to list all spark APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -501,3 +501,7 @@ api/api-internal-material-test-v1/out/
 api/api-internal-material-test-v1/target/
 api/api-internal-material-test-v1/logs/
 api/api-internal-material-test-v1/config/
+api/api-api-info-v1/out/
+api/api-api-info-v1/target/
+api/api-api-info-v1/logs/
+api/api-api-info-v1/config/

--- a/api/api-api-info-v1/build.gradle
+++ b/api/api-api-info-v1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'jacoco'
+apply plugin: 'groovy'
+
+dependencies {
+  compile project(':api:api-base')
+
+  testCompile project(path: ':api:api-base', configuration: 'testOutput')
+
+  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
+  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+}

--- a/api/api-api-info-v1/src/main/java/com/thoughtworks/go/apiv1/apiinfo/ApiInfoControllerV1.java
+++ b/api/api-api-info-v1/src/main/java/com/thoughtworks/go/apiv1/apiinfo/ApiInfoControllerV1.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.apiinfo;
+
+import com.thoughtworks.go.api.ApiController;
+import com.thoughtworks.go.api.ApiVersion;
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
+import com.thoughtworks.go.apiv1.apiinfo.representers.RouteEntryRepresenter;
+import com.thoughtworks.go.spark.Routes;
+import com.thoughtworks.go.spark.spring.RouteEntry;
+import com.thoughtworks.go.spark.spring.RouteInformationProvider;
+import com.thoughtworks.go.spark.spring.SparkSpringController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import spark.Request;
+import spark.Response;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static spark.Spark.*;
+
+@Component
+public class ApiInfoControllerV1 extends ApiController implements SparkSpringController {
+    private final ApiAuthenticationHelper apiAuthenticationHelper;
+    private final RouteInformationProvider provider;
+
+    @Autowired
+    public ApiInfoControllerV1(ApiAuthenticationHelper apiAuthenticationHelper,
+                               RouteInformationProvider provider) {
+        super(ApiVersion.v1);
+        this.apiAuthenticationHelper = apiAuthenticationHelper;
+        this.provider = provider;
+    }
+
+    @Override
+    public String controllerBasePath() {
+        return Routes.ApiInfo.BASE;
+    }
+
+    @Override
+    public void setupRoutes() {
+        path(controllerBasePath(), () -> {
+            before("", mimeType, this::setContentType);
+            before("", mimeType, this.apiAuthenticationHelper::checkUserAnd403);
+            get("", this::index);
+        });
+    }
+
+    public String index(Request request, Response response) throws IOException {
+        List<RouteEntry> filteredRoutes = provider.getRoutes().stream()
+            .filter(RouteEntry::isAPI)
+            .sorted(Comparator.comparing(RouteEntry::getPath))
+            .collect(Collectors.toList());
+
+        return writerForTopLevelArray(request, response, writer -> RouteEntryRepresenter.toJSON(writer, filteredRoutes));
+    }
+}

--- a/api/api-api-info-v1/src/main/java/com/thoughtworks/go/apiv1/apiinfo/representers/RouteEntryRepresenter.java
+++ b/api/api-api-info-v1/src/main/java/com/thoughtworks/go/apiv1/apiinfo/representers/RouteEntryRepresenter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.apiinfo.representers;
+
+import com.thoughtworks.go.api.base.OutputListWriter;
+import com.thoughtworks.go.spark.spring.RouteEntry;
+import spark.utils.SparkUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RouteEntryRepresenter {
+    public static void toJSON(OutputListWriter writer, List<RouteEntry> routes) {
+        routes.forEach(entry -> {
+            writer.addChild(entryWriter -> {
+                entryWriter
+                    .add("method", entry.getHttpMethod().name())
+                    .add("path", entry.getPath())
+                    .add("version", entry.getAcceptedType())
+                    .addChildList("path_params", getParams(entry));
+            });
+        });
+    }
+
+    public static List<String> getParams(RouteEntry entry) {
+        return SparkUtils.convertRouteToList(entry.getPath())
+            .stream()
+            .filter(SparkUtils::isParam)
+            .collect(Collectors.toList());
+    }
+}

--- a/api/api-api-info-v1/src/test/groovy/com/thoughtworks/go/apiv1/apiinfo/ApiInfoControllerV1Test.groovy
+++ b/api/api-api-info-v1/src/test/groovy/com/thoughtworks/go/apiv1/apiinfo/ApiInfoControllerV1Test.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.apiinfo
+
+import com.thoughtworks.go.api.SecurityTestTrait
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
+import com.thoughtworks.go.apiv1.apiinfo.representers.RouteEntryRepresenter
+import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.NormalUserSecurity
+import com.thoughtworks.go.spark.SecurityServiceTrait
+import com.thoughtworks.go.spark.spring.RouteEntry
+import com.thoughtworks.go.spark.spring.RouteInformationProvider
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import org.mockito.Mockito
+import spark.route.HttpMethod
+
+import static org.mockito.MockitoAnnotations.initMocks
+
+class ApiInfoControllerV1Test implements SecurityServiceTrait, ControllerTrait<ApiInfoControllerV1> {
+  @Mock
+  private RouteInformationProvider provider
+
+  @BeforeEach
+  void setUp() {
+    initMocks(this)
+  }
+
+  @Override
+  ApiInfoControllerV1 createControllerInstance() {
+    new ApiInfoControllerV1(new ApiAuthenticationHelper(securityService, goConfigService), provider)
+  }
+
+  @Nested
+  class Index {
+
+    @BeforeEach
+    void setUp() {
+      loginAsUser()
+    }
+
+    @Test
+    void 'should return list of api routes'() {
+      def entries = List.of(new RouteEntry(HttpMethod.get, "/api/:foo/:bar", "application/vnd.go.cd+v1.json", new Object()))
+      Mockito.when(provider.getRoutes()).thenReturn(entries)
+
+      getWithApiHeader(controller.controllerBasePath())
+
+      assertThatResponse()
+        .isOk()
+        .hasBodyWithJsonArray(RouteEntryRepresenter, entries)
+    }
+
+    @Nested
+    class Security implements SecurityTestTrait, NormalUserSecurity {
+
+      @Override
+      String getControllerMethodUnderTest() {
+        return "index"
+      }
+
+      @Override
+      void makeHttpCall() {
+        getWithApiHeader(controller.controllerBasePath())
+      }
+    }
+  }
+}

--- a/api/api-api-info-v1/src/test/groovy/com/thoughtworks/go/apiv1/apiinfo/representers/RouteEntryRepresenterTest.groovy
+++ b/api/api-api-info-v1/src/test/groovy/com/thoughtworks/go/apiv1/apiinfo/representers/RouteEntryRepresenterTest.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.apiinfo.representers
+
+import com.thoughtworks.go.spark.spring.RouteEntry
+import org.junit.jupiter.api.Test
+import spark.route.HttpMethod
+
+import static com.thoughtworks.go.api.base.JsonUtils.toArrayString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class RouteEntryRepresenterTest {
+
+  @Test
+  void shouldConvertRouteEntriesToJson() {
+    def entries = List.of(new RouteEntry(HttpMethod.get, "/api/:foo/:bar", "application/vnd.go.cd+v1.json", new Object()))
+    def json = toArrayString({
+      RouteEntryRepresenter.toJSON(it, entries)
+    })
+
+    def expectedJSON = [
+      ["method"     : "get",
+       "path"       : "/api/:foo/:bar",
+       "version"    : "application/vnd.go.cd+v1.json",
+       "path_params": [":foo", ":bar"]
+      ]
+    ]
+
+    assertThatJson(json).isEqualTo(expectedJSON)
+  }
+}

--- a/server/src/main/resources/applicationContext-global.xml
+++ b/server/src/main/resources/applicationContext-global.xml
@@ -25,6 +25,7 @@
 
   <context:annotation-config/>
 
+  <context:component-scan base-package="com.thoughtworks.go.apiv1.apiinfo"/>
   <context:component-scan base-package="com.thoughtworks.go.apiv2.notificationfilter"/>
   <context:component-scan base-package="com.thoughtworks.go.apiv1.internalmaterialtest"/>
   <context:component-scan base-package="com.thoughtworks.go.apiv6.admin.templateconfig"/>

--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -38,6 +38,12 @@
   </rule>
 
   <rule>
+    <name>APIs info API</name>
+    <from>^/api/apis(/?)$</from>
+    <to last="true">/spark/api/apis</to>
+  </rule>
+
+  <rule>
     <name>Notification filter CRUD APIs</name>
     <condition name="Accept">application\/vnd\.go\.cd(.v2)*\+json</condition>
     <from>^/api/notification_filters/(.*)$</from>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 ThoughtWorks, Inc.
+ * Copyright 2020 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ include ':api:api-access-token-v1'
 include ':api:api-admins-config-v2'
 include ':api:api-agent-job-history-v1'
 include ':api:api-agents-v6'
+include ':api:api-api-info-v1'
 include ':api:api-artifact-config-v1'
 include ':api:api-artifact-store-config-v1'
 include ':api:api-backup-config-v1'

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -836,4 +836,8 @@ public class Routes {
     public class StatusReports {
         public static final String SPA_BASE = "/admin/status_reports";
     }
+
+    public static class ApiInfo {
+        public static final String BASE = "/api/apis";
+    }
 }

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/SparkPreFilter.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/SparkPreFilter.java
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.startsWithAny;
 
 public class SparkPreFilter extends SparkFilter {
 
@@ -42,11 +43,16 @@ public class SparkPreFilter extends SparkFilter {
     @Override
     public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws ServletException, IOException {
         HttpServletRequest request = (HttpServletRequest) req;
+        boolean allowWithoutApiHeader = startsWithAny(request.getRequestURI().toLowerCase(),
+            "/go/spark/api/plugin_images",
+            "/go/spark/api/support",
+            "/go/spark/api/v1/health",
+            "/go/spark/api/apis"
+        );
+
         if (request.getRequestURI().startsWith("/go/spark/api/") &&
-                !request.getRequestURI().startsWith("/go/spark/api/plugin_images") &&
-                !request.getRequestURI().startsWith("/go/spark/api/support") &&
-                !request.getRequestURI().startsWith("/go/spark/api/v1/health") &&
-                noApiVersionInAcceptHeader((HttpServletRequest) req)) {
+            !allowWithoutApiHeader &&
+            noApiVersionInAcceptHeader((HttpServletRequest) req)) {
             render404((HttpServletResponse) resp);
             return;
         }

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/Application.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/Application.java
@@ -26,10 +26,13 @@ import spark.servlet.SparkApplication;
 public class Application implements SparkApplication {
 
     @Autowired
-    public Application(RerouteLatestApis rerouteLatestApis, SparkSpringController... controllers) {
+    public Application(RouteInformationProvider routeInformationProvider,
+                       RerouteLatestApis rerouteLatestApis,
+                       SparkSpringController... controllers) {
         ServletFlag.runFromServlet();
         RoutesHelper routesHelper = new RoutesHelper(controllers);
         routesHelper.init();
+        routeInformationProvider.cacheRouteInformation();
         rerouteLatestApis.registerLatest();
     }
 
@@ -37,5 +40,4 @@ public class Application implements SparkApplication {
     public void init() {
 
     }
-
 }

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/RouteEntry.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/RouteEntry.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.spark.spring;
+
+import spark.route.HttpMethod;
+
+import java.util.List;
+
+import static org.apache.commons.lang3.StringUtils.startsWith;
+
+public class RouteEntry {
+    private final List<String> METHODS = List.of("get", "post", "put", "patch", "delete", "trace");
+    private HttpMethod httpMethod;
+    private String path;
+    private String acceptedType;
+    private Object target;
+
+    public RouteEntry(HttpMethod httpMethod, String path, String acceptedType, Object target) {
+        this.httpMethod = httpMethod;
+        this.path = path;
+        this.acceptedType = acceptedType;
+        this.target = target;
+    }
+
+    public HttpMethod getHttpMethod() {
+        return httpMethod;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getAcceptedType() {
+        return acceptedType;
+    }
+
+    public Object getTarget() {
+        return target;
+    }
+
+    public boolean isAPI() {
+        return METHODS.contains(httpMethod.name().toLowerCase()) &&
+            startsWith(acceptedType, "application/vnd.go.cd");
+    }
+}

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/RouteInformationProvider.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/RouteInformationProvider.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.spark.spring;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.ReflectionUtils;
+import spark.Service;
+import spark.Spark;
+import spark.route.Routes;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+public class RouteInformationProvider {
+    private static final List<RouteEntry> routes = new ArrayList<>();
+
+    public RouteInformationProvider() {
+    }
+
+    public void cacheRouteInformation() {
+        routes.clear();
+        routeList().forEach(routeEntry -> {
+            routes.add(new RouteEntry(
+                getField(routeEntry, "httpMethod"),
+                getField(routeEntry, "path"),
+                getField(routeEntry, "acceptedType"),
+                getField(routeEntry, "target")
+            ));
+        });
+    }
+
+    public List<RouteEntry> getRoutes() {
+        return Collections.unmodifiableList(routes);
+    }
+
+    private List<?> routeList() {
+        Service service = getService();
+
+        // reflection equivalent of:
+        // Routes routes = service.routes
+        Routes routes = getField(service, "routes");
+
+        // reflection equivalent of:
+        // List<RouteEntry> routesList = routes.routes
+        List<?> routesList = getField(routes, "routes");
+
+        // return a copy of the array, instead of the reference
+        return new ArrayList<>(routesList);
+    }
+
+    public Service getService() {
+        // reflection equivalent of:
+        // Service service = Spark.getInstance()
+        Method getInstanceMethod = ReflectionUtils.findMethod(Spark.class, "getInstance");
+        ReflectionUtils.makeAccessible(getInstanceMethod);
+        return (Service) ReflectionUtils.invokeMethod(getInstanceMethod, null);
+    }
+
+    private static <T> T getField(Object o, String fieldName) {
+        Field field = ReflectionUtils.findField(o.getClass(), fieldName);
+        ReflectionUtils.makeAccessible(field);
+        return (T) ReflectionUtils.getField(field, o);
+    }
+}

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/spring/RouteInformationProviderTest.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/spring/RouteInformationProviderTest.groovy
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.thoughtworks.go.api.spring
+
+package com.thoughtworks.go.spark.spring
 
 import com.thoughtworks.go.config.exceptions.HttpException
 import com.thoughtworks.go.spark.SparkController
 import com.thoughtworks.go.spark.mocks.TestApplication
 import com.thoughtworks.go.spark.mocks.TestSparkPreFilter
-import com.thoughtworks.go.spark.spring.RouteInformationProvider
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -37,8 +37,7 @@ import static org.mockito.Mockito.when
 import static org.mockito.MockitoAnnotations.initMocks
 import static spark.Spark.*
 
-class RerouteLatestApisImplTest {
-
+class RouteInformationProviderTest {
   @Mock
   Filter apiv11BeforeFilter1
   @Mock
@@ -176,18 +175,5 @@ class RerouteLatestApisImplTest {
   void routeAssertions() {
     routeInformationProvider.cacheRouteInformation()
     assertThat(routeInformationProvider.routes).hasSize(16)
-  }
-
-  @Test
-  void shouldRegisterLatestRoutes() {
-    // original route list
-    RerouteLatestApisImpl rerouteLatestApis = new RerouteLatestApisImpl(routeInformationProvider)
-    routeInformationProvider.cacheRouteInformation()
-    assertThat(routeInformationProvider.routes).hasSize(16)
-
-    rerouteLatestApis.registerLatest()
-    // add 5 routes for `/foo/bar`
-    // add 3 routes for `/something-else/bar`
-    assertThat(routeInformationProvider.routes).hasSize(24)
   }
 }


### PR DESCRIPTION
Endpoint to list all spark APIs `url: https://go-server/go/api/apis`

> Example response

```json
[
    {
        "method": "get",
        "path": "/api/admin/access_tokens",
        "path_params": [],
        "version": "application/vnd.go.cd.v1+json"
    },
    {
        "method": "get",
        "path": "/api/admin/access_tokens",
        "path_params": [],
        "version": "application/vnd.go.cd+json"
    },
    {
        "method": "get",
        "path": "/api/admin/access_tokens/:id",
        "path_params": [
            ":id"
        ],
        "version": "application/vnd.go.cd.v1+json"
    },
    {
        "method": "get",
        "path": "/api/admin/access_tokens/:id",
        "path_params": [
            ":id"
        ],
        "version": "application/vnd.go.cd+json"
    },
    {
        "method": "post",
        "path": "/api/admin/access_tokens/:id/revoke",
        "path_params": [
            ":id"
        ],
        "version": "application/vnd.go.cd.v1+json"
    },
    ...
]
```

