### PR TITLE
Pipeline history spa fix

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity.tsx
@@ -162,6 +162,7 @@ export class PipelineActivityPage extends Page<null, State> implements ResultAwa
 
   onFailure(message: string) {
     this.flashMessage.setMessage(MessageType.alert, message);
+    this.pageState = PageState.OK;
   }
 
   onSuccess(data: PipelineActivity) {
@@ -171,6 +172,10 @@ export class PipelineActivityPage extends Page<null, State> implements ResultAwa
   }
 
   pageChangeCallback(pageNumber: number) {
+    if (pageNumber === this.pagination().currentPageNumber()) {
+      return;
+    }
+    this.pageState = PageState.LOADING;
     const offset = this.pipelineActivity().perPage() * (pageNumber - 1);
     this.pagination(new Pagination(offset, this.pagination().total, this.pagination().pageSize));
     this.fetchPipelineHistory();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/index.scss
@@ -341,6 +341,10 @@ $stage-action-icon-z-index: 1;
       width:      40%;
       max-height: 6.4em;
       padding:    3px 10px;
+
+      a {
+        color: $link-color;
+      }
     }
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/page_header.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/page_header.tsx
@@ -52,7 +52,7 @@ export class PipelineActivityHeader extends MithrilViewComponent<Attrs> {
   private static pipelineSettingsLink(vnode: m.Vnode<Attrs>) {
     if ((vnode.attrs.isAdmin || vnode.attrs.isGroupAdmin)) {
       return <div class={styles.iconContainer} data-test-id="page-header-pipeline-settings">
-        <Link target={"_blank"} href={`/go/admin/pipelines/${vnode.attrs.pipelineActivity.pipelineName()}/general`}>
+        <Link href={`/go/admin/pipelines/${vnode.attrs.pipelineActivity.pipelineName()}/general`}>
           <Icons.Settings iconOnly={true}/>
         </Link>
       </div>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/pipeline_run_info_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/pipeline_run_info_widget.tsx
@@ -155,7 +155,7 @@ export class PipelineRunWidget extends MithrilViewComponent<PipelineRunAttrs> {
       return;
     }
 
-    const infoIcon = <Link target="_blank" href={`/go/pipelines/${stage.stageLocator()}`}>
+    const infoIcon = <Link href={`/go/pipelines/${stage.stageLocator()}`}>
       <Icons.InfoCircle iconOnly={true} data-test-id="stage-info-icon" title="Stage details"/>
     </Link>;
     if (stage.getCanRun()) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/pipeline_run_info_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/pipeline_run_info_widget.tsx
@@ -61,8 +61,9 @@ export class PipelineRunWidget extends MithrilViewComponent<PipelineRunAttrs> {
         </div>
         <div class={styles.revision}>Revision: {pipelineRunInfo.revision()}</div>
         <div class={styles.scheduleInfo}
-             data-test-id={"time"}>
-          {PipelineRunWidget.getTime(pipelineRunInfo.scheduledTimestamp())}
+             data-test-id={"time"}
+             title={PipelineRunWidget.getTimeServer(pipelineRunInfo.scheduledTimestamp())}>
+          {PipelineRunWidget.getTimeLocal(pipelineRunInfo.scheduledTimestamp())}
         </div>
         <BuildCauseWidget pipelineRunInfo={pipelineRunInfo}
                           showBuildCaseFor={vnode.attrs.showBuildCaseFor}
@@ -146,8 +147,12 @@ export class PipelineRunWidget extends MithrilViewComponent<PipelineRunAttrs> {
     return <a href={link}>VSM</a>;
   }
 
-  private static getTime(timestamp: Date) {
+  private static getTimeLocal(timestamp: Date) {
     return timestamp ? TimeFormatter.format(timestamp) : "N/A";
+  }
+
+  private static getTimeServer(timestamp: Date) {
+    return timestamp ? TimeFormatter.formatInServerTime(timestamp) : null;
   }
 
   private getStageActions(stage: Stage, vnode: m.Vnode<PipelineRunAttrs>): m.Children {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/spec/pipeline_run_info_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/spec/pipeline_run_info_widget_spec.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {timeFormatter} from "helpers/time_formatter";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {PipelineRunInfo, Stage, StageConfig, StageConfigs, Stages} from "models/pipeline_activity/pipeline_activity";
@@ -74,6 +75,21 @@ describe("PipelineRunInfoWidget", () => {
       const pipelineRunContainer = helper.byTestId(`pipeline-instance-${pipelineRunInfo.label()}`);
       expect(helper.byTestId("time", pipelineRunContainer)).toBeInDOM();
       expect(helper.byTestId("time", pipelineRunContainer)).toHaveText("N/A");
+      expect(helper.byTestId("time", pipelineRunContainer)).not.toHaveAttr("title", "N/A");
+    });
+
+    it("should render modification time", () => {
+      const pipelineRunInfoJSON = PipelineActivityData.pipelineRunInfo(passed("Test"));
+      const pipelineRunInfo     = PipelineRunInfo.fromJSON(pipelineRunInfoJSON);
+
+      mount(pipelineRunInfo);
+
+      const pipelineRunContainer = helper.byTestId(`pipeline-instance-${pipelineRunInfo.label()}`);
+      expect(helper.byTestId("time", pipelineRunContainer)).toBeInDOM();
+      expect(helper.byTestId("time", pipelineRunContainer))
+        .toHaveText(timeFormatter.format(pipelineRunInfo.scheduledTimestamp()));
+      expect(helper.byTestId("time", pipelineRunContainer))
+        .toHaveAttr("title", timeFormatter.formatInServerTime(pipelineRunInfo.scheduledTimestamp()));
     });
   });
 
@@ -134,7 +150,8 @@ describe("PipelineRunInfoWidget", () => {
   });
 
   it("should render multiple stages", () => {
-    const pipelineRunInfo = PipelineRunInfo.fromJSON(PipelineActivityData.pipelineRunInfo(passed("unit"), building("integration")));
+    const pipelineRunInfo = PipelineRunInfo.fromJSON(PipelineActivityData.pipelineRunInfo(passed("unit"),
+                                                                                          building("integration")));
     mount(pipelineRunInfo);
 
     const pipelineRunContainer = helper.byTestId(`pipeline-instance-${pipelineRunInfo.label()}`);
@@ -216,7 +233,8 @@ describe("PipelineRunInfoWidget", () => {
 
         const stageStatusContainer = stageContainer(pipelineRunInfo.label(), "integration");
         expect(helper.byTestId("gate-icon", stageStatusContainer)).toBeInDOM();
-        expect(helper.byTestId("gate-icon", stageStatusContainer)).toHaveAttr("title", "Can not schedule stage as previous stage is failed");
+        expect(helper.byTestId("gate-icon", stageStatusContainer))
+          .toHaveAttr("title", "Can not schedule stage as previous stage is failed");
       });
     });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/spec/pipeline_run_info_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/spec/pipeline_run_info_widget_spec.tsx
@@ -339,7 +339,6 @@ describe("PipelineRunInfoWidget", () => {
       const infoActionIcon     = helper.byTestId("stage-info-icon", unitStageContainer);
       expect(infoActionIcon).toBeInDOM();
       expect(infoActionIcon).toBeHidden();
-      expect(infoActionIcon.parentElement).toHaveAttr("target", "_blank");
       expect(infoActionIcon.parentElement).toHaveAttr("href", `/go/pipelines/${unitTestStage.stageLocator}`);
 
       expect(helper.byTestId("rerun-stage-icon", unitStageContainer)).not.toBeInDOM();


### PR DESCRIPTION
## Fixed following issues

- Change link color for the tracking tool to global link color
- Open pipeline settings and stage details page in the same tab
- Show spinner when on change of page.
- Show server time on hover of local time

#### Change link color for the tracking tool to global link color
<img width="958" alt="Screenshot 2020-01-17 at 1 40 29 PM" src="https://user-images.githubusercontent.com/7871209/72599827-6e516000-3938-11ea-90c0-1dcd8dc7fc5b.png">

---

#### Show spinner when on change of page

![show-spinner](https://user-images.githubusercontent.com/7871209/72599843-76110480-3938-11ea-9023-9e6e2c0d2401.gif)
