### PR TITLE
Fixes for Elastic Agent Configurations Page (#7549)(#7649)

### DIFF
--- a/api/api-elastic-profile-operation-v1/src/main/java/com/thoughtworks/go/apiv1/elasticprofileoperation/ElasticProfileOperationControllerV1.java
+++ b/api/api-elastic-profile-operation-v1/src/main/java/com/thoughtworks/go/apiv1/elasticprofileoperation/ElasticProfileOperationControllerV1.java
@@ -19,6 +19,7 @@ import com.thoughtworks.go.api.ApiController;
 import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv1.elasticprofileoperation.representers.ElasticProfileUsageRepresenter;
+import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.config.policy.SupportedEntity;
 import com.thoughtworks.go.domain.ElasticProfileUsage;
 import com.thoughtworks.go.server.service.ElasticProfileService;
@@ -59,7 +60,8 @@ public class ElasticProfileOperationControllerV1 extends ApiController implement
             before("/*", mimeType, this::setContentType);
 
             before(Routes.ElasticProfileAPI.ID + Routes.ElasticProfileAPI.USAGES, mimeType, (request, response) -> {
-                apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.ELASTIC_AGENT_PROFILE, request.params(PROFILE_ID_PARAM));
+                ElasticProfile profile = elasticProfileService.findProfile(request.params(PROFILE_ID_PARAM));
+                apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.ELASTIC_AGENT_PROFILE, profile.getId(), profile.getClusterProfileId());
             });
 
             get(Routes.ElasticProfileAPI.ID + Routes.ElasticProfileAPI.USAGES, mimeType, this::usages);

--- a/api/api-elastic-profile-operation-v1/src/test/groovy/com/thoughtworks/go/apiv1/elasticprofileoperation/ElasticProfileOperationControllerV1Test.groovy
+++ b/api/api-elastic-profile-operation-v1/src/test/groovy/com/thoughtworks/go/apiv1/elasticprofileoperation/ElasticProfileOperationControllerV1Test.groovy
@@ -17,13 +17,13 @@ package com.thoughtworks.go.apiv1.elasticprofileoperation
 
 import com.thoughtworks.go.api.SecurityTestTrait
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
+import com.thoughtworks.go.config.elastic.ElasticProfile
 import com.thoughtworks.go.config.exceptions.EntityType
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException
 import com.thoughtworks.go.domain.ElasticProfileUsage
 import com.thoughtworks.go.server.service.ElasticProfileService
 import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait
-import com.thoughtworks.go.spark.GroupAdminUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import groovy.json.JsonBuilder
 import org.junit.jupiter.api.BeforeEach
@@ -42,6 +42,7 @@ class ElasticProfileOperationControllerV1Test implements SecurityServiceTrait, C
   @BeforeEach
   void setup() {
     initMocks(this)
+    when(elasticProfileService.findProfile("docker")).thenReturn(new ElasticProfile("docker", "cluster"))
   }
 
   @Override

--- a/api/api-elastic-profile-v2/src/main/java/com/thoughtworks/go/apiv2/elasticprofile/ElasticProfileControllerV2.java
+++ b/api/api-elastic-profile-v2/src/main/java/com/thoughtworks/go/apiv2/elasticprofile/ElasticProfileControllerV2.java
@@ -92,7 +92,7 @@ public class ElasticProfileControllerV2 extends ApiController implements SparkSp
                 apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.ELASTIC_AGENT_PROFILE, resourceToOperateOn, resourceToOperateWithin);
             });
 
-            before(Routes.ClusterProfilesAPI.ID, mimeType, (request, response) -> {
+            before(Routes.ElasticProfileAPI.ID, mimeType, (request, response) -> {
                 ElasticProfile elasticProfile = fetchEntityFromConfig(request.params(PROFILE_ID_PARAM));
                 apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.ELASTIC_AGENT_PROFILE, elasticProfile.getId(), elasticProfile.getClusterProfileId());
             });

--- a/api/api-elastic-profile-v2/src/main/java/com/thoughtworks/go/apiv2/elasticprofile/ElasticProfileControllerV2.java
+++ b/api/api-elastic-profile-v2/src/main/java/com/thoughtworks/go/apiv2/elasticprofile/ElasticProfileControllerV2.java
@@ -93,7 +93,8 @@ public class ElasticProfileControllerV2 extends ApiController implements SparkSp
             });
 
             before(Routes.ClusterProfilesAPI.ID, mimeType, (request, response) -> {
-                apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.ELASTIC_AGENT_PROFILE, request.params(PROFILE_ID_PARAM));
+                ElasticProfile elasticProfile = fetchEntityFromConfig(request.params(PROFILE_ID_PARAM));
+                apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.ELASTIC_AGENT_PROFILE, elasticProfile.getId(), elasticProfile.getClusterProfileId());
             });
 
             get("", mimeType, this::index);

--- a/api/api-elastic-profile-v2/src/test/groovy/com/thoughtworks/go/apiv2/elasticprofile/ElasticProfileControllerV2Test.groovy
+++ b/api/api-elastic-profile-v2/src/test/groovy/com/thoughtworks/go/apiv2/elasticprofile/ElasticProfileControllerV2Test.groovy
@@ -116,6 +116,10 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
 
   @Nested
   class Show {
+    @BeforeEach
+    void setUp() {
+      when(elasticProfileService.findProfile('docker')).thenReturn(new ElasticProfile("docker", "prod-cluster"))
+    }
 
     @Nested
     class Security implements SecurityTestTrait, AdminUserSecurity {
@@ -156,6 +160,8 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
 
       @Test
       void 'should return 404 if elastic profile with id does not exist'() {
+        when(elasticProfileService.findProfile('docker')).thenReturn(null)
+
         getWithApiHeader(controller.controllerPath('/docker'))
 
         assertThatResponse()
@@ -343,6 +349,10 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
 
   @Nested
   class Update {
+    @BeforeEach
+    void setUp() {
+      when(elasticProfileService.findProfile('docker')).thenReturn(new ElasticProfile("docker", "prod-cluster"))
+    }
 
     @Nested
     class Security implements SecurityTestTrait, AdminUserSecurity {
@@ -525,6 +535,11 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
 
   @Nested
   class Destroy {
+    @BeforeEach
+    void setUp() {
+      when(elasticProfileService.findProfile('docker')).thenReturn(new ElasticProfile("docker", "prod-cluster"))
+    }
+
     @Nested
     class Security implements SecurityTestTrait, AdminUserSecurity {
 

--- a/api/api-elastic-profile-v3/src/main/java/com/thoughtworks/go/apiv3/elasticprofile/ElasticProfileControllerV3.java
+++ b/api/api-elastic-profile-v3/src/main/java/com/thoughtworks/go/apiv3/elasticprofile/ElasticProfileControllerV3.java
@@ -94,7 +94,8 @@ public class ElasticProfileControllerV3 extends ApiController implements SparkSp
             });
 
             before(Routes.ElasticProfileAPI.ID, mimeType, (request, response) -> {
-                apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.ELASTIC_AGENT_PROFILE, request.params(PROFILE_ID_PARAM));
+                ElasticProfile elasticProfile = fetchEntityFromConfig(request.params(PROFILE_ID_PARAM));
+                apiAuthenticationHelper.checkUserHasPermissions(currentUsername(), getAction(request), SupportedEntity.ELASTIC_AGENT_PROFILE, elasticProfile.getId(), elasticProfile.getClusterProfileId());
             });
 
             get("", mimeType, this::index);

--- a/api/api-elastic-profile-v3/src/test/groovy/com/thoughtworks/go/apiv3/elasticprofile/ElasticProfileControllerV3Test.groovy
+++ b/api/api-elastic-profile-v3/src/test/groovy/com/thoughtworks/go/apiv3/elasticprofile/ElasticProfileControllerV3Test.groovy
@@ -116,6 +116,10 @@ class ElasticProfileControllerV3Test implements SecurityServiceTrait, Controller
 
   @Nested
   class Show {
+    @BeforeEach
+    void setUp() {
+      when(elasticProfileService.findProfile('docker')).thenReturn(new ElasticProfile("docker", "prod-cluster"))
+    }
 
     @Nested
     class Security implements SecurityTestTrait, AdminUserSecurity {
@@ -156,6 +160,8 @@ class ElasticProfileControllerV3Test implements SecurityServiceTrait, Controller
 
       @Test
       void 'should return 404 if elastic profile with id does not exist'() {
+        when(elasticProfileService.findProfile('docker')).thenReturn(null)
+
         getWithApiHeader(controller.controllerPath('/docker'))
 
         assertThatResponse()
@@ -345,6 +351,10 @@ class ElasticProfileControllerV3Test implements SecurityServiceTrait, Controller
 
   @Nested
   class Update {
+    @BeforeEach
+    void setUp() {
+      when(elasticProfileService.findProfile('docker')).thenReturn(new ElasticProfile("docker", "prod-cluster"))
+    }
 
     @Nested
     class Security implements SecurityTestTrait, AdminUserSecurity {
@@ -528,6 +538,11 @@ class ElasticProfileControllerV3Test implements SecurityServiceTrait, Controller
 
   @Nested
   class Destroy {
+    @BeforeEach
+    void setUp() {
+      when(elasticProfileService.findProfile('docker')).thenReturn(new ElasticProfile("docker", "prod-cluster"))
+    }
+
     @Nested
     class Security implements SecurityTestTrait, AdminUserSecurity {
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/policy/elasticagents/ElasticAgentProfilesAllowDirective.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/policy/elasticagents/ElasticAgentProfilesAllowDirective.java
@@ -39,7 +39,6 @@ public class ElasticAgentProfilesAllowDirective extends ElasticAgentProfilesAbst
     }
 
     public static ElasticAgentProfilesAllowDirective parseResource(String action, String type, String resource) {
-        //todo: add some validations at the time of save that the elastic agent profile resource should not contain more than 1 :
         String[] parts = resource.split(SEPARATOR);
         if (parts.length == 2) {
             return new ElasticAgentProfilesAllowDirective(action, type, parts[1], parts[0]);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/table/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/table/index.scss
@@ -52,7 +52,8 @@ $draggable-row-color: #e2f7fa;
   }
 
   tr {
-    display: table-row;
+    display:        table-row;
+    vertical-align: top;
   }
 
   td {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/cluster_profile_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/cluster_profile_widget.tsx
@@ -149,7 +149,7 @@ export class ClusterProfileWidget extends MithrilComponent<ClusterProfileWidgetA
         vnode.attrs.elasticAgentOperations.onAdd(new ElasticAgentProfile("", vnode.attrs.clusterProfile.pluginId(), vnode.attrs.clusterProfile.id(), true, new Configurations([])), e);
       }}
                          data-test-id={"new-elastic-agent-profile-button"}
-                         disabled={isDisabled}
+                         disabled={!pluginInfo}
                          title={disabledReason}
                          icon={ButtonIcon.ADD}>
         Elastic Agent Profile

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/elastic_agent_profiles_modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/elastic_agent_profiles_modals.tsx
@@ -79,6 +79,8 @@ abstract class BaseElasticProfileModal extends Modal {
       const profile = ElasticAgentProfile.fromJSON(JSON.parse(errorResponse.body).data);
       profile.pluginId(this.clusterProfiles.findCluster(profile.clusterProfileId()!).pluginId());
       this.elasticProfile(profile);
+    } else {
+      this.noClusterProfileError = JSON.parse(errorResponse.body!).message;
     }
   }
 
@@ -108,7 +110,6 @@ abstract class BaseElasticProfileModal extends Modal {
 
     const selectedPluginId = this.pluginInfo().id;
 
-    this.noClusterProfileError      = undefined;
     const clustersBelongingToPlugin = this.clusterProfiles.all().filter((cluster: ClusterProfile) => {
       return cluster.pluginId() === selectedPluginId;
     });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/cluster_profiles_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/spec/cluster_profiles_widget_spec.tsx
@@ -210,7 +210,7 @@ describe("ClusterProfilesWidget", () => {
     helper.unmount();
   });
 
-  it("should disable new elastic agent profile button when user does not have administer permissions", () => {
+  it("should always enable new elastic agent profile button", () => {
     const clusterProfile = ClusterProfile.fromJSON(TestData.dockerClusterProfile());
     clusterProfile.canAdminister(false);
 
@@ -218,8 +218,7 @@ describe("ClusterProfilesWidget", () => {
     mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
 
     const dockerClusterProfilePanel = helper.byTestId("cluster-profile-panel");
-    expect(helper.byTestId("new-elastic-agent-profile-button", dockerClusterProfilePanel)).toBeDisabled();
-    expect(helper.byTestId("new-elastic-agent-profile-button", dockerClusterProfilePanel).title).toBe("You dont have permissions to administer 'cluster_3' cluster profile.");
+    expect(helper.byTestId("new-elastic-agent-profile-button", dockerClusterProfilePanel)).not.toBeDisabled();
 
     helper.unmount();
   });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agents/wizard.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agents/wizard.tsx
@@ -174,6 +174,7 @@ class ElasticProfileWidget extends MithrilViewComponent<Attrs> {
     return (
       <div class={styles.container}>
         <div>
+          <FlashMessage type={MessageType.alert} message={vnode.attrs.errMessage}/>
           <div class={styles.profileForm}>
             <TextField label="Elastic Profile Name"
                        property={vnode.attrs.elasticProfile().id}
@@ -414,6 +415,7 @@ class ElasticProfileStep extends Step {
   protected readonly clusterProfile: Stream<ClusterProfile>;
   protected readonly elasticProfile: Stream<ElasticAgentProfile>;
   protected readonly onSuccessfulSave: (msg: m.Children) => any;
+  protected readonly errMessage: Stream<string | undefined>;
   protected readonly onError: (msg: m.Children) => any;
   protected etag?: string;
   protected footerError: Stream<string> = Stream("");
@@ -429,12 +431,14 @@ class ElasticProfileStep extends Step {
     this.elasticProfile   = elasticProfile;
     this.onSuccessfulSave = onSuccessfulSave;
     this.onError          = onError;
+    this.errMessage       = Stream();
   }
 
   body(): m.Children {
     return <ElasticProfileWidget pluginInfos={this.pluginInfos}
                                  elasticProfile={this.elasticProfile}
                                  clusterProfile={this.clusterProfile}
+                                 errMessage={this.errMessage()}
                                  readonly={false}
                                  etag={this.etag}/>;
   }
@@ -508,7 +512,9 @@ class ElasticProfileStep extends Step {
       this.footerError("Please fix the validation errors above before proceeding.");
     } else {
       this.footerError("Save Failed!");
-      this.onError(JSON.parse(errorResponse.body!).message);
+      const msg = JSON.parse(errorResponse.body!).message;
+      this.onError(msg);
+      this.errMessage(msg);
     }
   }
 }


### PR DESCRIPTION
Issue: #7649 

Description:
	- Allow users with permission to perform CRUD on elastic agent profiles
	- Fix Elastic profiles usage API
	- Always enable 'Add Elastic Profiles' button for a user
	- Show errors on the Elastic Agent Profiles Wizard Step
	- Show errors on the Elastic Agent Profiles Modal
	- Fix UI alignment on the roles page
