### PR TITLE
Add support for defining cluster_profile and elastic_agent_profile type on a policy

### DIFF
--- a/api/api-roles-config-v3/src/main/java/com/thoughtworks/go/apiv3/rolesconfig/InternalRolesControllerV3.java
+++ b/api/api-roles-config-v3/src/main/java/com/thoughtworks/go/apiv3/rolesconfig/InternalRolesControllerV3.java
@@ -21,10 +21,10 @@ import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv3.rolesconfig.models.RolesViewModel;
 import com.thoughtworks.go.apiv3.rolesconfig.representers.RolesViewModelRepresenter;
 import com.thoughtworks.go.config.RolesConfig;
+import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
-import com.thoughtworks.go.server.service.ConfigRepoService;
-import com.thoughtworks.go.server.service.EnvironmentConfigService;
-import com.thoughtworks.go.server.service.RoleConfigService;
+import com.thoughtworks.go.server.service.*;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,16 +45,23 @@ public class InternalRolesControllerV3 extends ApiController implements SparkSpr
     private final RoleConfigService roleConfigService;
     private final EnvironmentConfigService environmentConfigService;
     private final ConfigRepoService configRepoService;
+    private final ElasticProfileService elasticProfileService;
+    private final ClusterProfilesService clusterProfilesService;
 
     @Autowired
-    public InternalRolesControllerV3(ApiAuthenticationHelper apiAuthenticationHelper, RoleConfigService roleConfigService,
+    public InternalRolesControllerV3(ApiAuthenticationHelper apiAuthenticationHelper,
+                                     RoleConfigService roleConfigService,
                                      EnvironmentConfigService environmentConfigService,
-                                     ConfigRepoService configRepoService) {
+                                     ConfigRepoService configRepoService,
+                                     ElasticProfileService elasticProfileService,
+                                     ClusterProfilesService clusterProfilesService) {
         super(ApiVersion.v3);
         this.apiAuthenticationHelper = apiAuthenticationHelper;
         this.roleConfigService = roleConfigService;
         this.environmentConfigService = environmentConfigService;
         this.configRepoService = configRepoService;
+        this.elasticProfileService = elasticProfileService;
+        this.clusterProfilesService = clusterProfilesService;
     }
 
     @Override
@@ -77,13 +84,18 @@ public class InternalRolesControllerV3 extends ApiController implements SparkSpr
     String index(Request request, Response response) throws IOException {
         String pluginType = request.queryParams("type");
         RolesConfig roles = roleConfigService.getRoles().ofType(pluginType);
-        List<String> envNames = environmentConfigService.getEnvironmentNames();
-        List<String> configRepoNames = configRepoService.getConfigRepos().stream()
-                .map(ConfigRepoConfig::getId)
-                .collect(toList());
         RolesViewModel rolesViewModel = new RolesViewModel().setRolesConfig(roles);
+
+        List<String> envNames = environmentConfigService.getEnvironmentNames();
+        List<String> configRepoNames = configRepoService.getConfigRepos().stream().map(ConfigRepoConfig::getId).collect(toList());
+        List<String> clusterProfileIds = clusterProfilesService.getPluginProfiles().stream().map(ClusterProfile::getId).collect(toList());
+        List<String> elasticAgentProfileIds = elasticProfileService.getPluginProfiles().stream().map(ElasticProfile::getId).collect(toList());
+
         rolesViewModel.getAutoSuggestions().put("environment", envNames);
         rolesViewModel.getAutoSuggestions().put("config_repo", configRepoNames);
+        rolesViewModel.getAutoSuggestions().put("cluster_profile", clusterProfileIds);
+        rolesViewModel.getAutoSuggestions().put("elastic_agent_profile", elasticAgentProfileIds);
+
         return writerForTopLevelObject(request, response, (outputWriter) -> RolesViewModelRepresenter.toJSON(outputWriter, rolesViewModel));
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Role.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Role.java
@@ -24,13 +24,12 @@ import java.util.*;
 import static com.thoughtworks.go.config.CaseInsensitiveString.isBlank;
 import static com.thoughtworks.go.config.policy.SupportedAction.ADMINISTER;
 import static com.thoughtworks.go.config.policy.SupportedAction.VIEW;
-import static com.thoughtworks.go.config.policy.SupportedEntity.CONFIG_REPO;
-import static com.thoughtworks.go.config.policy.SupportedEntity.ENVIRONMENT;
+import static com.thoughtworks.go.config.policy.SupportedEntity.*;
 
 @ConfigInterface
 public interface Role extends Validatable, PolicyAware {
     List<String> allowedActions = SupportedAction.unmodifiableListOf(VIEW, ADMINISTER);
-    List<String> allowedTypes = SupportedEntity.unmodifiableListOf(ENVIRONMENT, CONFIG_REPO);
+    List<String> allowedTypes = SupportedEntity.unmodifiableListOf(ENVIRONMENT, CONFIG_REPO, ELASTIC_AGENT_PROFILE, CLUSTER_PROFILE);
 
     CaseInsensitiveString getName();
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/SupportedEntity.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/SupportedEntity.java
@@ -16,8 +16,9 @@
 package com.thoughtworks.go.config.policy;
 
 import com.thoughtworks.go.config.EnvironmentConfig;
-import com.thoughtworks.go.config.PipelineConfigs;
 import com.thoughtworks.go.config.Validatable;
+import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 
 import java.util.Arrays;
@@ -28,6 +29,8 @@ import static java.util.Collections.unmodifiableList;
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 
 public enum SupportedEntity {
+    CLUSTER_PROFILE("cluster_profile", ClusterProfile.class),
+    ELASTIC_AGENT_PROFILE("elastic_agent_profile", ElasticProfile.class),
     ENVIRONMENT("environment", EnvironmentConfig.class),
     CONFIG_REPO("config_repo", ConfigRepoConfig.class),
     UNKNOWN(null, null);

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/policy/SupportedEntityTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/policy/SupportedEntityTest.java
@@ -17,6 +17,8 @@ package com.thoughtworks.go.config.policy;
 
 import com.thoughtworks.go.config.BasicEnvironmentConfig;
 import com.thoughtworks.go.config.EnvironmentConfig;
+import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.config.merge.MergeEnvironmentConfig;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import org.junit.jupiter.api.Test;
@@ -41,6 +43,18 @@ class SupportedEntityTest {
     void shouldSupportConfigRepo() {
         assertThat(CONFIG_REPO.getType()).isEqualTo("config_repo");
         assertThat(CONFIG_REPO.getEntityType()).isEqualTo(ConfigRepoConfig.class);
+    }
+
+    @Test
+    void shouldSupportElasticAgentProfile() {
+        assertThat(ELASTIC_AGENT_PROFILE.getType()).isEqualTo("elastic_agent_profile");
+        assertThat(ELASTIC_AGENT_PROFILE.getEntityType()).isEqualTo(ElasticProfile.class);
+    }
+
+    @Test
+    void shouldSupportClusterProfile() {
+        assertThat(CLUSTER_PROFILE.getType()).isEqualTo("cluster_profile");
+        assertThat(CLUSTER_PROFILE.getEntityType()).isEqualTo(ClusterProfile.class);
     }
 
     @Test

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/policy_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/policy_widget.tsx
@@ -188,6 +188,12 @@ export class CreatePolicyWidget extends MithrilViewComponent<AutoCompleteAttrs> 
         id: "environment", text: "Environment"
       }, {
         id: "config_repo", text: "Config Repository"
+      },
+      {
+        id: "cluster_profile", text: "Cluster Profile"
+      },
+      {
+        id: "elastic_agent_profile", text: "Elastic Agent Profile"
       }
     ];
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/policy_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/policy_widget_spec.tsx
@@ -104,13 +104,17 @@ describe('PolicyWidgetSpecs', () => {
 
     const typeOptions = helper.qa("option", helper.byTestId("permission-type"));
 
-    expect(typeOptions.length).toBe(4);
+    expect(typeOptions.length).toBe(6);
     expect(typeOptions[1]).toHaveText("All");
     expect(typeOptions[1]).toHaveValue("*");
     expect(typeOptions[2]).toHaveText("Environment");
     expect(typeOptions[2]).toHaveValue("environment");
     expect(typeOptions[3]).toHaveText("Config Repository");
     expect(typeOptions[3]).toHaveValue("config_repo");
+    expect(typeOptions[4]).toHaveText("Cluster Profile");
+    expect(typeOptions[4]).toHaveValue("cluster_profile");
+    expect(typeOptions[5]).toHaveText("Elastic Agent Profile");
+    expect(typeOptions[5]).toHaveValue("elastic_agent_profile");
   });
 
   it("should render 4 items in supported actions dropdown", () => {


### PR DESCRIPTION
Issue: #7549

Description:
* Add support for defining cluster_profile and elastic_agent_profile type on a policy
* Add cluster_profile and elastic_agent_profile autosuggestion information as part of roles API response
* Allow users to define policy for elastic_agent_profile and cluster_profile from roles SPA

