### PR TITLE
Show parameter related resource errors while editing pipeline and template config 

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/update/PipelineConfigErrorCopier.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/PipelineConfigErrorCopier.java
@@ -56,6 +56,7 @@ public class PipelineConfigErrorCopier {
                 copyCollectionErrors(fromJob.artifactTypeConfigs(), toJob.artifactTypeConfigs());
                 copyCollectionErrors(fromJob.getTabs(), toJob.getTabs());
                 copyCollectionErrors(fromJob.getVariables(), toJob.getVariables());
+                copyCollectionErrors(fromJob.resourceConfigs(), toJob.resourceConfigs());
                 Tasks toTasks = toJob.getTasks();
                 Tasks fromTasks = fromJob.getTasks();
                 copyCollectionErrors(fromTasks, toTasks);

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/settings.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/settings.html.erb
@@ -1,6 +1,6 @@
 <div class="config-container config-job-settings">
 <h3>Job Settings</h3>
-
+<%= render :partial => "admin/shared/global_errors.html", :locals => {:scope => {}} -%>
 <%= form_for @job,
                 :as => :job,
                 :url => admin_job_update_path(:current_tab => "settings"),


### PR DESCRIPTION
Issue: #3103

Description:

The pipeline config edit view uses the entity config save flow which copies errors from a preprocessed config to the pipeline config object being updated. We had missed copying errors on resource configs before.

The template config edit uses the old config save flow and does not show a specific error when non existent params are used as resources. If non-existent params were used elsewhere, like environment variables, the exception `Parameter x is not defined is shown`. This is fixed by displaying the global errors that are created as a result of the param exception in the old config save flow. 
