### PR TITLE
Parse failed config repos on Elastic Profile entity change

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.config;
 
+import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
@@ -148,7 +149,8 @@ public class ConfigReposMaterialParseResultManager {
                 EnvironmentConfig.class,
                 PipelineTemplateConfig.class,
                 SCM.class,
-                ConfigRepoConfig.class
+                ConfigRepoConfig.class,
+                ElasticProfile.class
         );
         private final ConfigReposMaterialParseResultManager configReposMaterialParseResultManager;
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.config;
 
+import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.PartialConfig;
@@ -255,7 +256,7 @@ class ConfigReposMaterialParseResultManagerTest {
     @Nested
     class ConfigRepoReparseListenerTest {
         @ParameterizedTest
-        @ValueSource(classes = {PipelineConfig.class, EnvironmentConfig.class, PipelineTemplateConfig.class, SCM.class, ConfigRepoConfig.class})
+        @ValueSource(classes = {PipelineConfig.class, EnvironmentConfig.class, PipelineTemplateConfig.class, SCM.class, ConfigRepoConfig.class, ElasticProfile.class})
         void shouldCareAboutSpecifiedConfigClasses(Class<? extends Validatable> configClassToCareAbout) {
             final ConfigReposMaterialParseResultManager manager = mock(ConfigReposMaterialParseResultManager.class);
             final ConfigRepoReparseListener configRepoReparseListener = new ConfigRepoReparseListener(manager);


### PR DESCRIPTION
Issue: #7509 

Description:
 - The partial config from config repo can fail if the supplied elastic profile is not found. Hence, reparsing the failed config repos on change of elastic profile is needed. Added ElasticProfile.class to config classes to care about list


