### PR TITLE
Added config migration to support rules in config repo

### DIFF
--- a/api/api-agents-v6/src/test/groovy/com/thoughtworks/go/apiv6/agents/representers/AgentRepresenterTest.groovy
+++ b/api/api-agents-v6/src/test/groovy/com/thoughtworks/go/apiv6/agents/representers/AgentRepresenterTest.groovy
@@ -55,7 +55,7 @@ class AgentRepresenterTest {
     AgentInstance agentInstance = idleWith("some-uuid", "agent01.example.com", "127.0.0.1", "/var/lib/go-server", 10l, "Linux", Arrays.asList("linux", "firefox"))
     agentInstance.getAgent().setEnvironments("uat,load_test,non-existent-env")
     def envFromConfigRepo = environment("dev")
-    envFromConfigRepo.setOrigins(new RepoConfigOrigin(new ConfigRepoConfig(null, "yaml", "foo"), "revision"))
+    envFromConfigRepo.setOrigins(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(null, "yaml", "foo"), "revision"))
     envFromConfigRepo.addAgent("some-uuid")
     def json = toObjectString({
       def environments = Stream.of(environment("uat"), environment("load_test"), envFromConfigRepo)
@@ -165,7 +165,7 @@ class AgentRepresenterTest {
     AgentInstance agentInstance = idleWith("some-uuid", "agent01.example.com", "127.0.0.1", "/var/lib/go-server", 10l, "Linux", Arrays.asList("linux", "firefox"))
     agentInstance.getAgent().setEnvironments("uat")
     def envFromConfigRepo = environment("dev")
-    envFromConfigRepo.setOrigins(new RepoConfigOrigin(new ConfigRepoConfig(null, "yaml", "foo"), "revision"))
+    envFromConfigRepo.setOrigins(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(null, "yaml", "foo"), "revision"))
     envFromConfigRepo.addAgent("some-uuid")
     def json = toObjectString({
       def environments = Stream.of(environment("uat"), envFromConfigRepo)

--- a/api/api-config-repo-operations-v1/src/main/java/com/thoughtworks/go/apiv1/configrepooperations/ConfigRepoOperationsControllerV1.java
+++ b/api/api-config-repo-operations-v1/src/main/java/com/thoughtworks/go/apiv1/configrepooperations/ConfigRepoOperationsControllerV1.java
@@ -171,7 +171,7 @@ public class ConfigRepoOperationsControllerV1 extends ApiController implements S
              */
             @Override
             public MaterialConfig configMaterial() {
-                return null == repo ? dummyMaterial() : repo.getMaterialConfig();
+                return null == repo ? dummyMaterial() : repo.getRepo();
             }
 
             private MaterialConfig dummyMaterial() {

--- a/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2.java
+++ b/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2.java
@@ -133,7 +133,7 @@ public class ConfigReposInternalControllerV2 extends ApiController implements Sp
     }
 
     String triggerUpdate(Request req, Response res) {
-        MaterialConfig materialConfig = repoFromRequest(req).getMaterialConfig();
+        MaterialConfig materialConfig = repoFromRequest(req).getRepo();
         if (mus.updateMaterial(converter.toMaterial(materialConfig))) {
             res.status(HttpStatus.CREATED.value());
             return MessageJson.create("OK");
@@ -144,7 +144,7 @@ public class ConfigReposInternalControllerV2 extends ApiController implements Sp
     }
 
     String inProgress(Request req, Response res) {
-        MaterialConfig materialConfig = repoFromRequest(req).getMaterialConfig();
+        MaterialConfig materialConfig = repoFromRequest(req).getRepo();
         final boolean state = mus.isInProgress(converter.toMaterial(materialConfig));
         return String.format("{\"inProgress\":%b}", state);
     }
@@ -176,7 +176,7 @@ public class ConfigReposInternalControllerV2 extends ApiController implements Sp
             throw new RecordNotFoundException(EntityType.ConfigRepo, repoId);
         }
 
-        PartialConfigParseResult result = dataSource.getLastParseResult(repo.getMaterialConfig());
+        PartialConfigParseResult result = dataSource.getLastParseResult(repo.getRepo());
 
         return new ConfigRepoWithResult(repo, result, isMaterialUpdateInProgress(repo));
     }
@@ -194,12 +194,12 @@ public class ConfigReposInternalControllerV2 extends ApiController implements Sp
 
     private List<ConfigRepoWithResult> allRepos() {
         return service.getConfigRepos().stream().map(r -> {
-            PartialConfigParseResult result = dataSource.getLastParseResult(r.getMaterialConfig());
+            PartialConfigParseResult result = dataSource.getLastParseResult(r.getRepo());
             return new ConfigRepoWithResult(r, result, isMaterialUpdateInProgress(r));
         }).collect(Collectors.toList());
     }
 
     private boolean isMaterialUpdateInProgress(ConfigRepoConfig configRepoConfig) {
-        return mus.isInProgress(converter.toMaterial(configRepoConfig.getMaterialConfig()));
+        return mus.isInProgress(converter.toMaterial(configRepoConfig.getRepo()));
     }
 }

--- a/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoConfigRepresenterV2.java
+++ b/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoConfigRepresenterV2.java
@@ -31,7 +31,7 @@ public class ConfigRepoConfigRepresenterV2 {
         attachLinks(json, repo);
         json.add("id", repo.getId());
         json.add("plugin_id", repo.getPluginId());
-        json.addChild("material", w -> MaterialsRepresenter.toJSON(w, repo.getMaterialConfig()));
+        json.addChild("material", w -> MaterialsRepresenter.toJSON(w, repo.getRepo()));
         if (!repo.errors().isEmpty()) {
             json.addChild("errors", errorWriter -> new ErrorGetter(Collections.emptyMap()).toJSON(errorWriter, repo));
         }
@@ -43,7 +43,7 @@ public class ConfigRepoConfigRepresenterV2 {
         ConfigRepoConfig repo = new ConfigRepoConfig();
         jsonReader.readStringIfPresent("id", repo::setId);
         jsonReader.readStringIfPresent("plugin_id", repo::setPluginId);
-        repo.setMaterialConfig(material);
+        repo.setRepo(material);
 
         repo.addConfigurations(ConfigurationPropertyRepresenter.fromJSONArray(jsonReader, "configuration"));
         return repo;

--- a/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultRepresenter.java
+++ b/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultRepresenter.java
@@ -31,7 +31,7 @@ public class ConfigRepoWithResultRepresenter {
         attachLinks(json, repo);
         json.add("id", repo.getId());
         json.add("plugin_id", repo.getPluginId());
-        json.addChild("material", w -> MaterialsRepresenter.toJSON(w, repo.getMaterialConfig()));
+        json.addChild("material", w -> MaterialsRepresenter.toJSON(w, repo.getRepo()));
         json.add("can_administer", canAdminister);
         attachConfigurations(json, repo);
 

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2Test.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2Test.groovy
@@ -132,8 +132,8 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
 
       ConfigReposConfig repos = new ConfigReposConfig(repo(ID_1), repo(ID_2), repo("test-id"))
       when(service.getConfigRepos()).thenReturn(repos)
-      when(dataSource.getLastParseResult(repos.get(0).getMaterialConfig())).thenReturn(null)
-      when(dataSource.getLastParseResult(repos.get(1).getMaterialConfig())).thenReturn(result)
+      when(dataSource.getLastParseResult(repos.get(0).getRepo())).thenReturn(null)
+      when(dataSource.getLastParseResult(repos.get(1).getRepo())).thenReturn(result)
 
       getWithApiHeader(controller.controllerBasePath())
 
@@ -191,7 +191,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
 
       ConfigRepoConfig repo = repo(ID_1)
       when(service.getConfigRepo(ID_1)).thenReturn(repo)
-      when(dataSource.getLastParseResult(repo.getMaterialConfig())).thenReturn(result)
+      when(dataSource.getLastParseResult(repo.getRepo())).thenReturn(result)
 
       getWithApiHeader(controller.controllerPath(ID_1))
 

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2Test.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposInternalControllerV2Test.groovy
@@ -261,7 +261,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
 
   static ConfigRepoConfig repo(String id) {
     HgMaterialConfig materialConfig = hg("${TEST_REPO_URL}/$id", "")
-    ConfigRepoConfig repo = new ConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id)
+    ConfigRepoConfig repo = ConfigRepoConfig.createConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id)
 
     return repo
   }
@@ -368,7 +368,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
         MaterialConfig config = mock(MaterialConfig.class)
         Material material = mock(Material.class)
 
-        when(service.getConfigRepo(ID_1)).thenReturn(new ConfigRepoConfig(config, null, ID_1))
+        when(service.getConfigRepo(ID_1)).thenReturn(ConfigRepoConfig.createConfigRepoConfig(config, null, ID_1))
         when(converter.toMaterial(config)).thenReturn(material)
         when(materialUpdateService.isInProgress(material)).thenReturn(true)
 
@@ -386,7 +386,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
         MaterialConfig config = mock(MaterialConfig.class)
         Material material = mock(Material.class)
 
-        when(service.getConfigRepo(ID_1)).thenReturn(new ConfigRepoConfig(config, null, ID_1))
+        when(service.getConfigRepo(ID_1)).thenReturn(ConfigRepoConfig.createConfigRepoConfig(config, null, ID_1))
         when(converter.toMaterial(config)).thenReturn(material)
         when(materialUpdateService.isInProgress(material)).thenReturn(false)
 
@@ -437,7 +437,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
         MaterialConfig config = mock(MaterialConfig.class)
         Material material = mock(Material.class)
 
-        when(service.getConfigRepo(ID_1)).thenReturn(new ConfigRepoConfig(config, null, ID_1))
+        when(service.getConfigRepo(ID_1)).thenReturn(ConfigRepoConfig.createConfigRepoConfig(config, null, ID_1))
         when(converter.toMaterial(config)).thenReturn(material)
         when(materialUpdateService.updateMaterial(material)).thenReturn(true)
 
@@ -455,7 +455,7 @@ class ConfigReposInternalControllerV2Test implements SecurityServiceTrait, Contr
         MaterialConfig config = mock(MaterialConfig.class)
         Material material = mock(Material.class)
 
-        when(service.getConfigRepo(ID_1)).thenReturn(new ConfigRepoConfig(config, null, ID_1))
+        when(service.getConfigRepo(ID_1)).thenReturn(ConfigRepoConfig.createConfigRepoConfig(config, null, ID_1))
         when(converter.toMaterial(config)).thenReturn(material)
         when(materialUpdateService.updateMaterial(material)).thenReturn(false)
 

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoConfigRepresenterV2Test.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoConfigRepresenterV2Test.groovy
@@ -69,7 +69,7 @@ class ConfigRepoConfigRepresenterV2Test {
     ConfigRepoConfig configRepo = repo(ID)
     configRepo.addError("id", "Duplicate Id.")
     configRepo.addError("material", "You have defined multiple configuration repositories with the same repository.")
-    configRepo.getMaterialConfig().addError("autoUpdate", "Cannot be false.")
+    configRepo.getRepo().addError("autoUpdate", "Cannot be false.")
     String json = toObjectString({ w ->
       ConfigRepoConfigRepresenterV2.toJSON(w, configRepo)
     })

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoConfigRepresenterV2Test.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoConfigRepresenterV2Test.groovy
@@ -136,7 +136,7 @@ class ConfigRepoConfigRepresenterV2Test {
     c.addNewConfigurationWithValue("baz", "quu", false)
 
     GitMaterialConfig materialConfig = git(TEST_REPO_URL)
-    ConfigRepoConfig repo = new ConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id)
+    ConfigRepoConfig repo = ConfigRepoConfig.createConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id)
     repo.setConfiguration(c)
 
     return repo

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultListRepresenterTest.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultListRepresenterTest.groovy
@@ -103,6 +103,6 @@ class ConfigRepoWithResultListRepresenterTest {
 
     PartialConfig partialConfig = new PartialConfig()
     PartialConfigParseResult expectedParseResult = PartialConfigParseResult.parseSuccess(modification, partialConfig)
-    return new ConfigRepoWithResult(new ConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id), expectedParseResult, false)
+    return new ConfigRepoWithResult(ConfigRepoConfig.createConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id), expectedParseResult, false)
   }
 }

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultRepresenterTest.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigRepoWithResultRepresenterTest.groovy
@@ -94,7 +94,7 @@ class ConfigRepoWithResultRepresenterTest {
     c.addNewConfigurationWithValue("baz", "quu", false)
 
     HgMaterialConfig materialConfig = hg(TEST_REPO_URL, "")
-    ConfigRepoConfig repo = new ConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id)
+    ConfigRepoConfig repo = ConfigRepoConfig.createConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id)
     repo.setConfiguration(c)
 
     return new ConfigRepoWithResult(repo, expectedParseResult, false)

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigReposConfigRepresenterV2Test.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/representers/ConfigReposConfigRepresenterV2Test.groovy
@@ -76,7 +76,7 @@ class ConfigReposConfigRepresenterV2Test {
 
   static ConfigRepoConfig repo(String id) {
     HgMaterialConfig materialConfig = hg("${TEST_REPO_URL}/$id", "")
-    ConfigRepoConfig repo = new ConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id)
+    ConfigRepoConfig repo = ConfigRepoConfig.createConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id)
 
     return repo
   }

--- a/api/api-config-repos-v3/src/main/java/com/thoughtworks/go/apiv3/configrepos/ConfigReposControllerV3.java
+++ b/api/api-config-repos-v3/src/main/java/com/thoughtworks/go/apiv3/configrepos/ConfigReposControllerV3.java
@@ -183,13 +183,13 @@ public class ConfigReposControllerV3 extends ApiController implements SparkSprin
     }
 
     String inProgress(Request req, Response res) {
-        MaterialConfig materialConfig = repoFromRequest(req).getMaterialConfig();
+        MaterialConfig materialConfig = repoFromRequest(req).getRepo();
         final boolean state = materialUpdateService.isInProgress(converter.toMaterial(materialConfig));
         return String.format("{\"in_progress\":%b}", state);
     }
 
     String triggerUpdate(Request req, Response res) {
-        MaterialConfig materialConfig = repoFromRequest(req).getMaterialConfig();
+        MaterialConfig materialConfig = repoFromRequest(req).getRepo();
         if (materialUpdateService.updateMaterial(converter.toMaterial(materialConfig))) {
             res.status(HttpStatus.CREATED.value());
             return MessageJson.create("OK");

--- a/api/api-config-repos-v3/src/main/java/com/thoughtworks/go/apiv3/configrepos/ConfigReposInternalControllerV3.java
+++ b/api/api-config-repos-v3/src/main/java/com/thoughtworks/go/apiv3/configrepos/ConfigReposInternalControllerV3.java
@@ -99,12 +99,12 @@ public class ConfigReposInternalControllerV3 extends ApiController implements Sp
 
     private List<ConfigRepoWithResult> allRepos() {
         return service.getConfigRepos().stream().map(r -> {
-            PartialConfigParseResult result = dataSource.getLastParseResult(r.getMaterialConfig());
+            PartialConfigParseResult result = dataSource.getLastParseResult(r.getRepo());
             return new ConfigRepoWithResult(r, result, isMaterialUpdateInProgress(r));
         }).collect(Collectors.toList());
     }
 
     private boolean isMaterialUpdateInProgress(ConfigRepoConfig configRepoConfig) {
-        return mus.isInProgress(converter.toMaterial(configRepoConfig.getMaterialConfig()));
+        return mus.isInProgress(converter.toMaterial(configRepoConfig.getRepo()));
     }
 }

--- a/api/api-config-repos-v3/src/main/java/com/thoughtworks/go/apiv3/configrepos/representers/ConfigRepoConfigRepresenterV3.java
+++ b/api/api-config-repos-v3/src/main/java/com/thoughtworks/go/apiv3/configrepos/representers/ConfigRepoConfigRepresenterV3.java
@@ -31,7 +31,7 @@ public class ConfigRepoConfigRepresenterV3 {
         attachLinks(json, repo);
         json.add("id", repo.getId());
         json.add("plugin_id", repo.getPluginId());
-        json.addChild("material", w -> MaterialsRepresenter.toJSON(w, repo.getMaterialConfig()));
+        json.addChild("material", w -> MaterialsRepresenter.toJSON(w, repo.getRepo()));
         if (!repo.errors().isEmpty()) {
             json.addChild("errors", errorWriter -> new ErrorGetter(Collections.emptyMap()).toJSON(errorWriter, repo));
         }
@@ -43,7 +43,7 @@ public class ConfigRepoConfigRepresenterV3 {
         ConfigRepoConfig repo = new ConfigRepoConfig();
         jsonReader.readStringIfPresent("id", repo::setId);
         jsonReader.readStringIfPresent("plugin_id", repo::setPluginId);
-        repo.setMaterialConfig(material);
+        repo.setRepo(material);
 
         repo.addConfigurations(ConfigurationPropertyRepresenter.fromJSONArray(jsonReader, "configuration"));
         return repo;

--- a/api/api-config-repos-v3/src/main/java/com/thoughtworks/go/apiv3/configrepos/representers/ConfigRepoWithResultRepresenter.java
+++ b/api/api-config-repos-v3/src/main/java/com/thoughtworks/go/apiv3/configrepos/representers/ConfigRepoWithResultRepresenter.java
@@ -31,7 +31,7 @@ public class ConfigRepoWithResultRepresenter {
         attachLinks(json, repo);
         json.add("id", repo.getId());
         json.add("plugin_id", repo.getPluginId());
-        json.addChild("material", w -> MaterialsRepresenter.toJSON(w, repo.getMaterialConfig()));
+        json.addChild("material", w -> MaterialsRepresenter.toJSON(w, repo.getRepo()));
         json.add("can_administer", canAdminister);
         attachConfigurations(json, repo);
 

--- a/api/api-config-repos-v3/src/test/groovy/com/thoughtworks/go/apiv3/configrepos/ConfigReposInternalControllerV3Test.groovy
+++ b/api/api-config-repos-v3/src/test/groovy/com/thoughtworks/go/apiv3/configrepos/ConfigReposInternalControllerV3Test.groovy
@@ -198,7 +198,7 @@ class ConfigReposInternalControllerV3Test implements SecurityServiceTrait, Contr
 
   static ConfigRepoConfig repo(String id) {
     HgMaterialConfig materialConfig = hg("${TEST_REPO_URL}/$id", "")
-    ConfigRepoConfig repo = new ConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id)
+    ConfigRepoConfig repo = ConfigRepoConfig.createConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id)
 
     return repo
   }

--- a/api/api-config-repos-v3/src/test/groovy/com/thoughtworks/go/apiv3/configrepos/ConfigReposInternalControllerV3Test.groovy
+++ b/api/api-config-repos-v3/src/test/groovy/com/thoughtworks/go/apiv3/configrepos/ConfigReposInternalControllerV3Test.groovy
@@ -114,8 +114,8 @@ class ConfigReposInternalControllerV3Test implements SecurityServiceTrait, Contr
 
       ConfigReposConfig repos = new ConfigReposConfig(repo(ID_1), repo(ID_2), repo("test-id"))
       when(service.getConfigRepos()).thenReturn(repos)
-      when(dataSource.getLastParseResult(repos.get(0).getMaterialConfig())).thenReturn(null)
-      when(dataSource.getLastParseResult(repos.get(1).getMaterialConfig())).thenReturn(result)
+      when(dataSource.getLastParseResult(repos.get(0).getRepo())).thenReturn(null)
+      when(dataSource.getLastParseResult(repos.get(1).getRepo())).thenReturn(result)
 
       getWithApiHeader(controller.controllerBasePath())
 

--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/PipelineRepresenterTest.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/PipelineRepresenterTest.groovy
@@ -120,7 +120,7 @@ class PipelineRepresenterTest {
       def counter = mock(Counter.class)
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE)
-      def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
+      def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
       def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
@@ -138,7 +138,7 @@ class PipelineRepresenterTest {
       def counter = mock(Counter.class)
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE)
-      def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
+      def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
       def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
@@ -156,7 +156,7 @@ class PipelineRepresenterTest {
       def counter = mock(Counter.class)
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
-      def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
+      def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
       def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenterTest.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenterTest.groovy
@@ -121,7 +121,7 @@ class PipelineRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
-    def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
+    def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
     def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'p1l1', false, true, null), permissions, "grp", null, counter, origin, 0)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
@@ -140,7 +140,7 @@ class PipelineRepresenterTest {
       def counter = mock(Counter.class)
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE)
-      def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
+      def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
       def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
@@ -158,7 +158,7 @@ class PipelineRepresenterTest {
       def counter = mock(Counter.class)
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE)
-      def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
+      def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
       def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
@@ -176,7 +176,7 @@ class PipelineRepresenterTest {
       def counter = mock(Counter.class)
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
-      def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
+      def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
       def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 

--- a/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/EntityConfigOriginRepresenterTest.groovy
+++ b/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/EntityConfigOriginRepresenterTest.groovy
@@ -66,7 +66,7 @@ class EntityConfigOriginRepresenterTest {
 
   @Test
   void 'should render config repo origin with hal representation'() {
-    def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.git("foo.git"), "json-plugon", "repo1"), "revision1");
+    def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.git("foo.git"), "json-plugon", "repo1"), "revision1");
     def actualJSON = toObjectString({ EntityConfigOriginRepresenter.toJSON(it, origin) })
 
     def expectedJSON = [

--- a/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/EnvironmentAgentRepresenterTest.groovy
+++ b/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/EnvironmentAgentRepresenterTest.groovy
@@ -65,7 +65,7 @@ class EnvironmentAgentRepresenterTest {
 
   @Test
   void 'should represent agent with config repo origin'() {
-    def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.git("foo.git"), "json-plugon", "repo1"), "revision1");
+    def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.git("foo.git"), "json-plugon", "repo1"), "revision1");
     def agent = new EnvironmentAgentConfig("agent-1")
     when(environmentConfig.isLocal()).thenReturn(false)
     when(environmentConfig.getOriginForAgent(agent.uuid)).thenReturn(origin)

--- a/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/EnvironmentEnvironmentVariableRepresenterTest.groovy
+++ b/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/EnvironmentEnvironmentVariableRepresenterTest.groovy
@@ -69,7 +69,7 @@ class EnvironmentEnvironmentVariableRepresenterTest {
 
   @Test
   void 'should represent environmentVariable with config repo origin'() {
-    def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.git("foo.git"), "json-plugon", "repo1"), "revision1");
+    def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.git("foo.git"), "json-plugon", "repo1"), "revision1");
     def environmentVariable = new EnvironmentVariableConfig("env-name", "env-value")
     when(environmentConfig.isLocal()).thenReturn(false)
     when(environmentConfig.getOriginForEnvironmentVariable(environmentVariable.name)).thenReturn(origin)

--- a/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/EnvironmentPipelineRepresenterTest.groovy
+++ b/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/EnvironmentPipelineRepresenterTest.groovy
@@ -65,7 +65,7 @@ class EnvironmentPipelineRepresenterTest {
 
   @Test
   void 'should represent pipeline with config repo origin'() {
-    def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.git("foo.git"), "json-plugon", "repo1"), "revision1");
+    def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.git("foo.git"), "json-plugon", "repo1"), "revision1");
     def pipeline = new EnvironmentPipelineConfig("pipeline-1")
     when(environmentConfig.isLocal()).thenReturn(false)
     when(environmentConfig.getOriginForPipeline(pipeline.name)).thenReturn(origin)

--- a/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/configorigin/ConfigRepoOriginRepresenterTest.groovy
+++ b/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/configorigin/ConfigRepoOriginRepresenterTest.groovy
@@ -31,7 +31,7 @@ class ConfigRepoOriginRepresenterTest {
   void 'should render remote config origin'() {
     def gitMaterialConfig = git('https://github.com/config-repos/repo', 'master')
     def actualJson = toObjectString({
-      ConfigRepoOriginRepresenter.toJSON(it, new RepoConfigOrigin(new ConfigRepoConfig(gitMaterialConfig, 'json-plugon', 'repo1'), 'revision1'))
+      ConfigRepoOriginRepresenter.toJSON(it, new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(gitMaterialConfig, 'json-plugon', 'repo1'), 'revision1'))
     })
 
     assertThatJson(actualJson).isEqualTo(expectedJson)

--- a/api/api-internal-pipeline-structure-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalpipelinestructure/representers/InternalPipelineStructuresRepresenterTest.groovy
+++ b/api/api-internal-pipeline-structure-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalpipelinestructure/representers/InternalPipelineStructuresRepresenterTest.groovy
@@ -36,7 +36,7 @@ class InternalPipelineStructuresRepresenterTest {
     def template2 = PipelineTemplateConfigMother.createTemplate("second-template")
 
     def pipeline1 = PipelineConfigMother.createPipelineConfig("my-pipeline-1", "my-stage", "my-job1", "my-job2")
-    pipeline1.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(null, null, "some-config-repo-id"), "123"))
+    pipeline1.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(null, null, "some-config-repo-id"), "123"))
 
     def pipeline2 = PipelineConfigMother.createPipelineConfig("my-pipeline-2", "my-stage", "my-job1", "my-job2")
     pipeline2.setOrigin(new FileConfigOrigin())
@@ -138,7 +138,7 @@ class InternalPipelineStructuresRepresenterTest {
     def template2 = PipelineTemplateConfigMother.createTemplate("second-template")
 
     def pipeline1 = PipelineConfigMother.createPipelineConfig("my-pipeline-1", "my-stage", "my-job1", "my-job2")
-    pipeline1.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(null, null, "some-config-repo-id"), "123"))
+    pipeline1.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(null, null, "some-config-repo-id"), "123"))
 
     def pipeline2 = PipelineConfigMother.createPipelineConfig("my-pipeline-2", "my-stage", "my-job1", "my-job2")
     pipeline2.setOrigin(new FileConfigOrigin())

--- a/api/api-pipeline-config-v10/src/test/groovy/com/thoughtworks/go/apiv10/pipelineconfig/PipelineConfigControllerV10Test.groovy
+++ b/api/api-pipeline-config-v10/src/test/groovy/com/thoughtworks/go/apiv10/pipelineconfig/PipelineConfigControllerV10Test.groovy
@@ -525,7 +525,7 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
       void "should not update pipeline config when the pipeline is defined remotely"() {
         def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline1")
         def gitMaterial = git("https://github.com/config-repos/repo", "master")
-        def origin = new RepoConfigOrigin(new ConfigRepoConfig(gitMaterial, "json-plugib"), "revision1")
+        def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(gitMaterial, "json-plugib", "id"), "revision1")
         pipelineConfig.setOrigin(origin)
 
         when(pipelineConfigService.getPipelineConfig("pipeline1")).thenReturn(pipelineConfig)
@@ -738,7 +738,7 @@ class PipelineConfigControllerV10Test implements SecurityServiceTrait, Controlle
         def pipeline = PipelineConfigMother.pipelineConfig("pipeline1")
 
         def gitMaterial = git("https://github.com/config-repos/repo", "master")
-        def origin = new RepoConfigOrigin(new ConfigRepoConfig(gitMaterial, "json-plugin"), "revision1")
+        def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(gitMaterial, "json-plugin", "id"), "revision1")
         pipeline.setOrigin(origin)
 
         when(pipelineConfigService.getPipelineConfig("pipeline1")).thenReturn(pipeline)

--- a/api/api-roles-config-v3/src/test/groovy/com/thoughtworks/go/apiv3/rolesconfig/InternalRolesControllerV3Test.groovy
+++ b/api/api-roles-config-v3/src/test/groovy/com/thoughtworks/go/apiv3/rolesconfig/InternalRolesControllerV3Test.groovy
@@ -96,7 +96,7 @@ class InternalRolesControllerV3Test implements SecurityServiceTrait, ControllerT
         def gocdRoleConfig = new RoleConfig("gocd-role")
         def pluginRoleConfig = new PluginRoleConfig('foo', 'ldap')
         expectedRoles = new RolesConfig([gocdRoleConfig, pluginRoleConfig])
-        configRepo = new ConfigRepoConfig(git("https://foo.git", "master"), "json-config-repo-plugin", "repo-1");
+        configRepo = ConfigRepoConfig.createConfigRepoConfig(git("https://foo.git", "master"), "json-config-repo-plugin", "repo-1");
         envNames = asList("env1", "env2")
         def elasticProfile1 = new ElasticProfile("elastic_profile1", "cluster_profile")
         def elasticProfile2 = new ElasticProfile("elastic_profile2", "cluster_profile")

--- a/api/api-shared-v10/src/test/groovy/com/thoughtworks/go/apiv10/shared/representers/configorigin/ConfigRepoOriginRepresenterTest.groovy
+++ b/api/api-shared-v10/src/test/groovy/com/thoughtworks/go/apiv10/shared/representers/configorigin/ConfigRepoOriginRepresenterTest.groovy
@@ -31,7 +31,7 @@ class ConfigRepoOriginRepresenterTest {
   void 'should render remote config origin'() {
     def gitMaterialConfig = git('https://github.com/config-repos/repo', 'master')
     def actualJson = toObjectString({
-      ConfigRepoOriginRepresenter.toJSON(it, new RepoConfigOrigin(new ConfigRepoConfig(gitMaterialConfig, 'json-plugon', 'repo1'), 'revision1'))
+      ConfigRepoOriginRepresenter.toJSON(it, new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(gitMaterialConfig, 'json-plugon', 'repo1'), 'revision1'))
     })
 
     assertThatJson(actualJson).isEqualTo(expectedJson)

--- a/api/api-shared-v9/src/test/groovy/com/thoughtworks/go/apiv9/shared/representers/configorigin/ConfigRepoOriginRepresenterTest.groovy
+++ b/api/api-shared-v9/src/test/groovy/com/thoughtworks/go/apiv9/shared/representers/configorigin/ConfigRepoOriginRepresenterTest.groovy
@@ -31,7 +31,7 @@ class ConfigRepoOriginRepresenterTest {
   void 'should render remote config origin'() {
     def gitMaterialConfig = git('https://github.com/config-repos/repo', 'master')
     def actualJson = toObjectString({
-      ConfigRepoOriginRepresenter.toJSON(it, new RepoConfigOrigin(new ConfigRepoConfig(gitMaterialConfig, 'json-plugon', 'repo1'), 'revision1'))
+      ConfigRepoOriginRepresenter.toJSON(it, new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(gitMaterialConfig, 'json-plugon', 'repo1'), 'revision1'))
     })
 
     assertThatJson(actualJson).isEqualTo(expectedJson)

--- a/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
@@ -53,7 +53,7 @@ public class GoConstants {
 
     public static final String PRODUCT_NAME = "go";
 
-    public static final int CONFIG_SCHEMA_VERSION = 135;
+    public static final int CONFIG_SCHEMA_VERSION = 136;
 
     public static final String APPROVAL_SUCCESS = "success";
     public static final String APPROVAL_MANUAL = "manual";

--- a/common/src/main/java/com/thoughtworks/go/serverhealth/HealthStateScope.java
+++ b/common/src/main/java/com/thoughtworks/go/serverhealth/HealthStateScope.java
@@ -77,7 +77,7 @@ public class HealthStateScope implements Comparable<HealthStateScope> {
     }
 
     public static HealthStateScope forPartialConfigRepo(ConfigRepoConfig repoConfig) {
-        return new HealthStateScope(ScopeType.CONFIG_PARTIAL, repoConfig.getMaterialConfig().getFingerprint());
+        return new HealthStateScope(ScopeType.CONFIG_PARTIAL, repoConfig.getRepo().getFingerprint());
     }
 
     public static HealthStateScope forPartialConfigRepo(String fingerprint) {

--- a/common/src/test/java/com/thoughtworks/go/domain/BuildCauseTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/BuildCauseTest.java
@@ -93,7 +93,7 @@ public class BuildCauseTest {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfigWithStages("pipe1", "build");
         pipelineConfig.materialConfigs().clear();
         pipelineConfig.materialConfigs().add(materialConfig);
-        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig,"plug"),"revision2"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig,"plug", "id"),"revision2"));
 
         buildCause.assertPipelineConfigAndMaterialRevisionMatch(pipelineConfig);
     }
@@ -112,7 +112,7 @@ public class BuildCauseTest {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfigWithStages("pipe1", "build");
         pipelineConfig.materialConfigs().clear();
         pipelineConfig.materialConfigs().add(materialConfig);
-        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig,"plug"),"revision2"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig,"plug", "id"),"revision2"));
 
         try {
             buildCause.assertPipelineConfigAndMaterialRevisionMatch(pipelineConfig);
@@ -139,7 +139,7 @@ public class BuildCauseTest {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfigWithStages("pipe1", "build");
         pipelineConfig.materialConfigs().clear();
         pipelineConfig.materialConfigs().add(materialConfig);
-        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig,"plug"),"revision1"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig,"plug", "id"),"revision1"));
 
         buildCause.assertPipelineConfigAndMaterialRevisionMatch(pipelineConfig);
     }

--- a/common/src/test/java/com/thoughtworks/go/domain/BuildCauseTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/BuildCauseTest.java
@@ -93,7 +93,7 @@ public class BuildCauseTest {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfigWithStages("pipe1", "build");
         pipelineConfig.materialConfigs().clear();
         pipelineConfig.materialConfigs().add(materialConfig);
-        pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(materialConfig,"plug"),"revision2"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig,"plug"),"revision2"));
 
         buildCause.assertPipelineConfigAndMaterialRevisionMatch(pipelineConfig);
     }
@@ -112,7 +112,7 @@ public class BuildCauseTest {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfigWithStages("pipe1", "build");
         pipelineConfig.materialConfigs().clear();
         pipelineConfig.materialConfigs().add(materialConfig);
-        pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(materialConfig,"plug"),"revision2"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig,"plug"),"revision2"));
 
         try {
             buildCause.assertPipelineConfigAndMaterialRevisionMatch(pipelineConfig);
@@ -139,7 +139,7 @@ public class BuildCauseTest {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfigWithStages("pipe1", "build");
         pipelineConfig.materialConfigs().clear();
         pipelineConfig.materialConfigs().add(materialConfig);
-        pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(materialConfig,"plug"),"revision1"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig,"plug"),"revision1"));
 
         buildCause.assertPipelineConfigAndMaterialRevisionMatch(pipelineConfig);
     }

--- a/common/src/test/java/com/thoughtworks/go/serverhealth/HealthStateScopeTest.java
+++ b/common/src/test/java/com/thoughtworks/go/serverhealth/HealthStateScopeTest.java
@@ -77,7 +77,7 @@ public class HealthStateScopeTest {
     public void shouldNotRemoveScopeWhenMaterialBelongsToConfigRepoMaterial() throws Exception {
         HgMaterialConfig hgMaterialConfig = MaterialConfigsMother.hgMaterialConfig();
         CruiseConfig config = GoConfigMother.pipelineHavingJob("blahPipeline", "blahStage", "blahJob", "fii", "baz");
-        config.getConfigRepos().add(new ConfigRepoConfig(hgMaterialConfig, "id1", "foo"));
+        config.getConfigRepos().add(ConfigRepoConfig.createConfigRepoConfig(hgMaterialConfig, "id1", "foo"));
         assertThat(HealthStateScope.forMaterialConfig(hgMaterialConfig).isRemovedFromConfig(config),is(false));
     }
 
@@ -85,7 +85,7 @@ public class HealthStateScopeTest {
     public void shouldNotRemoveScopeWhenMaterialUpdateBelongsToConfigRepoMaterial() throws Exception {
         HgMaterialConfig hgMaterialConfig = MaterialConfigsMother.hgMaterialConfig();
         CruiseConfig config = GoConfigMother.pipelineHavingJob("blahPipeline", "blahStage", "blahJob", "fii", "baz");
-        config.getConfigRepos().add(new ConfigRepoConfig(hgMaterialConfig, "id1", "foo"));
+        config.getConfigRepos().add(ConfigRepoConfig.createConfigRepoConfig(hgMaterialConfig, "id1", "foo"));
         assertThat(HealthStateScope.forMaterialConfigUpdate(hgMaterialConfig).isRemovedFromConfig(config),is(false));
     }
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BasicCruiseConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BasicCruiseConfig.java
@@ -784,7 +784,7 @@ public class BasicCruiseConfig implements CruiseConfig {
             }
         }
         for (ConfigRepoConfig configRepo : this.configRepos) {
-            MaterialConfig materialConfig = configRepo.getMaterialConfig();
+            MaterialConfig materialConfig = configRepo.getRepo();
             if (!uniqueMaterials.contains(materialConfig.getFingerprint())) {
                 materialConfigs.add(materialConfig);
                 uniqueMaterials.add(materialConfig.getFingerprint());
@@ -1101,7 +1101,7 @@ public class BasicCruiseConfig implements CruiseConfig {
         }
         if (!ignoreConfigRepos) {
             for (ConfigRepoConfig configRepo : this.configRepos) {
-                MaterialConfig materialConfig = configRepo.getMaterialConfig();
+                MaterialConfig materialConfig = configRepo.getRepo();
                 if (!uniqueMaterials.contains(materialConfig.getSqlCriteria())) {
                     materialConfigs.add(materialConfig);
                     uniqueMaterials.add(materialConfig.getSqlCriteria());

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/SecretConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/SecretConfig.java
@@ -63,18 +63,7 @@ public class SecretConfig extends RuleAwarePluginProfile {
 
         return pluginInfo.getSecretsConfigSettings().getConfiguration(key).isSecure();
     }
-
-    @Override
-    public void addConfigurations(List<ConfigurationProperty> configurations) {
-        ConfigurationPropertyBuilder builder = new ConfigurationPropertyBuilder();
-        for (ConfigurationProperty property : configurations) {
-            this.getConfiguration().add(builder.create(property.getConfigKeyName(),
-                    property.getConfigValue(),
-                    property.getEncryptedValue(),
-                    isSecure(property.getConfigKeyName())));
-        }
-    }
-
+    
     @Override
     protected boolean hasPluginInfo() {
         return !isNull(this.metadataStore().getPluginInfo(getPluginId()));

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigRepoConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigRepoConfig.java
@@ -97,7 +97,7 @@ public class ConfigRepoConfig extends RuleAwarePluginProfile implements Cacheabl
     }
 
     private boolean isValidMaterial() {
-        MaterialConfig materialConfig = getMaterialConfig();
+        MaterialConfig materialConfig = getRepo();
         if (materialConfig == null) {
             return false;
         }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigRepoConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigRepoConfig.java
@@ -17,105 +17,51 @@ package com.thoughtworks.go.config.remote;
 
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
+import com.thoughtworks.go.config.rules.RuleAwarePluginProfile;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.config.Configuration;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
+import com.thoughtworks.go.plugin.access.configrepo.ConfigRepoMetadataStore;
+import com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo;
+import lombok.*;
+import lombok.experimental.Accessors;
 
-import java.util.*;
+import java.util.List;
 
+import static com.thoughtworks.go.config.rules.SupportedEntity.*;
 import static java.lang.String.format;
+import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
  * Defines single source of remote configuration and name of plugin to interpet it.
  * This goes to standard static xml configuration.
  */
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@Accessors(chain = true)
 @ConfigTag("config-repo")
-public class ConfigRepoConfig implements Validatable, Cacheable {
+@NoArgsConstructor
+public class ConfigRepoConfig extends RuleAwarePluginProfile implements Cacheable {
+    private List<String> allowedActions = List.of("refer");
+    private List<String> allowedTypes = unmodifiableListOf(PIPELINE, PIPELINE_GROUP, ENVIRONMENT);
     // defines source of configuration. Any will fit
     @ConfigSubtag(optional = false)
     private MaterialConfig repo;
 
-    @ConfigSubtag
-    private Configuration configuration = new Configuration();
-
-    // TODO something must instantiate this name into proper implementation of ConfigProvider
-    // which can be a plugin or embedded class
-    @ConfigAttribute(value = "pluginId", allowNull = false)
-    private String pluginId;
-    // plugin-name which will process the repository tree to return configuration.
-    // as in https://github.com/gocd/gocd/issues/1133#issuecomment-109014208
-    // then pattern-based plugin is just one option
-
-    @ConfigAttribute(value = "id", allowNull = false)
-    private String id = UUID.randomUUID().toString();
-
-    public static final String ID = "id";
-
-    private ConfigErrors errors = new ConfigErrors();
-
-    public ConfigRepoConfig() {
+    public static ConfigRepoConfig createConfigRepoConfig(MaterialConfig repo, String pluginId) {
+        return (ConfigRepoConfig) new ConfigRepoConfig().setRepo(repo).setPluginId(pluginId);
     }
 
-    public ConfigRepoConfig(MaterialConfig repo, String pluginId) {
-        this.repo = repo;
-        this.pluginId = pluginId;
-    }
-
-    public ConfigRepoConfig(MaterialConfig repo, String pluginId, String id) {
-        this(repo, pluginId);
-        this.id = id;
-    }
-
-    public MaterialConfig getMaterialConfig() {
-        return repo;
-    }
-
-    public void setMaterialConfig(MaterialConfig config) {
-        this.repo = config;
-    }
-
-    public String getPluginId() {
-        return pluginId;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        if (isBlank(id))
-            id = null;
-        this.id = id;
-    }
-
-    public void setPluginId(String pluginId) {
-        if (isBlank(pluginId))
-            pluginId = null;
-        this.pluginId = pluginId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ConfigRepoConfig that = (ConfigRepoConfig) o;
-        return Objects.equals(repo, that.repo) &&
-                Objects.equals(configuration, that.configuration) &&
-                Objects.equals(pluginId, that.pluginId) &&
-                Objects.equals(id, that.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(repo, configuration, pluginId, id);
+    public static ConfigRepoConfig createConfigRepoConfig(MaterialConfig repo, String pluginId, String id) {
+        return (ConfigRepoConfig) createConfigRepoConfig(repo, pluginId).setId(id);
     }
 
     @Override
     public void validate(ValidationContext validationContext) {
-        this.validatePresenceOfId();
-        this.validatePresenceOfPluginId();
+        super.validate(validationContext);
         this.validateUniquenessOfId(validationContext);
         this.validateRepoIsSet();
         this.validateMaterial(validationContext);
@@ -127,8 +73,8 @@ public class ConfigRepoConfig implements Validatable, Cacheable {
     }
 
     private void validateMaterialUniqueness(ValidationContext validationContext) {
-        if (this.getMaterialConfig() != null) {
-            if (!validationContext.getCruiseConfig().getConfigRepos().isUniqueMaterial(this.getMaterialConfig().getFingerprint())) {
+        if (getRepo() != null) {
+            if (!validationContext.getCruiseConfig().getConfigRepos().isUniqueMaterial(getRepo().getFingerprint())) {
                 this.errors.add("material", format(
                         "You have defined multiple configuration repositories with the same repository - '%s'.",
                         this.repo.getDisplayName()));
@@ -142,29 +88,8 @@ public class ConfigRepoConfig implements Validatable, Cacheable {
         }
     }
 
-    public boolean validateTree(ValidationContext validationContext) {
-        validate(validationContext);
-        boolean isValid = errors.isEmpty();
-
-        if (getMaterialConfig() != null) {
-            isValid = getMaterialConfig().errors().isEmpty() && isValid;
-        }
-
-        return isValid;
-    }
-
-    @Override
-    public ConfigErrors errors() {
-        return errors;
-    }
-
-    @Override
-    public void addError(String fieldName, String message) {
-        this.errors.add(fieldName, message);
-    }
-
     private void validateMaterial(ValidationContext validationContext) {
-        MaterialConfig materialConfig = getMaterialConfig();
+        MaterialConfig materialConfig = getRepo();
 
         if (materialConfig != null) {
             materialConfig.validateTree(validationContext);
@@ -181,63 +106,76 @@ public class ConfigRepoConfig implements Validatable, Cacheable {
     }
 
     private void validateAutoUpdateEnabled() {
-        if (this.getMaterialConfig() != null) {
-            if (!this.getMaterialConfig().isAutoUpdate())
-                this.getMaterialConfig().errors().add("autoUpdate", format(
+        if (getRepo() != null) {
+            if (!getRepo().isAutoUpdate())
+                getRepo().errors().add("autoUpdate", format(
                         "Configuration repository material '%s' must have autoUpdate enabled.",
-                        this.getMaterialConfig().getDisplayName()));
+                        getRepo().getDisplayName()));
         }
     }
 
     private void validateRepoIsSet() {
-        if (this.getMaterialConfig() == null) {
+        if (getRepo() == null) {
             this.errors.add("material", "Configuration repository material not specified.");
         }
     }
 
-    private void validatePresenceOfId() {
-        if (isBlank(this.getId())) {
-            this.errors.add(ID, "Configuration repository id not specified");
-        }
-    }
-
-    private void validatePresenceOfPluginId() {
-        if (isBlank(this.getPluginId())) {
-            this.errors.add("plugin_id", "Configuration repository plugin_id not specified");
-        }
-    }
-
     public boolean hasSameMaterial(MaterialConfig config) {
-        return this.getMaterialConfig().getFingerprint().equals(config.getFingerprint());
+        return getRepo().getFingerprint().equals(config.getFingerprint());
     }
 
     public boolean hasMaterialWithFingerprint(String fingerprint) {
-        return this.getMaterialConfig().getFingerprint().equals(fingerprint);
+        return getRepo().getFingerprint().equals(fingerprint);
     }
 
     private void validateAutoUpdateState(ValidationContext validationContext) {
         if (validationContext == null)
             return;
 
-        MaterialConfig material = this.getMaterialConfig();
+        MaterialConfig material = getRepo();
         if (material != null) {
             MaterialConfigs allMaterialsByFingerPrint = validationContext.getAllMaterialsByFingerPrint(material.getFingerprint());
             if (allMaterialsByFingerPrint.stream().anyMatch(m -> !m.isAutoUpdate())) {
-                getMaterialConfig().errors().add("autoUpdate", format("Material of type %s (%s) is specified as a configuration repository and pipeline material with disabled autoUpdate."
+                getRepo().errors().add("autoUpdate", format("Material of type %s (%s) is specified as a configuration repository and pipeline material with disabled autoUpdate."
                         + " All copies of this material must have autoUpdate enabled or configuration repository must be removed", material.getTypeForDisplay(), material.getDescription()));
             }
         }
     }
 
-    public Configuration getConfiguration() {
-        return configuration;
+    @Override
+    public List<String> allowedActions() {
+        return allowedActions;
     }
 
-    public void setConfiguration(Configuration configuration) {
-        this.configuration = configuration;
+    @Override
+    public List<String> allowedTypes() {
+        return allowedTypes;
     }
 
-    public void addConfigurations(List<ConfigurationProperty> configuration) {
-        this.configuration.addAll(configuration);
+    @Override
+    protected String getObjectDescription() {
+        return "Configuration repository";
+    }
+
+    @Override
+    protected boolean isSecure(String key) {
+        ConfigRepoPluginInfo pluginInfo = this.metadataStore().getPluginInfo(getPluginId());
+
+        if (pluginInfo == null
+                || pluginInfo.getPluginSettings() == null
+                || pluginInfo.getPluginSettings().getConfiguration(key) == null) {
+            return false;
+        }
+
+        return pluginInfo.getPluginSettings().getConfiguration(key).isSecure();
+    }
+
+    @Override
+    protected boolean hasPluginInfo() {
+        return !isNull(this.metadataStore().getPluginInfo(getPluginId()));
+    }
+
+    private ConfigRepoMetadataStore metadataStore() {
+        return ConfigRepoMetadataStore.instance();
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigRepoConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigRepoConfig.java
@@ -18,9 +18,6 @@ package com.thoughtworks.go.config.remote;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.rules.RuleAwarePluginProfile;
-import com.thoughtworks.go.domain.ConfigErrors;
-import com.thoughtworks.go.domain.config.Configuration;
-import com.thoughtworks.go.domain.config.ConfigurationProperty;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.plugin.access.configrepo.ConfigRepoMetadataStore;
 import com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo;
@@ -32,7 +29,6 @@ import java.util.List;
 import static com.thoughtworks.go.config.rules.SupportedEntity.*;
 import static java.lang.String.format;
 import static java.util.Objects.isNull;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
  * Defines single source of remote configuration and name of plugin to interpet it.
@@ -51,12 +47,8 @@ public class ConfigRepoConfig extends RuleAwarePluginProfile implements Cacheabl
     @ConfigSubtag(optional = false)
     private MaterialConfig repo;
 
-    public static ConfigRepoConfig createConfigRepoConfig(MaterialConfig repo, String pluginId) {
-        return (ConfigRepoConfig) new ConfigRepoConfig().setRepo(repo).setPluginId(pluginId);
-    }
-
     public static ConfigRepoConfig createConfigRepoConfig(MaterialConfig repo, String pluginId, String id) {
-        return (ConfigRepoConfig) createConfigRepoConfig(repo, pluginId).setId(id);
+        return (ConfigRepoConfig) new ConfigRepoConfig().setRepo(repo).setPluginId(pluginId).setId(id);
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigReposConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigReposConfig.java
@@ -36,14 +36,12 @@ public class ConfigReposConfig extends BaseCollection<ConfigRepoConfig> implemen
     }
 
     public ConfigReposConfig(ConfigRepoConfig... configRepos) {
-        for (ConfigRepoConfig repo : configRepos) {
-            this.add(repo);
-        }
+        this.addAll(Arrays.asList(configRepos));
     }
 
     public boolean hasMaterial(MaterialConfig materialConfig) {
         for (ConfigRepoConfig c : this) {
-            if (c.getMaterialConfig().equals(materialConfig)) {
+            if (c.getRepo().equals(materialConfig)) {
                 return true;
             }
         }
@@ -82,7 +80,7 @@ public class ConfigReposConfig extends BaseCollection<ConfigRepoConfig> implemen
     }
 
     private List<String> allMaterialFingerPrints() {
-        return this.stream().map(cr -> cr.getMaterialConfig().getFingerprint()).collect(Collectors.toList());
+        return this.stream().map(cr -> cr.getRepo().getFingerprint()).collect(Collectors.toList());
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/RepoConfigOrigin.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/RepoConfigOrigin.java
@@ -80,7 +80,7 @@ public class RepoConfigOrigin implements ConfigOrigin {
     @Override
     public String displayName() {
         MaterialConfig materialConfig = configRepo != null ?
-                configRepo.getMaterialConfig() : null;
+                configRepo.getRepo() : null;
         String materialName = materialConfig != null ?
                     materialConfig.getDisplayName() : "NULL material";
         return String.format("%s at %s", materialName, revision);
@@ -89,7 +89,7 @@ public class RepoConfigOrigin implements ConfigOrigin {
     public MaterialConfig getMaterial() {
         if(configRepo == null)
             return  null;
-        return configRepo.getMaterialConfig();
+        return configRepo.getRepo();
     }
 
     public boolean isFromRevision(String revision) {

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/rules/RuleAwarePluginProfile.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/rules/RuleAwarePluginProfile.java
@@ -21,39 +21,49 @@ import com.thoughtworks.go.config.validation.NameTypeValidator;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.config.Configuration;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 import javax.annotation.PostConstruct;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
+@Getter
+@Setter
+@EqualsAndHashCode
+@Accessors(chain = true)
 public abstract class RuleAwarePluginProfile implements Validatable, RulesAware {
-    public static final String ID = "id";
-    public static final String PLUGIN_ID = "pluginId";
+    protected static final String ID = "id";
+    protected static final String PLUGIN_ID = "pluginId";
 
     @ConfigAttribute(value = "id")
-    private String id;
+    protected String id;
 
     @ConfigAttribute(value = "pluginId")
-    private String pluginId;
+    protected String pluginId;
 
     @ConfigSubtag
-    private Configuration configuration;
+    protected Configuration configuration;
 
     @ConfigSubtag
-    private Rules rules = new Rules();
+    protected Rules rules = new Rules();
 
     @ConfigSubtag
-    private Description description = new Description();
-
+    protected Description description = new Description();
 
     public RuleAwarePluginProfile() {
         configuration = new Configuration();
     }
 
-    private final ConfigErrors errors = new ConfigErrors();
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    @EqualsAndHashCode.Exclude
+    protected final ConfigErrors errors = new ConfigErrors();
 
     public RuleAwarePluginProfile(String id, String pluginId, Rules rules, ConfigurationProperty... configurationProperties) {
         this.id = id;
@@ -65,11 +75,6 @@ public abstract class RuleAwarePluginProfile implements Validatable, RulesAware 
         }
     }
 
-    public Configuration getConfiguration() {
-        return configuration;
-    }
-
-
     public void addConfigurations(List<ConfigurationProperty> configurations) {
         ConfigurationPropertyBuilder builder = new ConfigurationPropertyBuilder();
         for (ConfigurationProperty property : configurations) {
@@ -80,14 +85,6 @@ public abstract class RuleAwarePluginProfile implements Validatable, RulesAware 
         }
     }
 
-    public String getId() {
-        return id;
-    }
-
-    public String getPluginId() {
-        return pluginId;
-    }
-
     public String getDescription() {
         return this.description.text;
     }
@@ -96,57 +93,11 @@ public abstract class RuleAwarePluginProfile implements Validatable, RulesAware 
         this.description.text = description;
     }
 
-    //TODO: return clone instead?
-    @Override
-    public Rules getRules() {
-        return this.rules;
-    }
-
     @ConfigTag("description")
+    @EqualsAndHashCode
     public static class Description {
         @ConfigValue
         private String text;
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            Description that = (Description) o;
-
-            return text != null ? text.equals(that.text) : that.text == null;
-        }
-
-        @Override
-        public int hashCode() {
-            return text != null ? text.hashCode() : 0;
-        }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        RuleAwarePluginProfile that = (RuleAwarePluginProfile) o;
-
-        if (id != null ? !id.equals(that.id) : that.id != null) return false;
-        if (pluginId != null ? !pluginId.equals(that.pluginId) : that.pluginId != null) return false;
-        if (configuration != null ? !configuration.equals(that.configuration) : that.configuration != null)
-            return false;
-        if (rules != null ? !rules.equals(that.rules) : that.rules != null) return false;
-        return description != null ? description.equals(that.description) : that.description == null;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-                id.hashCode(),
-                pluginId.hashCode(),
-                configuration.hashCode(),
-                (rules != null ? rules.hashCode() : 0),
-                (description != null ? description.hashCode() : 0)
-        );
     }
 
     @PostConstruct
@@ -184,7 +135,6 @@ public abstract class RuleAwarePluginProfile implements Validatable, RulesAware 
         });
     }
 
-
     @Override
     public void validate(ValidationContext validationContext) {
         configuration.validateUniqueness(getObjectDescription() + " " + (isBlank(id) ? "(noname)" : "'" + id + "'"));
@@ -200,10 +150,6 @@ public abstract class RuleAwarePluginProfile implements Validatable, RulesAware 
         if (new NameTypeValidator().isNameInvalid(id)) {
             addError(ID, String.format("Invalid id '%s'. %s", id, NameTypeValidator.ERROR_MESSAGE));
         }
-    }
-
-    public void setRules(Rules rules) {
-        this.rules = rules;
     }
 
     protected abstract String getObjectDescription();

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/rules/SupportedEntity.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/rules/SupportedEntity.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.config.rules;
 
 import com.thoughtworks.go.config.EnvironmentConfig;
+import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.PipelineConfigs;
 import com.thoughtworks.go.config.Validatable;
 
@@ -27,6 +28,7 @@ import static java.util.Collections.unmodifiableList;
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 
 public enum SupportedEntity {
+    PIPELINE("pipeline", PipelineConfig.class),
     PIPELINE_GROUP("pipeline_group", PipelineConfigs.class),
     ENVIRONMENT("environment", EnvironmentConfig.class),
     UNKNOWN(null, null);

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/BasicCruiseConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/BasicCruiseConfigTest.java
@@ -172,8 +172,8 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
     @Test
     public void shouldIncludeRemotePipelinesAsPartOfCachedPipelineConfigs() {
         BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("p1", "p2");
-        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
-        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
+        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin", "id-1");
+        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin", "id-1");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig1, repoConfig2));
         PartialConfig partialConfigInRepo1 = PartialConfigMother.withPipeline("pipeline_in_repo1", new RepoConfigOrigin(repoConfig1, "repo1_r1"));
         PartialConfig partialConfigInRepo2 = PartialConfigMother.withPipeline("pipeline_in_repo2", new RepoConfigOrigin(repoConfig2, "repo2_r1"));
@@ -186,8 +186,8 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
     @Test
     public void shouldRejectRemotePipelinesNotOriginatingFromRegisteredConfigReposFromCachedPipelineConfigs() {
         BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("p1", "p2");
-        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
-        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
+        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin", "id-1");
+        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin", "id-1");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig2));
         PartialConfig partialConfigInRepo1 = PartialConfigMother.withPipeline("pipeline_in_repo1", new RepoConfigOrigin(repoConfig1, "repo1_r1"));
         PartialConfig partialConfigInRepo2 = PartialConfigMother.withPipeline("pipeline_in_repo2", new RepoConfigOrigin(repoConfig2, "repo2_r1"));

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/BasicCruiseConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/BasicCruiseConfigTest.java
@@ -172,8 +172,8 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
     @Test
     public void shouldIncludeRemotePipelinesAsPartOfCachedPipelineConfigs() {
         BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("p1", "p2");
-        ConfigRepoConfig repoConfig1 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
-        ConfigRepoConfig repoConfig2 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
+        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
+        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig1, repoConfig2));
         PartialConfig partialConfigInRepo1 = PartialConfigMother.withPipeline("pipeline_in_repo1", new RepoConfigOrigin(repoConfig1, "repo1_r1"));
         PartialConfig partialConfigInRepo2 = PartialConfigMother.withPipeline("pipeline_in_repo2", new RepoConfigOrigin(repoConfig2, "repo2_r1"));
@@ -186,8 +186,8 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
     @Test
     public void shouldRejectRemotePipelinesNotOriginatingFromRegisteredConfigReposFromCachedPipelineConfigs() {
         BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("p1", "p2");
-        ConfigRepoConfig repoConfig1 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
-        ConfigRepoConfig repoConfig2 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
+        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
+        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig2));
         PartialConfig partialConfigInRepo1 = PartialConfigMother.withPipeline("pipeline_in_repo1", new RepoConfigOrigin(repoConfig1, "repo1_r1"));
         PartialConfig partialConfigInRepo2 = PartialConfigMother.withPipeline("pipeline_in_repo2", new RepoConfigOrigin(repoConfig2, "repo2_r1"));

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/CruiseConfigTestBase.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/CruiseConfigTestBase.java
@@ -837,7 +837,7 @@ public abstract class CruiseConfigTestBase {
         cruiseConfig = new BasicCruiseConfig(defaultGroup);
         ConfigReposConfig reposConfig = new ConfigReposConfig();
         GitMaterialConfig configRepoMaterial = git("http://git");
-        reposConfig.add(ConfigRepoConfig.createConfigRepoConfig(configRepoMaterial, "myplug"));
+        reposConfig.add(ConfigRepoConfig.createConfigRepoConfig(configRepoMaterial, "myplug", "id"));
         cruiseConfig.setConfigRepos(reposConfig);
 
 
@@ -859,7 +859,7 @@ public abstract class CruiseConfigTestBase {
         BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
         ConfigReposConfig reposConfig = new ConfigReposConfig();
         GitMaterialConfig configRepo = git("http://git");
-        reposConfig.add(ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplug"));
+        reposConfig.add(ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplug", "id"));
         mainCruiseConfig.setConfigRepos(reposConfig);
 
         PartialConfig partialConfig = PartialConfigMother.withPipeline("pipe2");

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/CruiseConfigTestBase.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/CruiseConfigTestBase.java
@@ -837,7 +837,7 @@ public abstract class CruiseConfigTestBase {
         cruiseConfig = new BasicCruiseConfig(defaultGroup);
         ConfigReposConfig reposConfig = new ConfigReposConfig();
         GitMaterialConfig configRepoMaterial = git("http://git");
-        reposConfig.add(new ConfigRepoConfig(configRepoMaterial, "myplug"));
+        reposConfig.add(ConfigRepoConfig.createConfigRepoConfig(configRepoMaterial, "myplug"));
         cruiseConfig.setConfigRepos(reposConfig);
 
 
@@ -859,7 +859,7 @@ public abstract class CruiseConfigTestBase {
         BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
         ConfigReposConfig reposConfig = new ConfigReposConfig();
         GitMaterialConfig configRepo = git("http://git");
-        reposConfig.add(new ConfigRepoConfig(configRepo, "myplug"));
+        reposConfig.add(ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplug"));
         mainCruiseConfig.setConfigRepos(reposConfig);
 
         PartialConfig partialConfig = PartialConfigMother.withPipeline("pipe2");

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/MergeCruiseConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/MergeCruiseConfigTest.java
@@ -61,8 +61,8 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
     @Test
     public void shouldMergeWhenSameEnvironmentExistsInManyPartials() {
         BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("p1", "p2");
-        ConfigRepoConfig repoConfig1 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
-        ConfigRepoConfig repoConfig2 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
+        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
+        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig1, repoConfig2));
         PartialConfig partialConfigInRepo1 = PartialConfigMother.withEnvironment("environment", new RepoConfigOrigin(repoConfig1, "repo1_r1"));
         RepoConfigOrigin configOrigin = new RepoConfigOrigin(repoConfig2, "repo2_r1");
@@ -78,8 +78,8 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
     @Test
     public void shouldHaveValidationErrorsForDuplicateValidSCMs() {
         BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("p1", "p2");
-        ConfigRepoConfig repoConfig1 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
-        ConfigRepoConfig repoConfig2 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
+        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
+        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig1, repoConfig2));
         PartialConfig partialConfigInRepo1 = PartialConfigMother.withSCM("scmid",
                 "name",
@@ -100,7 +100,7 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
     @Test
     public void shouldOnlyMergeLocalSCMsWhenEditIsTrue() {
         BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("p1", "p2");
-        ConfigRepoConfig repoConfig1 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
+        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig1));
         RepoConfigOrigin configOrigin = new RepoConfigOrigin(repoConfig1, "repo1_r1");
         PartialConfig completeSCM = PartialConfigMother.withSCM("scmid",
@@ -159,7 +159,7 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
         pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("local-pipeline-1"));
         cruiseConfig = new BasicCruiseConfig(pipelines);
         ConfigReposConfig reposConfig = new ConfigReposConfig();
-        ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(git("http://git"), "myplug");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplug");
         reposConfig.add(configRepoConfig);
         cruiseConfig.setConfigRepos(reposConfig);
         PartialConfig partialConfig = PartialConfigMother.withPipelineInGroup("remote-pipeline-1", "g2");
@@ -464,7 +464,7 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
         BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
         ConfigReposConfig reposConfig = new ConfigReposConfig();
         GitMaterialConfig configRepo = git("http://git");
-        reposConfig.add(new ConfigRepoConfig(configRepo, "myplug"));
+        reposConfig.add(ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplug"));
         mainCruiseConfig.setConfigRepos(reposConfig);
 
         PartialConfig partialConfig = PartialConfigMother.withPipeline("pipe2");
@@ -483,7 +483,7 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
         BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
         ConfigReposConfig reposConfig = new ConfigReposConfig();
         GitMaterialConfig configRepo = git("http://git");
-        reposConfig.add(new ConfigRepoConfig(configRepo, "myplug"));
+        reposConfig.add(ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplug"));
         mainCruiseConfig.setConfigRepos(reposConfig);
 
         PartialConfig partialConfig = PartialConfigMother.withPipeline("pipe2");
@@ -500,7 +500,7 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
     public void shouldUpdatePipelineConfigsListWhenAPartialIsMerged() {
         cruiseConfig = new BasicCruiseConfig(pipelines);
         PartialConfig partial = PartialConfigMother.withPipeline("pipeline3");
-        ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(git("http://git"), "myplug");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplug");
         partial.setOrigins(new RepoConfigOrigin(configRepoConfig, "123"));
         ConfigReposConfig reposConfig = new ConfigReposConfig();
         reposConfig.add(configRepoConfig);

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/MergeCruiseConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/MergeCruiseConfigTest.java
@@ -61,8 +61,8 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
     @Test
     public void shouldMergeWhenSameEnvironmentExistsInManyPartials() {
         BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("p1", "p2");
-        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
-        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
+        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin", "id-1");
+        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin", "id-2");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig1, repoConfig2));
         PartialConfig partialConfigInRepo1 = PartialConfigMother.withEnvironment("environment", new RepoConfigOrigin(repoConfig1, "repo1_r1"));
         RepoConfigOrigin configOrigin = new RepoConfigOrigin(repoConfig2, "repo2_r1");
@@ -78,8 +78,8 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
     @Test
     public void shouldHaveValidationErrorsForDuplicateValidSCMs() {
         BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("p1", "p2");
-        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
-        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
+        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin", "id-1");
+        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin", "id-2");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig1, repoConfig2));
         PartialConfig partialConfigInRepo1 = PartialConfigMother.withSCM("scmid",
                 "name",
@@ -100,7 +100,7 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
     @Test
     public void shouldOnlyMergeLocalSCMsWhenEditIsTrue() {
         BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("p1", "p2");
-        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
+        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin", "id-1");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig1));
         RepoConfigOrigin configOrigin = new RepoConfigOrigin(repoConfig1, "repo1_r1");
         PartialConfig completeSCM = PartialConfigMother.withSCM("scmid",
@@ -159,7 +159,7 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
         pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("local-pipeline-1"));
         cruiseConfig = new BasicCruiseConfig(pipelines);
         ConfigReposConfig reposConfig = new ConfigReposConfig();
-        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplug");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplug", "id");
         reposConfig.add(configRepoConfig);
         cruiseConfig.setConfigRepos(reposConfig);
         PartialConfig partialConfig = PartialConfigMother.withPipelineInGroup("remote-pipeline-1", "g2");
@@ -464,7 +464,7 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
         BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
         ConfigReposConfig reposConfig = new ConfigReposConfig();
         GitMaterialConfig configRepo = git("http://git");
-        reposConfig.add(ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplug"));
+        reposConfig.add(ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplug", "id"));
         mainCruiseConfig.setConfigRepos(reposConfig);
 
         PartialConfig partialConfig = PartialConfigMother.withPipeline("pipe2");
@@ -483,7 +483,7 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
         BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
         ConfigReposConfig reposConfig = new ConfigReposConfig();
         GitMaterialConfig configRepo = git("http://git");
-        reposConfig.add(ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplug"));
+        reposConfig.add(ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplug", "id"));
         mainCruiseConfig.setConfigRepos(reposConfig);
 
         PartialConfig partialConfig = PartialConfigMother.withPipeline("pipe2");
@@ -500,7 +500,7 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
     public void shouldUpdatePipelineConfigsListWhenAPartialIsMerged() {
         cruiseConfig = new BasicCruiseConfig(pipelines);
         PartialConfig partial = PartialConfigMother.withPipeline("pipeline3");
-        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplug");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplug", "id");
         partial.setOrigins(new RepoConfigOrigin(configRepoConfig, "123"));
         ConfigReposConfig reposConfig = new ConfigReposConfig();
         reposConfig.add(configRepoConfig);

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigTest.java
@@ -821,7 +821,7 @@ public class PipelineConfigTest {
     public void shouldReturnTrueWhenOneOfPipelineMaterialsIsTheSameAsConfigOrigin() {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline", "stage", "build");
         MaterialConfig material = pipelineConfig.materialConfigs().first();
-        pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(material, "plugin"), "1233"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(material, "plugin"), "1233"));
 
         assertThat(pipelineConfig.isConfigOriginSameAsOneOfMaterials(), is(true));
     }
@@ -836,7 +836,7 @@ public class PipelineConfigTest {
 
         GitMaterialConfig repoMaterialConfig = git("http://git");
 
-        pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(repoMaterialConfig, "plugin"), "1233"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(repoMaterialConfig, "plugin"), "1233"));
 
         assertThat(pipelineConfig.isConfigOriginSameAsOneOfMaterials(), is(true));
     }
@@ -845,7 +845,7 @@ public class PipelineConfigTest {
     public void shouldReturnFalseWhenOneOfPipelineMaterialsIsNotTheSameAsConfigOrigin() {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline", "stage", "build");
         MaterialConfig material = git("http://git");
-        pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(material, "plugin"), "1233"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(material, "plugin"), "1233"));
 
         assertThat(pipelineConfig.isConfigOriginSameAsOneOfMaterials(), is(false));
     }
@@ -862,7 +862,7 @@ public class PipelineConfigTest {
     public void shouldReturnTrueWhenConfigRevisionIsEqualToQuery() {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline", "stage", "build");
         MaterialConfig material = pipelineConfig.materialConfigs().first();
-        pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(material, "plugin"), "1233"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(material, "plugin"), "1233"));
 
         assertThat(pipelineConfig.isConfigOriginFromRevision("1233"), is(true));
     }
@@ -871,7 +871,7 @@ public class PipelineConfigTest {
     public void shouldReturnFalseWhenConfigRevisionIsNotEqualToQuery() {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline", "stage", "build");
         MaterialConfig material = pipelineConfig.materialConfigs().first();
-        pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(material, "plugin"), "1233"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(material, "plugin"), "1233"));
 
         assertThat(pipelineConfig.isConfigOriginFromRevision("32"), is(false));
     }
@@ -879,7 +879,7 @@ public class PipelineConfigTest {
     @Test
     public void shouldReturnConfigRepoOriginDisplayNameWhenOriginIsRemote() {
         PipelineConfig pipelineConfig = new PipelineConfig();
-        pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "revision1"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "revision1"));
         assertThat(pipelineConfig.getOriginDisplayName(), is("AwesomeGitMaterial at revision1"));
     }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigTest.java
@@ -821,7 +821,7 @@ public class PipelineConfigTest {
     public void shouldReturnTrueWhenOneOfPipelineMaterialsIsTheSameAsConfigOrigin() {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline", "stage", "build");
         MaterialConfig material = pipelineConfig.materialConfigs().first();
-        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(material, "plugin"), "1233"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(material, "plugin", "id"), "1233"));
 
         assertThat(pipelineConfig.isConfigOriginSameAsOneOfMaterials(), is(true));
     }
@@ -836,7 +836,7 @@ public class PipelineConfigTest {
 
         GitMaterialConfig repoMaterialConfig = git("http://git");
 
-        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(repoMaterialConfig, "plugin"), "1233"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(repoMaterialConfig, "plugin", "id"), "1233"));
 
         assertThat(pipelineConfig.isConfigOriginSameAsOneOfMaterials(), is(true));
     }
@@ -845,7 +845,7 @@ public class PipelineConfigTest {
     public void shouldReturnFalseWhenOneOfPipelineMaterialsIsNotTheSameAsConfigOrigin() {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline", "stage", "build");
         MaterialConfig material = git("http://git");
-        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(material, "plugin"), "1233"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(material, "plugin", "id"), "1233"));
 
         assertThat(pipelineConfig.isConfigOriginSameAsOneOfMaterials(), is(false));
     }
@@ -862,7 +862,7 @@ public class PipelineConfigTest {
     public void shouldReturnTrueWhenConfigRevisionIsEqualToQuery() {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline", "stage", "build");
         MaterialConfig material = pipelineConfig.materialConfigs().first();
-        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(material, "plugin"), "1233"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(material, "plugin", "id"), "1233"));
 
         assertThat(pipelineConfig.isConfigOriginFromRevision("1233"), is(true));
     }
@@ -871,7 +871,7 @@ public class PipelineConfigTest {
     public void shouldReturnFalseWhenConfigRevisionIsNotEqualToQuery() {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline", "stage", "build");
         MaterialConfig material = pipelineConfig.materialConfigs().first();
-        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(material, "plugin"), "1233"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(material, "plugin", "id"), "1233"));
 
         assertThat(pipelineConfig.isConfigOriginFromRevision("32"), is(false));
     }
@@ -879,7 +879,7 @@ public class PipelineConfigTest {
     @Test
     public void shouldReturnConfigRepoOriginDisplayNameWhenOriginIsRemote() {
         PipelineConfig pipelineConfig = new PipelineConfig();
-        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "revision1"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "id"), "revision1"));
         assertThat(pipelineConfig.getOriginDisplayName(), is("AwesomeGitMaterial at revision1"));
     }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/MaterialConfigsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/MaterialConfigsTest.java
@@ -137,8 +137,8 @@ Above scenario allowed
         PipelineConfig pipeline2 = goConfigMother.addPipeline(cruiseConfig, "pipeline2", "stage", "build");
         goConfigMother.setDependencyOn(cruiseConfig, pipeline2, "pipeline1", "stage");
 
-        pipeline1.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(svn("http://mysvn", false), "myplugin"), "123"));
-        pipeline2.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(svn("http://othersvn", false), "myplugin"), "2222"));
+        pipeline1.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(svn("http://mysvn", false), "myplugin", "id"), "123"));
+        pipeline2.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(svn("http://othersvn", false), "myplugin", "other-id"), "2222"));
 
         pipeline1.materialConfigs().validate(ConfigSaveValidationContext.forChain(cruiseConfig, new BasicPipelineConfigs(), pipeline1));
         assertThat(pipeline1.materialConfigs().errors().isEmpty(), is(true));

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/MaterialConfigsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/MaterialConfigsTest.java
@@ -137,8 +137,8 @@ Above scenario allowed
         PipelineConfig pipeline2 = goConfigMother.addPipeline(cruiseConfig, "pipeline2", "stage", "build");
         goConfigMother.setDependencyOn(cruiseConfig, pipeline2, "pipeline1", "stage");
 
-        pipeline1.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(svn("http://mysvn", false), "myplugin"), "123"));
-        pipeline2.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(svn("http://othersvn", false), "myplugin"), "2222"));
+        pipeline1.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(svn("http://mysvn", false), "myplugin"), "123"));
+        pipeline2.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(svn("http://othersvn", false), "myplugin"), "2222"));
 
         pipeline1.materialConfigs().validate(ConfigSaveValidationContext.forChain(cruiseConfig, new BasicPipelineConfigs(), pipeline1));
         assertThat(pipeline1.materialConfigs().errors().isEmpty(), is(true));

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/merge/MergeOriginConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/merge/MergeOriginConfigTest.java
@@ -30,7 +30,7 @@ public class MergeOriginConfigTest {
     public void shouldShowDisplayName()
     {
         FileConfigOrigin fileConfigOrigin = new FileConfigOrigin();
-        RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin(new ConfigRepoConfig(svn("http://mysvn", false), "myplugin"), "123");
+        RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(svn("http://mysvn", false), "myplugin"), "123");
         MergeConfigOrigin mergeOrigin = new MergeConfigOrigin(fileConfigOrigin, repoConfigOrigin);
         assertThat(mergeOrigin.displayName(),is("Merged: [ cruise-config.xml; http://mysvn at 123; ]"));
     }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/merge/MergeOriginConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/merge/MergeOriginConfigTest.java
@@ -30,7 +30,7 @@ public class MergeOriginConfigTest {
     public void shouldShowDisplayName()
     {
         FileConfigOrigin fileConfigOrigin = new FileConfigOrigin();
-        RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(svn("http://mysvn", false), "myplugin"), "123");
+        RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(svn("http://mysvn", false), "myplugin", "id"), "123");
         MergeConfigOrigin mergeOrigin = new MergeConfigOrigin(fileConfigOrigin, repoConfigOrigin);
         assertThat(mergeOrigin.displayName(),is("Merged: [ cruise-config.xml; http://mysvn at 123; ]"));
     }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/preprocessor/ConfigRepoPartialPreprocessorTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/preprocessor/ConfigRepoPartialPreprocessorTest.java
@@ -38,7 +38,7 @@ public class ConfigRepoPartialPreprocessorTest {
 
     public ConfigRepoPartialPreprocessorTest() {
         reposConfig = new ConfigReposConfig();
-        configRepoConfig = new ConfigRepoConfig(git("http://git"), "myplug");
+        configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplug");
         reposConfig.add(configRepoConfig);
     }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/preprocessor/ConfigRepoPartialPreprocessorTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/preprocessor/ConfigRepoPartialPreprocessorTest.java
@@ -38,7 +38,7 @@ public class ConfigRepoPartialPreprocessorTest {
 
     public ConfigRepoPartialPreprocessorTest() {
         reposConfig = new ConfigReposConfig();
-        configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplug");
+        configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplug", "id");
         reposConfig.add(configRepoConfig);
     }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigRepoConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigRepoConfigTest.java
@@ -58,7 +58,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         SvnMaterialConfig svn = svn("url", false);
         svn.setAutoUpdate(false);
 
-        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(svn, "plug");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(svn, "plug", "id");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig));
 
         ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(cruiseConfig);
@@ -119,7 +119,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         CruiseConfig cruiseConfig = new BasicCruiseConfig();
         GitMaterialConfig materialConfig = git(null, "master");
 
-        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(materialConfig, "plug");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(materialConfig, "plug", "id");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig));
 
         ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(cruiseConfig);
@@ -134,7 +134,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         MaterialConfig materialConfig = mock(MaterialConfig.class);
         when(materialConfig.errors()).thenReturn(new ConfigErrors());
 
-        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(materialConfig, "plug");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(materialConfig, "plug", "id");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig));
         ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(cruiseConfig);
 
@@ -170,7 +170,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         svnInPipelineConfig.setAutoUpdate(false);
         materialConfigs.add(svnInPipelineConfig);
 
-        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(svnInConfigRepo, "plug");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(svnInConfigRepo, "plug", "id");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig));
 
         PipelineConfig pipeline1 = mother.addPipeline(cruiseConfig, "badpipe", "build", materialConfigs, "build");
@@ -186,7 +186,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
     public void hasSameMaterial_shouldReturnTrueWhenFingerprintEquals() {
         MaterialConfig configRepo = git("url", "branch");
         MaterialConfig someRepo = git("url", "branch");
-        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin");
+        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin", "id");
 
         assertThat(config.hasSameMaterial(someRepo), is(true));
     }
@@ -195,7 +195,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
     public void hasSameMaterial_shouldReturnFalseWhenFingerprintNotEquals() {
         MaterialConfig configRepo = git("url", "branch");
         MaterialConfig someRepo = git("url", "branch1");
-        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin");
+        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin", "id");
 
         assertThat(config.hasSameMaterial(someRepo), is(false));
     }
@@ -205,7 +205,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         MaterialConfig configRepo = git("url", "branch");
         GitMaterialConfig someRepo = git("url", "branch");
         someRepo.setFolder("someFolder");
-        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin");
+        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin", "id");
 
         assertThat(config.hasSameMaterial(someRepo), is(true));
     }
@@ -215,7 +215,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         MaterialConfig configRepo = git("url", "branch");
         GitMaterialConfig someRepo = git("url", "branch");
         someRepo.setFolder("someFolder");
-        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin");
+        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin", "id");
 
         assertThat(config.hasMaterialWithFingerprint(someRepo.getFingerprint()), is(true));
     }
@@ -224,7 +224,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
     public void hasMaterialWithFingerprint_shouldReturnFalseWhenFingerprintNotEquals() {
         MaterialConfig configRepo = git("url", "branch");
         GitMaterialConfig someRepo = git("url", "branch1");
-        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin");
+        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin", "id");
 
         assertThat(config.hasMaterialWithFingerprint(someRepo.getFingerprint()), is(false));
     }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigRepoConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigRepoConfigTest.java
@@ -73,8 +73,8 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
     public void validate_shouldCheckUniquenessOfId() {
         CruiseConfig cruiseConfig = new BasicCruiseConfig();
 
-        ConfigRepoConfig configRepoConfig1 = new ConfigRepoConfig(null, "plug", "id_1");
-        ConfigRepoConfig configRepoConfig2 = new ConfigRepoConfig(null, "plug", "id_1");
+        ConfigRepoConfig configRepoConfig1 = ConfigRepoConfig.createConfigRepoConfig(null, "plug", "id_1");
+        ConfigRepoConfig configRepoConfig2 = ConfigRepoConfig.createConfigRepoConfig(null, "plug", "id_1");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig1, configRepoConfig2));
 
         ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(cruiseConfig);
@@ -102,8 +102,8 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         CruiseConfig cruiseConfig = new BasicCruiseConfig();
         SvnMaterialConfig svn = svn("url", false);
 
-        ConfigRepoConfig configRepoConfig1 = new ConfigRepoConfig(svn, "plug", "id_1");
-        ConfigRepoConfig configRepoConfig2 = new ConfigRepoConfig(svn, "plug", "id_2");
+        ConfigRepoConfig configRepoConfig1 = ConfigRepoConfig.createConfigRepoConfig(svn, "plug", "id_1");
+        ConfigRepoConfig configRepoConfig2 = ConfigRepoConfig.createConfigRepoConfig(svn, "plug", "id_2");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig1, configRepoConfig2));
 
         ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(cruiseConfig);
@@ -119,13 +119,13 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         CruiseConfig cruiseConfig = new BasicCruiseConfig();
         GitMaterialConfig materialConfig = git(null, "master");
 
-        ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(materialConfig, "plug");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(materialConfig, "plug");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig));
 
         ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(cruiseConfig);
         configRepoConfig.validate(validationContext);
 
-        assertThat(configRepoConfig.getMaterialConfig().errors().on("url"), is("URL cannot be blank"));
+        assertThat(configRepoConfig.getRepo().errors().on("url"), is("URL cannot be blank"));
     }
 
     @Test
@@ -134,7 +134,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         MaterialConfig materialConfig = mock(MaterialConfig.class);
         when(materialConfig.errors()).thenReturn(new ConfigErrors());
 
-        ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(materialConfig, "plug");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(materialConfig, "plug");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig));
         ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(cruiseConfig);
 
@@ -149,13 +149,13 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         MaterialConfig materialConfig = mock(MaterialConfig.class);
         when(materialConfig.errors()).thenReturn(new ConfigErrors());
 
-        ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(materialConfig, "plug", "id");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(materialConfig, "plug", "id");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig));
         ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(cruiseConfig);
 
-        assertFalse(configRepoConfig.validateTree(validationContext));
+        configRepoConfig.validateTree(validationContext);
         assertTrue(configRepoConfig.errors().isEmpty());
-        assertFalse(configRepoConfig.getMaterialConfig().errors().isEmpty());
+        assertFalse(configRepoConfig.getRepo().errors().isEmpty());
     }
 
     @Test
@@ -170,7 +170,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         svnInPipelineConfig.setAutoUpdate(false);
         materialConfigs.add(svnInPipelineConfig);
 
-        ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(svnInConfigRepo, "plug");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(svnInConfigRepo, "plug");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig));
 
         PipelineConfig pipeline1 = mother.addPipeline(cruiseConfig, "badpipe", "build", materialConfigs, "build");
@@ -186,7 +186,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
     public void hasSameMaterial_shouldReturnTrueWhenFingerprintEquals() {
         MaterialConfig configRepo = git("url", "branch");
         MaterialConfig someRepo = git("url", "branch");
-        ConfigRepoConfig config = new ConfigRepoConfig(configRepo, "myplugin");
+        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin");
 
         assertThat(config.hasSameMaterial(someRepo), is(true));
     }
@@ -195,7 +195,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
     public void hasSameMaterial_shouldReturnFalseWhenFingerprintNotEquals() {
         MaterialConfig configRepo = git("url", "branch");
         MaterialConfig someRepo = git("url", "branch1");
-        ConfigRepoConfig config = new ConfigRepoConfig(configRepo, "myplugin");
+        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin");
 
         assertThat(config.hasSameMaterial(someRepo), is(false));
     }
@@ -205,7 +205,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         MaterialConfig configRepo = git("url", "branch");
         GitMaterialConfig someRepo = git("url", "branch");
         someRepo.setFolder("someFolder");
-        ConfigRepoConfig config = new ConfigRepoConfig(configRepo, "myplugin");
+        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin");
 
         assertThat(config.hasSameMaterial(someRepo), is(true));
     }
@@ -215,7 +215,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         MaterialConfig configRepo = git("url", "branch");
         GitMaterialConfig someRepo = git("url", "branch");
         someRepo.setFolder("someFolder");
-        ConfigRepoConfig config = new ConfigRepoConfig(configRepo, "myplugin");
+        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin");
 
         assertThat(config.hasMaterialWithFingerprint(someRepo.getFingerprint()), is(true));
     }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigReposConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigReposConfigTest.java
@@ -41,7 +41,7 @@ public class ConfigReposConfigTest {
 
     @Test
     public void shouldReturnTrueThatHasMaterialWhenAddedConfigRepo() {
-        repos.add(ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplugin"));
+        repos.add(ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplugin", "id"));
         assertThat(repos.hasMaterial(git("http://git")), is(true));
     }
 
@@ -67,13 +67,13 @@ public class ConfigReposConfigTest {
     @Test
     public void shouldReturnFalseThatHasConfigRepoWhenEmpty() {
         assertThat(repos.isEmpty(), is(true));
-        assertThat(repos.contains(ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplugin")), is(false));
+        assertThat(repos.contains(ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplugin", "id")), is(false));
     }
 
     @Test
     public void shouldErrorWhenDuplicateReposExist() {
-        ConfigRepoConfig repo1 = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplugin");
-        ConfigRepoConfig repo2 = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myotherplugin");
+        ConfigRepoConfig repo1 = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplugin", "id");
+        ConfigRepoConfig repo2 = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myotherplugin", "other-id");
         repos.add(repo1);
         repos.add(repo2);
         // this is a limitation, we identify config repos by material fingerprint later

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigReposConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigReposConfigTest.java
@@ -41,14 +41,14 @@ public class ConfigReposConfigTest {
 
     @Test
     public void shouldReturnTrueThatHasMaterialWhenAddedConfigRepo() {
-        repos.add(new ConfigRepoConfig(git("http://git"), "myplugin"));
+        repos.add(ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplugin"));
         assertThat(repos.hasMaterial(git("http://git")), is(true));
     }
 
     @Test
     public void shouldFindConfigRepoWithSpecifiedId() {
         String id = "repo1";
-        ConfigRepoConfig configRepo1 = new ConfigRepoConfig(git("http://git"), "myplugin", id);
+        ConfigRepoConfig configRepo1 = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplugin", id);
         repos.add(configRepo1);
         assertThat(repos.getConfigRepo(id), is(configRepo1));
     }
@@ -60,20 +60,20 @@ public class ConfigReposConfigTest {
 
     @Test
     public void shouldReturnTrueThatHasConfigRepoWhenAddedConfigRepo() {
-        repos.add(new ConfigRepoConfig(git("http://git"), "myplugin", "repo-id"));
-        assertThat(repos.contains(new ConfigRepoConfig(git("http://git"), "myplugin", "repo-id")), is(true));
+        repos.add(ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplugin", "repo-id"));
+        assertThat(repos.contains(ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplugin", "repo-id")), is(true));
     }
 
     @Test
     public void shouldReturnFalseThatHasConfigRepoWhenEmpty() {
         assertThat(repos.isEmpty(), is(true));
-        assertThat(repos.contains(new ConfigRepoConfig(git("http://git"), "myplugin")), is(false));
+        assertThat(repos.contains(ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplugin")), is(false));
     }
 
     @Test
     public void shouldErrorWhenDuplicateReposExist() {
-        ConfigRepoConfig repo1 = new ConfigRepoConfig(git("http://git"), "myplugin");
-        ConfigRepoConfig repo2 = new ConfigRepoConfig(git("http://git"), "myotherplugin");
+        ConfigRepoConfig repo1 = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplugin");
+        ConfigRepoConfig repo2 = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myotherplugin");
         repos.add(repo1);
         repos.add(repo2);
         // this is a limitation, we identify config repos by material fingerprint later
@@ -86,8 +86,8 @@ public class ConfigReposConfigTest {
 
     @Test
     public void shouldErrorWhenDuplicateIdsExist() {
-        ConfigRepoConfig repo1 = new ConfigRepoConfig(git("http://git1"), "myplugin", "id");
-        ConfigRepoConfig repo2 = new ConfigRepoConfig(git("http://git2"), "myotherplugin", "id");
+        ConfigRepoConfig repo1 = ConfigRepoConfig.createConfigRepoConfig(git("http://git1"), "myplugin", "id");
+        ConfigRepoConfig repo2 = ConfigRepoConfig.createConfigRepoConfig(git("http://git2"), "myotherplugin", "id");
         repos.add(repo1);
         repos.add(repo2);
         repos.validate(null);
@@ -97,8 +97,8 @@ public class ConfigReposConfigTest {
 
     @Test
     public void shouldNotErrorWhenReposFingerprintDiffer() {
-        ConfigRepoConfig repo1 = new ConfigRepoConfig(git("http://git"), "myplugin", "id1");
-        ConfigRepoConfig repo2 = new ConfigRepoConfig(git("https://git", "develop"), "myotherplugin", "id2");
+        ConfigRepoConfig repo1 = ConfigRepoConfig.createConfigRepoConfig(git("http://git"), "myplugin", "id1");
+        ConfigRepoConfig repo2 = ConfigRepoConfig.createConfigRepoConfig(git("https://git", "develop"), "myotherplugin", "id2");
         repos.add(repo1);
         repos.add(repo2);
         repos.validate(null);
@@ -108,7 +108,7 @@ public class ConfigReposConfigTest {
 
     @Test
     public void shouldReturnTrueIfContainsConfigRepoWithTheSpecifiedId() {
-        ConfigRepoConfig repo = new ConfigRepoConfig(git("http://git1"), "myplugin", "id");
+        ConfigRepoConfig repo = ConfigRepoConfig.createConfigRepoConfig(git("http://git1"), "myplugin", "id");
         repos.add(repo);
 
         assertThat(repos.hasConfigRepo(repo.getId()), is(true));

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/remote/RepoConfigOriginTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/remote/RepoConfigOriginTest.java
@@ -26,7 +26,7 @@ public class RepoConfigOriginTest {
     @Test
     public void shouldShowDisplayName()
     {
-        RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(svn("http://mysvn", false), "myplugin"), "123");
+        RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(svn("http://mysvn", false), "myplugin", "id"), "123");
         assertThat(repoConfigOrigin.displayName(),is("http://mysvn at 123"));
     }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/remote/RepoConfigOriginTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/remote/RepoConfigOriginTest.java
@@ -26,7 +26,7 @@ public class RepoConfigOriginTest {
     @Test
     public void shouldShowDisplayName()
     {
-        RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin(new ConfigRepoConfig(svn("http://mysvn", false), "myplugin"), "123");
+        RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(svn("http://mysvn", false), "myplugin"), "123");
         assertThat(repoConfigOrigin.displayName(),is("http://mysvn at 123"));
     }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/domain/PipelineGroupsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/domain/PipelineGroupsTest.java
@@ -115,8 +115,8 @@ public class PipelineGroupsTest {
         PipelineConfig pipeline2 = createPipelineConfig("pipeline1", "stage1");
         PipelineConfig pipeline3 = createPipelineConfig("pipeline1", "stage1");
         PipelineConfig pipeline4 = createPipelineConfig("pipeline1", "stage1");
-        pipeline3.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "rev1"));
-        pipeline4.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin"), "1"));
+        pipeline3.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "git-id"), "rev1"));
+        pipeline4.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin", "svn-id"), "1"));
         PipelineConfigs defaultGroup = createGroup("defaultGroup", pipeline1);
         PipelineConfigs anotherGroup = createGroup("anotherGroup", pipeline2);
         PipelineConfigs thirdGroup = createGroup("thirdGroup", pipeline3);

--- a/config/config-api/src/test/java/com/thoughtworks/go/domain/PipelineGroupsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/domain/PipelineGroupsTest.java
@@ -115,8 +115,8 @@ public class PipelineGroupsTest {
         PipelineConfig pipeline2 = createPipelineConfig("pipeline1", "stage1");
         PipelineConfig pipeline3 = createPipelineConfig("pipeline1", "stage1");
         PipelineConfig pipeline4 = createPipelineConfig("pipeline1", "stage1");
-        pipeline3.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "rev1"));
-        pipeline4.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin"), "1"));
+        pipeline3.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "rev1"));
+        pipeline4.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin"), "1"));
         PipelineConfigs defaultGroup = createGroup("defaultGroup", pipeline1);
         PipelineConfigs anotherGroup = createGroup("anotherGroup", pipeline2);
         PipelineConfigs thirdGroup = createGroup("thirdGroup", pipeline3);

--- a/config/config-api/src/test/java/com/thoughtworks/go/helper/EnvironmentConfigMother.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/helper/EnvironmentConfigMother.java
@@ -38,7 +38,7 @@ public class EnvironmentConfigMother {
 
     public static BasicEnvironmentConfig remote(String name) {
         BasicEnvironmentConfig env = environment(name);
-        env.setOrigins(new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.git("foo.git"), "json-plugon", "repo1"), "revision1"));
+        env.setOrigins(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.git("foo.git"), "json-plugon", "repo1"), "revision1"));
         return env;
     }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/helper/GoConfigMother.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/helper/GoConfigMother.java
@@ -340,7 +340,7 @@ public class GoConfigMother {
 
     public static CruiseConfig configWithConfigRepo() {
         CruiseConfig cruiseConfig = new BasicCruiseConfig();
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(new ConfigRepoConfig(
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(
                 git("https://github.com/tomzo/gocd-indep-config-part.git"), "myplugin", "id2"
         )));
         return cruiseConfig;

--- a/config/config-api/src/test/java/com/thoughtworks/go/helper/PartialConfigMother.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/helper/PartialConfigMother.java
@@ -121,7 +121,7 @@ public class PartialConfigMother {
     }
 
     public static RepoConfigOrigin createRepoOrigin() {
-        return new RepoConfigOrigin(new ConfigRepoConfig(git("http://some.git"), "myplugin", "repo-id"), "1234fed");
+        return new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(git("http://some.git"), "myplugin", "repo-id"), "1234fed");
     }
 
     public static PartialConfig withEnvironment(String name, RepoConfigOrigin repoConfigOrigin) {

--- a/config/config-server/src/main/resources/schemas/135_cruise-config.xsd
+++ b/config/config-server/src/main/resources/schemas/135_cruise-config.xsd
@@ -84,7 +84,7 @@
           </xsd:unique>
         </xsd:element>
       </xsd:sequence>
-      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="136"/>
+      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="135"/>
     </xsd:complexType>
     <xsd:unique name="uniquePipelines">
       <xsd:selector xpath="pipelines"/>
@@ -190,7 +190,6 @@
         <xsd:element name="scm" type="configRepoScmReferenceType"/>
       </xsd:choice>
       <xsd:element name="configuration" minOccurs="0" maxOccurs="1" type="configurationType"/>
-      <xsd:element name="rules" minOccurs="0" maxOccurs="1" type="rulesType"/>
     </xsd:sequence>
     <xsd:attribute type="nameType" name="id" use="required"/>
     <xsd:attribute type="nameType" name="pluginId" use="optional"/>

--- a/config/config-server/src/main/resources/upgrades/136.xsl
+++ b/config/config-server/src/main/resources/upgrades/136.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2020 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:template match="/cruise/@schemaVersion">
+        <xsl:attribute name="schemaVersion">136</xsl:attribute>
+    </xsl:template>
+    <!-- Copy everything -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="/cruise/config-repos/config-repo">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+            <rules>
+                <allow action="refer" type="*">*</allow>
+            </rules>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
@@ -181,7 +181,7 @@ public class MagicalGoConfigXmlLoaderTest {
         CruiseConfig cruiseConfig = xmlLoader.loadConfigHolder(ONE_CONFIG_REPO).config;
         assertThat(cruiseConfig.getConfigRepos().size()).isEqualTo(1);
         ConfigRepoConfig configRepo = cruiseConfig.getConfigRepos().get(0);
-        assertThat(configRepo.getMaterialConfig()).isEqualTo(git("https://github.com/tomzo/gocd-indep-config-part.git"));
+        assertThat(configRepo.getRepo()).isEqualTo(git("https://github.com/tomzo/gocd-indep-config-part.git"));
     }
 
     @Test
@@ -212,9 +212,9 @@ public class MagicalGoConfigXmlLoaderTest {
         )).config;
         assertThat(cruiseConfig.getConfigRepos().size()).isEqualTo(2);
         ConfigRepoConfig configRepo1 = cruiseConfig.getConfigRepos().get(0);
-        assertThat(configRepo1.getMaterialConfig()).isEqualTo(git("https://github.com/tomzo/gocd-indep-config-part.git"));
+        assertThat(configRepo1.getRepo()).isEqualTo(git("https://github.com/tomzo/gocd-indep-config-part.git"));
         ConfigRepoConfig configRepo2 = cruiseConfig.getConfigRepos().get(1);
-        assertThat(configRepo2.getMaterialConfig()).isEqualTo(git("https://github.com/tomzo/gocd-refmain-config-part.git"));
+        assertThat(configRepo2.getRepo()).isEqualTo(git("https://github.com/tomzo/gocd-refmain-config-part.git"));
     }
 
     @Test
@@ -4353,7 +4353,7 @@ public class MagicalGoConfigXmlLoaderTest {
         assertThat(((HgMaterialConfig) pipelineConfig.materialConfigs().get(0)).getBranch()).isEqualTo("feature");
 
         assertThat(config.getConfigRepos()).hasSize(1);
-        assertThat(((HgMaterialConfig) config.getConfigRepos().get(0).getMaterialConfig()).getBranch()).isEqualTo("feature");
+        assertThat(((HgMaterialConfig) config.getConfigRepos().get(0).getRepo()).getBranch()).isEqualTo("feature");
 
     }
 

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlWriterTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlWriterTest.java
@@ -49,13 +49,12 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.xmlunit.assertj.XmlAssert;
 
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.SchemaFactory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-
-import org.xmlunit.assertj.XmlAssert;
 
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
 import static com.thoughtworks.go.helper.MaterialConfigsMother.tfs;
@@ -169,7 +168,8 @@ public class MagicalGoConfigXmlWriterTest {
         CruiseConfig config = GoConfigMother.configWithConfigRepo();
         config.initializeServer();
         xmlWriter.write(config, output, false);
-        assertThat(output.toString(), containsString("<config-repo pluginId=\"myplugin\" id=\"id2\">"));
+
+        assertThat(output.toString(), containsString("<config-repo id=\"id2\" pluginId=\"myplugin\">"));
         assertThat(output.toString(), containsString("<git url=\"https://github.com/tomzo/gocd-indep-config-part.git\" />"));
     }
 

--- a/server/config/cruise-config.xml
+++ b/server/config/cruise-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="135">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="136">
   <server agentAutoRegisterKey="323040d4-f2e4-4b8a-8394-7a2d122054d1" webhookSecret="3d5cd2f5-7fe7-43c0-ba34-7e01678ba8b6" commandRepositoryLocation="default" serverId="60f5f682-5248-4ba9-bb35-72c92841bd75" tokenGenerationKey="8c3c8dc9-08bf-4cd7-ac80-cecb3e7ae86c">
     <security>
       <authConfigs>

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
@@ -104,7 +104,7 @@ public class ConfigReposMaterialParseResultManager {
     }
 
     private PartialConfigParseResult checkForMaterialErrors(String fingerprint) {
-        MaterialConfig naterial = configRepoService.findByFingerprint(fingerprint).getMaterialConfig();
+        MaterialConfig naterial = configRepoService.findByFingerprint(fingerprint).getRepo();
         HealthStateScope healthStateScope = HealthStateScope.forMaterialConfig(naterial);
         List<ServerHealthState> serverHealthStates = serverHealthService.filterByScope(healthStateScope);
 

--- a/server/src/main/java/com/thoughtworks/go/config/GoPartialConfig.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoPartialConfig.java
@@ -70,7 +70,7 @@ public class GoPartialConfig implements PartialConfigUpdateCompletedListener, Ch
 
     @Override
     public void onSuccessPartialConfig(ConfigRepoConfig repoConfig, PartialConfig newPart) {
-        String fingerprint = repoConfig.getMaterialConfig().getFingerprint();
+        String fingerprint = repoConfig.getRepo().getFingerprint();
         if (this.configWatchList.hasConfigRepoWithFingerprint(fingerprint)) {
             //TODO maybe validate new part without context of other partials or main config
 

--- a/server/src/main/java/com/thoughtworks/go/config/GoRepoConfigDataSource.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoRepoConfigDataSource.java
@@ -225,7 +225,7 @@ public class GoRepoConfigDataSource implements ChangedRepoConfigWatchListListene
 
         @Override
         public MaterialConfig configMaterial() {
-            return this.repoConfig.getMaterialConfig();
+            return this.repoConfig.getRepo();
         }
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/ConfigRepoCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ConfigRepoCommand.java
@@ -60,7 +60,9 @@ abstract class ConfigRepoCommand implements EntityConfigUpdateCommand<ConfigRepo
 
         preprocessedConfigRepo = preprocessedConfig.getConfigRepos().getConfigRepo(this.configRepo.getId());
 
-        if (!preprocessedConfigRepo.validateTree(new ConfigSaveValidationContext(preprocessedConfig))) {
+        preprocessedConfigRepo.validateTree(new ConfigSaveValidationContext(preprocessedConfig));
+
+        if (preprocessedConfigRepo.hasErrors()) {
             BasicCruiseConfig.copyErrors(preprocessedConfigRepo, configRepo);
             return false;
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/ConfigRepoCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ConfigRepoCommand.java
@@ -18,13 +18,17 @@ package com.thoughtworks.go.config.update;
 import com.thoughtworks.go.config.BasicCruiseConfig;
 import com.thoughtworks.go.config.ConfigSaveValidationContext;
 import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.ErrorCollector;
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
+import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.plugin.access.configrepo.ConfigRepoExtension;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+
+import java.util.List;
 
 import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static java.lang.String.format;
@@ -59,10 +63,10 @@ abstract class ConfigRepoCommand implements EntityConfigUpdateCommand<ConfigRepo
         }
 
         preprocessedConfigRepo = preprocessedConfig.getConfigRepos().getConfigRepo(this.configRepo.getId());
-
         preprocessedConfigRepo.validateTree(new ConfigSaveValidationContext(preprocessedConfig));
 
-        if (preprocessedConfigRepo.hasErrors()) {
+        List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(preprocessedConfigRepo);
+        if (!allErrors.isEmpty()) {
             BasicCruiseConfig.copyErrors(preprocessedConfigRepo, configRepo);
             return false;
         }

--- a/server/src/main/java/com/thoughtworks/go/server/service/ConfigRepoService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ConfigRepoService.java
@@ -63,7 +63,7 @@ public class ConfigRepoService {
             @Override
             public void onEntityConfigChange(ConfigRepoConfig entity) {
                 if (getConfigRepo(entity.getId()) != null) {
-                    materialUpdateService.updateMaterial(converter.toMaterial(entity.getMaterialConfig()));
+                    materialUpdateService.updateMaterial(converter.toMaterial(entity.getRepo()));
                 }
             }
         });
@@ -114,7 +114,7 @@ public class ConfigRepoService {
 
     public ConfigRepoConfig findByFingerprint(String fingerprint) {
         return getConfigRepos().stream()
-                .filter(configRepo -> configRepo.getMaterialConfig().getFingerprint().equalsIgnoreCase(fingerprint))
+                .filter(configRepo -> configRepo.getRepo().getFingerprint().equalsIgnoreCase(fingerprint))
                 .findFirst().orElse(null);
 
     }

--- a/server/src/main/webapp/WEB-INF/rails/spec/presenters/api_v1/shared/config_origin/config_repo_origin_representer_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/presenters/api_v1/shared/config_origin/config_repo_origin_representer_spec.rb
@@ -18,7 +18,7 @@ require 'rails_helper'
 
 describe ApiV1::Shared::ConfigOrigin::ConfigRepoOriginRepresenter do
   it 'should render remote config origin with hal representation' do
-    config_repo = ConfigRepoConfig.new(com.thoughtworks.go.helper.MaterialConfigsMother.git('https://github.com/config-repos/repo', 'master'), 'json-plugin', 'repo1')
+    config_repo = ConfigRepoConfig.createConfigRepoConfig(com.thoughtworks.go.helper.MaterialConfigsMother.git('https://github.com/config-repos/repo', 'master'), 'json-plugin', 'repo1')
     config_repo_origin = RepoConfigOrigin.new(config_repo, 'revision1')
     actual_json = ApiV1::Shared::ConfigOrigin::ConfigRepoOriginRepresenter.new(config_repo_origin).to_hash(url_builder: UrlBuilder.new)
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/CachedGoPartialsTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/CachedGoPartialsTest.java
@@ -45,9 +45,9 @@ public class CachedGoPartialsTest {
     public void setUp() throws Exception {
         serverHealthService = new ServerHealthService();
         partials = new CachedGoPartials(serverHealthService);
-        configRepo1 = ConfigRepoConfig.createConfigRepoConfig(git("url1"), "plugin");
+        configRepo1 = ConfigRepoConfig.createConfigRepoConfig(git("url1"), "plugin", "id1");
         part1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(configRepo1, "1"));
-        configRepo2 = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin");
+        configRepo2 = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin", "id2");
         part2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(configRepo2, "1"));
         partials.addOrUpdate(configRepo1.getRepo().getFingerprint(), part1);
         partials.addOrUpdate(configRepo2.getRepo().getFingerprint(), part2);

--- a/server/src/test-fast/java/com/thoughtworks/go/config/CachedGoPartialsTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/CachedGoPartialsTest.java
@@ -45,12 +45,12 @@ public class CachedGoPartialsTest {
     public void setUp() throws Exception {
         serverHealthService = new ServerHealthService();
         partials = new CachedGoPartials(serverHealthService);
-        configRepo1 = new ConfigRepoConfig(git("url1"), "plugin");
+        configRepo1 = ConfigRepoConfig.createConfigRepoConfig(git("url1"), "plugin");
         part1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(configRepo1, "1"));
-        configRepo2 = new ConfigRepoConfig(git("url2"), "plugin");
+        configRepo2 = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin");
         part2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(configRepo2, "1"));
-        partials.addOrUpdate(configRepo1.getMaterialConfig().getFingerprint(), part1);
-        partials.addOrUpdate(configRepo2.getMaterialConfig().getFingerprint(), part2);
+        partials.addOrUpdate(configRepo1.getRepo().getFingerprint(), part1);
+        partials.addOrUpdate(configRepo2.getRepo().getFingerprint(), part2);
         fingerprintForRepo1 = ((RepoConfigOrigin) part1.getOrigin()).getMaterial().getFingerprint();
         fingerprintForRepo2 = ((RepoConfigOrigin) part2.getOrigin()).getMaterial().getFingerprint();
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/CachedGoPartialsTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/CachedGoPartialsTest.java
@@ -88,7 +88,7 @@ public class CachedGoPartialsTest {
     public void shouldRemoveServerHealthMessageForAPartialWhenItsRemovedFromKnownList() {
         serverHealthService.update(ServerHealthState.error("err_repo1", "err desc", HealthStateType.general(HealthStateScope.forPartialConfigRepo(configRepo1))));
         serverHealthService.update(ServerHealthState.error("err_repo2", "err desc", HealthStateType.general(HealthStateScope.forPartialConfigRepo(configRepo2))));
-        partials.removeKnown(configRepo1.getMaterialConfig().getFingerprint());
+        partials.removeKnown(configRepo1.getRepo().getFingerprint());
         assertThat(partials.lastKnownPartials().contains(part1), is(false));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(configRepo1)).isEmpty(), is(true));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(configRepo2)).isEmpty(), is(false));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
@@ -60,7 +60,7 @@ class ConfigReposMaterialParseResultManagerTest {
 
         when(serverHealthService.filterByScope(any())).thenReturn(Collections.emptyList());
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
         when(configRepoService.findByFingerprint(anyString())).thenReturn(configRepoConfig);
 
         manager = new ConfigReposMaterialParseResultManager(serverHealthService, configRepoService);

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
@@ -60,7 +60,7 @@ class ConfigReposMaterialParseResultManagerTest {
 
         when(serverHealthService.filterByScope(any())).thenReturn(Collections.emptyList());
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
         when(configRepoService.findByFingerprint(anyString())).thenReturn(configRepoConfig);
 
         manager = new ConfigReposMaterialParseResultManager(serverHealthService, configRepoService);

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoConfigDaoMergedTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoConfigDaoMergedTest.java
@@ -43,7 +43,7 @@ public class GoConfigDaoMergedTest extends GoConfigDaoTestBase {
         List<PartialConfig> parts = new ArrayList<>();
         parts.add(new PartialConfig(new PipelineGroups(
                 PipelineConfigMother.createGroup("part1", PipelineConfigMother.pipelineConfig("remote-pipe")))));
-        parts.get(0).setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(git("http://config-repo.git"), "someplugin"), "3213455"));
+        parts.get(0).setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(git("http://config-repo.git"), "someplugin"), "3213455"));
 
         when(partials.lastPartials()).thenReturn(parts);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoConfigDaoMergedTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoConfigDaoMergedTest.java
@@ -43,7 +43,7 @@ public class GoConfigDaoMergedTest extends GoConfigDaoTestBase {
         List<PartialConfig> parts = new ArrayList<>();
         parts.add(new PartialConfig(new PipelineGroups(
                 PipelineConfigMother.createGroup("part1", PipelineConfigMother.pipelineConfig("remote-pipe")))));
-        parts.get(0).setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(git("http://config-repo.git"), "someplugin"), "3213455"));
+        parts.get(0).setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(git("http://config-repo.git"), "someplugin", "id"), "3213455"));
 
         when(partials.lastPartials()).thenReturn(parts);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoConfigWatchListTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoConfigWatchListTest.java
@@ -68,7 +68,7 @@ public class GoConfigWatchListTest {
     public void shouldNotifyConfigListenersWhenSingleConfigRepoHasChanged() throws Exception {
         final ChangedRepoConfigWatchListListener listener = mock(ChangedRepoConfigWatchListListener.class);
         watchList.registerListener(listener);
-        watchList.onEntityConfigChange(new ConfigRepoConfig(git("http://git1"), "myplugin", "id"));
+        watchList.onEntityConfigChange(ConfigRepoConfig.createConfigRepoConfig(git("http://git1"), "myplugin", "id"));
 
         verify(listener, times(2)).onChangedRepoConfigWatchList(notNull(ConfigReposConfig.class));
     }
@@ -77,7 +77,7 @@ public class GoConfigWatchListTest {
     public void shouldReturnTrueWhenHasConfigRepoWithFingerprint() {
         GitMaterialConfig gitrepo = git("http://configrepo.git");
         when(cruiseConfig.getConfigRepos()).thenReturn(new ConfigReposConfig(
-                new ConfigRepoConfig(gitrepo, "myplugin")));
+                ConfigRepoConfig.createConfigRepoConfig(gitrepo, "myplugin")));
 
         watchList = new GoConfigWatchList(cachedGoConfig, goConfigService);
 
@@ -88,7 +88,7 @@ public class GoConfigWatchListTest {
     public void shouldReturnFalseWhenDoesNotHaveConfigRepoWithFingerprint() {
         GitMaterialConfig gitrepo = git("http://configrepo.git");
         when(cruiseConfig.getConfigRepos()).thenReturn(new ConfigReposConfig(
-                new ConfigRepoConfig(gitrepo, "myplugin")));
+                ConfigRepoConfig.createConfigRepoConfig(gitrepo, "myplugin")));
 
         watchList = new GoConfigWatchList(cachedGoConfig, mock(GoConfigService.class));
 
@@ -100,7 +100,7 @@ public class GoConfigWatchListTest {
     @Test
     public void shouldReturnConfigRepoForMaterial() {
         GitMaterialConfig gitrepo = git("http://configrepo.git");
-        ConfigRepoConfig repoConfig = new ConfigRepoConfig(gitrepo, "myplugin");
+        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(gitrepo, "myplugin");
         when(cruiseConfig.getConfigRepos()).thenReturn(new ConfigReposConfig(
                 repoConfig));
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoConfigWatchListTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoConfigWatchListTest.java
@@ -77,7 +77,7 @@ public class GoConfigWatchListTest {
     public void shouldReturnTrueWhenHasConfigRepoWithFingerprint() {
         GitMaterialConfig gitrepo = git("http://configrepo.git");
         when(cruiseConfig.getConfigRepos()).thenReturn(new ConfigReposConfig(
-                ConfigRepoConfig.createConfigRepoConfig(gitrepo, "myplugin")));
+                ConfigRepoConfig.createConfigRepoConfig(gitrepo, "myplugin", "id")));
 
         watchList = new GoConfigWatchList(cachedGoConfig, goConfigService);
 
@@ -88,7 +88,7 @@ public class GoConfigWatchListTest {
     public void shouldReturnFalseWhenDoesNotHaveConfigRepoWithFingerprint() {
         GitMaterialConfig gitrepo = git("http://configrepo.git");
         when(cruiseConfig.getConfigRepos()).thenReturn(new ConfigReposConfig(
-                ConfigRepoConfig.createConfigRepoConfig(gitrepo, "myplugin")));
+                ConfigRepoConfig.createConfigRepoConfig(gitrepo, "myplugin", "id")));
 
         watchList = new GoConfigWatchList(cachedGoConfig, mock(GoConfigService.class));
 
@@ -100,7 +100,7 @@ public class GoConfigWatchListTest {
     @Test
     public void shouldReturnConfigRepoForMaterial() {
         GitMaterialConfig gitrepo = git("http://configrepo.git");
-        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(gitrepo, "myplugin");
+        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(gitrepo, "myplugin", "id");
         when(cruiseConfig.getConfigRepos()).thenReturn(new ConfigReposConfig(
                 repoConfig));
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoFileConfigDataSourceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoFileConfigDataSourceTest.java
@@ -115,8 +115,8 @@ public class GoFileConfigDataSourceTest {
 
     @Test
     public void shouldReturnTrueWhenValidPartialsListIsSameAsKnownPartialList() {
-        ConfigRepoConfig repo1 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin");
-        ConfigRepoConfig repo2 = new ConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin");
+        ConfigRepoConfig repo1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin");
+        ConfigRepoConfig repo2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin");
         PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(repo1, "git_r1"));
         PartialConfig partialConfig2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(repo2, "svn_r1"));
         List<PartialConfig> known = asList(partialConfig1, partialConfig2);
@@ -126,10 +126,10 @@ public class GoFileConfigDataSourceTest {
 
     @Test
     public void shouldReturnFalseWhenValidPartialsListIsNotTheSameAsKnownPartialList() {
-        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r1"));
-        PartialConfig partialConfig2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin"), "svn_r1"));
-        PartialConfig partialConfig3 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r2"));
-        PartialConfig partialConfig4 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin"), "svn_r2"));
+        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r1"));
+        PartialConfig partialConfig2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin"), "svn_r1"));
+        PartialConfig partialConfig3 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r2"));
+        PartialConfig partialConfig4 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin"), "svn_r2"));
         List<PartialConfig> known = asList(partialConfig1, partialConfig2);
         List<PartialConfig> valid = asList(partialConfig3, partialConfig4);
         assertThat(dataSource.areKnownPartialsSameAsValidPartials(known, valid), is(false));
@@ -137,8 +137,8 @@ public class GoFileConfigDataSourceTest {
 
     @Test
     public void shouldReturnFalseWhenValidPartialsListIsEmptyWhenKnownListIsNot() {
-        ConfigRepoConfig repo1 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin");
-        ConfigRepoConfig repo2 = new ConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin");
+        ConfigRepoConfig repo1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin");
+        ConfigRepoConfig repo2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin");
         PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(repo1, "git_r1"));
         PartialConfig partialConfig2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(repo2, "svn_r1"));
         List<PartialConfig> known = asList(partialConfig1, partialConfig2);
@@ -185,8 +185,8 @@ public class GoFileConfigDataSourceTest {
     @Test
     public void shouldFallbackOnLastValidPartialsIfUpdateWithLastKnownPartialsFails_OnWriteFullConfigWithLock() throws Exception {
         com.thoughtworks.go.server.newsecurity.SessionUtilsHelper.loginAs("loser_boozer");
-        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r1"));
-        PartialConfig partialConfig2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin"), "svn_r1"));
+        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r1"));
+        PartialConfig partialConfig2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin"), "svn_r1"));
         List<PartialConfig> known = asList(partialConfig1);
         List<PartialConfig> valid = asList(partialConfig2);
 
@@ -225,7 +225,7 @@ public class GoFileConfigDataSourceTest {
 
     @Test(expected = RuntimeException.class)
     public void shouldNotRetryConfigUpdateIfLastKnownAndValidPartialsAreSame_OnWriteFullConfigWithLock() throws Exception {
-        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r1"));
+        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r1"));
         List<PartialConfig> known = asList(partialConfig1);
         List<PartialConfig> valid = asList(partialConfig1);
 
@@ -260,7 +260,7 @@ public class GoFileConfigDataSourceTest {
 
     @Test
     public void shouldUpdateAndReloadConfigUsingFullSaveNormalFlowWithLastKnownPartials_onLoad() throws Exception {
-        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r1"));
+        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r1"));
         List<PartialConfig> lastKnownPartials = asList(partialConfig1);
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         MagicalGoConfigXmlLoader.setMd5(cruiseConfig, "md5");

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoFileConfigDataSourceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoFileConfigDataSourceTest.java
@@ -115,8 +115,8 @@ public class GoFileConfigDataSourceTest {
 
     @Test
     public void shouldReturnTrueWhenValidPartialsListIsSameAsKnownPartialList() {
-        ConfigRepoConfig repo1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin");
-        ConfigRepoConfig repo2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin");
+        ConfigRepoConfig repo1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "id1");
+        ConfigRepoConfig repo2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin", "id2");
         PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(repo1, "git_r1"));
         PartialConfig partialConfig2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(repo2, "svn_r1"));
         List<PartialConfig> known = asList(partialConfig1, partialConfig2);
@@ -126,10 +126,10 @@ public class GoFileConfigDataSourceTest {
 
     @Test
     public void shouldReturnFalseWhenValidPartialsListIsNotTheSameAsKnownPartialList() {
-        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r1"));
-        PartialConfig partialConfig2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin"), "svn_r1"));
-        PartialConfig partialConfig3 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r2"));
-        PartialConfig partialConfig4 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin"), "svn_r2"));
+        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "id1"), "git_r1"));
+        PartialConfig partialConfig2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin", "id2"), "svn_r1"));
+        PartialConfig partialConfig3 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "id3"), "git_r2"));
+        PartialConfig partialConfig4 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin", "id4"), "svn_r2"));
         List<PartialConfig> known = asList(partialConfig1, partialConfig2);
         List<PartialConfig> valid = asList(partialConfig3, partialConfig4);
         assertThat(dataSource.areKnownPartialsSameAsValidPartials(known, valid), is(false));
@@ -137,8 +137,8 @@ public class GoFileConfigDataSourceTest {
 
     @Test
     public void shouldReturnFalseWhenValidPartialsListIsEmptyWhenKnownListIsNot() {
-        ConfigRepoConfig repo1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin");
-        ConfigRepoConfig repo2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin");
+        ConfigRepoConfig repo1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "id1");
+        ConfigRepoConfig repo2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin", "id2");
         PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(repo1, "git_r1"));
         PartialConfig partialConfig2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(repo2, "svn_r1"));
         List<PartialConfig> known = asList(partialConfig1, partialConfig2);
@@ -185,8 +185,8 @@ public class GoFileConfigDataSourceTest {
     @Test
     public void shouldFallbackOnLastValidPartialsIfUpdateWithLastKnownPartialsFails_OnWriteFullConfigWithLock() throws Exception {
         com.thoughtworks.go.server.newsecurity.SessionUtilsHelper.loginAs("loser_boozer");
-        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r1"));
-        PartialConfig partialConfig2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin"), "svn_r1"));
+        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "id1"), "git_r1"));
+        PartialConfig partialConfig2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.svnMaterialConfig(), "plugin", "id2"), "svn_r1"));
         List<PartialConfig> known = asList(partialConfig1);
         List<PartialConfig> valid = asList(partialConfig2);
 
@@ -225,7 +225,7 @@ public class GoFileConfigDataSourceTest {
 
     @Test(expected = RuntimeException.class)
     public void shouldNotRetryConfigUpdateIfLastKnownAndValidPartialsAreSame_OnWriteFullConfigWithLock() throws Exception {
-        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r1"));
+        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "id"), "git_r1"));
         List<PartialConfig> known = asList(partialConfig1);
         List<PartialConfig> valid = asList(partialConfig1);
 
@@ -260,7 +260,7 @@ public class GoFileConfigDataSourceTest {
 
     @Test
     public void shouldUpdateAndReloadConfigUsingFullSaveNormalFlowWithLastKnownPartials_onLoad() throws Exception {
-        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin"), "git_r1"));
+        PartialConfig partialConfig1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "id"), "git_r1"));
         List<PartialConfig> lastKnownPartials = asList(partialConfig1);
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         MagicalGoConfigXmlLoader.setMd5(cruiseConfig, "md5");

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoPartialConfigTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoPartialConfigTest.java
@@ -62,7 +62,7 @@ public class GoPartialConfigTest {
         when(configPluginService.partialConfigProviderFor(any(ConfigRepoConfig.class))).thenReturn(plugin);
 
         cruiseConfig = new BasicCruiseConfig();
-        configRepoConfig = new ConfigRepoConfig(git("url"), "plugin");
+        configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url"), "plugin");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig));
         cachedGoConfig = mock(CachedGoConfig.class);
         when(cachedGoConfig.currentConfig()).thenReturn(cruiseConfig);
@@ -110,7 +110,7 @@ public class GoPartialConfigTest {
 
     private ScmMaterialConfig setOneConfigRepo() {
         ScmMaterialConfig material = git("http://my.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(new ConfigRepoConfig(material, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin")));
         configWatchList.onConfigChange(cruiseConfig);
         return material;
     }
@@ -176,7 +176,7 @@ public class GoPartialConfigTest {
 
         // we change current configuration
         ScmMaterialConfig othermaterial = git("http://myother.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(new ConfigRepoConfig(othermaterial, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(othermaterial, "myplugin")));
         configWatchList.onConfigChange(cruiseConfig);
 
         assertThat(partialConfig.lastPartials().size(), is(0));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoPartialConfigTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoPartialConfigTest.java
@@ -62,7 +62,7 @@ public class GoPartialConfigTest {
         when(configPluginService.partialConfigProviderFor(any(ConfigRepoConfig.class))).thenReturn(plugin);
 
         cruiseConfig = new BasicCruiseConfig();
-        configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url"), "plugin");
+        configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url"), "plugin", "id");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig));
         cachedGoConfig = mock(CachedGoConfig.class);
         when(cachedGoConfig.currentConfig()).thenReturn(cruiseConfig);
@@ -110,7 +110,7 @@ public class GoPartialConfigTest {
 
     private ScmMaterialConfig setOneConfigRepo() {
         ScmMaterialConfig material = git("http://my.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id")));
         configWatchList.onConfigChange(cruiseConfig);
         return material;
     }
@@ -176,7 +176,7 @@ public class GoPartialConfigTest {
 
         // we change current configuration
         ScmMaterialConfig othermaterial = git("http://myother.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(othermaterial, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(othermaterial, "myplugin", "other-id")));
         configWatchList.onConfigChange(cruiseConfig);
 
         assertThat(partialConfig.lastPartials().size(), is(0));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoRepoConfigDataSourceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoRepoConfigDataSourceTest.java
@@ -72,14 +72,14 @@ public class GoRepoConfigDataSourceTest {
         repoConfigDataSource = new GoRepoConfigDataSource(configWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
 
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
         when(configRepoService.findByFingerprint(anyString())).thenReturn(configRepoConfig);
     }
 
     @Test
     public void shouldCallPluginLoadOnCheckout_WhenMaterialInWatchList() {
         ScmMaterialConfig material = git("http://my.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id")));
         configWatchList.onConfigChange(cruiseConfig);
 
         repoConfigDataSource.onCheckoutComplete(material, folder, getModificationFor("7a8f"));
@@ -90,7 +90,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldAssignConfigOrigin() throws Exception {
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepo));
         configWatchList.onConfigChange(cruiseConfig);
 
@@ -105,7 +105,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldAssignConfigOriginInPipelines() throws Exception {
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepo));
         configWatchList.onConfigChange(cruiseConfig);
 
@@ -127,7 +127,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldAssignConfigOriginInEnvironments() throws Exception {
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepo));
         configWatchList.onConfigChange(cruiseConfig);
 
@@ -150,7 +150,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldProvideParseContextWhenCallingPlugin() throws Exception {
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig));
         configWatchList.onConfigChange(cruiseConfig);
 
@@ -164,7 +164,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldProvideConfigurationInParseContextWhenCallingPlugin() throws Exception {
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig));
         configWatchList.onConfigChange(cruiseConfig);
 
@@ -209,7 +209,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldReturnLatestPartialConfigForMaterial_WhenPartialExists() throws Exception {
         ScmMaterialConfig material = git("http://my.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id")));
         configWatchList.onConfigChange(cruiseConfig);
 
         repoConfigDataSource.onCheckoutComplete(material, folder, getModificationFor("7a8f"));
@@ -224,7 +224,7 @@ public class GoRepoConfigDataSourceTest {
                 .thenReturn(new BrokenConfigPlugin());
 
         ScmMaterialConfig material = git("http://my.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id")));
         configWatchList.onConfigChange(cruiseConfig);
 
         repoConfigDataSource.onCheckoutComplete(material, folder, getModificationFor("7a8f"));
@@ -246,7 +246,7 @@ public class GoRepoConfigDataSourceTest {
                 .thenReturn(new BrokenConfigPlugin());
 
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig));
         configWatchList.onConfigChange(cruiseConfig);
 
@@ -260,7 +260,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldSetOKHealthState_AtConfigRepoScope_WhenPluginHasParsed() {
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig));
         configWatchList.onConfigChange(cruiseConfig);
 
@@ -297,7 +297,7 @@ public class GoRepoConfigDataSourceTest {
                 .thenThrow(new RuntimeException("Failed to initialize plugin"));
 
         ScmMaterialConfig material = git("http://my.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id")));
         configWatchList.onConfigChange(cruiseConfig);
 
         repoConfigDataSource.onCheckoutComplete(material, folder, getModificationFor("7a8f"));
@@ -314,7 +314,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldRemovePartialsWhenRemovedFromWatchList() throws Exception {
         ScmMaterialConfig material = git("http://my.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id")));
         configWatchList.onConfigChange(cruiseConfig);
 
         repoConfigDataSource.onCheckoutComplete(material, folder, getModificationFor("7a8f"));
@@ -322,7 +322,7 @@ public class GoRepoConfigDataSourceTest {
 
         // we change current configuration
         ScmMaterialConfig othermaterial = git("http://myother.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(othermaterial, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(othermaterial, "myplugin", "id")));
         configWatchList.onConfigChange(cruiseConfig);
 
         assertNull(repoConfigDataSource.latestPartialConfigForMaterial(material));
@@ -336,7 +336,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldMaintainAListOfConfigReposWhichHaveChangedSinceLastParse() {
         GitMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
         GoConfigWatchList goConfigWatchList = mock(GoConfigWatchList.class);
         repoConfigDataSource = new GoRepoConfigDataSource(goConfigWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
 
@@ -350,7 +350,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void onParseOfConfigRepo_shouldUpdateTheListOfConfigReposWhichHaveChanged() {
         GitMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
         GoConfigWatchList goConfigWatchList = mock(GoConfigWatchList.class);
         repoConfigDataSource = new GoRepoConfigDataSource(goConfigWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoRepoConfigDataSourceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoRepoConfigDataSourceTest.java
@@ -72,14 +72,14 @@ public class GoRepoConfigDataSourceTest {
         repoConfigDataSource = new GoRepoConfigDataSource(configWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
 
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
         when(configRepoService.findByFingerprint(anyString())).thenReturn(configRepoConfig);
     }
 
     @Test
     public void shouldCallPluginLoadOnCheckout_WhenMaterialInWatchList() {
         ScmMaterialConfig material = git("http://my.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(new ConfigRepoConfig(material, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin")));
         configWatchList.onConfigChange(cruiseConfig);
 
         repoConfigDataSource.onCheckoutComplete(material, folder, getModificationFor("7a8f"));
@@ -90,7 +90,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldAssignConfigOrigin() throws Exception {
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepo = new ConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepo));
         configWatchList.onConfigChange(cruiseConfig);
 
@@ -105,7 +105,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldAssignConfigOriginInPipelines() throws Exception {
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepo = new ConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepo));
         configWatchList.onConfigChange(cruiseConfig);
 
@@ -127,7 +127,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldAssignConfigOriginInEnvironments() throws Exception {
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepo = new ConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepo));
         configWatchList.onConfigChange(cruiseConfig);
 
@@ -150,7 +150,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldProvideParseContextWhenCallingPlugin() throws Exception {
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig repoConfig = new ConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig));
         configWatchList.onConfigChange(cruiseConfig);
 
@@ -164,7 +164,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldProvideConfigurationInParseContextWhenCallingPlugin() throws Exception {
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig repoConfig = new ConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig));
         configWatchList.onConfigChange(cruiseConfig);
 
@@ -209,7 +209,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldReturnLatestPartialConfigForMaterial_WhenPartialExists() throws Exception {
         ScmMaterialConfig material = git("http://my.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(new ConfigRepoConfig(material, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin")));
         configWatchList.onConfigChange(cruiseConfig);
 
         repoConfigDataSource.onCheckoutComplete(material, folder, getModificationFor("7a8f"));
@@ -224,7 +224,7 @@ public class GoRepoConfigDataSourceTest {
                 .thenReturn(new BrokenConfigPlugin());
 
         ScmMaterialConfig material = git("http://my.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(new ConfigRepoConfig(material, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin")));
         configWatchList.onConfigChange(cruiseConfig);
 
         repoConfigDataSource.onCheckoutComplete(material, folder, getModificationFor("7a8f"));
@@ -246,7 +246,7 @@ public class GoRepoConfigDataSourceTest {
                 .thenReturn(new BrokenConfigPlugin());
 
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig));
         configWatchList.onConfigChange(cruiseConfig);
 
@@ -260,7 +260,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldSetOKHealthState_AtConfigRepoScope_WhenPluginHasParsed() {
         ScmMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(configRepoConfig));
         configWatchList.onConfigChange(cruiseConfig);
 
@@ -297,7 +297,7 @@ public class GoRepoConfigDataSourceTest {
                 .thenThrow(new RuntimeException("Failed to initialize plugin"));
 
         ScmMaterialConfig material = git("http://my.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(new ConfigRepoConfig(material, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin")));
         configWatchList.onConfigChange(cruiseConfig);
 
         repoConfigDataSource.onCheckoutComplete(material, folder, getModificationFor("7a8f"));
@@ -314,7 +314,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldRemovePartialsWhenRemovedFromWatchList() throws Exception {
         ScmMaterialConfig material = git("http://my.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(new ConfigRepoConfig(material, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(material, "myplugin")));
         configWatchList.onConfigChange(cruiseConfig);
 
         repoConfigDataSource.onCheckoutComplete(material, folder, getModificationFor("7a8f"));
@@ -322,7 +322,7 @@ public class GoRepoConfigDataSourceTest {
 
         // we change current configuration
         ScmMaterialConfig othermaterial = git("http://myother.git");
-        cruiseConfig.setConfigRepos(new ConfigReposConfig(new ConfigRepoConfig(othermaterial, "myplugin")));
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(ConfigRepoConfig.createConfigRepoConfig(othermaterial, "myplugin")));
         configWatchList.onConfigChange(cruiseConfig);
 
         assertNull(repoConfigDataSource.latestPartialConfigForMaterial(material));
@@ -336,7 +336,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void shouldMaintainAListOfConfigReposWhichHaveChangedSinceLastParse() {
         GitMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
         GoConfigWatchList goConfigWatchList = mock(GoConfigWatchList.class);
         repoConfigDataSource = new GoRepoConfigDataSource(goConfigWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
 
@@ -350,7 +350,7 @@ public class GoRepoConfigDataSourceTest {
     @Test
     public void onParseOfConfigRepo_shouldUpdateTheListOfConfigReposWhichHaveChanged() {
         GitMaterialConfig material = git("http://my.git");
-        ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(material, "myplugin");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin");
         GoConfigWatchList goConfigWatchList = mock(GoConfigWatchList.class);
         repoConfigDataSource = new GoRepoConfigDataSource(goConfigWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateConfigRepoCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateConfigRepoCommandTest.java
@@ -17,7 +17,6 @@ package com.thoughtworks.go.config.update;
 
 import com.thoughtworks.go.config.BasicCruiseConfig;
 import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.helper.GoConfigMother;
@@ -30,7 +29,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
-import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -56,7 +54,7 @@ public class CreateConfigRepoCommandTest {
         result = new HttpLocalizedOperationResult();
 
         cruiseConfig = new GoConfigMother().defaultCruiseConfig();
-        configRepo = new ConfigRepoConfig(git("https://foo.git", "master"), "json-plugin", repoId);
+        configRepo = ConfigRepoConfig.createConfigRepoConfig(git("https://foo.git", "master"), "json-plugin", repoId);
     }
 
     @Test
@@ -71,14 +69,14 @@ public class CreateConfigRepoCommandTest {
     public void isValid_shouldValidateConfigRepo() {
         GitMaterialConfig material = git("https://foo.git", "master");
         material.setAutoUpdate(false);
-        configRepo.setMaterialConfig(material);
+        configRepo.setRepo(material);
         when(configRepoExtension.canHandlePlugin(configRepo.getPluginId())).thenReturn(true);
 
         CreateConfigRepoCommand command = new CreateConfigRepoCommand(securityService, configRepo, currentUser, result, configRepoExtension);
         command.update(cruiseConfig);
 
         assertFalse(command.isValid(cruiseConfig));
-        assertThat(configRepo.getMaterialConfig().errors().on("autoUpdate"), is("Configuration repository material 'https://foo.git' must have autoUpdate enabled."));
+        assertThat(configRepo.getRepo().errors().on("autoUpdate"), is("Configuration repository material 'https://foo.git' must have autoUpdate enabled."));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateConfigRepoCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateConfigRepoCommandTest.java
@@ -53,7 +53,7 @@ public class CreateConfigRepoCommandTest {
         currentUser = new Username(new CaseInsensitiveString("user"));
         result = new HttpLocalizedOperationResult();
 
-        cruiseConfig = new GoConfigMother().defaultCruiseConfig();
+        cruiseConfig = GoConfigMother.defaultCruiseConfig();
         configRepo = ConfigRepoConfig.createConfigRepoConfig(git("https://foo.git", "master"), "json-plugin", repoId);
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteConfigRepoCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteConfigRepoCommandTest.java
@@ -51,7 +51,7 @@ public class DeleteConfigRepoCommandTest {
         currentUser = new Username(new CaseInsensitiveString("user"));
         cruiseConfig = new GoConfigMother().defaultCruiseConfig();
         repoId = "repo-1";
-        configRepo = new ConfigRepoConfig(git("http://foo.git", "master"), "plugin-id", repoId);
+        configRepo = ConfigRepoConfig.createConfigRepoConfig(git("http://foo.git", "master"), "plugin-id", repoId);
         result = new HttpLocalizedOperationResult();
         cruiseConfig.getConfigRepos().add(configRepo);
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteEnvironmentCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteEnvironmentCommandTest.java
@@ -18,10 +18,8 @@ package com.thoughtworks.go.config.update;
 import com.thoughtworks.go.config.BasicCruiseConfig;
 import com.thoughtworks.go.config.BasicEnvironmentConfig;
 import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.merge.MergeConfigOrigin;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
-import com.thoughtworks.go.config.remote.FileConfigOrigin;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.helper.MaterialConfigsMother;
@@ -34,7 +32,6 @@ import org.mockito.Mock;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class DeleteEnvironmentCommandTest {
@@ -82,7 +79,7 @@ public class DeleteEnvironmentCommandTest {
     @Test
     public void shouldNotBeAbleToDeleteIfEnvironmentPartiallyDefinedInConfigRepository() {
         BasicEnvironmentConfig environmentConfig = new BasicEnvironmentConfig(environmentName);
-        RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1");
+        RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1");
         MergeConfigOrigin origins = new MergeConfigOrigin(repoConfigOrigin);
         environmentConfig.setOrigins(origins);
         DeleteEnvironmentCommand command = new DeleteEnvironmentCommand(goConfigService, environmentConfig, currentUser, actionFailed, result);

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/PatchEnvironmentCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/PatchEnvironmentCommandTest.java
@@ -16,7 +16,6 @@
 package com.thoughtworks.go.config.update;
 
 import com.thoughtworks.go.config.*;
-import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.merge.MergeEnvironmentConfig;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.FileConfigOrigin;
@@ -25,7 +24,6 @@ import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
-import com.thoughtworks.go.serverhealth.HealthStateType;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -35,7 +33,6 @@ import java.util.ArrayList;
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class PatchEnvironmentCommandTest {
@@ -186,7 +183,7 @@ public class PatchEnvironmentCommandTest {
         local.setOrigins(new FileConfigOrigin());
         BasicEnvironmentConfig remote = new BasicEnvironmentConfig(environmentName);
         remote.addPipeline(pipelineName);
-        ConfigRepoConfig configRepo = new ConfigRepoConfig(git("foo/bar.git", "master"), "myPlugin");
+        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(git("foo/bar.git", "master"), "myPlugin");
         remote.setOrigins(new RepoConfigOrigin(configRepo, "latest"));
 
         MergeEnvironmentConfig mergedConfig = new MergeEnvironmentConfig(local, remote);
@@ -216,7 +213,7 @@ public class PatchEnvironmentCommandTest {
         local.setOrigins(new FileConfigOrigin());
         BasicEnvironmentConfig remote = new BasicEnvironmentConfig(environmentName);
         remote.addEnvironmentVariable(variableName, "bar");
-        ConfigRepoConfig configRepo = new ConfigRepoConfig(git("foo/bar.git", "master"), "myPlugin");
+        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(git("foo/bar.git", "master"), "myPlugin");
         remote.setOrigins(new RepoConfigOrigin(configRepo, "latest"));
 
         MergeEnvironmentConfig mergedConfig = new MergeEnvironmentConfig(local, remote);

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/PatchEnvironmentCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/PatchEnvironmentCommandTest.java
@@ -183,7 +183,7 @@ public class PatchEnvironmentCommandTest {
         local.setOrigins(new FileConfigOrigin());
         BasicEnvironmentConfig remote = new BasicEnvironmentConfig(environmentName);
         remote.addPipeline(pipelineName);
-        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(git("foo/bar.git", "master"), "myPlugin");
+        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(git("foo/bar.git", "master"), "myPlugin", "id");
         remote.setOrigins(new RepoConfigOrigin(configRepo, "latest"));
 
         MergeEnvironmentConfig mergedConfig = new MergeEnvironmentConfig(local, remote);
@@ -213,7 +213,7 @@ public class PatchEnvironmentCommandTest {
         local.setOrigins(new FileConfigOrigin());
         BasicEnvironmentConfig remote = new BasicEnvironmentConfig(environmentName);
         remote.addEnvironmentVariable(variableName, "bar");
-        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(git("foo/bar.git", "master"), "myPlugin");
+        ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(git("foo/bar.git", "master"), "myPlugin", "id");
         remote.setOrigins(new RepoConfigOrigin(configRepo, "latest"));
 
         MergeEnvironmentConfig mergedConfig = new MergeEnvironmentConfig(local, remote);

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateConfigRepoCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateConfigRepoCommandTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
-import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -62,8 +61,8 @@ public class UpdateConfigRepoCommandTest {
         cruiseConfig = new GoConfigMother().defaultCruiseConfig();
         oldConfigRepoId = "old-repo";
         newConfigRepoId = "new-repo";
-        oldConfigRepo = new ConfigRepoConfig(git("foo.git", "master"), "json-plugin", oldConfigRepoId);
-        newConfigRepo = new ConfigRepoConfig(git("bar.git", "master"), "yaml-plugin", newConfigRepoId);
+        oldConfigRepo = ConfigRepoConfig.createConfigRepoConfig(git("foo.git", "master"), "json-plugin", oldConfigRepoId);
+        newConfigRepo = ConfigRepoConfig.createConfigRepoConfig(git("bar.git", "master"), "yaml-plugin", newConfigRepoId);
         result = new HttpLocalizedOperationResult();
         md5 = "md5";
         cruiseConfig.getConfigRepos().add(oldConfigRepo);
@@ -92,7 +91,7 @@ public class UpdateConfigRepoCommandTest {
 
     @Test
     public void isValid_shouldValidateConfigRepo() {
-        newConfigRepo.setMaterialConfig(git("foobar.git", "master"));
+        newConfigRepo.setRepo(git("foobar.git", "master"));
         cruiseConfig.getConfigRepos().add(newConfigRepo);
         UpdateConfigRepoCommand command = new UpdateConfigRepoCommand(securityService, entityHashingService, oldConfigRepoId, newConfigRepo, md5, currentUser, result, configRepoExtension);
         when(configRepoExtension.canHandlePlugin(newConfigRepo.getPluginId())).thenReturn(true);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/scheduling/BuildCauseProducerServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/scheduling/BuildCauseProducerServiceTest.java
@@ -398,7 +398,7 @@ public class BuildCauseProducerServiceTest {
         HgMaterialConfig materialConfig1 = hg("url", null);
 
         pipelineConfig.addMaterialConfig(materialConfig1);
-        pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(materialConfig1, "plug"), "revision1"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig1, "plug"), "revision1"));
 
         when(materialConfigConverter.toMaterial(materialConfig1)).thenReturn(material1);
         when(goConfigService.hasPipelineNamed(pipelineConfig.name())).thenReturn(true);
@@ -422,7 +422,7 @@ public class BuildCauseProducerServiceTest {
         HgMaterialConfig materialConfig2 = hg("url2", null);
 
         pipelineConfig.addMaterialConfig(materialConfig1);
-        pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(materialConfig2, "plug"), "revision1"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig2, "plug"), "revision1"));
 
         when(materialConfigConverter.toMaterial(materialConfig1)).thenReturn(material1);
         when(materialConfigConverter.toMaterial(materialConfig2)).thenReturn(new MaterialConfigConverter().toMaterial(materialConfig2));
@@ -448,7 +448,7 @@ public class BuildCauseProducerServiceTest {
         HgMaterialConfig materialConfig2 = hg("url2", null);
 
         pipelineConfig.addMaterialConfig(materialConfig1);
-        pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(materialConfig1, "plug"), "revision1"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig1, "plug"), "revision1"));
 
         when(materialConfigConverter.toMaterial(materialConfig1)).thenReturn(material1);
         when(materialConfigConverter.toMaterial(materialConfig2)).thenReturn(material2);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/scheduling/BuildCauseProducerServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/scheduling/BuildCauseProducerServiceTest.java
@@ -398,7 +398,7 @@ public class BuildCauseProducerServiceTest {
         HgMaterialConfig materialConfig1 = hg("url", null);
 
         pipelineConfig.addMaterialConfig(materialConfig1);
-        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig1, "plug"), "revision1"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig1, "plug", "id"), "revision1"));
 
         when(materialConfigConverter.toMaterial(materialConfig1)).thenReturn(material1);
         when(goConfigService.hasPipelineNamed(pipelineConfig.name())).thenReturn(true);
@@ -422,7 +422,7 @@ public class BuildCauseProducerServiceTest {
         HgMaterialConfig materialConfig2 = hg("url2", null);
 
         pipelineConfig.addMaterialConfig(materialConfig1);
-        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig2, "plug"), "revision1"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig2, "plug", "id"), "revision1"));
 
         when(materialConfigConverter.toMaterial(materialConfig1)).thenReturn(material1);
         when(materialConfigConverter.toMaterial(materialConfig2)).thenReturn(new MaterialConfigConverter().toMaterial(materialConfig2));
@@ -448,7 +448,7 @@ public class BuildCauseProducerServiceTest {
         HgMaterialConfig materialConfig2 = hg("url2", null);
 
         pipelineConfig.addMaterialConfig(materialConfig1);
-        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig1, "plug"), "revision1"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(materialConfig1, "plug", "id"), "revision1"));
 
         when(materialConfigConverter.toMaterial(materialConfig1)).thenReturn(material1);
         when(materialConfigConverter.toMaterial(materialConfig2)).thenReturn(material2);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ConfigRepoServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ConfigRepoServiceTest.java
@@ -55,7 +55,7 @@ class ConfigRepoServiceTest {
         this.repoId = "repo-1";
         this.pluginId = "json-config-repo-plugin";
         MaterialConfig repoMaterial = git("https://foo.git", "master");
-        this.configRepo = new ConfigRepoConfig(repoMaterial, pluginId, repoId);
+        this.configRepo = ConfigRepoConfig.createConfigRepoConfig(repoMaterial, pluginId, repoId);
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
@@ -57,7 +57,7 @@ public class PipelineConfigServiceTest {
         cruiseConfig = new BasicCruiseConfig(configs);
         cruiseConfig.addEnvironment(environment("foo", "in_env"));
         PipelineConfig remotePipeline = PipelineConfigMother.pipelineConfig("remote");
-        remotePipeline.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(git("url"), "plugin"), "1234"));
+        remotePipeline.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(git("url"), "plugin", "id"), "1234"));
         cruiseConfig.addPipeline("group", remotePipeline);
 
         goConfigService = mock(GoConfigService.class);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
@@ -57,7 +57,7 @@ public class PipelineConfigServiceTest {
         cruiseConfig = new BasicCruiseConfig(configs);
         cruiseConfig.addEnvironment(environment("foo", "in_env"));
         PipelineConfig remotePipeline = PipelineConfigMother.pipelineConfig("remote");
-        remotePipeline.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(git("url"), "plugin"), "1234"));
+        remotePipeline.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(git("url"), "plugin"), "1234"));
         cruiseConfig.addPipeline("group", remotePipeline);
 
         goConfigService = mock(GoConfigService.class);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSchedulerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSchedulerTest.java
@@ -211,8 +211,8 @@ public class PipelineSchedulerTest {
     public void shouldRemovePipelinesOnConfigRepoDeletion() {
         //setup 2 config repos
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
-        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
-        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
+        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin", "id1");
+        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin", "id2");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig1, repoConfig2));
         PartialConfig partialConfigInRepo1 = PartialConfigMother.withPipeline("pipeline_in_repo1", new RepoConfigOrigin(repoConfig1, "repo1_r1"));
         PartialConfig partialConfigInRepo2 = PartialConfigMother.withPipeline("pipeline_in_repo2", new RepoConfigOrigin(repoConfig2, "repo2_r1"));

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSchedulerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSchedulerTest.java
@@ -211,8 +211,8 @@ public class PipelineSchedulerTest {
     public void shouldRemovePipelinesOnConfigRepoDeletion() {
         //setup 2 config repos
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
-        ConfigRepoConfig repoConfig1 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
-        ConfigRepoConfig repoConfig2 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
+        ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
+        ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
         cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig1, repoConfig2));
         PartialConfig partialConfigInRepo1 = PartialConfigMother.withPipeline("pipeline_in_repo1", new RepoConfigOrigin(repoConfig1, "repo1_r1"));
         PartialConfig partialConfigInRepo2 = PartialConfigMother.withPipeline("pipeline_in_repo2", new RepoConfigOrigin(repoConfig2, "repo2_r1"));

--- a/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
@@ -151,7 +151,7 @@ public class CachedGoConfigIntegrationTest {
         configHelper.onSetUp();
         externalConfigRepo = temporaryFolder.newFolder();
         latestModification = setupExternalConfigRepo(externalConfigRepo);
-        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(git(externalConfigRepo.getAbsolutePath()), XmlPartialConfigProvider.providerName));
+        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(git(externalConfigRepo.getAbsolutePath()), XmlPartialConfigProvider.providerName, "gocd-id"));
         goConfigService.forceNotifyListeners();
         configRepo = configWatchList.getCurrentConfigRepos().get(0);
         cachedGoPartials.clear();
@@ -177,7 +177,7 @@ public class CachedGoConfigIntegrationTest {
         File downstreamExternalConfigRepo = temporaryFolder.newFolder();
         /*here is a pipeline 'downstream' with material dependency on 'pipe1' in other repository*/
         Modification downstreamLatestModification = setupExternalConfigRepo(downstreamExternalConfigRepo, "external_git_config_repo_referencing_first");
-        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(git(downstreamExternalConfigRepo.getAbsolutePath()), "gocd-xml"));
+        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(git(downstreamExternalConfigRepo.getAbsolutePath()), "gocd-xml", "id"));
         goConfigService.forceNotifyListeners();//TODO what if this is not called?
         ConfigRepoConfig downstreamConfigRepo = configWatchList.getCurrentConfigRepos().get(1);
         assertThat(configWatchList.getCurrentConfigRepos().size()).isEqualTo(2);
@@ -211,11 +211,11 @@ public class CachedGoConfigIntegrationTest {
         File secondDownstreamExternalConfigRepo = temporaryFolder.newFolder();
         /*here is a pipeline 'downstream2' with material dependency on 'downstream' in other repository*/
         Modification secondDownstreamLatestModification = setupExternalConfigRepo(secondDownstreamExternalConfigRepo, "external_git_config_repo_referencing_second");
-        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(git(secondDownstreamExternalConfigRepo.getAbsolutePath()), "gocd-xml"));
+        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(git(secondDownstreamExternalConfigRepo.getAbsolutePath()), "gocd-xml", "id1"));
         File firstDownstreamExternalConfigRepo = temporaryFolder.newFolder();
         /*here is a pipeline 'downstream' with material dependency on 'pipe1' in other repository*/
         Modification firstDownstreamLatestModification = setupExternalConfigRepo(firstDownstreamExternalConfigRepo, "external_git_config_repo_referencing_first");
-        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(git(firstDownstreamExternalConfigRepo.getAbsolutePath()), "gocd-xml"));
+        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(git(firstDownstreamExternalConfigRepo.getAbsolutePath()), "gocd-xml", "id2"));
         goConfigService.forceNotifyListeners();
         ConfigRepoConfig firstDownstreamConfigRepo = configWatchList.getCurrentConfigRepos().get(1);
         ConfigRepoConfig secondDownstreamConfigRepo = configWatchList.getCurrentConfigRepos().get(2);
@@ -967,8 +967,8 @@ public class CachedGoConfigIntegrationTest {
 
     @Test
     public void shouldRemoveCorrespondingRemotePipelinesFromCachedGoConfigIfTheConfigRepoIsDeleted() {
-        final ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), XmlPartialConfigProvider.providerName);
-        final ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), XmlPartialConfigProvider.providerName);
+        final ConfigRepoConfig repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), XmlPartialConfigProvider.providerName, "id1");
+        final ConfigRepoConfig repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), XmlPartialConfigProvider.providerName, "id2");
         goConfigService.updateConfig(new UpdateConfigCommand() {
             @Override
             public CruiseConfig update(CruiseConfig cruiseConfig) throws Exception {

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
@@ -1207,7 +1207,7 @@ public class GoConfigMigrationIntegrationTest {
                 "    </config-repo>\n" +
                 "  </config-repos>\n" +
                 "</cruise>";
-        String migratedContent = migrateXmlString(configXml, 114);
+        String migratedContent = ConfigMigrator.migrate(configXml, 114, 115);
 
         assertStringContainsIgnoringCarriageReturn(migratedContent,
                 "<config-repos>\n" +
@@ -2054,6 +2054,25 @@ public class GoConfigMigrationIntegrationTest {
 
         final String migratedXml = ConfigMigrator.migrate(configXml, 134, 135);
         XmlAssert.assertThat(migratedXml).and(expectedConfig).areIdentical();
+    }
+
+    @Test
+    public void shouldAddADefaultAllowRuleForConfigRepos_Migration135To136() {
+        String configXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<cruise schemaVersion=\"135\">" +
+                "   <config-repos>" +
+                "      <config-repo id=\"json\" pluginId=\"yaml.config.plugin\">" +
+                "          <git url=\"/tmp/config\" />" +
+                "      </config-repo>" +
+                "   </config-repos>" +
+                "</cruise>";
+
+        String defaultRuleAdded = "<allow action=\"refer\" type=\"*\">*</allow>";
+
+        final String migratedXml = migrateXmlString(configXml, 135);
+
+        XmlAssert.assertThat(migratedXml).nodesByXPath("/cruise/config-repos/config-repo/rules").exist();
+        assertThat(migratedXml).contains(defaultRuleAdded);
     }
 
     private void assertStringContainsIgnoringCarriageReturn(String actual, String substring) {

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
@@ -566,7 +566,7 @@ public class GoConfigMigrationIntegrationTest {
 
         String migratedContent = migrateXmlString(configXml, 98);
         CruiseConfig cruiseConfig = loader.deserializeConfig(migratedContent);
-        GitMaterialConfig materialConfig = (GitMaterialConfig) cruiseConfig.getConfigRepos().getConfigRepo("config-repo-1").getMaterialConfig();
+        GitMaterialConfig materialConfig = (GitMaterialConfig) cruiseConfig.getConfigRepos().getConfigRepo("config-repo-1").getRepo();
 
         assertThat(migratedContent).doesNotContain("<filter>");
         assertThat(migratedContent).doesNotContain("dest='dest'");
@@ -601,7 +601,7 @@ public class GoConfigMigrationIntegrationTest {
 
         String migratedContent = migrateXmlString(configXml, 98);
         CruiseConfig cruiseConfig = loader.deserializeConfig(migratedContent);
-        MaterialConfig materialConfig = cruiseConfig.getConfigRepos().getConfigRepo("config-repo-1").getMaterialConfig();
+        MaterialConfig materialConfig = cruiseConfig.getConfigRepos().getConfigRepo("config-repo-1").getRepo();
 
         assertThat(migratedContent).doesNotContain("<filter>");
         assertThat(migratedContent).doesNotContain("dest='dest'");
@@ -635,7 +635,7 @@ public class GoConfigMigrationIntegrationTest {
 
         String migratedContent = migrateXmlString(configXml, 98);
         CruiseConfig cruiseConfig = loader.deserializeConfig(migratedContent);
-        MaterialConfig materialConfig = cruiseConfig.getConfigRepos().getConfigRepo("config-repo-1").getMaterialConfig();
+        MaterialConfig materialConfig = cruiseConfig.getConfigRepos().getConfigRepo("config-repo-1").getRepo();
 
         assertThat(migratedContent).doesNotContain("dest=\"dest\"");
         assertThat(migratedContent).doesNotContain("<filter>");
@@ -668,7 +668,7 @@ public class GoConfigMigrationIntegrationTest {
 
         String migratedContent = migrateXmlString(configXml, 98);
         CruiseConfig cruiseConfig = loader.deserializeConfig(migratedContent);
-        MaterialConfig materialConfig = cruiseConfig.getConfigRepos().getConfigRepo("config-repo-1").getMaterialConfig();
+        MaterialConfig materialConfig = cruiseConfig.getConfigRepos().getConfigRepo("config-repo-1").getRepo();
 
         assertThat(migratedContent).doesNotContain("<filter>");
         assertThat(migratedContent).doesNotContain("dest='dest'");
@@ -701,7 +701,7 @@ public class GoConfigMigrationIntegrationTest {
 
         String migratedContent = migrateXmlString(configXml, 98);
         CruiseConfig cruiseConfig = loader.deserializeConfig(migratedContent);
-        MaterialConfig materialConfig = cruiseConfig.getConfigRepos().getConfigRepo("config-repo-1").getMaterialConfig();
+        MaterialConfig materialConfig = cruiseConfig.getConfigRepos().getConfigRepo("config-repo-1").getRepo();
 
         assertThat(migratedContent).doesNotContain("<filter>");
         assertThat(migratedContent).doesNotContain("dest='dest'");
@@ -732,7 +732,7 @@ public class GoConfigMigrationIntegrationTest {
 
         String migratedContent = migrateXmlString(configXml, 98);
         CruiseConfig cruiseConfig = loader.deserializeConfig(migratedContent);
-        MaterialConfig materialConfig = cruiseConfig.getConfigRepos().getConfigRepo("config-repo-1").getMaterialConfig();
+        MaterialConfig materialConfig = cruiseConfig.getConfigRepos().getConfigRepo("config-repo-1").getRepo();
 
         assertThat(migratedContent).doesNotContain("<filter>");
         assertThat(migratedContent).doesNotContain("dest='dest'");

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
@@ -112,7 +112,7 @@ public class GoFileConfigDataSourceIntegrationTest {
         configHelper = new GoConfigFileHelper(DEFAULT_XML_WITH_2_AGENTS);
         configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
         configHelper.onSetUp();
-        repoConfig = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url"), XmlPartialConfigProvider.providerName);
+        repoConfig = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url"), XmlPartialConfigProvider.providerName, "git-id");
         configHelper.addConfigRepo(repoConfig);
         configHelper.addPipeline("upstream", "upstream_stage_original");
         goConfigService.forceNotifyListeners();

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
@@ -112,7 +112,7 @@ public class GoFileConfigDataSourceIntegrationTest {
         configHelper = new GoConfigFileHelper(DEFAULT_XML_WITH_2_AGENTS);
         configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
         configHelper.onSetUp();
-        repoConfig = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url"), XmlPartialConfigProvider.providerName);
+        repoConfig = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url"), XmlPartialConfigProvider.providerName);
         configHelper.addConfigRepo(repoConfig);
         configHelper.addPipeline("upstream", "upstream_stage_original");
         goConfigService.forceNotifyListeners();
@@ -232,7 +232,7 @@ public class GoFileConfigDataSourceIntegrationTest {
         String remotePipeline = "remote_pipeline";
         RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin(this.repoConfig, "1");
         PartialConfig partialConfig = PartialConfigMother.pipelineWithDependencyMaterial(remotePipeline, upstream, repoConfigOrigin);
-        cachedGoPartials.addOrUpdate(this.repoConfig.getMaterialConfig().getFingerprint(), partialConfig);
+        cachedGoPartials.addOrUpdate(this.repoConfig.getRepo().getFingerprint(), partialConfig);
         cachedGoPartials.markAllKnownAsValid();
         thrown.expect(RuntimeException.class);
         thrown.expectCause(Matchers.any(GoConfigInvalidException.class));
@@ -486,9 +486,9 @@ public class GoFileConfigDataSourceIntegrationTest {
         final String pipelineInMain = "pipeline_in_main";
         PartialConfig validPartialConfig = PartialConfigMother.withPipeline(pipelineOneFromConfigRepo, new RepoConfigOrigin(repoConfig, "1"));
         PartialConfig invalidPartialConfig = PartialConfigMother.invalidPartial(invalidPartial, new RepoConfigOrigin(repoConfig, "2"));
-        cachedGoPartials.addOrUpdate(repoConfig.getMaterialConfig().getFingerprint(), validPartialConfig);
+        cachedGoPartials.addOrUpdate(repoConfig.getRepo().getFingerprint(), validPartialConfig);
         cachedGoPartials.markAllKnownAsValid();
-        cachedGoPartials.addOrUpdate(repoConfig.getMaterialConfig().getFingerprint(), invalidPartialConfig);
+        cachedGoPartials.addOrUpdate(repoConfig.getRepo().getFingerprint(), invalidPartialConfig);
 
         GoFileConfigDataSource.GoConfigSaveResult result = dataSource.writeWithLock(cruiseConfig -> {
             cruiseConfig.addPipeline("default", PipelineConfigMother.createPipelineConfig(pipelineInMain, "stage", "job"));
@@ -509,7 +509,7 @@ public class GoFileConfigDataSourceIntegrationTest {
         String pipelineFromConfigRepo = "pipeline_from_config_repo";
         final String pipelineInMain = "pipeline_in_main";
         PartialConfig partialConfig = PartialConfigMother.withPipeline(pipelineFromConfigRepo, new RepoConfigOrigin(repoConfig, "r2"));
-        cachedGoPartials.addOrUpdate(repoConfig.getMaterialConfig().getFingerprint(), partialConfig);
+        cachedGoPartials.addOrUpdate(repoConfig.getRepo().getFingerprint(), partialConfig);
         assertThat(cachedGoPartials.lastValidPartials().size(), is(1));
         assertThat(cachedGoPartials.lastValidPartials().get(0).getGroups().findGroup("group").hasPipeline(new CaseInsensitiveString(pipelineFromConfigRepo)), is(false));
 

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoPartialConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoPartialConfigIntegrationTest.java
@@ -76,8 +76,8 @@ public class GoPartialConfigIntegrationTest {
         goCache.clear();
         configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
-        repoConfig1 = new ConfigRepoConfig(git("url1"), "plugin");
-        repoConfig2 = new ConfigRepoConfig(git("url2"), "plugin");
+        repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(git("url1"), "plugin");
+        repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin");
         configHelper.addConfigRepo(repoConfig1);
         configHelper.addConfigRepo(repoConfig2);
 
@@ -117,7 +117,7 @@ public class GoPartialConfigIntegrationTest {
 
     @Test
     public void shouldTryToValidateMergeAndSaveAllKnownPartialsWhenAPartialChange() {
-        cachedGoPartials.addOrUpdate(repoConfig1.getMaterialConfig().getFingerprint(), PartialConfigMother.withPipeline("p1_repo1", new RepoConfigOrigin(repoConfig1, "1234")));
+        cachedGoPartials.addOrUpdate(repoConfig1.getRepo().getFingerprint(), PartialConfigMother.withPipeline("p1_repo1", new RepoConfigOrigin(repoConfig1, "1234")));
         assertThat(goConfigDao.loadConfigHolder().config.getAllPipelineNames().contains(new CaseInsensitiveString("p1_repo1")), is(false));
 
         goPartialConfig.onSuccessPartialConfig(repoConfig2, PartialConfigMother.withPipeline("p2_repo2", new RepoConfigOrigin(repoConfig2, "4567")));
@@ -132,7 +132,7 @@ public class GoPartialConfigIntegrationTest {
     public void shouldValidateAndMergeJustTheChangedPartialAlongWithAllValidPartialsIfValidationOfAllKnownPartialsFail() {
         goPartialConfig.onSuccessPartialConfig(repoConfig1, PartialConfigMother.withPipeline("p1_repo1", new RepoConfigOrigin(repoConfig1, "1")));
         assertThat(goConfigDao.loadConfigHolder().config.getAllPipelineNames().contains(new CaseInsensitiveString("p1_repo1")), is(true));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1.getMaterialConfig().getFingerprint())).isEmpty(), is(true));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1.getRepo().getFingerprint())).isEmpty(), is(true));
 
         final String invalidPipelineInPartial = "p1_repo1_invalid";
         PartialConfig invalidPartial = PartialConfigMother.invalidPartial(invalidPipelineInPartial, new RepoConfigOrigin(repoConfig1, "2"));
@@ -171,7 +171,7 @@ public class GoPartialConfigIntegrationTest {
 
     @Test
     public void shouldMarkAnInvalidKnownPartialAsValidWhenLoadingAnotherPartialMakesThisOneValid_InterConfigRepoDependency() {
-        ConfigRepoConfig repoConfig3 = new ConfigRepoConfig(git("url3"), "plugin");
+        ConfigRepoConfig repoConfig3 = ConfigRepoConfig.createConfigRepoConfig(git("url3"), "plugin");
         configHelper.addConfigRepo(repoConfig3);
 
         PartialConfig repo1 = PartialConfigMother.withPipeline("p1_repo1", new RepoConfigOrigin(repoConfig1, "1"));

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoPartialConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoPartialConfigIntegrationTest.java
@@ -76,8 +76,8 @@ public class GoPartialConfigIntegrationTest {
         goCache.clear();
         configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
-        repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(git("url1"), "plugin");
-        repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin");
+        repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(git("url1"), "plugin", "id-1");
+        repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin", "id-2");
         configHelper.addConfigRepo(repoConfig1);
         configHelper.addConfigRepo(repoConfig2);
 
@@ -171,7 +171,7 @@ public class GoPartialConfigIntegrationTest {
 
     @Test
     public void shouldMarkAnInvalidKnownPartialAsValidWhenLoadingAnotherPartialMakesThisOneValid_InterConfigRepoDependency() {
-        ConfigRepoConfig repoConfig3 = ConfigRepoConfig.createConfigRepoConfig(git("url3"), "plugin");
+        ConfigRepoConfig repoConfig3 = ConfigRepoConfig.createConfigRepoConfig(git("url3"), "plugin", "id-3");
         configHelper.addConfigRepo(repoConfig3);
 
         PartialConfig repo1 = PartialConfigMother.withPipeline("p1_repo1", new RepoConfigOrigin(repoConfig1, "1"));

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoRepoConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoRepoConfigDataSourceIntegrationTest.java
@@ -86,7 +86,7 @@ public class GoRepoConfigDataSourceIntegrationTest {
         configHelper.addTemplate("t1", "param1", "stage");
         File templateConfigRepo = temporaryFolder.newFolder();
         String latestRevision = setupExternalConfigRepo(templateConfigRepo, "external_git_config_repo_referencing_template_with_params");
-        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git(templateConfigRepo.getAbsolutePath()), "gocd-xml");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git(templateConfigRepo.getAbsolutePath()), "gocd-xml", "config-id");
         configHelper.addConfigRepo(configRepoConfig);
 
         goConfigService.forceNotifyListeners();

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoRepoConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoRepoConfigDataSourceIntegrationTest.java
@@ -86,13 +86,13 @@ public class GoRepoConfigDataSourceIntegrationTest {
         configHelper.addTemplate("t1", "param1", "stage");
         File templateConfigRepo = temporaryFolder.newFolder();
         String latestRevision = setupExternalConfigRepo(templateConfigRepo, "external_git_config_repo_referencing_template_with_params");
-        ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(git(templateConfigRepo.getAbsolutePath()), "gocd-xml");
+        ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git(templateConfigRepo.getAbsolutePath()), "gocd-xml");
         configHelper.addConfigRepo(configRepoConfig);
 
         goConfigService.forceNotifyListeners();
         Modification modification = new Modification();
         modification.setRevision(latestRevision);
-        repoConfigDataSource.onCheckoutComplete(configRepoConfig.getMaterialConfig(), templateConfigRepo, modification);
+        repoConfigDataSource.onCheckoutComplete(configRepoConfig.getRepo(), templateConfigRepo, modification);
 
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerIntegrationTest.java
@@ -105,7 +105,7 @@ public class ConfigMaterialUpdateListenerIntegrationTest {
         configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
 
         materialConfig = hg(hgRepo.projectRepositoryUrl(), null);
-        configHelper.addConfigRepo(new ConfigRepoConfig(materialConfig, "gocd-xml"));
+        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(materialConfig, "gocd-xml"));
 
         TestingEmailSender emailSender = new TestingEmailSender();
         SystemDiskSpaceChecker mockDiskSpaceChecker = Mockito.mock(SystemDiskSpaceChecker.class);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerIntegrationTest.java
@@ -105,7 +105,7 @@ public class ConfigMaterialUpdateListenerIntegrationTest {
         configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
 
         materialConfig = hg(hgRepo.projectRepositoryUrl(), null);
-        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(materialConfig, "gocd-xml"));
+        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(materialConfig, "gocd-xml", "gocd-id"));
 
         TestingEmailSender emailSender = new TestingEmailSender();
         SystemDiskSpaceChecker mockDiskSpaceChecker = Mockito.mock(SystemDiskSpaceChecker.class);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/scheduling/PipelineScheduleQueueIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/scheduling/PipelineScheduleQueueIntegrationTest.java
@@ -447,7 +447,7 @@ public class PipelineScheduleQueueIntegrationTest {
         MaterialConfig materialConfig = pipelineConfig.materialConfigs().first();
         cause.getMaterialRevisions().findRevisionFor(materialConfig);
         pipelineConfig.setOrigins(new RepoConfigOrigin(
-                ConfigRepoConfig.createConfigRepoConfig(materialConfig, "123"), "plug"));
+                ConfigRepoConfig.createConfigRepoConfig(materialConfig, "123", "id1"), "plug"));
         saveRev(cause);
         queue.schedule(new CaseInsensitiveString(fixture.pipelineName), cause);
         Pipeline pipeline = queue.createPipeline(cause, pipelineConfig, new DefaultSchedulingContext(cause.getApprover(), new Agents()), "md5-test", new TimeProvider());

--- a/server/src/test-integration/java/com/thoughtworks/go/server/scheduling/PipelineScheduleQueueIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/scheduling/PipelineScheduleQueueIntegrationTest.java
@@ -447,7 +447,7 @@ public class PipelineScheduleQueueIntegrationTest {
         MaterialConfig materialConfig = pipelineConfig.materialConfigs().first();
         cause.getMaterialRevisions().findRevisionFor(materialConfig);
         pipelineConfig.setOrigins(new RepoConfigOrigin(
-                new ConfigRepoConfig(materialConfig, "123"), "plug"));
+                ConfigRepoConfig.createConfigRepoConfig(materialConfig, "123"), "plug"));
         saveRev(cause);
         queue.schedule(new CaseInsensitiveString(fixture.pipelineName), cause);
         Pipeline pipeline = queue.createPipeline(cause, pipelineConfig, new DefaultSchedulingContext(cause.getApprover(), new Agents()), "md5-test", new TimeProvider());

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceConfigRepoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceConfigRepoIntegrationTest.java
@@ -133,7 +133,7 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
         configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
 
         materialConfig = hgRepo.materialConfig();
-        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(materialConfig,"gocd-xml"));
+        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(materialConfig,"gocd-xml", "gocd-id"));
 
         logger = mock(MDUPerformanceLogger.class);
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceConfigRepoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceConfigRepoIntegrationTest.java
@@ -133,7 +133,7 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
         configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
 
         materialConfig = hgRepo.materialConfig();
-        configHelper.addConfigRepo(new ConfigRepoConfig(materialConfig,"gocd-xml"));
+        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(materialConfig,"gocd-xml"));
 
         logger = mock(MDUPerformanceLogger.class);
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
@@ -472,7 +472,7 @@ public class BuildCauseProducerServiceIntegrationTest {
 
     @Test
     public void shouldTriggerMDUOfConfigRepoMaterialIfThePipelineIsDefinedRemotelyInAConfigRepo_ManualTriggerOfPipeline_EvenIfMDUOptionIsTurnedOFFInRequest() throws Exception {
-        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin");
+        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin", "id-2");
         configHelper.addConfigRepo(repoConfig);
         PartialConfig partialConfig = PartialConfigMother.withPipelineMultipleMaterials("remote_pipeline", new RepoConfigOrigin(repoConfig, "4567"));
         PipelineConfig remotePipeline = partialConfig.getGroups().first().getPipelines().get(0);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
@@ -472,7 +472,7 @@ public class BuildCauseProducerServiceIntegrationTest {
 
     @Test
     public void shouldTriggerMDUOfConfigRepoMaterialIfThePipelineIsDefinedRemotelyInAConfigRepo_ManualTriggerOfPipeline_EvenIfMDUOptionIsTurnedOFFInRequest() throws Exception {
-        ConfigRepoConfig repoConfig = new ConfigRepoConfig(git("url2"), "plugin");
+        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin");
         configHelper.addConfigRepo(repoConfig);
         PartialConfig partialConfig = PartialConfigMother.withPipelineMultipleMaterials("remote_pipeline", new RepoConfigOrigin(repoConfig, "4567"));
         PipelineConfig remotePipeline = partialConfig.getGroups().first().getPipelines().get(0);
@@ -480,7 +480,7 @@ public class BuildCauseProducerServiceIntegrationTest {
         u.checkinInOrder(git, u.d(1), "g1r1");
         SvnMaterial svn = u.wf((SvnMaterial) new MaterialConfigConverter().toMaterial(remotePipeline.materialConfigs().getSvnMaterial()), "svn");
         u.checkinInOrder(svn, u.d(1), "svn1r11");
-        GitMaterial configRepoMaterial = u.wf((GitMaterial) new MaterialConfigConverter().toMaterial(repoConfig.getMaterialConfig()), "git");
+        GitMaterial configRepoMaterial = u.wf((GitMaterial) new MaterialConfigConverter().toMaterial(repoConfig.getRepo()), "git");
         u.checkinInOrder(configRepoMaterial, u.d(1), "s1");
         goPartialConfig.onSuccessPartialConfig(repoConfig, partialConfig);
         assertTrue(goConfigService.hasPipelineNamed(remotePipeline.name()));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigRepoServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigRepoServiceIntegrationTest.java
@@ -89,7 +89,7 @@ public class ConfigRepoServiceIntegrationTest {
         this.repoId = "repo-1";
         this.pluginId = "json-config-repo-plugin";
         MaterialConfig repoMaterial = git("https://foo.git", "master");
-        this.configRepo = new ConfigRepoConfig(repoMaterial, pluginId, repoId);
+        this.configRepo = ConfigRepoConfig.createConfigRepoConfig(repoMaterial, pluginId, repoId);
 
         configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
         configHelper.onSetUp();
@@ -173,7 +173,7 @@ public class ConfigRepoServiceIntegrationTest {
             }
         });
         String newRepoId = "repo-2";
-        ConfigRepoConfig toUpdateWith = new ConfigRepoConfig(git("http://bar.git", "master"), "yaml-plugin", newRepoId);
+        ConfigRepoConfig toUpdateWith = ConfigRepoConfig.createConfigRepoConfig(git("http://bar.git", "master"), "yaml-plugin", newRepoId);
 
         assertThat(configRepoService.getConfigRepos().size(), is(1));
         assertThat(configRepoService.getConfigRepo(repoId), is(configRepo));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
@@ -140,14 +140,14 @@ public class ConfigSaveDeadlockDetectionIntegrationTest {
 
         ConfigReposConfig configRepos = new ConfigReposConfig();
         for (int i = 0; i < configRepoAdditionThreadCount; i++) {
-            ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url" + i), "plugin");
+            ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url" + i), "plugin", "id-" + i);
             configRepos.add(configRepoConfig);
             Thread thread = configRepoSaveThread(configRepoConfig, i);
             group3.add(thread);
         }
 
         for (int i = 0; i < configRepoDeletionThreadCount; i++) {
-            ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("to-be-deleted-url" + i), "plugin");
+            ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("to-be-deleted-url" + i), "plugin", "to-be-deleted-" + i);
             cachedGoPartials.addOrUpdate(configRepoConfig.getRepo().getFingerprint(), PartialConfigMother.withPipeline("to-be-deleted" + i, new RepoConfigOrigin(configRepoConfig, "plugin")));
             configRepos.add(configRepoConfig);
             Thread thread = configRepoDeleteThread(configRepoConfig, i);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
@@ -140,15 +140,15 @@ public class ConfigSaveDeadlockDetectionIntegrationTest {
 
         ConfigReposConfig configRepos = new ConfigReposConfig();
         for (int i = 0; i < configRepoAdditionThreadCount; i++) {
-            ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(git("url" + i), "plugin");
+            ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url" + i), "plugin");
             configRepos.add(configRepoConfig);
             Thread thread = configRepoSaveThread(configRepoConfig, i);
             group3.add(thread);
         }
 
         for (int i = 0; i < configRepoDeletionThreadCount; i++) {
-            ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(git("to-be-deleted-url" + i), "plugin");
-            cachedGoPartials.addOrUpdate(configRepoConfig.getMaterialConfig().getFingerprint(), PartialConfigMother.withPipeline("to-be-deleted" + i, new RepoConfigOrigin(configRepoConfig, "plugin")));
+            ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("to-be-deleted-url" + i), "plugin");
+            cachedGoPartials.addOrUpdate(configRepoConfig.getRepo().getFingerprint(), PartialConfigMother.withPipeline("to-be-deleted" + i, new RepoConfigOrigin(configRepoConfig, "plugin")));
             configRepos.add(configRepoConfig);
             Thread thread = configRepoDeleteThread(configRepoConfig, i);
             group4.add(thread);
@@ -268,7 +268,7 @@ public class ConfigSaveDeadlockDetectionIntegrationTest {
                         ConfigRepoConfig repoConfig = cruiseConfig.getConfigRepos().stream().filter(new Predicate<ConfigRepoConfig>() {
                             @Override
                             public boolean test(ConfigRepoConfig item) {
-                                return configRepoToBeDeleted.getMaterialConfig().equals(item.getMaterialConfig());
+                                return configRepoToBeDeleted.getRepo().equals(item.getRepo());
                             }
                         }).findFirst().orElse(null);
                         cruiseConfig.getConfigRepos().remove(repoConfig);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
@@ -124,8 +124,8 @@ public class PipelineConfigServiceIntegrationTest {
         user = new Username(new CaseInsensitiveString("current"));
         pipelineConfig = GoConfigMother.createPipelineConfigWithMaterialConfig(UUID.randomUUID().toString(), git("FOO"));
         goConfigService.addPipeline(pipelineConfig, groupName);
-        repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url"), XmlPartialConfigProvider.providerName);
-        repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), XmlPartialConfigProvider.providerName);
+        repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url"), XmlPartialConfigProvider.providerName, "git-id1");
+        repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), XmlPartialConfigProvider.providerName, "git-id2");
         goConfigService.updateConfig(new UpdateConfigCommand() {
             @Override
             public CruiseConfig update(CruiseConfig cruiseConfig) throws Exception {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
@@ -124,8 +124,8 @@ public class PipelineConfigServiceIntegrationTest {
         user = new Username(new CaseInsensitiveString("current"));
         pipelineConfig = GoConfigMother.createPipelineConfigWithMaterialConfig(UUID.randomUUID().toString(), git("FOO"));
         goConfigService.addPipeline(pipelineConfig, groupName);
-        repoConfig1 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url"), XmlPartialConfigProvider.providerName);
-        repoConfig2 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), XmlPartialConfigProvider.providerName);
+        repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url"), XmlPartialConfigProvider.providerName);
+        repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), XmlPartialConfigProvider.providerName);
         goConfigService.updateConfig(new UpdateConfigCommand() {
             @Override
             public CruiseConfig update(CruiseConfig cruiseConfig) throws Exception {
@@ -838,8 +838,8 @@ public class PipelineConfigServiceIntegrationTest {
         CruiseConfig currentConfig = goConfigService.getCurrentConfig();
         assertThat(currentConfig.getAllPipelineNames().contains(remoteDownstreamPipeline.name()), is(true));
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision(), is("repo1_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r1"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n- For Config Repo: url at repo1_r2"));
@@ -854,8 +854,8 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(currentConfig.getAllPipelineNames().contains(remoteDownstreamPipeline.name()), is(true));
         assertThat(currentConfig.getPipelineConfigByName(pipelineConfig.name()).getVariables().contains(new EnvironmentVariableConfig("key", "value")), is(true));
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision(), is("repo1_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r1"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
 
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
@@ -877,8 +877,8 @@ public class PipelineConfigServiceIntegrationTest {
         DependencyMaterialConfig dependencyMaterialForRemotePipelineInConfigCache = currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).materialConfigs().findDependencyMaterial(pipelineConfig.name());
         assertThat(dependencyMaterialForRemotePipelineInConfigCache.getStageName(), is(new CaseInsensitiveString("stage")));
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision(), is("repo1_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r1"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
@@ -897,8 +897,8 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).materialConfigs().findDependencyMaterial(pipelineConfig.name()).getStageName(), is(upstreamStageRenamed));
         assertThat(currentConfig.getPipelineConfigByName(pipelineConfig.name()).getFirstStageConfig().name(), is(upstreamStageRenamed));
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision(), is("repo1_r2"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).isEmpty(), is(true));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
     }
@@ -913,8 +913,8 @@ public class PipelineConfigServiceIntegrationTest {
         //introduce an invalid change in the independent partial
         PartialConfig invalidIndependentPartial = PartialConfigMother.invalidPartial(independentRemotePipeline, new RepoConfigOrigin(repoConfig2, "repo2_r2"));
         goPartialConfig.onSuccessPartialConfig(repoConfig2, invalidIndependentPartial);
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig2.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo2_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig2.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo2_r2"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig2.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo2_r1"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig2.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo2_r2"));
         assertThat(((RepoConfigOrigin) goConfigService.getCurrentConfig().getPipelineConfigByName(new CaseInsensitiveString(independentRemotePipeline)).getOrigin()).getRevision(), is("repo2_r1"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).isEmpty(), is(true));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size(), is(1));
@@ -928,8 +928,8 @@ public class PipelineConfigServiceIntegrationTest {
         DependencyMaterialConfig dependencyMaterialForRemotePipelineInConfigCache = currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).materialConfigs().findDependencyMaterial(pipelineConfig.name());
         assertThat(dependencyMaterialForRemotePipelineInConfigCache.getStageName(), is(new CaseInsensitiveString("stage")));
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision(), is("repo1_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r1"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
@@ -958,11 +958,11 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).materialConfigs().findDependencyMaterial(pipelineConfig.name()).getStageName(), is(new CaseInsensitiveString("stage")));
         assertThat(currentConfig.getPipelineConfigByName(pipelineConfig.name()).getFirstStageConfig().name(), is(new CaseInsensitiveString("stage")));
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision(), is("repo1_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r1"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(new CaseInsensitiveString(independentRemotePipeline)).getOrigin()).getRevision(), is("repo2_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig2.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo2_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig2.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo2_r2"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig2.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo2_r1"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig2.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo2_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
@@ -983,8 +983,8 @@ public class PipelineConfigServiceIntegrationTest {
         DependencyMaterialConfig dependencyMaterialForRemotePipelineInConfigCache = currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).materialConfigs().findDependencyMaterial(pipelineConfig.name());
         assertThat(dependencyMaterialForRemotePipelineInConfigCache.getStageName(), is(new CaseInsensitiveString("stage")));
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision(), is("repo1_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r1"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
@@ -1008,8 +1008,8 @@ public class PipelineConfigServiceIntegrationTest {
         currentConfig = goConfigService.getCurrentConfig();
         assertThat(currentConfig.getAllPipelineNames().contains(remoteDownstreamPipeline.name()), is(true));
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision(), is("repo1_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r1"));
-        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r1"));
+        assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).materialConfigs().findDependencyMaterial(pipelineConfig.name()).getStageName(), is(new CaseInsensitiveString("stage")));
         assertThat(currentConfig.getPipelineConfigByName(pipelineConfig.name()).getFirstStageConfig().name(), is(new CaseInsensitiveString("stage")));
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision(), is("repo1_r1"));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineLabelCorrectorIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineLabelCorrectorIntegrationTest.java
@@ -78,7 +78,7 @@ public class PipelineLabelCorrectorIntegrationTest {
         configHelper.onSetUp();
         dbHelper.onSetUp();
         scheduleUtil = new ScheduleTestUtil(transactionTemplate, materialRepository, dbHelper, configHelper);
-        repoConfig = new ConfigRepoConfig(git("url1"), "plugin");
+        repoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url1"), "plugin");
         configHelper.addConfigRepo(repoConfig);
     }
 
@@ -157,7 +157,7 @@ public class PipelineLabelCorrectorIntegrationTest {
     public void shouldRemoveDuplicateEntriesForPipelineCounterFromDbIfTheConfigRepoPipelineHasNotBeenLoadedUpYetLeavingBehindTheOneWhichMatchesTheCaseOfTheLastRunPipeline() throws SQLException {
         // Such a scenario could be created in pre 18.4 world when the pipeline defined in a config-repo was created/renamed with different cases, and has had a few runs. After this the server is upgraded to a version >= 18.4
         String pipelineName = "Pipeline-Name";
-        ConfigRepoConfig repoConfig = new ConfigRepoConfig(git("url2"), "plugin");
+        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin");
         configHelper.addConfigRepo(repoConfig);
         PipelineConfig pipelineConfig = addConfigRepoPipeline(repoConfig, pipelineName);
         scheduleUtil.runAndPass(new ScheduleTestUtil.AddedPipeline(pipelineConfig, new DependencyMaterial(pipelineConfig.name(), pipelineConfig.first().name())), "svn1r11");
@@ -186,7 +186,7 @@ public class PipelineLabelCorrectorIntegrationTest {
         PipelineConfig remotePipeline = partialConfig.getGroups().first().getPipelines().get(0);
         SvnMaterial svn = scheduleUtil.wf((SvnMaterial) new MaterialConfigConverter().toMaterial(remotePipeline.materialConfigs().getSvnMaterial()), "svn");
         scheduleUtil.checkinInOrder(svn, scheduleUtil.d(1), "svn1r11");
-        GitMaterial configRepoMaterial = scheduleUtil.wf((GitMaterial) new MaterialConfigConverter().toMaterial(repoConfig.getMaterialConfig()), "git");
+        GitMaterial configRepoMaterial = scheduleUtil.wf((GitMaterial) new MaterialConfigConverter().toMaterial(repoConfig.getRepo()), "git");
         scheduleUtil.checkinInOrder(configRepoMaterial, scheduleUtil.d(1), "s1");
         goPartialConfig.onSuccessPartialConfig(repoConfig, partialConfig);
         return remotePipeline;

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineLabelCorrectorIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineLabelCorrectorIntegrationTest.java
@@ -78,7 +78,7 @@ public class PipelineLabelCorrectorIntegrationTest {
         configHelper.onSetUp();
         dbHelper.onSetUp();
         scheduleUtil = new ScheduleTestUtil(transactionTemplate, materialRepository, dbHelper, configHelper);
-        repoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url1"), "plugin");
+        repoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url1"), "plugin", "id1");
         configHelper.addConfigRepo(repoConfig);
     }
 
@@ -157,7 +157,7 @@ public class PipelineLabelCorrectorIntegrationTest {
     public void shouldRemoveDuplicateEntriesForPipelineCounterFromDbIfTheConfigRepoPipelineHasNotBeenLoadedUpYetLeavingBehindTheOneWhichMatchesTheCaseOfTheLastRunPipeline() throws SQLException {
         // Such a scenario could be created in pre 18.4 world when the pipeline defined in a config-repo was created/renamed with different cases, and has had a few runs. After this the server is upgraded to a version >= 18.4
         String pipelineName = "Pipeline-Name";
-        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin");
+        ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin", "id2");
         configHelper.addConfigRepo(repoConfig);
         PipelineConfig pipelineConfig = addConfigRepoPipeline(repoConfig, pipelineName);
         scheduleUtil.runAndPass(new ScheduleTestUtil.AddedPipeline(pipelineConfig, new DependencyMaterial(pipelineConfig.name(), pipelineConfig.first().name())), "svn1r11");


### PR DESCRIPTION
Issue: #7605 

Description:
 - Added support for `rules` to the config repo to allow/deny creation/access to environments, pipeline groups and pipelines.
 - Since the general rule will be `deny all`, added a default `allow all` rule to all existing config repos in the migration.