### PR TITLE
Show agent status reports to users with elastic agent view permissions (#7549)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
@@ -208,10 +208,12 @@ public class JobController {
         final ElasticAgentPluginInfo pluginInfo = elasticAgentMetadataStore.getPluginInfo(pluginId);
 
         if (pluginInfo != null && pluginInfo.getCapabilities().supportsAgentStatusReport()) {
-            data.put("clusterProfileId", jobAgentMetadata.clusterProfile().getId());
-            data.put("elasticAgentProfileId", jobAgentMetadata.elasticProfile().getId());
+            String clusterProfileId = jobAgentMetadata.clusterProfile().getId();
+            String elasticProfileId = jobAgentMetadata.elasticProfile().getId();
+            data.put("clusterProfileId", clusterProfileId);
+            data.put("elasticAgentProfileId", elasticProfileId);
             data.put("elasticAgentPluginId", pluginId);
-            data.put("doesUserHaveViewAccessToStatusReportPage", securityService.doesUserHasPermissionsToViewAgentStatusReport(SessionUtils.currentUsername(), jobAgentMetadata.elasticProfile().getId()));
+            data.put("doesUserHaveViewAccessToStatusReportPage", securityService.doesUserHasPermissionsToViewAgentStatusReport(SessionUtils.currentUsername(), elasticProfileId, clusterProfileId));
 
             final Agent agent = agentService.getAgentByUUID(jobInstance.getAgentUuid());
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/SecurityService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/SecurityService.java
@@ -211,7 +211,7 @@ public class SecurityService {
 
     //todo: needs refactoring use AbstractAuthenticationHelper.doesUserHasPermissions
     //a specific method to check whether a user has permission to access agent status report has been added
-    public boolean doesUserHasPermissionsToViewAgentStatusReport(Username username, String elasticAgentProfileId) {
+    public boolean doesUserHasPermissionsToViewAgentStatusReport(Username username, String elasticAgentProfileId, String clusterProfileId) {
         if (this.isUserAdmin(username)) {
             return true;
         }
@@ -221,11 +221,11 @@ public class SecurityService {
         List<Role> roles = goConfigService.rolesForUser(username.getUsername());
         boolean hasPermission = false;
         for (Role role : roles) {
-            if (role.hasExplicitDenyPermissionsFor(action, entity.getEntityType(), elasticAgentProfileId, null)) {
+            if (role.hasExplicitDenyPermissionsFor(action, entity.getEntityType(), elasticAgentProfileId, clusterProfileId)) {
                 return false;
             }
 
-            if (role.hasPermissionsFor(action, entity.getEntityType(), elasticAgentProfileId, null)) {
+            if (role.hasPermissionsFor(action, entity.getEntityType(), elasticAgentProfileId, clusterProfileId)) {
                 hasPermission = true;
             }
         }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/controller/JobControllerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/controller/JobControllerTest.java
@@ -201,7 +201,7 @@ public class JobControllerTest {
             ElasticProfile elasticProfile = new ElasticProfile("elastic_id", "cluster_id");
             ClusterProfile clusterProfile = new ClusterProfile("cluster_id", "cd.go.example.plugin");
 
-            when(securityService.doesUserHasPermissionsToViewAgentStatusReport(any(), eq("elastic_id"))).thenReturn(true);
+            when(securityService.doesUserHasPermissionsToViewAgentStatusReport(any(), eq("elastic_id"), eq("cluster_id"))).thenReturn(true);
             when(jobAgentMetadataDao.load(12L)).thenReturn(new JobAgentMetadata(12L, elasticProfile, clusterProfile));
 
             ModelAndView modelAndView = jobController.jobDetail("p1", "1", "s1", "2", "job1");

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/SecurityServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/SecurityServiceTest.java
@@ -343,6 +343,7 @@ public class SecurityServiceTest {
     @Test
     public void shouldAllowUserToAccessAgentStatusReportPageWhenAllowViewPermissionIsDefined() {
         String elasticAgentProfileId = "elastic-profile-id";
+        String clusterProfileId = "cluster-profile-id";
         Username bob = new Username("Bob" + UUID.randomUUID());
         RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("elastic-profile-users"), new RoleUser(bob.getUsername()));
         Policy policy = new Policy();
@@ -351,12 +352,13 @@ public class SecurityServiceTest {
         when(goConfigService.isSecurityEnabled()).thenReturn(true);
         when(goConfigService.rolesForUser(bob.getUsername())).thenReturn(new RolesConfig(roleConfig));
 
-        assertThat(securityService.doesUserHasPermissionsToViewAgentStatusReport(bob, elasticAgentProfileId), is(true));
+        assertThat(securityService.doesUserHasPermissionsToViewAgentStatusReport(bob, elasticAgentProfileId, clusterProfileId), is(true));
     }
 
     @Test
     public void shouldDenyUserToAccessAgentStatusReportPageWhenDenyViewPermissionIsDefined() {
         String elasticAgentProfileId = "elastic-profile-id";
+        String clusterProfileId = "cluster-profile-id";
         Username bob = new Username("Bob" + UUID.randomUUID());
         RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("elastic-profile-users"), new RoleUser(bob.getUsername()));
         Policy policy = new Policy();
@@ -365,17 +367,18 @@ public class SecurityServiceTest {
         when(goConfigService.isSecurityEnabled()).thenReturn(true);
         when(goConfigService.rolesForUser(bob.getUsername())).thenReturn(new RolesConfig(roleConfig));
 
-        assertThat(securityService.doesUserHasPermissionsToViewAgentStatusReport(bob, elasticAgentProfileId), is(false));
+        assertThat(securityService.doesUserHasPermissionsToViewAgentStatusReport(bob, elasticAgentProfileId, clusterProfileId), is(false));
     }
 
     @Test
     public void shouldDenyUserToAccessAgentStatusReportPageWhenNoViewPermissionIsDefined() {
         String elasticAgentProfileId = "elastic-profile-id";
+        String clusterProfileId = "cluster-profile-id";
         Username bob = new Username("Bob" + UUID.randomUUID());
         when(goConfigService.isSecurityEnabled()).thenReturn(true);
         when(goConfigService.rolesForUser(bob.getUsername())).thenReturn(new RolesConfig());
 
-        assertThat(securityService.doesUserHasPermissionsToViewAgentStatusReport(bob, elasticAgentProfileId), is(false));
+        assertThat(securityService.doesUserHasPermissionsToViewAgentStatusReport(bob, elasticAgentProfileId, clusterProfileId), is(false));
     }
 
     private BasicCruiseConfig getCruiseConfigWithSecurityEnabled() {


### PR DESCRIPTION
Issue: #7549

Description:
- Pass along resourceToOperate within information to determine whether
  the current user has access to the elastic agent profile, within a
  specific cluster profile.