### PR TITLE
Add schema migration to migrate pipeline label template consisting of package repo material name (#7654)

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
@@ -53,7 +53,7 @@ public class GoConstants {
 
     public static final String PRODUCT_NAME = "go";
 
-    public static final int CONFIG_SCHEMA_VERSION = 134;
+    public static final int CONFIG_SCHEMA_VERSION = 135;
 
     public static final String APPROVAL_SUCCESS = "success";
     public static final String APPROVAL_MANUAL = "manual";

--- a/config/config-server/src/main/resources/schemas/134_cruise-config.xsd
+++ b/config/config-server/src/main/resources/schemas/134_cruise-config.xsd
@@ -84,7 +84,7 @@
           </xsd:unique>
         </xsd:element>
       </xsd:sequence>
-      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="135"/>
+      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="134"/>
     </xsd:complexType>
     <xsd:unique name="uniquePipelines">
       <xsd:selector xpath="pipelines"/>

--- a/config/config-server/src/main/resources/upgrades/135.xsl
+++ b/config/config-server/src/main/resources/upgrades/135.xsl
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2020 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:migratorClass="com.thoughtworks.go.domain.label.PipelineLabel"
+                version="1.0">
+    <xsl:template match="/cruise/@schemaVersion">
+        <xsl:attribute name="schemaVersion">135</xsl:attribute>
+    </xsl:template>
+    <!-- Copy everything -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template name="migratePipelineLabel">
+        <xsl:param name="templateValue"/>
+        <xsl:value-of select="migratorClass:migratePipelineLabelTemplate($templateValue)"/>
+    </xsl:template>
+
+    <xsl:template match="//pipeline/@labeltemplate">
+        <xsl:attribute name="{name(.)}">
+            <xsl:call-template name="migratePipelineLabel">
+                <xsl:with-param name="templateValue" select="."/>
+            </xsl:call-template>
+        </xsl:attribute>
+    </xsl:template>
+</xsl:stylesheet>

--- a/server/config/cruise-config.xml
+++ b/server/config/cruise-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="134">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="135">
   <server agentAutoRegisterKey="323040d4-f2e4-4b8a-8394-7a2d122054d1" webhookSecret="3d5cd2f5-7fe7-43c0-ba34-7e01678ba8b6" commandRepositoryLocation="default" serverId="60f5f682-5248-4ba9-bb35-72c92841bd75" tokenGenerationKey="8c3c8dc9-08bf-4cd7-ac80-cecb3e7ae86c">
     <security>
       <authConfigs>

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
@@ -2001,6 +2001,61 @@ public class GoConfigMigrationIntegrationTest {
         XmlAssert.assertThat(migratedXml).and(expectedConfig).areIdentical();
     }
 
+    @Test
+    public void shouldMigratePipelineLabelTemplateColonToUnderscore_Migration134To135() {
+        String originalConfig = "<repositories>\n" +
+                "    <repository id=\"0c24bd20-2b24-4fba-9410-aea494d29bf5\" name=\"npm\">\n" +
+                "      <pluginConfiguration id=\"npm\" version=\"1\" />\n" +
+                "      <configuration>\n" +
+                "        <property>\n" +
+                "          <key>REPO_URL</key>\n" +
+                "          <value>http://npmjs.com/</value>\n" +
+                "        </property>\n" +
+                "      </configuration>\n" +
+                "      <packages>\n" +
+                "        <package id=\"07951410-c70e-4a91-be53-8968cf0c07bc\" name=\"my-package\">\n" +
+                "          <configuration>\n" +
+                "            <property>\n" +
+                "              <key>PACKAGE_ID</key>\n" +
+                "              <value>v1.0.0</value>\n" +
+                "            </property>\n" +
+                "          </configuration>\n" +
+                "        </package>\n" +
+                "      </packages>\n" +
+                "    </repository>\n" +
+                "  </repositories>" +
+                "<pipelines group=\"first\">"
+                + "    <pipeline name=\"Test\" template=\"test_template\" labeltemplate=\"${npm:my-package}\">"
+                + "      <materials>"
+                + "          <git url=\"http://\" dest=\"dest_dir14\" />"
+                + "      </materials>"
+                + "     </pipeline>"
+                + "  </pipelines>"
+                + "  <templates>"
+                + "    <pipeline name=\"test_template\">"
+                + "      <stage name=\"Functional\">"
+                + "        <approval type=\"manual\" />"
+                + "        <jobs>"
+                + "          <job name=\"Functional\">"
+                + "            <tasks>"
+                + "              <exec command=\"echo\" args=\"Hello World!!!\" />"
+                + "            </tasks>"
+                + "           </job>"
+                + "        </jobs>"
+                + "      </stage>"
+                + "    </pipeline>"
+                + "  </templates>";
+
+        String configXml =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                        "<cruise schemaVersion=\"134\">" + originalConfig + "</cruise>";
+
+        String expectedConfig = configXml.replace("134", "135").replace("npm:my-package", "npm_my-package");
+
+        final String migratedXml = ConfigMigrator.migrate(configXml, 134, 135);
+        XmlAssert.assertThat(migratedXml).and(expectedConfig).areIdentical();
+    }
+
     private void assertStringContainsIgnoringCarriageReturn(String actual, String substring) {
         assertThat(actual.replaceAll("\\r", "")).contains(substring.replaceAll("\\r", ""));
     }


### PR DESCRIPTION
Issue: #7654

Description:

- As part of GoCD release v19.12.0 package repository material name format has
changed from 'repo:package' to 'repo_package'.

- Perform config xml schema migration to change such material name references
from pipeline label.

---

- Migrate `${repo:package}` to `${repo_package}`
- Do not migrate truncating colon `${svn[:7]}`
- Do not migrate env vars `${env:var}`
- Do not migrate env vars consisting colon in them `${env:my:fancy:env}`
- Do not migrate normal colons `release:v1-${github}`
- Do not migrate parameters `#{my:fancy:param}`
