### PR TITLE
Deprecate config repos API v2

### DIFF
--- a/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/ConfigReposControllerV2.java
+++ b/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/ConfigReposControllerV2.java
@@ -24,6 +24,7 @@ import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.api.util.GsonTransformer;
 import com.thoughtworks.go.apiv2.configrepos.representers.ConfigRepoConfigRepresenterV2;
 import com.thoughtworks.go.apiv2.configrepos.representers.ConfigReposConfigRepresenterV2;
+import com.thoughtworks.go.spark.DeprecatedAPI;
 import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.ConfigReposConfig;
@@ -46,6 +47,7 @@ import static java.util.stream.Collectors.toCollection;
 import static spark.Spark.*;
 
 @Component
+@DeprecatedAPI(deprecatedApiVersion = ApiVersion.v2, successorApiVersion = ApiVersion.v3, deprecatedIn = "20.2.0", removalIn = "20.5.0", entityName = "Config Repo")
 public class ConfigReposControllerV2 extends ApiController implements SparkSpringController, CrudController<ConfigRepoConfig> {
     private final ApiAuthenticationHelper authHelper;
     private final ConfigRepoService service;

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposControllerV2Test.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposControllerV2Test.groovy
@@ -31,6 +31,7 @@ import com.thoughtworks.go.server.service.ConfigRepoService
 import com.thoughtworks.go.server.service.EntityHashingService
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult
 import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.DeprecatedApiTrait
 import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.Routes
 import com.thoughtworks.go.spark.SecurityServiceTrait
@@ -47,7 +48,7 @@ import static org.mockito.Mockito.*
 import static org.mockito.MockitoAnnotations.initMocks
 import static org.mockito.internal.verification.VerificationModeFactory.times
 
-class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTrait<ConfigReposControllerV2> {
+class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTrait<ConfigReposControllerV2>, DeprecatedApiTrait {
   private static final String TEST_PLUGIN_ID = "test.configrepo.plugin"
   private static final String TEST_REPO_URL = "https://fakeurl.com"
   private static final String ID_1 = "repo-01"

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/DeprecatedAPI.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/DeprecatedAPI.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.spark;
+
+import com.thoughtworks.go.api.ApiVersion;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(ElementType.TYPE)
+public @interface DeprecatedAPI {
+    ApiVersion deprecatedApiVersion();
+
+    ApiVersion successorApiVersion();
+
+    String deprecatedIn();
+
+    String removalIn();
+
+    String entityName();
+}

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/DeprecatedApiTrait.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/DeprecatedApiTrait.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.spark
+
+
+import org.junit.jupiter.api.Test
+
+import static org.assertj.core.api.Java6Assertions.assertThat
+
+trait DeprecatedApiTrait {
+  @Test
+  void 'should verify the Controller is marked as deprecated'() {
+    def deprecatedApiAnnotation = controller.getClass().getAnnotation(DeprecatedAPI.class)
+    assertThat(deprecatedApiAnnotation).isNotNull()
+  }
+}

--- a/spark/spark-base/src/test/java/com/thoughtworks/go/spark/RoutesHelperTest.java
+++ b/spark/spark-base/src/test/java/com/thoughtworks/go/spark/RoutesHelperTest.java
@@ -16,7 +16,10 @@
 
 package com.thoughtworks.go.spark;
 
+import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
+import com.thoughtworks.go.spark.spring.SparkSpringController;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import spark.Request;
@@ -32,14 +35,14 @@ class RoutesHelperTest {
 
     private static Stream<Data> data() {
         return Stream.of(
-            new Data(TEXT_HTML_VALUE, HtmlErrorPage.errorPage(404, "Boom!!")),
-            new Data(APPLICATION_XHTML_XML_VALUE, HtmlErrorPage.errorPage(404, "Boom!!")),
-            new Data(APPLICATION_XML_VALUE, new RecordNotFoundException("Boom!!").asXML()),
-            new Data(TEXT_XML_VALUE, new RecordNotFoundException("Boom!!").asXML()),
-            new Data(APPLICATION_RSS_XML_VALUE, new RecordNotFoundException("Boom!!").asXML()),
-            new Data(APPLICATION_ATOM_XML_VALUE, new RecordNotFoundException("Boom!!").asXML()),
-            new Data(APPLICATION_JSON_VALUE, JSON_MESSAGE),
-            new Data("BAR", JSON_MESSAGE)
+                new Data(TEXT_HTML_VALUE, HtmlErrorPage.errorPage(404, "Boom!!")),
+                new Data(APPLICATION_XHTML_XML_VALUE, HtmlErrorPage.errorPage(404, "Boom!!")),
+                new Data(APPLICATION_XML_VALUE, new RecordNotFoundException("Boom!!").asXML()),
+                new Data(TEXT_XML_VALUE, new RecordNotFoundException("Boom!!").asXML()),
+                new Data(APPLICATION_RSS_XML_VALUE, new RecordNotFoundException("Boom!!").asXML()),
+                new Data(APPLICATION_ATOM_XML_VALUE, new RecordNotFoundException("Boom!!").asXML()),
+                new Data(APPLICATION_JSON_VALUE, JSON_MESSAGE),
+                new Data("BAR", JSON_MESSAGE)
         );
     }
 
@@ -50,8 +53,7 @@ class RoutesHelperTest {
         Response response = mock(Response.class);
         when(request.headers("Accept")).thenReturn(data.mimeType);
 
-        new RoutesHelper(mock(SparkController.class))
-            .httpException(new RecordNotFoundException("Boom!!"), request, response);
+        new RoutesHelper(mock(SparkController.class)).httpException(new RecordNotFoundException("Boom!!"), request, response);
 
         verify(response).body(data.responseText);
     }
@@ -63,6 +65,32 @@ class RoutesHelperTest {
         Data(String mimeType, String responseText) {
             this.mimeType = mimeType;
             this.responseText = responseText;
+        }
+    }
+
+    @Test
+    void shouldAddDeprecationHeaders() {
+        DoNothingApiV1 doNothingApiV1 = new DoNothingApiV1();
+
+        RoutesHelper helper = new RoutesHelper(doNothingApiV1);
+
+        Request request = mock(Request.class);
+        Response response = mock(Response.class);
+        when(request.url()).thenReturn("http://test.host:80/go");
+
+        helper.setDeprecationHeaders(request, response, doNothingApiV1.getClass().getAnnotation(DeprecatedAPI.class));
+
+        verify(response).header("X-GoCD-API-Deprecated-In", "v20.2.0");
+        verify(response).header("X-GoCD-API-Removal-In", "v20.5.0");
+        verify(response).header("X-GoCD-API-Deprecation-Info", "https://api.gocd.org/20.2.0/#api-changelog");
+        verify(response).header("Link", "<http://test.host:80/go>; Accept=\"application/vnd.go.cd.v2+json\"; rel=\"successor-version\"");
+        verify(response).header("Warning", "299 GoCD/v20.2.0 \"The Do Nothing API version v1 has been deprecated in GoCD Release v20.2.0. This version will be removed in GoCD Release v20.5.0. Version v2 of the API is available, and users are encouraged to use it\"");
+    }
+
+    @DeprecatedAPI(deprecatedApiVersion = ApiVersion.v1, successorApiVersion = ApiVersion.v2, deprecatedIn = "20.2.0", removalIn = "20.5.0", entityName = "Do Nothing")
+    private class DoNothingApiV1 implements SparkSpringController {
+        @Override
+        public void setupRoutes() {
         }
     }
 }


### PR DESCRIPTION
#### Issue: #7713

#### Description:
Add deprecation headers to config repos API v2

```bash
$ curl --head 'http://localhost:8153/go/api/admin/config_repos/repo' \
      -u 'admin:badger' \
      -H 'Accept:application/vnd.go.cd.v2+json'

HTTP/1.1 200 OK
Date: Wed, 12 Feb 2020 07:50:52 GMT
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-UA-Compatible: chrome=1
Set-Cookie: JSESSIONID=node01oj2xj1fxm0ni1q1ksufyzxvx418.node0; Path=/go; Expires=Wed, 26-Feb-2020 07:50:52 GMT; Max-Age=1209600; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Cache-Control: max-age=0, private, must-revalidate
X-GoCD-API-Deprecated-In: v20.2.0
X-GoCD-API-Removal-In: v20.5.0
X-GoCD-API-Deprecation-Info: https://api.gocd.org/20.2.0/#api-changelog
Link: <http://localhost:8153/go/api/admin/config_repos/repo1>; Accept="application/vnd.go.cd.v3+json"; rel="successor-version"
Warning: 299 GoCD/v20.2.0 "The Config Repo API version v2 has been deprecated in GoCD Release v20.2.0. This version will be removed in GoCD Release v20.5.0. Version v3 of the API is available, and users are encouraged to use it"
Content-Type: application/vnd.go.cd.v2+json;charset=utf-8
X-Runtime: 1
Vary: Accept-Encoding, User-Agent
Transfer-Encoding: chunked
```


