### PR TITLE
Allow specifying colon separator only for elastic agent profile permission (#7549)

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/AbstractDirective.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/AbstractDirective.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.IOCase;
 import java.util.List;
 import java.util.Objects;
 
+import static com.thoughtworks.go.config.policy.SupportedEntity.ELASTIC_AGENT_PROFILE;
 import static com.thoughtworks.go.config.policy.SupportedEntity.fromString;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
@@ -66,6 +67,14 @@ public abstract class AbstractDirective implements Directive {
         if (isInvalidType(type, policyValidationContext.getAllowedTypes())) {
             this.addError("type", format("Invalid type, must be one of %s.", policyValidationContext.getAllowedTypes()));
         }
+
+        if (isInvalidResource(resource)) {
+            this.addError("resource", format("Invalid resource, %s permissions can not contain ':' separator.", type));
+        }
+    }
+
+    private boolean isInvalidResource(String resource) {
+        return resource.contains(":") && !this.isDirectiveOfType(ELASTIC_AGENT_PROFILE);
     }
 
     private boolean isInvalidType(String type, List<String> allowedTypes) {

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/policy/AbstractDirectiveTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/policy/AbstractDirectiveTest.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.ValidationContext;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Collections.singletonList;
@@ -96,6 +97,28 @@ class AbstractDirectiveTest {
 
             assertThat(directive.errors()).hasSize(0);
         }
+
+        @Test
+        void shouldNotAddAnErrorForColonSeparatorOnElasticAgentProfileResource() {
+            Directive directive = getDirective("view", "elastic_agent_profile", "test:resource");
+
+            directive.validate(rulesValidationContext(singletonList("view"), Arrays.asList("environment", "elastic_agent_profile")));
+
+            assertThat(directive.errors()).hasSize(0);
+        }
+
+        @Test
+        void shouldAddErrorIfColonSeparatorIsSpecifiedAsResourceForAnyTypeApartFromElasticAgentProfile() {
+            Directive directive = getDirective("view", "environment", "test:resource");
+
+            directive.validate(rulesValidationContext(singletonList("view"), Arrays.asList("environment", "elastic_agent_profile")));
+
+            assertThat(directive.errors()).hasSize(1);
+            assertThat(directive.errors().get("resource"))
+                    .hasSize(1)
+                    .contains("Invalid resource, environment permissions can not contain ':' separator.");
+        }
+
     }
 
     private ValidationContext rulesValidationContext(List<String> allowedAction, List<String> allowedType) {


### PR DESCRIPTION
Issue: #7549