### PR TITLE
Pipeline Grp Admin should receive a 403 on create if group doesnot exist

### DIFF
--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/AbstractAuthenticationHelper.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/AbstractAuthenticationHelper.java
@@ -37,6 +37,7 @@ import spark.Response;
 import java.util.List;
 
 import static com.thoughtworks.go.config.exceptions.EntityType.Pipeline;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public abstract class AbstractAuthenticationHelper {
     protected static final Logger LOG = LoggerFactory.getLogger(AbstractAuthenticationHelper.class);
@@ -147,7 +148,7 @@ public abstract class AbstractAuthenticationHelper {
             return;
         }
         String templateName = request.params("template_name");
-        if (StringUtils.isNotBlank(templateName) && !securityService.isAuthorizedToEditTemplate(new CaseInsensitiveString(templateName), currentUsername())) {
+        if (isNotBlank(templateName) && !securityService.isAuthorizedToEditTemplate(new CaseInsensitiveString(templateName), currentUsername())) {
             throw renderForbiddenResponse();
         }
 
@@ -162,7 +163,7 @@ public abstract class AbstractAuthenticationHelper {
         }
 
         String templateName = request.params("template_name");
-        if (StringUtils.isNotBlank(templateName) && !securityService.isAuthorizedToViewTemplate(new CaseInsensitiveString(templateName), currentUsername())) {
+        if (isNotBlank(templateName) && !securityService.isAuthorizedToViewTemplate(new CaseInsensitiveString(templateName), currentUsername())) {
             throw renderForbiddenResponse();
         }
 
@@ -181,7 +182,9 @@ public abstract class AbstractAuthenticationHelper {
             throw new UnprocessableEntityException("Pipeline group must be specified for creating a pipeline.");
         } else {
             String groupName = group.getAsString();
-            if (StringUtils.isNotBlank(groupName) && !securityService.isUserAdminOfGroup(currentUsername(), groupName)) {
+            boolean groupDoesNotExists = !goConfigService.groups().hasGroup(groupName);
+            boolean userNotAdminOfTheGrp = !securityService.isUserAdminOfGroup(currentUsername(), groupName);
+            if (isNotBlank(groupName) && (groupDoesNotExists || userNotAdminOfTheGrp)) {
                 throw renderForbiddenResponse();
             }
         }

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/SecurityServiceTrait.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/SecurityServiceTrait.groovy
@@ -28,6 +28,7 @@ import com.thoughtworks.go.util.SystemEnvironment
 import org.junit.jupiter.api.AfterEach
 
 import static org.mockito.ArgumentMatchers.any
+import static org.mockito.ArgumentMatchers.anyString
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
@@ -84,14 +85,15 @@ trait SecurityServiceTrait {
     Username username = loginAsRandomUser()
     String groupName = generateGroupName()
 
+    PipelineGroups groups = mock(PipelineGroups.class)
+    when(goConfigService.groups()).thenReturn(groups)
+    when(groups.hasGroup(anyString())).thenReturn(true)
+
     when(securityService.isUserAdmin(username)).thenReturn(false)
     when(securityService.isUserGroupAdmin(username)).thenReturn(true)
     when(securityService.isUserAdminOfGroup(eq(username.username) as CaseInsensitiveString, eq(groupName))).thenReturn(true)
     when(securityService.isUserAdminOfGroup(eq(username) as Username, any(String.class))).thenReturn(true)
 
-    PipelineGroups groups = mock(PipelineGroups.class)
-    when(goConfigService.groups()).thenReturn(groups)
-    when(groups.hasGroup(groupName)).thenReturn(true)
     when(securityService.hasOperatePermissionForGroup(username.username, groupName)).thenReturn(true)
     when(goConfigService.findGroupNameByPipeline(new CaseInsensitiveString(pipelineName))).thenReturn(groupName)
   }
@@ -119,6 +121,10 @@ trait SecurityServiceTrait {
 
   void loginAsTemplateAdmin() {
     Username username = loginAsRandomUser()
+
+    PipelineGroups groups = mock(PipelineGroups.class)
+    when(goConfigService.groups()).thenReturn(groups)
+    when(groups.hasGroup(anyString())).thenReturn(true)
 
     when(securityService.isUserAdmin(username)).thenReturn(false)
     when(securityService.isUserGroupAdmin(username)).thenReturn(false)


### PR DESCRIPTION
Issue: #7609 (See point 2 in II)

Description:
 - the before filter on create pipeline config api - checks whether or not the current user is an admin of the given group (if user is not a system admin) - which throws RecordNotFoundException if the group does not exist.
  Updated the check to include the group existence test before admin check



