### PR TITLE
Remove admin user authorization check from commands (#7549)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/update/ClusterProfileCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ClusterProfileCommand.java
@@ -62,11 +62,6 @@ public abstract class ClusterProfileCommand extends PluginProfileCommand<Cluster
 
     @Override
     public boolean isAuthorized() {
-        if (!goConfigService.isAdministrator(currentUser.getUsername())) {
-            result.forbidden(LocalizedMessage.forbiddenToEditResource("Cluster Profile", profile.getId(), currentUser.getDisplayName()), HealthStateType.forbidden());
-            return false;
-        }
-
         return true;
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileCommand.java
@@ -81,10 +81,6 @@ public abstract class ElasticAgentProfileCommand implements EntityConfigUpdateCo
     }
 
     protected final boolean isAuthorized() {
-        if (!(goConfigService.isUserAdmin(currentUser) || goConfigService.isGroupAdministrator(currentUser.getUsername()))) {
-            result.forbidden(EntityType.ElasticProfile.forbiddenToEdit(elasticProfile.getId(), currentUser.getUsername()), forbidden());
-            return false;
-        }
         return true;
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/AddClusterProfileCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/AddClusterProfileCommandTest.java
@@ -56,22 +56,6 @@ class AddClusterProfileCommandTest {
     }
 
     @Test
-    void shouldAllowAdministratorToAddClusterProfile() {
-        when(goConfigService.isAdministrator(username.getUsername())).thenReturn(true);
-
-        boolean canContinue = command.canContinue(config);
-        assertThat(canContinue).isTrue();
-    }
-
-    @Test
-    void shouldNotAllowNonAdministratorToAddClusterProfile() {
-        when(goConfigService.isAdministrator(username.getUsername())).thenReturn(false);
-
-        boolean canContinue = command.canContinue(config);
-        assertThat(canContinue).isFalse();
-    }
-
-    @Test
     void shouldAddClusterProfile() throws Exception {
         assertThat(config.getElasticConfig().getClusterProfiles()).hasSize(0);
         command.update(config);

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteClusterProfileCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteClusterProfileCommandTest.java
@@ -59,22 +59,6 @@ class DeleteClusterProfileCommandTest {
     }
 
     @Test
-    void shouldAllowAdministratorToDeleteClusterProfile() {
-        when(goConfigService.isAdministrator(username.getUsername())).thenReturn(true);
-
-        boolean canContinue = command.canContinue(config);
-        assertThat(canContinue).isTrue();
-    }
-
-    @Test
-    void shouldNotAllowNonAdministratorToDeleteClusterProfile() {
-        when(goConfigService.isAdministrator(username.getUsername())).thenReturn(false);
-
-        boolean canContinue = command.canContinue(config);
-        assertThat(canContinue).isFalse();
-    }
-
-    @Test
     void shouldSetPreprocessedEntityAsPartOfUpdate() throws Exception {
         assertNull(command.getPreprocessedEntityConfig());
         command.update(config);

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateClusterProfileCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateClusterProfileCommandTest.java
@@ -62,22 +62,6 @@ class UpdateClusterProfileCommandTest {
     }
 
     @Test
-    void shouldAllowAdministratorToUpdateClusterProfile() {
-        when(goConfigService.isAdministrator(username.getUsername())).thenReturn(true);
-
-        boolean canContinue = command.canContinue(config);
-        assertThat(canContinue).isTrue();
-    }
-
-    @Test
-    void shouldNotAllowNonAdministratorToUpdateClusterProfile() {
-        when(goConfigService.isAdministrator(username.getUsername())).thenReturn(false);
-
-        boolean canContinue = command.canContinue(config);
-        assertThat(canContinue).isFalse();
-    }
-
-    @Test
     void shouldUpdateClusterProfile() throws Exception {
         assertThat(config.getElasticConfig().getClusterProfiles().get(0)).isEqualTo(clusterProfile);
         command.update(config);


### PR DESCRIPTION
Issue: #7549

Description:
* Remove super admin check from cluster profiles command
* Remove super admin or pipeline group admin check from elastic profiles command