### PR TITLE
Fix for failing /bin/bash task

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/ExecTask.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/ExecTask.java
@@ -104,7 +104,7 @@ public class ExecTask extends AbstractTask implements CommandTask {
             clearCurrentArgsAndArgList();
             String value = (String) attributeMap.get(ARG_LIST_STRING);
             if (!StringUtils.isBlank(value)) {
-                String[] arguments = value.split("\n");
+                String[] arguments = value.split("\\R");
                 for (String arg : arguments) {
                     argList.add(new Argument(arg));
                 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/ExecTaskTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/ExecTaskTest.java
@@ -234,4 +234,17 @@ public class ExecTaskTest {
 
         assertFalse(task.equals(new ExecTask(null, new Arguments())));
     }
+
+    @Test
+    public void shouldSetConfigAttributesWithCarriageReturnCharPresent() {
+        ExecTask exec = new ExecTask();
+        exec.setConfigAttributes(m(ExecTask.COMMAND, null, ExecTask.ARG_LIST_STRING, "ls\r\n-al\r\n&&\npwd"));
+        assertThat(exec.command(), is(nullValue()));
+        assertThat(exec.getArgListString(), is("ls\n-al\n&&\npwd"));
+        assertThat(exec.getArgList().size(), is(4));
+        assertThat(exec.getArgList().get(0), is(new Argument("ls")));
+        assertThat(exec.getArgList().get(1), is(new Argument("-al")));
+        assertThat(exec.getArgList().get(2), is(new Argument("&&")));
+        assertThat(exec.getArgList().get(3), is(new Argument("pwd")));
+    }
 }


### PR DESCRIPTION
Issue: #7557 

Description:
 - the textarea field returns `\r\n` as new line char whereas the split was taking place on `\n`. The remaining `\r` was causing the command line to move to next line leaving the command to be executed as `/bin/bash -c` which throws error.

Fixed by spliting on Linebreak matcher `\R` which is supported from Java 8.
Link: https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html


