### PR TITLE
Apply policy permissions for elastic agent status report pages (#7549)

### DIFF
--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/StatusReportsController.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/StatusReportsController.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.spark.spa;
 
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
+import com.thoughtworks.go.config.policy.SupportedEntity;
 import com.thoughtworks.go.domain.JobInstance;
 import com.thoughtworks.go.server.service.ElasticAgentPluginService;
 import com.thoughtworks.go.server.service.JobInstanceService;
@@ -60,8 +61,16 @@ public class StatusReportsController implements SparkController {
     @Override
     public void setupRoutes() {
         path(controllerBasePath(), () -> {
-            before("", authenticationHelper::checkAdminUserAnd403);
-            before("/*", authenticationHelper::checkAdminUserAnd403);
+            before("/:plugin_id", authenticationHelper::checkAdminUserAnd403);
+
+            before("/:plugin_id/agent/:elastic_agent_id", (request, response) -> {
+                authenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.ELASTIC_AGENT_PROFILE, request.params("elastic_agent_id"));
+            });
+
+            before("/:plugin_id/cluster/:cluster_profile_id", (request, response) -> {
+                authenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.CLUSTER_PROFILE, request.params("cluster_profile_id"));
+            });
+
             get("/:plugin_id", this::pluginStatusReport, engine);
             get("/:plugin_id/agent/:elastic_agent_id", this::agentStatusReport, engine);
             get("/:plugin_id/cluster/:cluster_profile_id", this::clusterStatusReport, engine);

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/SecurityTestTrait.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/SecurityTestTrait.groovy
@@ -60,6 +60,5 @@ trait SecurityTestTrait {
     ((MockHttpServletResponseAssert) assertThatResponse())
       .hasContentType("text/html")
       .hasStatus(403)
-      .hasBody(HtmlErrorPage.errorPage(403, "Forbidden"))
   }
 }

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/StatusReportsControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/StatusReportsControllerTest.groovy
@@ -63,7 +63,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
 
       @Override
       void makeHttpCall() {
-        get(controller.controllerBasePath() + "/some_plugin_id")
+        get(controller.controllerPath("/some_plugin_id"))
       }
     }
 
@@ -74,7 +74,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
       when(elasticAgentPluginService.getPluginStatusReport("pluginId"))
         .thenThrow(new RecordNotFoundException(errorMessage))
 
-      get(controller.controllerBasePath() + "/pluginId")
+      get(controller.controllerPath("/pluginId"))
 
       def expectedBody = new StubTemplateEngine().render(new ModelAndView([message: errorMessage, viewTitle: "Plugin Status Report"],
         "status_reports/error.ftlh"))
@@ -90,7 +90,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
       when(elasticAgentPluginService.getPluginStatusReport("pluginId"))
         .thenReturn("Plugin Status Report View")
 
-      get(controller.controllerBasePath() + "/pluginId")
+      get(controller.controllerPath("/pluginId"))
 
       assertThatResponse()
         .isOk()
@@ -105,7 +105,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
       when(elasticAgentPluginService.getPluginStatusReport("pluginId"))
         .thenThrow(new UnsupportedOperationException("Plugin does not plugin support status report."))
 
-      get(controller.controllerBasePath() + "/pluginId")
+      get(controller.controllerPath("/pluginId"))
 
       def expectedBody = new StubTemplateEngine().render(new ModelAndView([message: errorMessage, viewTitle: "Plugin Status Report"],
         "status_reports/error.ftlh"))
@@ -128,7 +128,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
 
       @Override
       void makeHttpCall() {
-        get(controller.controllerBasePath() + "/plugin_id/agent/elastic_agent_id")
+        get(controller.controllerPath("/plugin_id/agent/elastic_agent_id"))
       }
     }
 
@@ -141,7 +141,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
       when(elasticAgentPluginService.getAgentStatusReport("pluginId", jobInstance.getIdentifier(), "elasticAgentId"))
         .thenThrow(new RecordNotFoundException(errorMessage))
 
-      get(controller.controllerBasePath() + "/pluginId/agent/elasticAgentId?job_id=1")
+      get(controller.controllerPath("/pluginId/agent/elasticAgentId?job_id=1"))
 
       def expectedBody = new StubTemplateEngine().render(new ModelAndView([message  : errorMessage,
                                                                            viewTitle: "Agent Status Report"],
@@ -156,7 +156,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
     void 'should be unprocessable entity when job id is not provided'() {
       loginAsAdmin()
 
-      get(controller.controllerBasePath() + "/pluginId/agent/elasticAgentId")
+      get(controller.controllerPath("/pluginId/agent/elasticAgentId"))
 
       assertThatResponse()
         .isUnprocessableEntity()
@@ -168,7 +168,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
     void 'should be unprocessable entity when job id is not not a number'() {
       loginAsAdmin()
 
-      get(controller.controllerBasePath() + "/pluginId/agent/elasticAgentId?job_id=foobar")
+      get(controller.controllerPath("/pluginId/agent/elasticAgentId?job_id=foobar"))
 
       assertThatResponse()
         .isUnprocessableEntity()
@@ -184,7 +184,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
       when(elasticAgentPluginService.getAgentStatusReport("pluginId", jobInstance.getIdentifier(), "elasticAgentId"))
         .thenThrow(new UnsupportedOperationException(""))
 
-      get(controller.controllerBasePath() + "/pluginId/agent/elasticAgentId?job_id=1")
+      get(controller.controllerPath("/pluginId/agent/elasticAgentId?job_id=1"))
 
       def expectedBody = new StubTemplateEngine().render(new ModelAndView(
         [
@@ -207,7 +207,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
       when(elasticAgentPluginService.getAgentStatusReport("pluginId", jobInstance.getIdentifier(), "elasticAgentId"))
         .thenReturn("Agent Status Report View From Plugin")
 
-      get(controller.controllerBasePath() + "/pluginId/agent/elasticAgentId?job_id=1")
+      get(controller.controllerPath("/pluginId/agent/elasticAgentId?job_id=1"))
 
       assertThatResponse()
         .isOk()
@@ -223,7 +223,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
       when(elasticAgentPluginService.getAgentStatusReport("pluginId", jobInstance.getIdentifier(), null))
         .thenReturn("Agent Status Report View From Plugin")
 
-      get(controller.controllerBasePath() + "/pluginId/agent/unassigned?job_id=1")
+      get(controller.controllerPath("/pluginId/agent/unassigned?job_id=1"))
 
       assertThatResponse()
         .isOk()
@@ -244,7 +244,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
 
       @Override
       void makeHttpCall() {
-        get(controller.controllerBasePath() + "/plugin_id/cluster/cluster_profile_id")
+        get(controller.controllerPath("/plugin_id/cluster/cluster_profile_id"))
       }
     }
 
@@ -254,7 +254,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
       when(elasticAgentPluginService.getClusterStatusReport("pluginId", "clusterId")).thenReturn('view from plugin')
       def expectedBody = new StubTemplateEngine().render(new ModelAndView([viewTitle: "Cluster Status Report", viewFromPlugin: 'view from plugin'], "status_reports/index.ftlh"))
 
-      get(controller.controllerBasePath() + "/pluginId/cluster/clusterId")
+      get(controller.controllerPath("/pluginId/cluster/clusterId"))
 
       assertThatResponse()
         .isOk()
@@ -269,7 +269,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
       when(elasticAgentPluginService.getClusterStatusReport("pluginId", "clusterId"))
         .thenThrow(new RecordNotFoundException(errorMessage))
 
-      get(controller.controllerBasePath() + "/pluginId/cluster/clusterId")
+      get(controller.controllerPath("/pluginId/cluster/clusterId"))
 
       def expectedBody = new StubTemplateEngine().render(new ModelAndView([message: errorMessage, viewTitle: "Cluster Status Report"],
         "status_reports/error.ftlh"))
@@ -286,7 +286,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
       when(elasticAgentPluginService.getClusterStatusReport("pluginId", "clusterId"))
         .thenThrow(new RecordNotFoundException(errorMessage))
 
-      get(controller.controllerBasePath() + "/pluginId/cluster/clusterId")
+      get(controller.controllerPath("/pluginId/cluster/clusterId"))
 
       def expectedBody = new StubTemplateEngine().render(new ModelAndView([message: errorMessage, viewTitle: "Cluster Status Report"],
         "status_reports/error.ftlh"))
@@ -303,7 +303,7 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
       when(elasticAgentPluginService.getClusterStatusReport("pluginId", "clusterId"))
         .thenThrow(new UnsupportedOperationException("Plugin does not support cluster status report."))
 
-      get(controller.controllerBasePath() + "/pluginId/cluster/clusterId")
+      get(controller.controllerPath("/pluginId/cluster/clusterId"))
 
       def expectedBody = new StubTemplateEngine().render(new ModelAndView([message: errorMessage, viewTitle: "Cluster Status Report"],
         "status_reports/error.ftlh"))


### PR DESCRIPTION
Issue: #7549

Description:
* Allow user to access Elastic Agent Status Reports when the user has
  view access to specific entity.

* Permissions:
	- Plugin Status Report => Super Admin Permission
	- Cluster Status Report => View Cluster Profile Permission
	- Elastic Agent Status Report => View Elastic Agent Profile Permission