### PR TITLE
Adding GO_AGENT_RESOURCES as environment variable

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/remote/work/BuildAssignment.java
+++ b/common/src/main/java/com/thoughtworks/go/remote/work/BuildAssignment.java
@@ -81,9 +81,7 @@ public class BuildAssignment implements Serializable, SecretParamAware {
         if (contextFromEnvironment != null) {
             buildAssignment.initialEnvironmentVariableContext().addAll(contextFromEnvironment);
         }
-        
-        String commaSeparatedResources = plan.getResources().stream().map (Object::toString).collect(Collectors.joining(","));
-        buildAssignment.initialEnvironmentVariableContext().setProperty("GO_AGENT_RESOURCES", commaSeparatedResources, false);
+
         buildAssignment.initialEnvironmentVariableContext().setProperty("GO_TRIGGER_USER", buildAssignment.getBuildApprover(), false);
         buildAssignment.getJobIdentifier().populateEnvironmentVariables(buildAssignment.initialEnvironmentVariableContext());
         buildAssignment.materialRevisions().populateEnvironmentVariables(buildAssignment.initialEnvironmentVariableContext(), buildWorkingDirectory);

--- a/common/src/main/java/com/thoughtworks/go/remote/work/BuildAssignment.java
+++ b/common/src/main/java/com/thoughtworks/go/remote/work/BuildAssignment.java
@@ -81,7 +81,9 @@ public class BuildAssignment implements Serializable, SecretParamAware {
         if (contextFromEnvironment != null) {
             buildAssignment.initialEnvironmentVariableContext().addAll(contextFromEnvironment);
         }
-
+        
+        String commaSeparatedResources = plan.getResources().stream().map (Object::toString).collect(Collectors.joining(","));
+        buildAssignment.initialEnvironmentVariableContext().setProperty("GO_AGENT_RESOURCES", commaSeparatedResources, false);
         buildAssignment.initialEnvironmentVariableContext().setProperty("GO_TRIGGER_USER", buildAssignment.getBuildApprover(), false);
         buildAssignment.getJobIdentifier().populateEnvironmentVariables(buildAssignment.initialEnvironmentVariableContext());
         buildAssignment.materialRevisions().populateEnvironmentVariables(buildAssignment.initialEnvironmentVariableContext(), buildWorkingDirectory);

--- a/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
@@ -292,9 +292,11 @@ public class BuildAssignmentService implements ConfigChangedListener {
 
                     final EnvironmentVariableContext environmentVariableContext = buildEnvVarContext(job.getIdentifier().getPipelineName());
 
-                    // Agent may have a NULL "resources" so we check and set an empty default here so that tests pass
-                    String agentResourcesAsCsv = agent.getResourceConfigs() == null ? "" : agent.getResourceConfigs().getCommaSeparatedResourceNames();
-                    environmentVariableContext.setProperty(GO_AGENT_RESOURCES, agentResourcesAsCsv, false);
+                    // Agent may have a NULL "resources"
+                    if (agent.getResourceConfigs() != null) {
+                        // Users relying on this env. var. can test for its existence rather than checking for an empty string
+                        environmentVariableContext.setProperty(GO_AGENT_RESOURCES, agent.getResourceConfigs().getCommaSeparatedResourceNames(), false);
+                    }
 
                     final ArtifactStores requiredArtifactStores = goConfigService.artifactStores().getArtifactStores(getArtifactStoreIdsRequiredByArtifactPlans(job.getArtifactPlans()));
                     BuildAssignment buildAssignment = BuildAssignment.create(job, pipeline.getBuildCause(), builders, pipeline.defaultWorkingFolder(), environmentVariableContext, requiredArtifactStores);

--- a/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
@@ -58,6 +58,7 @@ public class BuildAssignmentService implements ConfigChangedListener {
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(BuildAssignmentService.class.getName());
     public static final NoWork NO_WORK = new NoWork();
     public static final String GO_PIPELINE_GROUP_NAME = "GO_PIPELINE_GROUP_NAME";
+    public static final String GO_AGENT_RESOURCES = "GO_AGENT_RESOURCES";
 
     private GoConfigService goConfigService;
     private JobInstanceService jobInstanceService;
@@ -290,6 +291,10 @@ public class BuildAssignmentService implements ConfigChangedListener {
                     }
 
                     final EnvironmentVariableContext environmentVariableContext = buildEnvVarContext(job.getIdentifier().getPipelineName());
+
+                    // Agent may have a NULL "resources" so we check and set an empty default here so that tests pass
+                    String agentResourcesAsCsv = agent.getResourceConfigs() == null ? "" : agent.getResourceConfigs().getCommaSeparatedResourceNames();
+                    environmentVariableContext.setProperty(GO_AGENT_RESOURCES, agentResourcesAsCsv, false);
 
                     final ArtifactStores requiredArtifactStores = goConfigService.artifactStores().getArtifactStores(getArtifactStoreIdsRequiredByArtifactPlans(job.getArtifactPlans()));
                     BuildAssignment buildAssignment = BuildAssignment.create(job, pipeline.getBuildCause(), builders, pipeline.defaultWorkingFolder(), environmentVariableContext, requiredArtifactStores);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/BuildAssignmentServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/BuildAssignmentServiceTest.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.UUID;
 
+import static com.thoughtworks.go.server.service.BuildAssignmentService.GO_AGENT_RESOURCES;
 import static com.thoughtworks.go.server.service.BuildAssignmentService.GO_PIPELINE_GROUP_NAME;
 import static com.thoughtworks.go.util.command.EnvironmentVariableContext.GO_ENVIRONMENT_NAME;
 import static java.util.Collections.singletonList;
@@ -277,7 +278,12 @@ class BuildAssignmentServiceTest {
 
             final PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString());
             pipelineConfig.get(0).getJobs().add(JobConfigMother.jobWithNoResourceRequirement());
+
             final AgentInstance agentInstance = mock(AgentInstance.class);
+            when(agentInstance.getResourceConfigs()).thenReturn (mock (ResourceConfigs.class));
+            agentInstance.getResourceConfigs().add(new ResourceConfig("resource-1"));
+            agentInstance.getResourceConfigs().add(new ResourceConfig("resource-2"));
+
             final Pipeline pipeline = mock(Pipeline.class);
             final JobPlan jobPlan1 = getJobPlan(pipelineConfig.getName(), pipelineConfig.get(0).name(), pipelineConfig.get(0).getJobs().last());
 
@@ -300,6 +306,7 @@ class BuildAssignmentServiceTest {
             EnvironmentVariableContext environmentVariableContext = work.getAssignment().initialEnvironmentVariableContext();
             assertThat(environmentVariableContext.getProperty("GIT_USERNAME")).isEqualTo("bob");
             assertThat(environmentVariableContext.getProperty("GIT_TOKEN")).isEqualTo("some-token");
+            assertThat(environmentVariableContext.getProperty(GO_AGENT_RESOURCES)).isEqualTo(agentInstance.getResourceConfigs().getCommaSeparatedResourceNames());
             assertThat(environmentVariableContext.getSecureEnvironmentVariables())
                     .contains(new EnvironmentVariableContext.EnvironmentVariable("GIT_TOKEN", "some-token"));
         }
@@ -311,9 +318,15 @@ class BuildAssignmentServiceTest {
             gitMaterial.setPassword("{{SECRET:[secret_config_id][GIT_PASSWORD]}}");
             final Modification modification = new Modification("user", null, null, null, "rev1");
             final MaterialRevisions materialRevisions = new MaterialRevisions(new MaterialRevision(gitMaterial, modification));
+
             final PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString());
             pipelineConfig.get(0).getJobs().add(JobConfigMother.jobWithNoResourceRequirement());
+
             final AgentInstance agentInstance = mock(AgentInstance.class);
+            when(agentInstance.getResourceConfigs()).thenReturn (mock (ResourceConfigs.class));
+            agentInstance.getResourceConfigs().add(new ResourceConfig("resource-1"));
+            agentInstance.getResourceConfigs().add(new ResourceConfig("resource-2"));
+
             final Pipeline pipeline = mock(Pipeline.class);
             final JobPlan jobPlan1 = getJobPlan(pipelineConfig.getName(), pipelineConfig.get(0).name(), pipelineConfig.get(0).getJobs().last());
 


### PR DESCRIPTION
The issue fixes upstream GoCD #7575 issue by serializing the agent resources to an environment variable. Note I have signed the CLA.

Issue: #7575 

Description:
We think that adding a GO_AGENT_RESOURCES environment variable with a comma-separated or JSON/YAML list of assigned agent resources would help in continuous delivery situations where the DevOps people want to get smart/fancy about how pipelines execute. In our case it unblocks using more agents for CM with Ansible.
