### PR TITLE
Applied rules after a successful config repo parse

### DIFF
--- a/api/api-config-repo-operations-v1/src/main/java/com/thoughtworks/go/apiv1/configrepooperations/ConfigRepoOperationsControllerV1.java
+++ b/api/api-config-repo-operations-v1/src/main/java/com/thoughtworks/go/apiv1/configrepooperations/ConfigRepoOperationsControllerV1.java
@@ -123,7 +123,7 @@ public class ConfigRepoOperationsControllerV1 extends ApiController implements S
             } else {
                 PartialConfig partialConfig = plugin.parseContent(contents, context);
                 partialConfig.setOrigins(adHocConfigOrigin(repo));
-                CruiseConfig config = partialConfigService.merge(partialConfig, context.configMaterial().getFingerprint(), gcs.clonedConfigForEdit());
+                CruiseConfig config = partialConfigService.merge(partialConfig, context.configMaterial().getFingerprint(), gcs.clonedConfigForEdit(), repo);
 
                 gcs.validateCruiseConfig(config);
                 result.update(Collections.emptyList(), true);

--- a/api/api-config-repo-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepooperations/ConfigRepoOperationsControllerV1Test.groovy
+++ b/api/api-config-repo-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepooperations/ConfigRepoOperationsControllerV1Test.groovy
@@ -21,6 +21,7 @@ import com.thoughtworks.go.config.*
 import com.thoughtworks.go.config.exceptions.EntityType
 import com.thoughtworks.go.config.exceptions.GoConfigInvalidException
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException
+import com.thoughtworks.go.config.remote.ConfigRepoConfig
 import com.thoughtworks.go.config.remote.EphemeralConfigOrigin
 import com.thoughtworks.go.config.remote.PartialConfig
 import com.thoughtworks.go.plugin.access.configrepo.InvalidPartialConfigException
@@ -35,8 +36,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mock
 
 import static com.thoughtworks.go.spark.Routes.ConfigRepos.PREFLIGHT_PATH
-import static org.mockito.ArgumentMatchers.any
-import static org.mockito.ArgumentMatchers.eq
+import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
 import static org.mockito.MockitoAnnotations.initMocks
 
@@ -142,7 +142,7 @@ class ConfigRepoOperationsControllerV1Test implements SecurityServiceTrait, Cont
         def cruiseConfig = mock(CruiseConfig.class)
         when(plugin.parseContent(any() as Map<String, String>, any() as PartialConfigLoadContext)).thenReturn(partialConfig)
         when(pluginService.partialConfigProviderFor(PLUGIN_ID)).thenReturn(plugin)
-        when(partialConfigService.merge(eq(partialConfig), any() as String, any() as CruiseConfig)).thenReturn(cruiseConfig)
+        when(partialConfigService.merge(eq(partialConfig), any() as String, any() as CruiseConfig, any() as ConfigRepoConfig)).thenReturn(cruiseConfig)
 
         postWithApiHeader(controller.controllerPath("$PREFLIGHT_PATH?pluginId=$PLUGIN_ID"), [:])
 
@@ -162,7 +162,7 @@ class ConfigRepoOperationsControllerV1Test implements SecurityServiceTrait, Cont
 
         postWithApiHeader(controller.controllerPath("$PREFLIGHT_PATH?pluginId=$PLUGIN_ID"), [:])
 
-        verify(partialConfigService, never()).merge(any() as PartialConfig, any() as String, any() as CruiseConfig)
+        verify(partialConfigService, never()).merge(any(PartialConfig.class), anyString(), any(CruiseConfig.class), any(ConfigRepoConfig.class))
         verify(goConfigService, never()).validateCruiseConfig(any() as CruiseConfig)
 
         assertThatResponse().hasJsonBody([
@@ -178,7 +178,7 @@ class ConfigRepoOperationsControllerV1Test implements SecurityServiceTrait, Cont
         def cruiseConfig = mock(CruiseConfig.class)
         when(plugin.parseContent(any() as Map<String, String>, any() as PartialConfigLoadContext)).thenReturn(partialConfig)
         when(pluginService.partialConfigProviderFor(PLUGIN_ID)).thenReturn(plugin)
-        when(partialConfigService.merge(eq(partialConfig), any() as String, any() as CruiseConfig)).thenReturn(cruiseConfig)
+        when(partialConfigService.merge(eq(partialConfig), any() as String, any() as CruiseConfig, any() as ConfigRepoConfig)).thenReturn(cruiseConfig)
         when(goConfigService.validateCruiseConfig(cruiseConfig)).thenThrow(new GoConfigInvalidException(cruiseConfig, "nope!"))
 
         postWithApiHeader(controller.controllerPath("$PREFLIGHT_PATH?pluginId=$PLUGIN_ID"), [:])

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/EntityType.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/EntityType.java
@@ -51,6 +51,7 @@ public enum EntityType {
 
     private final String entityType;
     private final NameOrId nameOrId;
+    public static final String RULE_ERROR_PREFIX = "Not allowed to refer";
 
     EntityType(String entityType, NameOrId nameOrId) {
         this.entityType = entityType;
@@ -194,5 +195,13 @@ public enum EntityType {
 
     public String alreadyUsesATemplate(String id) {
         return format("%s %s '%s' already uses a template.", StringUtils.capitalize(this.entityType), this.nameOrId.descriptor, id);
+    }
+
+    public String notAllowedToRefer(CaseInsensitiveString identifier) {
+        return notAllowedToRefer(identifier.toString());
+    }
+
+    public String notAllowedToRefer(String identifier) {
+        return format("%s %s '%s' from the config repository.", RULE_ERROR_PREFIX, this.entityType, identifier);
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/util/DFSCycleDetector.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/util/DFSCycleDetector.java
@@ -71,15 +71,15 @@ public class DFSCycleDetector {
 
     private void validateRootExists(CaseInsensitiveString root, PipelineDependencyState pipelineDependencyState, Stack<CaseInsensitiveString> visiting) throws Exception {
         if (!pipelineDependencyState.hasPipeline(root)) {
-            StringBuffer sb = new StringBuffer("Pipeline \"");
+            StringBuffer sb = new StringBuffer("Pipeline '");
             sb.append(root);
-            sb.append("\" does not exist.");
+            sb.append("' does not exist.");
             visiting.pop();
             if (!visiting.empty()) {
                 CaseInsensitiveString parent = visiting.peek();
-                sb.append(" It is used from pipeline \"");
+                sb.append(" It is used from pipeline '");
                 sb.append(parent);
-                sb.append("\".");
+                sb.append("'.");
             }
             throw new Exception(sb.toString());
         }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/CruiseConfigTestBase.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/CruiseConfigTestBase.java
@@ -512,7 +512,7 @@ public abstract class CruiseConfigTestBase {
             errors.addAll(allError.getAllOn("base"));
         }
         assertThat(errors.size(), is(1));
-        assertThat(errors.get(0), is("Pipeline \"invalid\" does not exist. It is used from pipeline \"pipeline1\"."));
+        assertThat(errors.get(0), is("Pipeline 'invalid' does not exist. It is used from pipeline 'pipeline1'."));
     }
 
     @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/util/DFSCycleDetectorTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/util/DFSCycleDetectorTest.java
@@ -76,7 +76,7 @@ public class DFSCycleDetectorTest {
         try {
             project.topoSort(new CaseInsensitiveString("a"), state);
         } catch (Exception e) {
-            assertThat(e.getMessage(), is("Pipeline \"z\" does not exist. It is used from pipeline \"b\"."));
+            assertThat(e.getMessage(), is("Pipeline 'z' does not exist. It is used from pipeline 'b'."));
         }
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/GoPartialConfig.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoPartialConfig.java
@@ -82,19 +82,19 @@ public class GoPartialConfig implements PartialConfigUpdateCompletedListener, Ch
         }
     }
 
-    public CruiseConfig merge(PartialConfig partialConfig, String fingerprint, CruiseConfig cruiseConfig) {
-        PartialConfigUpdateCommand command = buildUpdateCommand(partialConfig, fingerprint);
+    public CruiseConfig merge(PartialConfig partialConfig, String fingerprint, CruiseConfig cruiseConfig, ConfigRepoConfig repoConfig) {
+        PartialConfigUpdateCommand command = buildUpdateCommand(partialConfig, fingerprint, repoConfig);
         command.update(cruiseConfig);
         return cruiseConfig;
     }
 
-    public PartialConfigUpdateCommand buildUpdateCommand(final PartialConfig partial, final String fingerprint) {
-        return new PartialConfigUpdateCommand(partial, fingerprint, cachedGoPartials);
+    public PartialConfigUpdateCommand buildUpdateCommand(final PartialConfig partial, final String fingerprint, ConfigRepoConfig configRepoConfig) {
+        return new PartialConfigUpdateCommand(partial, fingerprint, cachedGoPartials, configRepoConfig);
     }
 
     private boolean updateConfig(final PartialConfig newPart, final String fingerprint, ConfigRepoConfig repoConfig) {
         try {
-            goConfigService.updateConfig(buildUpdateCommand(newPart, fingerprint));
+            goConfigService.updateConfig(buildUpdateCommand(newPart, fingerprint, repoConfig));
             return true;
         } catch (Exception e) {
             if (repoConfig != null) {

--- a/server/src/main/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommand.java
@@ -89,13 +89,13 @@ public class PartialConfigUpdateCommand implements UpdateConfigCommand {
         partialConfig.getEnvironments().stream()
                 .filter(env -> !configRepoConfig.canRefer(ENVIRONMENT.getEntityType(), env.name().toString()))
                 .forEach(envThatCanNotBeReferred -> {
-                    envThatCanNotBeReferred.addError(ENVIRONMENT.getType(), format("Cannot refer environment: '%s' from the config repository.", envThatCanNotBeReferred.name()));
+                    envThatCanNotBeReferred.addError(ENVIRONMENT.getType(), format("Not allowed to refer environment '%s' from the config repository.", envThatCanNotBeReferred.name()));
                 });
 
         partialConfig.getGroups().stream()
                 .filter(pipelineGrp -> !configRepoConfig.canRefer(PIPELINE_GROUP.getEntityType(), pipelineGrp.getGroup()))
                 .forEach(pipelineGrpThatCannotBeReferred -> {
-                    pipelineGrpThatCannotBeReferred.addError(PIPELINE_GROUP.getType(), format("Cannot refer pipeline group: '%s' from the config repository.", pipelineGrpThatCannotBeReferred.getGroup()));
+                    pipelineGrpThatCannotBeReferred.addError(PIPELINE_GROUP.getType(), format("Not allowed to refer pipeline group '%s' from the config repository.", pipelineGrpThatCannotBeReferred.getGroup()));
                 });
 
         List<DependencyMaterialConfig> dependencyMaterialConfigs = new ArrayList<>();
@@ -106,7 +106,7 @@ public class PartialConfigUpdateCommand implements UpdateConfigCommand {
                 .filter(dependencyMaterialConfig -> !doesPipelineExistInPartialConfig(partialConfig, dependencyMaterialConfig.getPipelineName()))
                 .filter(dependencyMaterialConfig -> !configRepoConfig.canRefer(PIPELINE.getEntityType(), dependencyMaterialConfig.getPipelineName().toString()))
                 .forEach(dependencyMaterialConfigThatCannotBeReferred -> {
-                    dependencyMaterialConfigThatCannotBeReferred.addError(PIPELINE.getType(), format("Cannot refer pipeline: '%s' from the config repository.", dependencyMaterialConfigThatCannotBeReferred.getPipelineName()));
+                    dependencyMaterialConfigThatCannotBeReferred.addError(PIPELINE.getType(), format("Not allowed to refer pipeline '%s' from the config repository.", dependencyMaterialConfigThatCannotBeReferred.getPipelineName()));
                 });
 
         return ErrorCollector.getAllErrors(partialConfig).isEmpty();

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoPartialConfigTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoPartialConfigTest.java
@@ -76,9 +76,9 @@ public class GoPartialConfigTest {
         updateCommand = null;
         partialConfig = new GoPartialConfig(repoConfigDataSource, configWatchList, goConfigService, cachedGoPartials, serverHealthService) {
             @Override
-            public PartialConfigUpdateCommand buildUpdateCommand(PartialConfig partial, String fingerprint) {
+            public PartialConfigUpdateCommand buildUpdateCommand(PartialConfig partial, String fingerprint, ConfigRepoConfig repoConfig) {
                 if (null == updateCommand) {
-                    return super.buildUpdateCommand(partial, fingerprint);
+                    return super.buildUpdateCommand(partial, fingerprint, configRepoConfig);
                 }
                 return updateCommand;
             }
@@ -92,7 +92,7 @@ public class GoPartialConfigTest {
         updateCommand = mock(PartialConfigUpdateCommand.class);
         PartialConfig partial = new PartialConfig();
 
-        partialConfig.merge(partial, "finger", cruiseConfig);
+        partialConfig.merge(partial, "finger", cruiseConfig, configRepoConfig);
         verify(updateCommand, times(1)).update(cruiseConfig);
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommandTest.java
@@ -99,7 +99,7 @@ class PartialConfigUpdateCommandTest {
 
         List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
         assertThat(allErrors).hasSize(1);
-        assertThat(allErrors.get(0).on("pipeline_group")).isEqualTo("Cannot refer pipeline group: 'first' from the config repository.");
+        assertThat(allErrors.get(0).on("pipeline_group")).isEqualTo("Not allowed to refer pipeline group 'first' from the config repository.");
         assertThat(updated.hasPipelineGroup("first")).isFalse();
     }
 
@@ -118,7 +118,7 @@ class PartialConfigUpdateCommandTest {
 
         List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
         assertThat(allErrors).hasSize(1);
-        assertThat(allErrors.get(0).on("environment")).isEqualTo("Cannot refer environment: 'uat' from the config repository.");
+        assertThat(allErrors.get(0).on("environment")).isEqualTo("Not allowed to refer environment 'uat' from the config repository.");
         assertThat(updated.getEnvironments().hasEnvironmentNamed(uatEnv)).isFalse();
     }
 
@@ -136,7 +136,7 @@ class PartialConfigUpdateCommandTest {
 
         List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
         assertThat(allErrors).hasSize(1);
-        assertThat(allErrors.get(0).on("pipeline")).isEqualTo("Cannot refer pipeline: 'deploy' from the config repository.");
+        assertThat(allErrors.get(0).on("pipeline")).isEqualTo("Not allowed to refer pipeline 'deploy' from the config repository.");
         assertThat(updated.hasPipelineGroup("first")).isFalse();
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommandTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.update;
+
+import com.thoughtworks.go.config.ErrorCollector;
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.materials.MaterialConfigs;
+import com.thoughtworks.go.config.remote.ConfigRepoConfig;
+import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.config.remote.RepoConfigOrigin;
+import com.thoughtworks.go.config.rules.Allow;
+import com.thoughtworks.go.domain.ConfigErrors;
+import com.thoughtworks.go.domain.PipelineGroups;
+import com.thoughtworks.go.helper.PipelineConfigMother;
+import com.thoughtworks.go.plugin.access.configrepo.InvalidPartialConfigException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.List;
+
+import static com.thoughtworks.go.helper.MaterialConfigsMother.dependencyMaterialConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+class PartialConfigUpdateCommandTest {
+
+    private BasicCruiseConfig cruiseConfig;
+    private ConfigRepoConfig configRepoConfig;
+    private PartialConfig partial;
+    private String fingerprint;
+    @Mock
+    private PartialConfigResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+        cruiseConfig = new BasicCruiseConfig();
+        configRepoConfig = new ConfigRepoConfig();
+        partial = new PartialConfig();
+        fingerprint = "some-fingerprint";
+    }
+
+    @Test
+    void shouldUpdateSuccessfully() {
+        configRepoConfig.getRules().add(new Allow("refer", "*", "*"));
+
+        BasicPipelineConfigs group = new BasicPipelineConfigs("first", new Authorization());
+        group.setOrigin(new RepoConfigOrigin());
+        group.add(PipelineConfigMother.pipelineConfig("up42"));
+        partial.setPipelines(new PipelineGroups(group));
+        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, configRepoConfig);
+        CruiseConfig updated = command.update(cruiseConfig);
+
+        assertThat(ErrorCollector.getAllErrors(this.partial)).isEmpty();
+        assertThat(updated.hasPipelineGroup("first")).isTrue();
+        assertThat(updated.getPartials()).hasSize(1);
+    }
+
+    @Test
+    void shouldFailToUpdateWhenNoRulesAreConfigured() {
+        BasicPipelineConfigs group = new BasicPipelineConfigs("first", new Authorization());
+        group.setOrigin(new RepoConfigOrigin());
+        group.add(PipelineConfigMother.pipelineConfig("up42"));
+        partial.setPipelines(new PipelineGroups(group));
+        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, configRepoConfig);
+
+        assertThatCode(() -> command.update(cruiseConfig))
+                .isInstanceOf(InvalidPartialConfigException.class)
+                .hasMessage("Configurations can not be merged as no rules are defined.");
+    }
+
+    @Test
+    void shouldFailToDefinePipelineGroupWhenNoRuleMatches() {
+        configRepoConfig.getRules().add(new Allow("refer", "pipeline_group", "team1"));
+
+        BasicPipelineConfigs team1 = new BasicPipelineConfigs("team1", new Authorization());
+        BasicPipelineConfigs first = new BasicPipelineConfigs("first", new Authorization());
+        first.setOrigin(new RepoConfigOrigin());
+        first.add(PipelineConfigMother.pipelineConfig("up42"));
+        partial.setPipelines(new PipelineGroups(first, team1));
+        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, configRepoConfig);
+        CruiseConfig updated = command.update(cruiseConfig);
+
+        List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
+        assertThat(allErrors).hasSize(1);
+        assertThat(allErrors.get(0).on("pipeline_group")).isEqualTo("Cannot refer pipeline group: 'first' from the config repository.");
+        assertThat(updated.hasPipelineGroup("first")).isFalse();
+    }
+
+    @Test
+    void shouldFailToDefineEnvironmentWhenNoRuleMatches() {
+        configRepoConfig.getRules().add(new Allow("refer", "environment", "prod"));
+
+        EnvironmentsConfig allEnvs = new EnvironmentsConfig();
+        CaseInsensitiveString prodEnv = new CaseInsensitiveString("prod");
+        CaseInsensitiveString uatEnv = new CaseInsensitiveString("uat");
+        allEnvs.add(new BasicEnvironmentConfig(uatEnv));
+        allEnvs.add(new BasicEnvironmentConfig(prodEnv));
+        partial.setEnvironments(allEnvs);
+        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, configRepoConfig);
+        CruiseConfig updated = command.update(cruiseConfig);
+
+        List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
+        assertThat(allErrors).hasSize(1);
+        assertThat(allErrors.get(0).on("environment")).isEqualTo("Cannot refer environment: 'uat' from the config repository.");
+        assertThat(updated.getEnvironments().hasEnvironmentNamed(uatEnv)).isFalse();
+    }
+
+    @Test
+    void shouldFailToDefineUpstreamDependencyWhenNoRuleMatches() {
+        configRepoConfig.getRules().add(new Allow("refer", "pipeline_group", "*"));
+        configRepoConfig.getRules().add(new Allow("refer", "pipeline", "build"));
+
+        BasicPipelineConfigs group = new BasicPipelineConfigs("first", new Authorization());
+        group.setOrigin(new RepoConfigOrigin());
+        group.add(PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs(dependencyMaterialConfig("build", "stage"), dependencyMaterialConfig("deploy", "stage"))));
+        partial.setPipelines(new PipelineGroups(group));
+        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, configRepoConfig);
+        CruiseConfig updated = command.update(cruiseConfig);
+
+        List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
+        assertThat(allErrors).hasSize(1);
+        assertThat(allErrors.get(0).on("pipeline")).isEqualTo("Cannot refer pipeline: 'deploy' from the config repository.");
+        assertThat(updated.hasPipelineGroup("first")).isFalse();
+    }
+
+    @Test
+    void shouldAllowToDefineUpstreamDependencyFromTheSameConfigRepositoryRegardlessOfRules() {
+        configRepoConfig.getRules().add(new Allow("refer", "pipeline_group", "*"));
+        configRepoConfig.getRules().add(new Allow("refer", "pipeline", "build"));
+
+        BasicPipelineConfigs group = new BasicPipelineConfigs("first", new Authorization());
+        group.setOrigin(new RepoConfigOrigin());
+        group.add(PipelineConfigMother.pipelineConfig("upstream", new MaterialConfigs(dependencyMaterialConfig("build", "stage"))));
+        group.add(PipelineConfigMother.pipelineConfig("downstream", new MaterialConfigs(dependencyMaterialConfig("upstream", "stage"))));
+        partial.setPipelines(new PipelineGroups(group));
+        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, configRepoConfig);
+        CruiseConfig updated = command.update(cruiseConfig);
+
+        assertThat(ErrorCollector.getAllErrors(this.partial)).isEmpty();
+        assertThat(updated.hasPipelineGroup("first")).isTrue();
+        assertThat(updated.getPartials()).hasSize(1);
+    }
+
+    @Test
+    void shouldNotApplyRulesForPreflightCheck_WhenNoConfigRepositoryIsSpecified() {
+        BasicPipelineConfigs group = new BasicPipelineConfigs("first", new Authorization());
+        group.setOrigin(new RepoConfigOrigin());
+        group.add(PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs(dependencyMaterialConfig("build", "stage"), dependencyMaterialConfig("deploy", "stage"))));
+        partial.setPipelines(new PipelineGroups(group));
+        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, null);
+        CruiseConfig updated = command.update(cruiseConfig);
+
+        assertThat(ErrorCollector.getAllErrors(this.partial)).isEmpty();
+        assertThat(updated.hasPipelineGroup("first")).isTrue();
+        assertThat(updated.getPartials()).hasSize(1);
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommandTest.java
@@ -80,9 +80,11 @@ class PartialConfigUpdateCommandTest {
         partial.setPipelines(new PipelineGroups(group));
         PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, configRepoConfig);
 
-        assertThatCode(() -> command.update(cruiseConfig))
-                .isInstanceOf(InvalidPartialConfigException.class)
-                .hasMessage("Configurations can not be merged as no rules are defined.");
+        CruiseConfig updated = command.update(cruiseConfig);
+        List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
+        assertThat(allErrors).hasSize(1);
+        assertThat(allErrors.get(0).on("pipeline_group")).isEqualTo("Not allowed to refer pipeline group 'first' from the config repository.");
+        assertThat(updated.hasPipelineGroup("first")).isFalse();
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
@@ -243,7 +243,7 @@ public class CachedGoConfigIntegrationTest {
         // and errors are still shown
         messageForInvalidMerge = serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(firstDownstreamConfigRepo));
         assertThat(messageForInvalidMerge.isEmpty()).isFalse();
-        assertThat(messageForInvalidMerge.get(0).getDescription()).contains("Pipeline &quot;pipe1&quot; does not exist. It is used from pipeline &quot;downstream&quot");
+        assertThat(messageForInvalidMerge.get(0).getDescription()).contains("Pipeline 'pipe1' does not exist. It is used from pipeline 'downstream'");
         // and current config is still old
         assertThat(goConfigService.hasPipelineNamed(new CaseInsensitiveString("downstream"))).isFalse();
         assertThat(goConfigService.hasPipelineNamed(new CaseInsensitiveString("downstream2"))).isFalse();

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
@@ -29,6 +29,7 @@ import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
+import com.thoughtworks.go.config.rules.Allow;
 import com.thoughtworks.go.domain.GoConfigRevision;
 import com.thoughtworks.go.helper.*;
 import com.thoughtworks.go.server.service.GoConfigService;
@@ -112,7 +113,9 @@ public class GoFileConfigDataSourceIntegrationTest {
         configHelper = new GoConfigFileHelper(DEFAULT_XML_WITH_2_AGENTS);
         configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
         configHelper.onSetUp();
-        repoConfig = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url"), XmlPartialConfigProvider.providerName, "git-id");
+        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url"), XmlPartialConfigProvider.providerName, "git-id");
+        config.getRules().add(new Allow("refer", "*", "*"));
+        repoConfig = config;
         configHelper.addConfigRepo(repoConfig);
         configHelper.addPipeline("upstream", "upstream_stage_original");
         goConfigService.forceNotifyListeners();

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoPartialConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoPartialConfigIntegrationTest.java
@@ -16,9 +16,11 @@
 package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
+import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
+import com.thoughtworks.go.config.rules.Allow;
 import com.thoughtworks.go.domain.config.Configuration;
 import com.thoughtworks.go.domain.config.PluginConfiguration;
 import com.thoughtworks.go.domain.scm.SCM;
@@ -76,11 +78,17 @@ public class GoPartialConfigIntegrationTest {
         goCache.clear();
         configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
-        repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(git("url1"), "plugin", "id-1");
-        repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin", "id-2");
+        repoConfig1 = createConfigRepoWithDefaultRules(git("url1"), "plugin", "id-1");
+        repoConfig2 = createConfigRepoWithDefaultRules(git("url2"), "plugin", "id-2");
         configHelper.addConfigRepo(repoConfig1);
         configHelper.addConfigRepo(repoConfig2);
 
+    }
+
+    private ConfigRepoConfig createConfigRepoWithDefaultRules(GitMaterialConfig materialConfig, String plugin, String id) {
+        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(materialConfig, plugin, id);
+        config.getRules().add(new Allow("refer", "*", "*"));
+        return config;
     }
 
     @After
@@ -171,7 +179,7 @@ public class GoPartialConfigIntegrationTest {
 
     @Test
     public void shouldMarkAnInvalidKnownPartialAsValidWhenLoadingAnotherPartialMakesThisOneValid_InterConfigRepoDependency() {
-        ConfigRepoConfig repoConfig3 = ConfigRepoConfig.createConfigRepoConfig(git("url3"), "plugin", "id-3");
+        ConfigRepoConfig repoConfig3 = createConfigRepoWithDefaultRules(git("url3"), "plugin", "id-3");
         configHelper.addConfigRepo(repoConfig3);
 
         PartialConfig repo1 = PartialConfigMother.withPipeline("p1_repo1", new RepoConfigOrigin(repoConfig1, "1"));

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoPartialConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoPartialConfigIntegrationTest.java
@@ -197,7 +197,7 @@ public class GoPartialConfigIntegrationTest {
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(false));
         ServerHealthState healthStateForInvalidConfigMerge = serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0);
         assertThat(healthStateForInvalidConfigMerge.getMessage(), is("Invalid Merged Configuration"));
-        assertThat(healthStateForInvalidConfigMerge.getDescription(), is("Number of errors: 3+\n1. Pipeline &quot;p1_repo1&quot; does not exist. It is used from pipeline &quot;p2_repo2&quot;.;; \n2. Pipeline with name 'p1_repo1' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at 1);; \n3. Pipeline with name 'p3_repo3' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at 1);; \n- For Config Repo: url2 at 1"));
+        assertThat(healthStateForInvalidConfigMerge.getDescription(), is("Number of errors: 3+\n1. Pipeline 'p1_repo1' does not exist. It is used from pipeline 'p2_repo2'.;; \n2. Pipeline with name 'p1_repo1' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at 1);; \n3. Pipeline with name 'p3_repo3' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at 1);; \n- For Config Repo: url2 at 1"));
         assertThat(healthStateForInvalidConfigMerge.getLogLevel(), is(HealthStateLevel.ERROR));
         assertThat(cachedGoPartials.lastValidPartials().isEmpty(), is(true));
         assertThat(cachedGoPartials.lastKnownPartials().size(), is(1));

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoRepoConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoRepoConfigDataSourceIntegrationTest.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
+import com.thoughtworks.go.config.rules.Allow;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.server.service.ConfigRepoService;
 import com.thoughtworks.go.server.service.GoConfigService;
@@ -87,6 +88,7 @@ public class GoRepoConfigDataSourceIntegrationTest {
         File templateConfigRepo = temporaryFolder.newFolder();
         String latestRevision = setupExternalConfigRepo(templateConfigRepo, "external_git_config_repo_referencing_template_with_params");
         ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git(templateConfigRepo.getAbsolutePath()), "gocd-xml", "config-id");
+        configRepoConfig.getRules().add(new Allow("refer", "*", "*"));
         configHelper.addConfigRepo(configRepoConfig);
 
         goConfigService.forceNotifyListeners();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerIntegrationTest.java
@@ -19,6 +19,7 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterial;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.config.rules.Allow;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.helper.ConfigTestRepo;
 import com.thoughtworks.go.helper.GoConfigMother;
@@ -105,7 +106,9 @@ public class ConfigMaterialUpdateListenerIntegrationTest {
         configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
 
         materialConfig = hg(hgRepo.projectRepositoryUrl(), null);
-        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(materialConfig, "gocd-xml", "gocd-id"));
+        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(materialConfig, "gocd-xml", "gocd-id");
+        config.getRules().add(new Allow("refer", "*", "*"));
+        configHelper.addConfigRepo(config);
 
         TestingEmailSender emailSender = new TestingEmailSender();
         SystemDiskSpaceChecker mockDiskSpaceChecker = Mockito.mock(SystemDiskSpaceChecker.class);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceConfigRepoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceConfigRepoIntegrationTest.java
@@ -24,17 +24,14 @@ import com.thoughtworks.go.config.materials.mercurial.HgMaterial;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
+import com.thoughtworks.go.config.rules.Allow;
 import com.thoughtworks.go.domain.MaterialRevisions;
 import com.thoughtworks.go.domain.Pipeline;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.git.GitTestRepo;
-import com.thoughtworks.go.helper.ConfigTestRepo;
-import com.thoughtworks.go.helper.HgTestRepo;
-import com.thoughtworks.go.helper.PipelineConfigMother;
-import com.thoughtworks.go.helper.PipelineMother;
-import com.thoughtworks.go.helper.TestRepo;
+import com.thoughtworks.go.helper.*;
 import com.thoughtworks.go.server.cronjob.GoDiskSpaceMonitor;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.dao.PipelineDao;
@@ -133,7 +130,9 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
         configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
 
         materialConfig = hgRepo.materialConfig();
-        configHelper.addConfigRepo(ConfigRepoConfig.createConfigRepoConfig(materialConfig,"gocd-xml", "gocd-id"));
+        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(materialConfig, "gocd-xml", "gocd-id");
+        config.getRules().add(new Allow("refer", "*", "*"));
+        configHelper.addConfigRepo(config);
 
         logger = mock(MDUPerformanceLogger.class);
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
@@ -30,6 +30,7 @@ import com.thoughtworks.go.config.materials.svn.SvnMaterial;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
+import com.thoughtworks.go.config.rules.Allow;
 import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.MaterialRevisions;
 import com.thoughtworks.go.domain.Pipeline;
@@ -473,6 +474,7 @@ public class BuildCauseProducerServiceIntegrationTest {
     @Test
     public void shouldTriggerMDUOfConfigRepoMaterialIfThePipelineIsDefinedRemotelyInAConfigRepo_ManualTriggerOfPipeline_EvenIfMDUOptionIsTurnedOFFInRequest() throws Exception {
         ConfigRepoConfig repoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin", "id-2");
+        repoConfig.getRules().add(new Allow("refer", "*", "*"));
         configHelper.addConfigRepo(repoConfig);
         PartialConfig partialConfig = PartialConfigMother.withPipelineMultipleMaterials("remote_pipeline", new RepoConfigOrigin(repoConfig, "4567"));
         PipelineConfig remotePipeline = partialConfig.getGroups().first().getPipelines().get(0);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/GoConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/GoConfigServiceIntegrationTest.java
@@ -679,7 +679,7 @@ public class GoConfigServiceIntegrationTest {
         assertThat(validity.isValid(), is(false));
         GoConfigValidity.InvalidGoConfig invalidGoConfig = (GoConfigValidity.InvalidGoConfig) validity;
         assertThat(validity.toString(), invalidGoConfig.isType(GoConfigValidity.VT_MERGE_POST_VALIDATION_ERROR), is(true));
-        assertThat(invalidGoConfig.errorMessage(), is("Pipeline \"up_pipeline\" does not exist. It is used from pipeline \"down_pipeline\"."));
+        assertThat(invalidGoConfig.errorMessage(), is("Pipeline 'up_pipeline' does not exist. It is used from pipeline 'down_pipeline'."));
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
@@ -21,11 +21,13 @@ import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.materials.PackageMaterialConfig;
 import com.thoughtworks.go.config.materials.PluggableSCMMaterialConfig;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
+import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.config.parts.XmlPartialConfigProvider;
 import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
+import com.thoughtworks.go.config.rules.Allow;
 import com.thoughtworks.go.domain.config.*;
 import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.helper.*;
@@ -124,8 +126,8 @@ public class PipelineConfigServiceIntegrationTest {
         user = new Username(new CaseInsensitiveString("current"));
         pipelineConfig = GoConfigMother.createPipelineConfigWithMaterialConfig(UUID.randomUUID().toString(), git("FOO"));
         goConfigService.addPipeline(pipelineConfig, groupName);
-        repoConfig1 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url"), XmlPartialConfigProvider.providerName, "git-id1");
-        repoConfig2 = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), XmlPartialConfigProvider.providerName, "git-id2");
+        repoConfig1 = createConfigRepoWithDefaultRules(MaterialConfigsMother.gitMaterialConfig("url"), XmlPartialConfigProvider.providerName, "git-id1");
+        repoConfig2 = createConfigRepoWithDefaultRules(MaterialConfigsMother.gitMaterialConfig("url2"), XmlPartialConfigProvider.providerName, "git-id2");
         goConfigService.updateConfig(new UpdateConfigCommand() {
             @Override
             public CruiseConfig update(CruiseConfig cruiseConfig) throws Exception {
@@ -1089,5 +1091,11 @@ public class PipelineConfigServiceIntegrationTest {
     private void saveConfig(CruiseConfig cruiseConfig) throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         new MagicalGoConfigXmlWriter(configCache, registry).write(cruiseConfig, buffer, false);
+    }
+
+    private ConfigRepoConfig createConfigRepoWithDefaultRules(GitMaterialConfig materialConfig, String plugin, String id) {
+        ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(materialConfig, plugin, id);
+        config.getRules().add(new Allow("refer", "*", "*"));
+        return config;
     }
 }


### PR DESCRIPTION
Issue: #7605 

Description:
 - The PartialConfig is validated against the rules defined in the config repo while updating the config in the PartialConfigUpdateCommand.
 - In case of pre-flight api where no config-repo id is specified, the check is skipped.

Preview:

<img width="1000" alt="Screen Shot 2020-02-03 at 5 20 54 PM" src="https://user-images.githubusercontent.com/41165891/73651141-d1b5ee80-46a9-11ea-9245-c87423dbe4d2.png">


