### PR TITLE
GO_AGENT_RESOURCES should not be added if resources are empty

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
@@ -33,6 +33,7 @@ import com.thoughtworks.go.server.service.builders.BuilderFactory;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.IterableUtils;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -293,7 +294,7 @@ public class BuildAssignmentService implements ConfigChangedListener {
                     final EnvironmentVariableContext environmentVariableContext = buildEnvVarContext(job.getIdentifier().getPipelineName());
 
                     // Agent may have a NULL "resources"
-                    if (agent.getResourceConfigs() != null) {
+                    if (CollectionUtils.isNotEmpty(agent.getResourceConfigs())) {
                         // Users relying on this env. var. can test for its existence rather than checking for an empty string
                         environmentVariableContext.setProperty(GO_AGENT_RESOURCES, agent.getResourceConfigs().getCommaSeparatedResourceNames(), false);
                     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/BuildAssignmentServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/BuildAssignmentServiceTest.java
@@ -323,9 +323,6 @@ class BuildAssignmentServiceTest {
             pipelineConfig.get(0).getJobs().add(JobConfigMother.jobWithNoResourceRequirement());
 
             final AgentInstance agentInstance = mock(AgentInstance.class);
-            when(agentInstance.getResourceConfigs()).thenReturn (mock (ResourceConfigs.class));
-            agentInstance.getResourceConfigs().add(new ResourceConfig("resource-1"));
-            agentInstance.getResourceConfigs().add(new ResourceConfig("resource-2"));
 
             final Pipeline pipeline = mock(Pipeline.class);
             final JobPlan jobPlan1 = getJobPlan(pipelineConfig.getName(), pipelineConfig.get(0).name(), pipelineConfig.get(0).getJobs().last());
@@ -352,6 +349,7 @@ class BuildAssignmentServiceTest {
             verifyZeroInteractions(jobStatusTopic);
             ScmMaterial material = (ScmMaterial) work.getAssignment().materialRevisions().getMaterialRevision(0).getMaterial();
             assertThat(material.passwordForCommandLine()).isEqualTo("some-password");
+            assertThat(work.getAssignment().initialEnvironmentVariableContext().hasProperty(GO_AGENT_RESOURCES)).isFalse();
         }
 
         @Test


### PR DESCRIPTION
Description:
there was only a null check on ResourceConfigs but it could be empty too (case with elastic agents)
updated the check and modified a test



