### PR TITLE
Recompute Dashboard Cache when Pipeline Group Config Changes (#7572)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardActivityListener.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardActivityListener.java
@@ -17,6 +17,7 @@ package com.thoughtworks.go.server.dashboard;
 
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.config.PipelineConfigs;
 import com.thoughtworks.go.config.PipelineTemplateConfig;
 import com.thoughtworks.go.listener.ConfigChangedListener;
 import com.thoughtworks.go.listener.EntityConfigChangedListener;
@@ -81,6 +82,7 @@ public class GoDashboardActivityListener implements Initializer, ConfigChangedLi
         goConfigService.register(pipelineConfigChangedListener());
         goConfigService.register(securityConfigChangeListener());
         goConfigService.register(templateConfigChangedListener());
+        goConfigService.register(pipelineGroupsChangedListener());
         stageService.addStageStatusListener(stageStatusChangedListener());
         pipelinePauseService.registerListener(this);
         pipelineLockService.registerListener(this);
@@ -119,6 +121,25 @@ public class GoDashboardActivityListener implements Initializer, ConfigChangedLi
                     @Override
                     public String description() {
                         return "pipeline config: " + pipelineConfig;
+                    }
+                });
+            }
+        };
+    }
+
+    protected EntityConfigChangedListener<PipelineConfigs> pipelineGroupsChangedListener() {
+        return new EntityConfigChangedListener<PipelineConfigs>() {
+            @Override
+            public void onEntityConfigChange(final PipelineConfigs pipelineConfigs) {
+                processor.add(new Action() {
+                    @Override
+                    public void call() {
+                        configChangeHandler.call(goConfigService.currentCruiseConfig());
+                    }
+
+                    @Override
+                    public String description() {
+                        return "pipeline configs: " + pipelineConfigs;
                     }
                 });
             }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardActivityListenerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardActivityListenerTest.java
@@ -162,6 +162,27 @@ public class GoDashboardActivityListenerTest {
     }
 
     @Test
+    public void onInitializationAndStartOfDaemons_shouldRegisterAListener_WhichCallsConfigChangeHandler_ForPipelineGroupConfigChangeHandling() throws Exception {
+        CruiseConfig aConfig = GoConfigMother.defaultCruiseConfig();
+        GoDashboardConfigChangeHandler handler = mock(GoDashboardConfigChangeHandler.class);
+        BasicPipelineConfigs pipelineConfigs = new BasicPipelineConfigs();
+
+        when(goConfigService.currentCruiseConfig()).thenReturn(aConfig);
+        ArgumentCaptor<ConfigChangedListener> captor = ArgumentCaptor.forClass(ConfigChangedListener.class);
+        doNothing().when(goConfigService).register(captor.capture());
+
+        GoDashboardActivityListener listener = new GoDashboardActivityListener(goConfigService, stageService, pipelinePauseService, pipelineLockService,
+                null, handler, null, null, null);
+        listener.initialize();
+        listener.startDaemon();
+
+        ((EntityConfigChangedListener<PipelineConfigs>) captor.getAllValues().get(4)).onEntityConfigChange(pipelineConfigs);
+        waitForProcessingToHappen();
+
+        verify(handler).call(aConfig);
+    }
+
+    @Test
     public void shouldRegisterSelfForPipelineStatusChangeHandlingOnInitialization() throws Exception {
         GoDashboardActivityListener listener = new GoDashboardActivityListener(goConfigService, stageService, pipelinePauseService, pipelineLockService,
                 null, null, null, null, null);


### PR DESCRIPTION
Issue: #7572

Description:
* Recompute the entire dashboard cache when pipeline group
  config changes.