### PR TITLE
Update UI for admin permissions on pipeline grp edit modal

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/admin_pipelines/admin_pipelines.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/admin_pipelines/admin_pipelines.ts
@@ -78,17 +78,17 @@ export class PipelineGroupViewModel {
   }
 
   getUpdatedPipelineGroup(): PipelineGroup {
-    const viewAccess    = new AuthorizedUsersAndRoles(
-      this.authorizedUsers().filter((user) => !_.isEmpty(user.name()) && user.view()).map((user) => user.name()),
-      this.authorizedRoles().filter((role) => !_.isEmpty(role.name()) && role.view()).map((role) => role.name())
-    );
     const adminAccess   = new AuthorizedUsersAndRoles(
       this.authorizedUsers().filter((user) => !_.isEmpty(user.name()) && user.admin()).map((user) => user.name()),
       this.authorizedRoles().filter((role) => !_.isEmpty(role.name()) && role.admin()).map((role) => role.name())
     );
     const operateAccess = new AuthorizedUsersAndRoles(
-      this.authorizedUsers().filter((user) => !_.isEmpty(user.name()) && user.operate()).map((user) => user.name()),
-      this.authorizedRoles().filter((role) => !_.isEmpty(role.name()) && role.operate()).map((role) => role.name())
+      this.authorizedUsers().filter((user) => !_.isEmpty(user.name()) && user.operate() && !user.admin()).map((user) => user.name()),
+      this.authorizedRoles().filter((role) => !_.isEmpty(role.name()) && role.operate() && !role.admin()).map((role) => role.name())
+    );
+    const viewAccess    = new AuthorizedUsersAndRoles(
+      this.authorizedUsers().filter((user) => !_.isEmpty(user.name()) && user.view() && !(user.admin() || user.operate())).map((user) => user.name()),
+      this.authorizedRoles().filter((role) => !_.isEmpty(role.name()) && role.view() && !(role.admin() || role.operate())).map((role) => role.name())
     );
     return new PipelineGroup(this.name(), new Authorization(viewAccess, adminAccess, operateAccess));
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/admin_pipelines/specs/admin_pipelines_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/admin_pipelines/specs/admin_pipelines_spec.ts
@@ -149,12 +149,12 @@ describe('PipelineGroupViewModel', () => {
 
       const updatedPipelineGroup = pipelineGroupViewModel.getUpdatedPipelineGroup();
 
-      expect(updatedPipelineGroup.authorization().view().users()).toEqual(["user1", "admin"]);
-      expect(updatedPipelineGroup.authorization().operate().users()).toEqual(["user1", "superUser", "admin"]);
+      expect(updatedPipelineGroup.authorization().view().users()).toEqual([]);
+      expect(updatedPipelineGroup.authorization().operate().users()).toEqual(["user1", "superUser"]);
       expect(updatedPipelineGroup.authorization().admin().users()).toEqual(["admin"]);
 
-      expect(updatedPipelineGroup.authorization().view().roles()).toEqual(["role1", "admin"]);
-      expect(updatedPipelineGroup.authorization().operate().roles()).toEqual(["role2", "admin"]);
+      expect(updatedPipelineGroup.authorization().view().roles()).toEqual(["role1"]);
+      expect(updatedPipelineGroup.authorization().operate().roles()).toEqual(["role2"]);
       expect(updatedPipelineGroup.authorization().admin().roles()).toEqual(["admin"]);
       expect(updatedPipelineGroup.name()).toEqual(pipelineGroup.name());
     });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/authorization/authorization.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/authorization/authorization.ts
@@ -115,9 +115,20 @@ export class PermissionForEntity extends ValidatableMixin {
     this.view    = Stream(view);
     this.operate = Stream(operate);
     this.admin   = Stream(admin);
+
+    this.setPermissions();
     ValidatableMixin.call(this);
 
     this.validateWith(new PermissionValidator({condition: () => !_.isEmpty(this.name())}), "name");
+  }
+
+  setPermissions() {
+    if (this.admin()) {
+      this.view(true);
+      this.operate(true);
+    } else if (this.operate()) {
+      this.view(true);
+    }
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/authorization/specs/authorization_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/authorization/specs/authorization_spec.ts
@@ -81,6 +81,26 @@ describe('AuthorizationViewModel', () => {
       expect(authorizationViewModel.authorizedUsers().includes(removedUser)).toBe(false);
       expect(authorizationViewModel.authorizedUsers().length).toBe(2);
     });
+
+    it('should set true for view and operate if admin privilege is present', () => {
+      const authorizationViewModel = new PermissionsForUsersAndRoles(new Authorization());
+
+      authorizationViewModel.addAuthorizedUser(new PermissionForEntity("new-user", false, false, true));
+
+      expect(authorizationViewModel.authorizedUsers()[0].view()).toBeTruthy();
+      expect(authorizationViewModel.authorizedUsers()[0].operate()).toBeTruthy();
+      expect(authorizationViewModel.authorizedUsers()[0].admin()).toBeTruthy();
+    });
+
+    it('should set true for view if operate privilege is present', () => {
+      const authorizationViewModel = new PermissionsForUsersAndRoles(new Authorization());
+
+      authorizationViewModel.addAuthorizedUser(new PermissionForEntity("new-user", false, true, false));
+
+      expect(authorizationViewModel.authorizedUsers()[0].view()).toBeTruthy();
+      expect(authorizationViewModel.authorizedUsers()[0].operate()).toBeTruthy();
+      expect(authorizationViewModel.authorizedUsers()[0].admin()).toBeFalsy();
+    });
   });
 
   describe('Role', () => {
@@ -108,6 +128,26 @@ describe('AuthorizationViewModel', () => {
 
       expect(authorizationViewModel.authorizedRoles().includes(removedRole)).toBe(false);
       expect(authorizationViewModel.authorizedRoles().length).toBe(2);
+    });
+
+    it('should set true for view and operate if admin privilege is present', () => {
+      const authorizationViewModel = new PermissionsForUsersAndRoles(new Authorization());
+
+      authorizationViewModel.addAuthorizedRole(new PermissionForEntity("new-role", false, false, true));
+
+      expect(authorizationViewModel.authorizedRoles()[0].view()).toBeTruthy();
+      expect(authorizationViewModel.authorizedRoles()[0].operate()).toBeTruthy();
+      expect(authorizationViewModel.authorizedRoles()[0].admin()).toBeTruthy();
+    });
+
+    it('should set true for view if operate privilege is present', () => {
+      const authorizationViewModel = new PermissionsForUsersAndRoles(new Authorization());
+
+      authorizationViewModel.addAuthorizedRole(new PermissionForEntity("new-role", false, true, false));
+
+      expect(authorizationViewModel.authorizedRoles()[0].view()).toBeTruthy();
+      expect(authorizationViewModel.authorizedRoles()[0].operate()).toBeTruthy();
+      expect(authorizationViewModel.authorizedRoles()[0].admin()).toBeFalsy();
     });
   });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/spec/edit_pipeline_group_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/spec/edit_pipeline_group_modal_spec.tsx
@@ -73,22 +73,26 @@ describe('EditPipelineGroupModal', () => {
       expect(testHelper.byTestId("users-permissions")).toBeInDOM();
       expect(testHelper.byTestId("users-permissions")).toContainHeaderCells(["Name", "View", "Operate", "Admin", ""]);
 
-      const row1 = testHelper.allByTestId("table-row", testHelper.byTestId("users-permissions"))[0] as HTMLElement;
+      const permissions = testHelper.allByTestId("table-row", testHelper.byTestId("users-permissions"));
+      const row1        = permissions[0] as HTMLElement;
       expect((testHelper.byTestId("user-name", row1) as HTMLInputElement).value).toBe("user1");
       expect((testHelper.byTestId("view-permission", row1) as HTMLInputElement)).toBeChecked();
       expect((testHelper.byTestId("operate-permission", row1) as HTMLInputElement)).not.toBeChecked();
       expect((testHelper.byTestId("admin-permission", row1) as HTMLInputElement)).not.toBeChecked();
 
-      const row2 = testHelper.allByTestId("table-row", testHelper.byTestId("users-permissions"))[1] as HTMLElement;
+      const row2 = permissions[1] as HTMLElement;
       expect((testHelper.byTestId("user-name", row2) as HTMLInputElement).value).toBe("superUser");
-      expect((testHelper.byTestId("view-permission", row2) as HTMLInputElement)).not.toBeChecked();
+      expect((testHelper.byTestId("view-permission", row2) as HTMLInputElement)).toBeChecked();
+      expect((testHelper.byTestId("view-permission", row2) as HTMLInputElement)).toBeDisabled();
       expect((testHelper.byTestId("operate-permission", row2) as HTMLInputElement)).toBeChecked();
       expect((testHelper.byTestId("admin-permission", row2) as HTMLInputElement)).not.toBeChecked();
 
-      const row3 = testHelper.allByTestId("table-row", testHelper.byTestId("users-permissions"))[2] as HTMLElement;
+      const row3 = permissions[2] as HTMLElement;
       expect((testHelper.byTestId("user-name", row3) as HTMLInputElement).value).toBe("admin");
-      expect((testHelper.byTestId("view-permission", row3) as HTMLInputElement)).not.toBeChecked();
-      expect((testHelper.byTestId("operate-permission", row3) as HTMLInputElement)).not.toBeChecked();
+      expect((testHelper.byTestId("view-permission", row3) as HTMLInputElement)).toBeChecked();
+      expect((testHelper.byTestId("view-permission", row3) as HTMLInputElement)).toBeDisabled();
+      expect((testHelper.byTestId("operate-permission", row3) as HTMLInputElement)).toBeChecked();
+      expect((testHelper.byTestId("operate-permission", row3) as HTMLInputElement)).toBeDisabled();
       expect((testHelper.byTestId("admin-permission", row3) as HTMLInputElement)).toBeChecked();
     });
 
@@ -198,22 +202,26 @@ describe('EditPipelineGroupModal', () => {
       expect(testHelper.byTestId("roles-permissions")).toBeInDOM();
       expect(testHelper.byTestId("roles-permissions")).toContainHeaderCells(["Name", "View", "Operate", "Admin", ""]);
 
-      const row1 = testHelper.allByTestId("table-row", testHelper.byTestId("roles-permissions"))[0] as HTMLElement;
+      const permissions = testHelper.allByTestId("table-row", testHelper.byTestId("roles-permissions"));
+      const row1        = permissions[0] as HTMLElement;
       expect((testHelper.byTestId("role-name", row1) as HTMLInputElement).value).toBe("role1");
       expect((testHelper.byTestId("view-permission", row1) as HTMLInputElement)).toBeChecked();
       expect((testHelper.byTestId("operate-permission", row1) as HTMLInputElement)).not.toBeChecked();
       expect((testHelper.byTestId("admin-permission", row1) as HTMLInputElement)).not.toBeChecked();
 
-      const row2 = testHelper.allByTestId("table-row", testHelper.byTestId("roles-permissions"))[1] as HTMLElement;
+      const row2 = permissions[1] as HTMLElement;
       expect((testHelper.byTestId("role-name", row2) as HTMLInputElement).value).toBe("role2");
-      expect((testHelper.byTestId("view-permission", row2) as HTMLInputElement)).not.toBeChecked();
+      expect((testHelper.byTestId("view-permission", row2) as HTMLInputElement)).toBeChecked();
+      expect((testHelper.byTestId("view-permission", row2) as HTMLInputElement)).toBeDisabled();
       expect((testHelper.byTestId("operate-permission", row2) as HTMLInputElement)).toBeChecked();
       expect((testHelper.byTestId("admin-permission", row2) as HTMLInputElement)).not.toBeChecked();
 
-      const row3 = testHelper.allByTestId("table-row", testHelper.byTestId("roles-permissions"))[2] as HTMLElement;
+      const row3 = permissions[2] as HTMLElement;
       expect((testHelper.byTestId("role-name", row3) as HTMLInputElement).value).toBe("admin");
-      expect((testHelper.byTestId("view-permission", row3) as HTMLInputElement)).not.toBeChecked();
-      expect((testHelper.byTestId("operate-permission", row3) as HTMLInputElement)).not.toBeChecked();
+      expect((testHelper.byTestId("view-permission", row3) as HTMLInputElement)).toBeChecked();
+      expect((testHelper.byTestId("view-permission", row3) as HTMLInputElement)).toBeDisabled();
+      expect((testHelper.byTestId("operate-permission", row3) as HTMLInputElement)).toBeChecked();
+      expect((testHelper.byTestId("operate-permission", row3) as HTMLInputElement)).toBeDisabled();
       expect((testHelper.byTestId("admin-permission", row3) as HTMLInputElement)).toBeChecked();
     });
 


### PR DESCRIPTION
Issue: #7551 

Description:
 - if a less restrictive permission is set, the more restrictive permissions are checked and disabled. e.g. if an entity is an admin, then it will have view and operate permissions as well
 - the updated grp payload send to update API call will set the users/roles to uppermost permissions. e.g. if an entity is an admin, the same won't be present in view or operate.



