### PR TITLE
Allow normal users to access elastic agent configurations page (#7549)

### DIFF
--- a/api/api-elastic-profile-v3/src/main/java/com/thoughtworks/go/apiv3/elasticprofile/ElasticProfileControllerV3.java
+++ b/api/api-elastic-profile-v3/src/main/java/com/thoughtworks/go/apiv3/elasticprofile/ElasticProfileControllerV3.java
@@ -93,7 +93,7 @@ public class ElasticProfileControllerV3 extends ApiController implements SparkSp
                 apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.ELASTIC_AGENT_PROFILE, resourceToOperateOn, resourceToOperateWithin);
             });
 
-            before(Routes.ClusterProfilesAPI.ID, mimeType, (request, response) -> {
+            before(Routes.ElasticProfileAPI.ID, mimeType, (request, response) -> {
                 apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.ELASTIC_AGENT_PROFILE, request.params(PROFILE_ID_PARAM));
             });
 

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
@@ -73,10 +73,13 @@ public class AuthorizeFilterChain extends FilterChainProxy {
                 .addAuthorityFilterChain("/admin/materials/**", genericAccessDeniedHandler, ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR)
                 .addAuthorityFilterChain("/admin/package_repositories/**", genericAccessDeniedHandler, ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR)
                 .addAuthorityFilterChain("/admin/package_definitions/**", genericAccessDeniedHandler, ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR)
-                .addAuthorityFilterChain("/admin/elastic_agent_configurations/**", genericAccessDeniedHandler, ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR)
-                //allow /go/admin/environments page to be accessible by normal users
+
                 .addAuthorityFilterChain("/admin/environments/**", genericAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/admin/config_repos/**", genericAccessDeniedHandler, ROLE_USER)
+                .addAuthorityFilterChain("/admin/elastic_agents/**", genericAccessDeniedHandler, ROLE_USER)
+                .addAuthorityFilterChain("/admin/admin/elastic_profiles/**", genericAccessDeniedHandler, ROLE_USER)
+                .addAuthorityFilterChain("/admin/elastic_agent_configurations/**", genericAccessDeniedHandler, ROLE_USER)
+
                 .addAuthorityFilterChain("/admin/**", genericAccessDeniedHandler, ROLE_SUPERVISOR)
                 .addAuthorityFilterChain("/agents/*/job_run_history/**", genericAccessDeniedHandler, ROLE_SUPERVISOR)
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/elastic_profiles/cluster_profiles_crud.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/elastic_profiles/cluster_profiles_crud.ts
@@ -19,7 +19,7 @@ import {SparkRoutes} from "helpers/spark_routes";
 import {ClusterProfile, ClusterProfileJSON, ClusterProfiles} from "./types";
 
 export class ClusterProfilesCRUD {
-  private static API_VERSION_HEADER = ApiVersion.v1;
+  private static API_VERSION_HEADER = ApiVersion.v2;
 
   static all() {
     return ApiRequestBuilder.GET(SparkRoutes.clusterProfilesListPath(), this.API_VERSION_HEADER)

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/elastic_profiles/elastic_agent_profiles_crud.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/elastic_profiles/elastic_agent_profiles_crud.ts
@@ -19,7 +19,7 @@ import {ElasticAgentProfile, ElasticAgentProfiles, ElasticProfileJSON, ProfileUs
 
 export class ElasticAgentProfilesCRUD {
   private static USAGES_API_VERSION_HEADER = ApiVersion.v1;
-  private static API_VERSION_HEADER        = ApiVersion.v2;
+  private static API_VERSION_HEADER        = ApiVersion.v3;
 
   static all() {
     return ApiRequestBuilder.GET(SparkRoutes.elasticProfileListPath(), this.API_VERSION_HEADER)

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/elastic_profiles/spec/cluster_profiles_crud_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/elastic_profiles/spec/cluster_profiles_crud_spec.ts
@@ -39,7 +39,7 @@ describe("ClusterProfileCRUD", () => {
     const request = jasmine.Ajax.requests.mostRecent();
     expect(request.url).toEqual(ALL_CLUSTER_PROFILES_PATH);
     expect(request.method).toEqual("GET");
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v2+json");
   });
 
   it("should get a cluster profile", (done) => {
@@ -58,7 +58,7 @@ describe("ClusterProfileCRUD", () => {
     const request = jasmine.Ajax.requests.mostRecent();
     expect(request.url).toEqual(GET_CLUSTER_PROFILE_PATH);
     expect(request.method).toEqual("GET");
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v2+json");
   });
 
   it("should create a cluster profile", (done) => {
@@ -78,7 +78,7 @@ describe("ClusterProfileCRUD", () => {
     const request = jasmine.Ajax.requests.mostRecent();
     expect(request.url).toEqual(ALL_CLUSTER_PROFILES_PATH);
     expect(request.method).toEqual("POST");
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v2+json");
   });
 
   it("should update a cluster profile", (done) => {
@@ -98,7 +98,7 @@ describe("ClusterProfileCRUD", () => {
     const request = jasmine.Ajax.requests.mostRecent();
     expect(request.url).toEqual(GET_CLUSTER_PROFILE_PATH);
     expect(request.method).toEqual("PUT");
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v2+json");
   });
 
   it("should delete a cluster profile", (done) => {
@@ -113,20 +113,20 @@ describe("ClusterProfileCRUD", () => {
     const request = jasmine.Ajax.requests.mostRecent();
     expect(request.url).toEqual(GET_CLUSTER_PROFILE_PATH);
     expect(request.method).toEqual("DELETE");
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v2+json");
   });
 
   function clusterProfilesResponse() {
     return {
       status: 200,
       responseHeaders: {
-        "Content-Type": "application/vnd.go.cd.v1+json; charset=utf-8",
+        "Content-Type": "application/vnd.go.cd.v2+json; charset=utf-8",
         "ETag": "some-etag"
       },
       responseText: JSON.stringify({
                                      _embedded: {
                                        cluster_profiles: [
-                                         clusterProfileTestData("dev1", "cd.go.contrib.elastic-agent.docker")
+                                         clusterProfileTestData("dev2", "cd.go.contrib.elastic-agent.docker")
                                        ]
                                      }
                                    })
@@ -137,17 +137,18 @@ describe("ClusterProfileCRUD", () => {
     return {
       status: 200,
       responseHeaders: {
-        "Content-Type": "application/vnd.go.cd.v1+json; charset=utf-8",
+        "Content-Type": "application/vnd.go.cd.v2+json; charset=utf-8",
         "ETag": "some-etag"
       },
       responseText: JSON.stringify(clusterProfileTestData("cluster_1", "plugin_1"))
     };
   }
 
-  function clusterProfileTestData(id: string, pluginID: string) {
+  function clusterProfileTestData(id: string, pluginID: string, canAdminister: boolean = false) {
     return {
       id,
       plugin_id: pluginID,
+      can_administer: canAdminister,
       properties: [
         {
           key: "docker_uri",

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/elastic_profiles/spec/types_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/elastic_profiles/spec/types_spec.ts
@@ -21,14 +21,14 @@ describe("Types", () => {
   describe("Elastic Agent Profiles", () => {
     describe("Validation", () => {
       it("should validate elastic agent profile", () => {
-        const elasticProfile = new ElasticAgentProfile("", "", "", new Configurations([]));
+        const elasticProfile = new ElasticAgentProfile("", "", "", true, new Configurations([]));
         expect(elasticProfile.isValid()).toBe(false);
         expect(elasticProfile.errors().count()).toBe(3);
         expect(elasticProfile.errors().keys().sort()).toEqual(["clusterProfileId", "id", "pluginId"]);
       });
 
       it("should validate elastic agent profile id format", () => {
-        const elasticProfile = new ElasticAgentProfile("invalid id", "pluginId", "foo", new Configurations([]));
+        const elasticProfile = new ElasticAgentProfile("invalid id", "pluginId", "foo", true, new Configurations([]));
         expect(elasticProfile.isValid()).toBe(false);
         expect(elasticProfile.errors().count()).toBe(1);
         expect(elasticProfile.errors().keys()).toEqual(["id"]);
@@ -37,7 +37,7 @@ describe("Types", () => {
       });
 
       it("should validate existence of cluster profile id", () => {
-        const elasticProfile = new ElasticAgentProfile("id", "pluginId", undefined, new Configurations([]));
+        const elasticProfile = new ElasticAgentProfile("id", "pluginId", undefined, true, new Configurations([]));
         expect(elasticProfile.isValid()).toBe(false);
         expect(elasticProfile.errors().count()).toBe(1);
         expect(elasticProfile.errors().keys()).toEqual(["clusterProfileId"]);
@@ -52,6 +52,7 @@ describe("Types", () => {
           "docker1",
           "cd.go.docker",
           "prod-cluster",
+          true,
           new Configurations([
                                new Configuration("image", new PlainTextValue("gocd/server")),
                                new Configuration("secret", new EncryptedValue("alskdad"))
@@ -78,6 +79,7 @@ describe("Types", () => {
                                                               id: "docker1",
                                                               plugin_id: "cd.go.docker",
                                                               cluster_profile_id: "prod-cluster",
+                                                              can_administer: true,
                                                               properties: [{
                                                                 key: "image",
                                                                 value: "gocd/server",
@@ -104,6 +106,7 @@ describe("Types", () => {
           "docker1",
           "cd.go.docker",
           "prod-cluster",
+          true,
           new Configurations([
                                new Configuration("image", new PlainTextValue("gocd/server")),
                                new Configuration("secret", new EncryptedValue("alskdad"))
@@ -129,7 +132,9 @@ describe("Types", () => {
       });
 
       it("should filter the elastic agent profiles by cluster profile", () => {
-        const elasticAgentProfiles = new ElasticAgentProfiles([new ElasticAgentProfile("profile_1", "plugin_id", "cluster1")]);
+        const elasticAgentProfiles = new ElasticAgentProfiles([new ElasticAgentProfile("profile_1",
+                                                                                       "plugin_id",
+                                                                                       "cluster1")]);
         expect(elasticAgentProfiles.filterByClusterProfile("cluster1").length).toEqual(1);
         expect(elasticAgentProfiles.filterByClusterProfile("cluster2").length).toEqual(0);
       });
@@ -139,14 +144,14 @@ describe("Types", () => {
   describe("Cluster Profiles", () => {
     describe("Validation", () => {
       it("should validate cluster profile", () => {
-        const clusterProfile = new ClusterProfile("", "", new Configurations([]));
+        const clusterProfile = new ClusterProfile("", "", true, new Configurations([]));
         expect(clusterProfile.isValid()).toBe(false);
         expect(clusterProfile.errors().count()).toBe(2);
         expect(clusterProfile.errors().keys().sort()).toEqual(["id", "pluginId"]);
       });
 
       it("should validate cluster profile id format", () => {
-        const clusterProfile = new ClusterProfile("invalid id", "pluginId", new Configurations([]));
+        const clusterProfile = new ClusterProfile("invalid id", "pluginId", true, new Configurations([]));
         expect(clusterProfile.isValid()).toBe(false);
         expect(clusterProfile.errors().count()).toBe(1);
         expect(clusterProfile.errors().keys()).toEqual(["id"]);
@@ -160,6 +165,7 @@ describe("Types", () => {
         const clusterProfile = new ClusterProfile(
           "docker1",
           "cd.go.docker",
+          true,
           new Configurations([
                                new Configuration("image", new PlainTextValue("gocd/server")),
                                new Configuration("secret", new EncryptedValue("alskdad"))
@@ -184,6 +190,7 @@ describe("Types", () => {
         const clusterProfile = ClusterProfile.fromJSON({
                                                          id: "docker1",
                                                          plugin_id: "cd.go.docker",
+                                                         can_administer: true,
                                                          properties: [{
                                                            key: "image",
                                                            value: "gocd/server",
@@ -208,6 +215,7 @@ describe("Types", () => {
         const clusterProfile = new ClusterProfile(
           "docker1",
           "cd.go.docker",
+          true,
           new Configurations([
                                new Configuration("image", new PlainTextValue("gocd/server")),
                                new Configuration("secret", new EncryptedValue("alskdad"))

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/elastic_profiles/types.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/elastic_profiles/types.ts
@@ -143,6 +143,7 @@ export interface ElasticProfileJSON {
   id: string;
   plugin_id: string;
   cluster_profile_id?: string;
+  can_administer: boolean;
   properties: PropertyJSON[];
   errors?: { [key: string]: string[] };
 }
@@ -150,6 +151,7 @@ export interface ElasticProfileJSON {
 export interface ClusterProfileJSON {
   id: string;
   plugin_id: string;
+  can_administer: boolean;
   properties: PropertyJSON[];
   errors?: { [key: string]: string[] };
 }
@@ -162,12 +164,18 @@ export class ElasticAgentProfile implements ValidatableMixin {
   id: Stream<string | undefined>;
   pluginId: Stream<string | undefined>;
   clusterProfileId: Stream<string | undefined>;
+  canAdminister: Stream<boolean>;
   properties: Stream<Configurations | undefined>;
 
-  constructor(id?: string, pluginId?: string, clusterProfileId?: string, properties?: Configurations) {
+  constructor(id?: string,
+              pluginId?: string,
+              clusterProfileId?: string,
+              canAdminister?: boolean,
+              properties?: Configurations) {
     this.id               = Stream(id);
     this.pluginId         = Stream(pluginId);
     this.clusterProfileId = Stream(clusterProfileId);
+    this.canAdminister    = Stream(canAdminister || false);
     this.properties       = Stream(properties);
 
     ValidatableMixin.call(this);
@@ -184,6 +192,7 @@ export class ElasticAgentProfile implements ValidatableMixin {
     const profile = new ElasticAgentProfile(profileJson.id,
                                             profileJson.plugin_id,
                                             profileJson.cluster_profile_id,
+                                            profileJson.can_administer,
                                             Configurations.fromJSON(profileJson.properties));
 
     profile.errors(new Errors(profileJson.errors));
@@ -221,12 +230,14 @@ export interface ClusterProfile extends ValidatableMixin {
 export class ClusterProfile implements ValidatableMixin {
   id: Stream<string | undefined>;
   pluginId: Stream<string | undefined>;
+  canAdminister: Stream<boolean>;
   properties: Stream<Configurations | undefined>;
 
-  constructor(id?: string, pluginId?: string, properties?: Configurations) {
-    this.id         = Stream(id);
-    this.pluginId   = Stream(pluginId);
-    this.properties = Stream(properties);
+  constructor(id?: string, pluginId?: string, canAdminister?: boolean, properties?: Configurations) {
+    this.id            = Stream(id);
+    this.pluginId      = Stream(pluginId);
+    this.canAdminister = Stream(canAdminister || false);
+    this.properties    = Stream(properties);
 
     ValidatableMixin.call(this);
     this.validatePresenceOf("pluginId");
@@ -240,6 +251,7 @@ export class ClusterProfile implements ValidatableMixin {
   static fromJSON(profileJson: ClusterProfileJSON): ClusterProfile {
     const profile = new ClusterProfile(profileJson.id,
                                        profileJson.plugin_id,
+                                       profileJson.can_administer,
                                        Configurations.fromJSON(profileJson.properties));
 
     profile.errors(new Errors(profileJson.errors));

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/cluster_profile_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/cluster_profile_widget.tsx
@@ -25,14 +25,17 @@ import {Configurations} from "models/shared/configuration";
 import {ExtensionTypeString} from "models/shared/plugin_infos_new/extension_type";
 import {ElasticAgentExtension} from "models/shared/plugin_infos_new/extensions";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
-import {ButtonIcon} from "views/components/buttons";
 import * as Buttons from "views/components/buttons";
+import {ButtonIcon} from "views/components/buttons";
 import {CollapsiblePanel} from "views/components/collapsible_panel";
 import {HeaderIcon} from "views/components/header_icon";
 import * as Icons from "views/components/icons";
 import {IconGroup} from "views/components/icons";
 import {KeyValuePair, KeyValueTitle} from "views/components/key_value_pair";
-import {Attrs as ElasticProfilesWidgetAttrs, ElasticProfilesWidget} from "views/pages/elastic_agent_configurations/elastic_profiles_widget";
+import {
+  Attrs as ElasticProfilesWidgetAttrs,
+  ElasticProfilesWidget
+} from "views/pages/elastic_agent_configurations/elastic_profiles_widget";
 import {AddOperation, CloneOperation, DeleteOperation, EditOperation} from "views/pages/page_operations";
 import styles from ".//index.scss";
 
@@ -125,23 +128,46 @@ export class ClusterProfileWidget extends MithrilComponent<ClusterProfileWidgetA
         <Buttons.Secondary onclick={this.goToStatusReportPage.bind(this, statusReportPath)}
                            data-test-id="status-report-link"
                            icon={ButtonIcon.DOC}
-                           disabled={!vnode.attrs.isUserAnAdmin || !pluginInfo}>
+                           disabled={!pluginInfo}>
           Status Report
         </Buttons.Secondary>);
     }
 
+    let isDisabled = false, disabledReason = "";
+    if (!pluginInfo) {
+      isDisabled     = true;
+      disabledReason = `Could not find plugin with id ${vnode.attrs.clusterProfile.pluginId()}`;
+    }
+
+    if (!vnode.attrs.clusterProfile.canAdminister()) {
+      isDisabled     = true;
+      disabledReason = `You dont have permissions to administer '${vnode.attrs.clusterProfile.id()}' cluster profile.`;
+    }
+
     actionButtons.push(
       <Buttons.Secondary onclick={(e: MouseEvent) => {
-        vnode.attrs.elasticAgentOperations.onAdd(new ElasticAgentProfile("", vnode.attrs.clusterProfile.pluginId(), vnode.attrs.clusterProfile.id(), new Configurations([])), e);
-      }} data-test-id={"new-elastic-agent-profile-button"} disabled={!pluginInfo} icon={ButtonIcon.ADD}>
+        vnode.attrs.elasticAgentOperations.onAdd(new ElasticAgentProfile("", vnode.attrs.clusterProfile.pluginId(), vnode.attrs.clusterProfile.id(), true, new Configurations([])), e);
+      }}
+                         data-test-id={"new-elastic-agent-profile-button"}
+                         disabled={isDisabled}
+                         title={disabledReason}
+                         icon={ButtonIcon.ADD}>
         Elastic Agent Profile
       </Buttons.Secondary>);
 
     actionButtons.push(<div class={styles.clusterProfileCrudActions}>
       <IconGroup>
-        <Icons.Edit data-test-id="edit-cluster-profile" onclick={vnode.attrs.clusterProfileOperations.onEdit.bind(this, vnode.attrs.clusterProfile)} disabled={!pluginInfo}/>
-        <Icons.Clone data-test-id="clone-cluster-profile" onclick={vnode.attrs.clusterProfileOperations.onClone.bind(this, vnode.attrs.clusterProfile)} disabled={!pluginInfo}/>
-        <Icons.Delete data-test-id="delete-cluster-profile" onclick={vnode.attrs.clusterProfileOperations.onDelete.bind(this, vnode.attrs.clusterProfile.id()!)}/>
+        <Icons.Edit data-test-id="edit-cluster-profile"
+                    onclick={vnode.attrs.clusterProfileOperations.onEdit.bind(this, vnode.attrs.clusterProfile)}
+                    title={disabledReason}
+                    disabled={isDisabled}/>
+        <Icons.Clone data-test-id="clone-cluster-profile"
+                     onclick={vnode.attrs.clusterProfileOperations.onClone.bind(this, vnode.attrs.clusterProfile)}
+                     disabled={!pluginInfo}/>
+        <Icons.Delete data-test-id="delete-cluster-profile"
+                      title={disabledReason}
+                      onclick={vnode.attrs.clusterProfileOperations.onDelete.bind(this, vnode.attrs.clusterProfile.id()!)}
+                      disabled={isDisabled}/>
       </IconGroup>
     </div>);
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/cluster_profiles_modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/cluster_profiles_modals.tsx
@@ -175,90 +175,19 @@ export abstract class BaseClusterProfileModal extends Modal {
         this.clusterProfile(new ClusterProfile(
           this.clusterProfile().id(),
           pluginInfo!.id,
+          this.clusterProfile().canAdminister(),
           new Configurations([])
         ));
 
         this.clusterProfile(new ClusterProfile(
           this.clusterProfile().id(),
           pluginInfo!.id,
+          this.clusterProfile().canAdminister(),
           new Configurations([])
         ));
       }
     }
     return this.elasticAgentPluginInfo().id;
-  }
-}
-
-export class NewClusterProfileModal extends BaseClusterProfileModal {
-  private readonly onSuccessfulSave: (msg: m.Children) => any;
-
-  constructor(pluginInfos: PluginInfos, onSuccessfulSave: (msg: m.Children) => any) {
-    const clusterProfile = new ClusterProfile("", pluginInfos[0].id, new Configurations([]));
-    super(pluginInfos, ModalType.create, clusterProfile);
-    this.onSuccessfulSave = onSuccessfulSave;
-  }
-
-  performSave() {
-    ClusterProfilesCRUD.create(this.clusterProfile())
-      .then((result) => {
-        result.do(
-          () => {
-            this.onSuccessfulSave(<span>The cluster profile <em>{this.clusterProfile().id()}</em> was created successfully!</span>);
-            this.close();
-          },
-          (errorResponse) => {
-            this.showErrors(result, errorResponse);
-          }
-        );
-      });
-  }
-
-  modalTitle() {
-    return "Add a new cluster profile";
-  }
-}
-
-export class EditClusterProfileModal extends BaseClusterProfileModal {
-  private readonly onSuccessfulSave: (msg: m.Children) => any;
-  private etag?: string;
-  private readonly clusterProfileId: string;
-
-  constructor(clusterProfileId: string, pluginInfos: PluginInfos, onSuccessfulSave: (msg: m.Children) => any) {
-    super(pluginInfos, ModalType.edit);
-    this.clusterProfileId = clusterProfileId;
-    this.onSuccessfulSave = onSuccessfulSave;
-
-    ClusterProfilesCRUD.get(clusterProfileId)
-      .then((result) => {
-        result.do(
-          (successResponse) => {
-            this.clusterProfile(successResponse.body.object);
-            this.etag = successResponse.body.etag;
-          },
-          ((errorResponse) => this.onError(JSON.parse(errorResponse.body!).message))
-        );
-      });
-  }
-
-  performSave() {
-    ClusterProfilesCRUD
-      .update(this.clusterProfile(), this.etag!)
-      .then((result) => {
-        result.do(
-          () => {
-            this.onSuccessfulSave(<span>The cluster profile <em>{this.clusterProfile().id()}</em> was updated successfully!</span>);
-            this.close();
-          },
-          (errorResponse) => {
-            this.onError(JSON.parse(errorResponse.body!).message);
-            this.showErrors(result, errorResponse);
-          }
-        );
-      });
-  }
-
-  modalTitle() {
-    return "Edit cluster profile " + this.clusterProfileId;
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/elastic_agent_profiles_modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/elastic_agent_profiles_modals.tsx
@@ -175,65 +175,12 @@ abstract class BaseElasticProfileModal extends Modal {
         this.elasticProfile(new ElasticAgentProfile(this.elasticProfile().id(),
                                                     this.elasticProfile().pluginId(),
                                                     newValue,
+                                                    this.elasticProfile().canAdminister(),
                                                     this.elasticProfile().properties()));
       }
     }
 
     return this.elasticProfile().clusterProfileId();
-  }
-}
-
-export class EditElasticProfileModal extends BaseElasticProfileModal {
-  private readonly onSuccessfulSave: (msg: m.Children) => any;
-  private etag?: string;
-  private readonly elasticProfileId: string;
-
-  constructor(elasticProfileId: string,
-              pluginId: string,
-              pluginInfos: PluginInfos,
-              clusterProfiles: ClusterProfiles,
-              onSuccessfulSave: (msg: m.Children) => any
-  ) {
-    super(pluginInfos, ModalType.edit, clusterProfiles);
-    this.elasticProfileId = elasticProfileId;
-    this.onSuccessfulSave = onSuccessfulSave;
-
-    ElasticAgentProfilesCRUD
-      .get(elasticProfileId)
-      .then((result) => {
-        result.do(
-          (successResponse) => {
-            this.elasticProfile(successResponse.body.object);
-            this.elasticProfile().pluginId(pluginId);
-            this.etag = successResponse.body.etag;
-          },
-          ((errorResponse) => this.onError(JSON.parse(errorResponse.body!).message))
-        );
-      });
-  }
-
-  performSave() {
-    ElasticAgentProfilesCRUD
-      .update(this.elasticProfile(), this.etag!)
-      .then((result) => {
-        result.do(
-          () => {
-            this.onSuccessfulSave(
-              <span>
-                The elastic agent profile <em>{this.elasticProfile().id()}</em> was updated successfully!
-                     </span>
-            );
-            this.close();
-          },
-          (errorResponse) => {
-            this.showErrors(result, errorResponse);
-          }
-        );
-      });
-  }
-
-  modalTitle() {
-    return "Edit elastic agent profile " + this.elasticProfileId;
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/elastic_profiles_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/elastic_profiles_widget.tsx
@@ -103,14 +103,34 @@ export class ElasticProfileWidget extends MithrilComponent<ProfileAttrs> {
 
   view(vnode: m.Vnode<ProfileAttrs, {}>) {
     const elasticProfile = vnode.attrs.elasticProfile;
-    const actions        = [
+
+    let isDisabled = false, disabledReason;
+
+    if (!vnode.attrs.pluginInfo) {
+      isDisabled     = true;
+      disabledReason = `Could not find plugin with id ${vnode.attrs.elasticProfile.pluginId()}`;
+    }
+
+    if (!vnode.attrs.elasticProfile.canAdminister()) {
+      isDisabled     = true;
+      disabledReason = `You dont have permissions to administer '${vnode.attrs.elasticProfile.id()}' elastic agent profile.`;
+    }
+
+    const actions = [
       <IconGroup>
-        <Icons.Edit data-test-id="edit-elastic-profile" onclick={vnode.attrs.onEdit}
-                    disabled={!vnode.attrs.pluginInfo}/>
-        <Icons.Clone data-test-id="clone-elastic-profile" onclick={vnode.attrs.onClone}
+        <Icons.Edit data-test-id="edit-elastic-profile"
+                    onclick={vnode.attrs.onEdit}
+                    title={disabledReason}
+                    disabled={isDisabled}/>
+        <Icons.Clone data-test-id="clone-elastic-profile"
+                     onclick={vnode.attrs.onClone}
                      disabled={!vnode.attrs.pluginInfo}/>
-        <Icons.Delete data-test-id="delete-elastic-profile" onclick={vnode.attrs.onDelete}/>
-        <Icons.Usage data-test-id="show-usage-elastic-profile" onclick={vnode.attrs.onShowUsage}/>
+        <Icons.Delete data-test-id="delete-elastic-profile"
+                      title={disabledReason}
+                      disabled={isDisabled}
+                      onclick={vnode.attrs.onDelete}/>
+        <Icons.Usage data-test-id="show-usage-elastic-profile"
+                     onclick={vnode.attrs.onShowUsage}/>
       </IconGroup>
     ];
     return (

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/cluster_profiles_modals_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/cluster_profiles_modals_spec.tsx
@@ -58,7 +58,7 @@ describe("ClusterProfileModal", () => {
 
   describe("CreateModalType", () => {
     it("id field should not be disabled for new modal type", () => {
-      const clusterProfile = new ClusterProfile("", "cd.go.contrib.elastic-agent.docker", new Configurations([]));
+      const clusterProfile = new ClusterProfile("", "cd.go.contrib.elastic-agent.docker", true, new Configurations([]));
       modal                = new TestClusterProfile(pluginInfos, ModalType.create, clusterProfile);
       helper.mount(modal.body.bind(modal));
 
@@ -69,7 +69,7 @@ describe("ClusterProfileModal", () => {
     });
 
     it("should display cluster profile properties form if selected plugin supports cluster profile", () => {
-      const clusterProfile = new ClusterProfile("", "cd.go.contrib.elastic-agent.docker", new Configurations([]));
+      const clusterProfile = new ClusterProfile("", "cd.go.contrib.elastic-agent.docker", true, new Configurations([]));
       modal                = new TestClusterProfile(pluginInfos, ModalType.create, clusterProfile);
       helper.mount(modal.body.bind(modal));
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/cluster_profiles_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/cluster_profiles_widget_spec.tsx
@@ -17,7 +17,12 @@
 import _ from "lodash";
 import m from "mithril";
 import Stream from "mithril/stream";
-import {ClusterProfile, ClusterProfiles, ElasticAgentProfile, ElasticAgentProfiles} from "models/elastic_profiles/types";
+import {
+  ClusterProfile,
+  ClusterProfiles,
+  ElasticAgentProfile,
+  ElasticAgentProfiles
+} from "models/elastic_profiles/types";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import collapsiblePanelStyles from "views/components/collapsible_panel/index.scss";
 import {ClusterProfilesWidget} from "views/pages/elastic_agent_configurations/cluster_profiles_widget";
@@ -187,7 +192,75 @@ describe("ClusterProfilesWidget", () => {
     expect(helper.byTestId("edit-cluster-profile", dockerClusterProfilePanel)).toBeDisabled();
     expect(helper.byTestId("clone-cluster-profile", dockerClusterProfilePanel)).toBeDisabled();
     expect(helper.byTestId("new-elastic-agent-profile-button", dockerClusterProfilePanel)).toBeDisabled();
-    expect(helper.byTestId("delete-cluster-profile", dockerClusterProfilePanel)).not.toBeDisabled();
+    expect(helper.byTestId("delete-cluster-profile", dockerClusterProfilePanel)).toBeDisabled();
+
+    helper.unmount();
+  });
+
+  it("should not disable status button when user does not have administer permissions", () => {
+    const clusterProfile = ClusterProfile.fromJSON(TestData.dockerClusterProfile());
+    clusterProfile.canAdminister(false);
+
+    const clusterProfiles = new ClusterProfiles([clusterProfile]);
+    mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
+
+    expect(helper.byTestId( "status-report-link", helper.allByTestId("cluster-profile-panel").item(0))).toBeInDOM();
+    expect(helper.byTestId( "status-report-link", helper.allByTestId("cluster-profile-panel").item(0))).not.toBeDisabled();
+
+    helper.unmount();
+  });
+
+  it("should disable new elastic agent profile button when user does not have administer permissions", () => {
+    const clusterProfile = ClusterProfile.fromJSON(TestData.dockerClusterProfile());
+    clusterProfile.canAdminister(false);
+
+    const clusterProfiles = new ClusterProfiles([clusterProfile]);
+    mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
+
+    const dockerClusterProfilePanel = helper.byTestId("cluster-profile-panel");
+    expect(helper.byTestId("new-elastic-agent-profile-button", dockerClusterProfilePanel)).toBeDisabled();
+    expect(helper.byTestId("new-elastic-agent-profile-button", dockerClusterProfilePanel).title).toBe("You dont have permissions to administer 'cluster_3' cluster profile.");
+
+    helper.unmount();
+  });
+
+  it("should disable edit button when user does not have administer permissions", () => {
+    const clusterProfile = ClusterProfile.fromJSON(TestData.dockerClusterProfile());
+    clusterProfile.canAdminister(false);
+
+    const clusterProfiles = new ClusterProfiles([clusterProfile]);
+    mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
+
+    const dockerClusterProfilePanel = helper.byTestId("cluster-profile-panel");
+    expect(helper.byTestId("edit-cluster-profile", dockerClusterProfilePanel)).toBeDisabled();
+    expect(helper.byTestId("edit-cluster-profile", dockerClusterProfilePanel).title).toBe("You dont have permissions to administer 'cluster_3' cluster profile.");
+
+    helper.unmount();
+  });
+
+  it("should not disable clone button when user does not have administer permissions", () => {
+    const clusterProfile = ClusterProfile.fromJSON(TestData.dockerClusterProfile());
+    clusterProfile.canAdminister(false);
+
+    const clusterProfiles = new ClusterProfiles([clusterProfile]);
+    mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
+
+    const dockerClusterProfilePanel = helper.byTestId("cluster-profile-panel");
+    expect(helper.byTestId("clone-cluster-profile", dockerClusterProfilePanel)).not.toBeDisabled();
+
+    helper.unmount();
+  });
+
+  it("should disable delete button when user does not have administer permissions", () => {
+    const clusterProfile = ClusterProfile.fromJSON(TestData.dockerClusterProfile());
+    clusterProfile.canAdminister(false);
+
+    const clusterProfiles = new ClusterProfiles([clusterProfile]);
+    mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
+
+    const dockerClusterProfilePanel = helper.byTestId("cluster-profile-panel");
+    expect(helper.byTestId("delete-cluster-profile", dockerClusterProfilePanel)).toBeDisabled();
+    expect(helper.byTestId("delete-cluster-profile", dockerClusterProfilePanel).title).toBe("You dont have permissions to administer 'cluster_3' cluster profile.");
 
     helper.unmount();
   });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/elastic_agent_profiles_modals_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/elastic_agent_profiles_modals_spec.tsx
@@ -37,7 +37,7 @@ describe("New Elastic Agent Profile Modals Spec", () => {
     const modal = new NewElasticProfileModal(
       new PluginInfos(pluginInfo),
       new ClusterProfiles(clusterProfiles),
-      new ElasticAgentProfile(undefined, undefined, undefined, new Configurations([])), _.noop);
+      new ElasticAgentProfile(undefined, undefined, undefined, undefined, new Configurations([])), _.noop);
 
     helper.mount(modal.body.bind(modal));
   }
@@ -46,7 +46,7 @@ describe("New Elastic Agent Profile Modals Spec", () => {
     const modal = new NewElasticProfileModal(
       new PluginInfos(pluginInfo),
       new ClusterProfiles(clusterProfiles),
-      new ElasticAgentProfile(undefined, undefined, undefined, new Configurations([])), _.noop);
+      new ElasticAgentProfile(undefined, undefined, undefined, undefined, new Configurations([])), _.noop);
 
     expect(modal.title()).toEqual("Add a new elastic agent profile");
   });
@@ -119,7 +119,7 @@ describe("New Elastic Agent Profile Modals Spec", () => {
     const pluginInfos = new PluginInfos(PluginInfo.fromJSON(TestData.dockerPluginJSON()), PluginInfo.fromJSON(data));
     clusterProfiles = [new ClusterProfile("cluster1", pluginInfo.id), new ClusterProfile("cluster2", data.id)];
 
-    const elasticAgentProfile = new ElasticAgentProfile("", data.id, "cluster2", new Configurations([]));
+    const elasticAgentProfile = new ElasticAgentProfile("", data.id, "cluster2", true, new Configurations([]));
 
     const modal = new NewElasticProfileModal(pluginInfos, new ClusterProfiles(clusterProfiles), elasticAgentProfile, _.noop);
 
@@ -139,7 +139,7 @@ describe("New Elastic Agent Profile Modals Spec", () => {
     const pluginInfos = new PluginInfos(PluginInfo.fromJSON(TestData.dockerPluginJSON()), PluginInfo.fromJSON(data));
     clusterProfiles = [new ClusterProfile("cluster1", pluginInfo.id), new ClusterProfile("cluster2", pluginInfo.id)];
 
-    const elasticAgentProfile = new ElasticAgentProfile("", "", "", new Configurations([]));
+    const elasticAgentProfile = new ElasticAgentProfile("", "", "", true, new Configurations([]));
 
     const modal = new NewElasticProfileModal(pluginInfos, new ClusterProfiles(clusterProfiles), elasticAgentProfile, _.noop);
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/elastic_profile_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/elastic_profile_widget_spec.tsx
@@ -94,7 +94,50 @@ describe("New Elastic Agent Profile Widget", () => {
 
     expect(helper.byTestId("edit-elastic-profile", helper.byTestId("elastic-profile-header"))).toBeDisabled();
     expect(helper.byTestId("clone-elastic-profile", helper.byTestId("elastic-profile-header"))).toBeDisabled();
-    expect(helper.byTestId("delete-elastic-profile", helper.byTestId("elastic-profile-header"))).not.toBeDisabled();
+    expect(helper.byTestId("delete-elastic-profile", helper.byTestId("elastic-profile-header"))).toBeDisabled();
+    expect(helper.byTestId("show-usage-elastic-profile", helper.byTestId("elastic-profile-header"))).not.toBeDisabled();
+
+    helper.unmount();
+  });
+
+  it("should disable edit button when user does not have administer permissions", () => {
+    const profile = ElasticAgentProfile.fromJSON(TestData.dockerElasticProfile());
+    profile.canAdminister(false);
+    mount(pluginInfo, profile);
+
+    expect(helper.byTestId("edit-elastic-profile", helper.byTestId("elastic-profile-header"))).toBeDisabled();
+    expect(helper.byTestId("edit-elastic-profile", helper.byTestId("elastic-profile-header")).title).toBe("You dont have permissions to administer 'Profile2' elastic agent profile.");
+
+    helper.unmount();
+  });
+
+  it("should not disable clone button when user does not have administer permissions", () => {
+    const profile = ElasticAgentProfile.fromJSON(TestData.dockerElasticProfile());
+    profile.canAdminister(false);
+    mount(pluginInfo, profile);
+
+    expect(helper.byTestId("clone-elastic-profile", helper.byTestId("elastic-profile-header"))).not.toBeDisabled();
+
+    helper.unmount();
+  });
+
+  it("should disable delete button when user does not have administer permissions", () => {
+    const profile = ElasticAgentProfile.fromJSON(TestData.dockerElasticProfile());
+    profile.canAdminister(false);
+    mount(pluginInfo, profile);
+
+    expect(helper.byTestId("delete-elastic-profile", helper.byTestId("elastic-profile-header"))).toBeDisabled();
+    expect(helper.byTestId("delete-elastic-profile", helper.byTestId("elastic-profile-header")).title).toBe("You dont have permissions to administer 'Profile2' elastic agent profile.");
+
+    helper.unmount();
+  });
+
+  it("should not disable usage button when user does not have administer permissions", () => {
+    const profile = ElasticAgentProfile.fromJSON(TestData.dockerElasticProfile());
+    profile.canAdminister(false);
+    mount(pluginInfo, profile);
+
+    expect(helper.byTestId("show-usage-elastic-profile", helper.byTestId("elastic-profile-header"))).not.toBeDisabled();
 
     helper.unmount();
   });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/elastic_profiles_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/elastic_profiles_widget_spec.tsx
@@ -87,7 +87,7 @@ describe("Elastic Agent Profiles Widget", () => {
 
     expect(helper.byTestId("edit-elastic-profile", elasticAgentProfilePanel)).toBeDisabled();
     expect(helper.byTestId("clone-elastic-profile", elasticAgentProfilePanel)).toBeDisabled();
-    expect(helper.byTestId("delete-elastic-profile", elasticAgentProfilePanel)).not.toBeDisabled();
+    expect(helper.byTestId("delete-elastic-profile", elasticAgentProfilePanel)).toBeDisabled();
     expect(helper.byTestId("show-usage-elastic-profile", elasticAgentProfilePanel)).not.toBeDisabled();
 
     helper.unmount();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/test_data.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/test_data.tsx
@@ -683,6 +683,7 @@ export class TestData {
       },
       id: "Profile2",
       plugin_id: "cd.go.contrib.elastic-agent.docker",
+      can_administer: true,
       properties: [{
         key: "Image",
         value: "docker-image122345"
@@ -714,6 +715,7 @@ export class TestData {
       },
       id: "Swarm1",
       plugin_id: "cd.go.contrib.elastic-agent.docker-swarm",
+      can_administer: true,
       properties: [{
         key: "Image",
         value: "Image1"
@@ -755,6 +757,7 @@ export class TestData {
       },
       id: "Kuber1",
       plugin_id: "cd.go.contrib.elasticagent.kubernetes",
+      can_administer: true,
       properties: [{
         key: "Image",
         value: "Image1"
@@ -791,6 +794,7 @@ export class TestData {
       },
       id: "cluster_3",
       plugin_id: "cd.go.contrib.elastic-agent.docker",
+      can_administer: true,
       properties: [
         {
           key: "go_server_url",
@@ -827,6 +831,7 @@ export class TestData {
       },
       id: "cluster_1",
       plugin_id: "cd.go.contrib.elasticagent.kubernetes",
+      can_administer: true,
       properties: [
         {
           key: "security_token",

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agents.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agents.tsx
@@ -184,6 +184,7 @@ export class ElasticAgentsPage extends Page<null, State> {
         const elasticProfile = new ElasticAgentProfile("",
                                                        vnode.state.clusterProfileBeingEdited().pluginId(),
                                                        vnode.state.clusterProfileBeingEdited().id(),
+                                                       vnode.state.clusterProfileBeingEdited().canAdminister(),
                                                        new Configurations([]));
 
         vnode.state.isWizardOpen(true);
@@ -226,10 +227,12 @@ export class ElasticAgentsPage extends Page<null, State> {
         vnode.state.isWizardOpen(true);
         vnode.state.clusterProfileBeingEdited(new ClusterProfile("",
                                                                  vnode.state.pluginInfos()[0].id,
+                                                                 true,
                                                                  new Configurations([])));
         vnode.state.elasticProfileBeingEdited(new ElasticAgentProfile("",
                                                                       vnode.state.clusterProfileBeingEdited().pluginId(),
                                                                       vnode.state.clusterProfileBeingEdited().id(),
+                                                                      vnode.state.clusterProfileBeingEdited().canAdminister(),
                                                                       new Configurations([])));
 
         vnode.state.isWizardOpen(true);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agents/wizard_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agents/wizard_spec.tsx
@@ -35,7 +35,8 @@ import {Wizard} from "views/components/wizard";
 import {ElasticAgentsPage} from "views/pages/elastic_agents";
 import styles from "views/pages/elastic_agents/index.scss";
 import {
-  openWizardForAdd, openWizardForAddElasticProfile,
+  openWizardForAdd,
+  openWizardForAddElasticProfile,
   openWizardForEditClusterProfile,
   openWizardForEditElasticProfile
 } from "views/pages/elastic_agents/wizard";
@@ -56,8 +57,10 @@ describe("ElasticAgentWizard", () => {
     pluginInfos      = Stream(new PluginInfos(PluginInfo.fromJSON(pluginInfoWithElasticAgentExtensionV5)));
     clusterProfile   = Stream(new ClusterProfile(undefined,
                                                  undefined,
+                                                 undefined,
                                                  new Configurations([])));
     elasticProfile   = Stream(new ElasticAgentProfile(undefined,
+                                                      undefined,
                                                       undefined,
                                                       undefined,
                                                       new Configurations([])));
@@ -95,7 +98,7 @@ describe("ElasticAgentWizard", () => {
 
     it("should save cluster profile and exit", (done) => {
       const configurations       = new Configurations([new Configuration("GO_SERVER_URL", new PlainTextValue(""))]);
-      const clusterProfileObj    = new ClusterProfile("cluster-profile-id", "ecs-elastic-agent", configurations);
+      const clusterProfileObj    = new ClusterProfile("cluster-profile-id", "ecs-elastic-agent", true, configurations);
       const promiseForCreateCall = successResponseForClusterProfile().catch(done.fail);
       clusterProfileObj.create   = jasmine.createSpy("create call").and.returnValue(promiseForCreateCall);
       clusterProfile             = Stream(clusterProfileObj);
@@ -115,6 +118,7 @@ describe("ElasticAgentWizard", () => {
       const configurations       = new Configurations([new Configuration("GO_SERVER_URL", new PlainTextValue(""))]);
       const clusterProfileObj    = new ClusterProfile("cluster-profile-id",
                                                       "cd.go.contrib.elastic-agent.docker",
+                                                      true,
                                                       configurations);
       const promiseForCreateCall = validationErrorResponseForClusterProfile().catch(done.fail);
       clusterProfileObj.create   = jasmine.createSpy("create call").and.returnValue(promiseForCreateCall);
@@ -182,7 +186,7 @@ describe("ElasticAgentWizard", () => {
 
     it("should go back and make changes to cluster profile", (done) => {
       const configurations       = new Configurations([new Configuration("GO_SERVER_URL", new PlainTextValue(""))]);
-      const clusterProfileObj    = new ClusterProfile("cluster-profile-id", "ecs-elastic-agent", configurations);
+      const clusterProfileObj    = new ClusterProfile("cluster-profile-id", "ecs-elastic-agent", true, configurations);
       const promiseForCreateCall = successResponseForClusterProfile().catch(done.fail);
       clusterProfileObj.create   = jasmine.createSpy().and.returnValue(promiseForCreateCall);
       clusterProfile             = Stream(clusterProfileObj);
@@ -227,6 +231,7 @@ describe("ElasticAgentWizard", () => {
       elasticProfile().create    = jasmine.createSpy("create call").and.returnValue(promiseForCreateCall);
       clusterProfile             = Stream(new ClusterProfile("cluster-profile-id",
                                                              "plugin-id",
+                                                             true,
                                                              new Configurations([])));
       wizard                     = openWizardForAddElasticProfile(pluginInfos,
                                                                   clusterProfile,
@@ -278,10 +283,12 @@ describe("ElasticAgentWizard", () => {
     it("should load data and render form", (done) => {
       clusterProfile = Stream(new ClusterProfile("cluster-profile-id",
                                                  "plugin-id",
+                                                 true,
                                                  new Configurations([])));
       elasticProfile = Stream(new ElasticAgentProfile("elastic-profile-id",
                                                       "plugin-id",
                                                       "cluster-profile-id",
+                                                      true,
                                                       new Configurations([])));
 
       const promiseForGetCall = successResponseForElasticProfile().catch(done.fail);
@@ -315,10 +322,12 @@ describe("ElasticAgentWizard", () => {
     it("should load data and render form", (done) => {
       clusterProfile = Stream(new ClusterProfile("cluster-profile-id",
                                                  "plugin-id",
+                                                 true,
                                                  new Configurations([])));
       elasticProfile = Stream(new ElasticAgentProfile("elastic-profile-id",
                                                       "plugin-id",
                                                       "cluster-profile-id",
+                                                      true,
                                                       new Configurations([])));
 
       const promiseForGetCall = successResponseForClusterProfile().catch(done.fail);
@@ -344,10 +353,12 @@ describe("ElasticAgentWizard", () => {
     pluginInfos             = Stream(new PluginInfos(PluginInfo.fromJSON(pluginInfoWithElasticAgentExtensionV4)));
     clusterProfile          = Stream(new ClusterProfile("cluster-profile-id",
                                                         "plugin-id",
+                                                        true,
                                                         new Configurations([])));
     elasticProfile          = Stream(new ElasticAgentProfile("elastic-profile-id",
                                                              "plugin-id",
                                                              "cluster-profile-id",
+                                                             true,
                                                              new Configurations([])));
     const promiseForGetCall = successResponseForClusterProfile().catch(done.fail);
     clusterProfile().get    = jasmine.createSpy("get elastic profile").and.returnValue(promiseForGetCall);

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/ElasticAgentConfigurationsController.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/ElasticAgentConfigurationsController.java
@@ -45,7 +45,7 @@ public class ElasticAgentConfigurationsController implements SparkController {
     @Override
     public void setupRoutes() {
         path(controllerBasePath(), () -> {
-            before("", authenticationHelper::checkAdminUserOrGroupAdminUserAnd403);
+            before("", authenticationHelper::checkUserAnd403);
             get("", this::index, engine);
         });
     }

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ElasticAgentConfigurationsControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ElasticAgentConfigurationsControllerTest.groovy
@@ -16,7 +16,7 @@
 package com.thoughtworks.go.spark.spa
 
 import com.thoughtworks.go.spark.ControllerTrait
-import com.thoughtworks.go.spark.GroupAdminUserSecurity
+import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
 import org.junit.jupiter.api.BeforeEach
@@ -34,7 +34,7 @@ class ElasticAgentConfigurationsControllerTest implements ControllerTrait<Elasti
   @Nested
   class Index {
     @Nested
-    class Security implements SecurityTestTrait, GroupAdminUserSecurity {
+    class Security implements SecurityTestTrait, NormalUserSecurity {
 
       @Override
       String getControllerMethodUnderTest() {


### PR DESCRIPTION
Issue: #7549

Description:
	- Make elastic agent configurations page accessible to normal users
	- Use elastic agent profiles API v3 on SPA
 	- Use cluster profiles API v2 on SPA
 	- Disable cluster profile and elastic agent profiles action buttons
 	  when user does not have administer permissions
 	- Show error message on the cluster profiles wizard
 	- Remove dead code