### PR TITLE
Deprecate GoCD based apis

### DIFF
--- a/api/api-stage-operations-v1/src/main/java/com/thoughtworks/go/apiv1/stageoperations/StageOperationsControllerV1.java
+++ b/api/api-stage-operations-v1/src/main/java/com/thoughtworks/go/apiv1/stageoperations/StageOperationsControllerV1.java
@@ -35,6 +35,7 @@ import com.thoughtworks.go.server.service.result.HttpOperationResult;
 import com.thoughtworks.go.server.util.Pagination;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
+import com.thoughtworks.go.spark.DeprecatedAPI;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
 import org.slf4j.Logger;
@@ -54,6 +55,7 @@ import static com.thoughtworks.go.api.util.HaltApiResponses.haltBecauseOfReason;
 import static spark.Spark.*;
 
 @Component
+@DeprecatedAPI(deprecatedApiVersion = ApiVersion.v1, successorApiVersion = ApiVersion.v2, deprecatedIn = "20.1.0", removalIn = "20.4.0", entityName = "Stages")
 public class StageOperationsControllerV1 extends ApiController implements SparkSpringController {
     private static final Logger LOGGER = LoggerFactory.getLogger(StageOperationsControllerV1.class);
     private final static String JOB_NAMES_PROPERTY = "jobs";

--- a/api/api-stage-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/stageoperations/StageOperationsControllerV1Test.groovy
+++ b/api/api-stage-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/stageoperations/StageOperationsControllerV1Test.groovy
@@ -35,6 +35,7 @@ import com.thoughtworks.go.server.util.Pagination
 import com.thoughtworks.go.serverhealth.HealthStateScope
 import com.thoughtworks.go.serverhealth.HealthStateType
 import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.DeprecatedApiTrait
 import com.thoughtworks.go.spark.PipelineAccessSecurity
 import com.thoughtworks.go.spark.PipelineGroupOperateUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
@@ -49,7 +50,7 @@ import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
 import static org.mockito.MockitoAnnotations.initMocks
 
-class StageOperationsControllerV1Test implements SecurityServiceTrait, ControllerTrait<StageOperationsControllerV1> {
+class StageOperationsControllerV1Test implements SecurityServiceTrait, ControllerTrait<StageOperationsControllerV1>, DeprecatedApiTrait {
   @Mock
   ScheduleService scheduleService
 

--- a/api/api-template-config-v5/src/main/java/com/thoughtworks/go/apiv5/admin/templateconfig/TemplateConfigControllerV5.java
+++ b/api/api-template-config-v5/src/main/java/com/thoughtworks/go/apiv5/admin/templateconfig/TemplateConfigControllerV5.java
@@ -33,6 +33,7 @@ import com.thoughtworks.go.server.newsecurity.utils.SessionUtils;
 import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.TemplateConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import com.thoughtworks.go.spark.DeprecatedAPI;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,6 +49,7 @@ import static com.thoughtworks.go.api.util.HaltApiResponses.*;
 import static spark.Spark.*;
 
 @Component
+@DeprecatedAPI(deprecatedApiVersion = ApiVersion.v5, successorApiVersion = ApiVersion.v7, deprecatedIn = "19.12.0", removalIn = "20.3.0", entityName = "Templates")
 public class TemplateConfigControllerV5 extends ApiController implements SparkSpringController, CrudController<PipelineTemplateConfig> {
 
     private final TemplateConfigService templateConfigService;

--- a/api/api-template-config-v5/src/test/groovy/com/thoughtworks/go/apiv5/admin/templateconfig/TemplateConfigControllerV5Test.groovy
+++ b/api/api-template-config-v5/src/test/groovy/com/thoughtworks/go/apiv5/admin/templateconfig/TemplateConfigControllerV5Test.groovy
@@ -37,7 +37,7 @@ import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
 import static org.mockito.MockitoAnnotations.initMocks
 
-class TemplateConfigControllerV5Test implements SecurityServiceTrait, ControllerTrait<TemplateConfigControllerV5> {
+class TemplateConfigControllerV5Test implements SecurityServiceTrait, ControllerTrait<TemplateConfigControllerV5>, DeprecatedApiTrait {
 
   private PipelineTemplateConfig template
 

--- a/api/api-template-config-v6/src/main/java/com/thoughtworks/go/apiv6/admin/templateconfig/TemplateConfigControllerV6.java
+++ b/api/api-template-config-v6/src/main/java/com/thoughtworks/go/apiv6/admin/templateconfig/TemplateConfigControllerV6.java
@@ -33,6 +33,7 @@ import com.thoughtworks.go.server.newsecurity.utils.SessionUtils;
 import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.TemplateConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import com.thoughtworks.go.spark.DeprecatedAPI;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,6 +49,7 @@ import static com.thoughtworks.go.api.util.HaltApiResponses.*;
 import static spark.Spark.*;
 
 @Component
+@DeprecatedAPI(deprecatedApiVersion = ApiVersion.v6, successorApiVersion = ApiVersion.v7, deprecatedIn = "20.2.0", removalIn = "20.5.0", entityName = "Templates")
 public class TemplateConfigControllerV6 extends ApiController implements SparkSpringController, CrudController<PipelineTemplateConfig> {
 
     private final TemplateConfigService templateConfigService;

--- a/api/api-template-config-v6/src/test/groovy/com/thoughtworks/go/apiv6/admin/templateconfig/TemplateConfigControllerV6Test.groovy
+++ b/api/api-template-config-v6/src/test/groovy/com/thoughtworks/go/apiv6/admin/templateconfig/TemplateConfigControllerV6Test.groovy
@@ -37,7 +37,7 @@ import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
 import static org.mockito.MockitoAnnotations.initMocks
 
-class TemplateConfigControllerV6Test implements SecurityServiceTrait, ControllerTrait<TemplateConfigControllerV6> {
+class TemplateConfigControllerV6Test implements SecurityServiceTrait, ControllerTrait<TemplateConfigControllerV6>, DeprecatedApiTrait {
 
   private PipelineTemplateConfig template
 

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/api/agents_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/api/agents_controller.rb
@@ -16,6 +16,7 @@
 
 class Api::AgentsController < Api::ApiController
   include AuthenticationHelper
+  include DeprecatedApiHelper
 
   before_action :check_user_and_404
   before_action :check_admin_user_and_403, except: [:index, :show, :job_run_history]
@@ -23,6 +24,8 @@ class Api::AgentsController < Api::ApiController
   JobHistoryColumns = com.thoughtworks.go.server.service.JobInstanceService::JobHistoryColumns
 
   def job_run_history
+    add_deprecation_headers(request, response, "unversioned", nil, "v1", "19.12.0", "20.3.0", "Agent Job Run History")
+
     offset = params[:offset].to_i
     page_size = 10
     job_instance_count = job_instance_service.totalCompletedJobsCountOn(params[:uuid])

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/api/jobs_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/api/jobs_controller.rb
@@ -17,6 +17,7 @@
 java_import 'org.springframework.dao.DataRetrievalFailureException'
 
 class Api::JobsController < Api::ApiController
+  include DeprecatedApiHelper
   include ApplicationHelper
 
   def render_not_found()
@@ -40,6 +41,8 @@ class Api::JobsController < Api::ApiController
   end
 
   def history
+    add_deprecation_headers(request, response, "unversioned", nil, "v1", "20.1.0", "20.4.0", "Job History")
+
     pipeline_name = params[:pipeline_name]
     stage_name = params[:stage_name]
     job_name = params[:job_name]

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/api/jobs_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/api/jobs_controller.rb
@@ -25,6 +25,9 @@ class Api::JobsController < Api::ApiController
   end
 
   def index
+    add_deprecation_headers(request, response, "unversioned", "/go/api/feed/pipelines/:pipeline_name/:pipeline_counter/:stage_name/:stage_counter/:job_name.xml",
+                            nil, "20.1.0", "20.4.0", "Job Feed")
+
     return render_not_found unless number?(params[:id])
     job_id = Integer(params[:id])
     begin

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/api/pipeline_groups_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/api/pipeline_groups_controller.rb
@@ -15,9 +15,11 @@
 #
 
 class Api::PipelineGroupsController < Api::ApiController
+  include DeprecatedApiHelper
   before_action :check_api_enabled_toggle_and_404
 
   def list_configs
+    add_deprecation_headers(request, response, "unversioned", "/go/api/admin/pipeline_groups", "v1", "19.12.0", "20.3.0", "Pipeline Groups Config Listing")
     pipeline_group_configs = pipeline_configs_service.getGroupsForUser(CaseInsensitiveString.str(current_user.getUsername()))
     pipeline_group_config_api_models = pipeline_group_configs.collect do |pipeline_group_config|
       PipelineGroupConfigAPIModel.new(pipeline_group_config)

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/api/pipelines_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/api/pipelines_controller.rb
@@ -74,6 +74,9 @@ class Api::PipelinesController < Api::ApiController
   end
 
   def pipeline_instance
+    add_deprecation_headers(request, response, "unversioned", "/go/api/feed/pipelines/#{params[:name]}/#{params[:id]}.xml", nil,
+                            "20.1.0", "20.4.0", "Pipeline Feed")
+
     pipeline = pipeline_history_service.load(params[:id].to_i, current_user, result = HttpOperationResult.new)
     if (result.canContinue())
       @doc = xml_api_service.write(PipelineXmlViewModel.new(pipeline), "#{request.protocol}#{request.host_with_port}/go")
@@ -82,10 +85,15 @@ class Api::PipelinesController < Api::ApiController
   end
 
   def pipelines
+    add_deprecation_headers(request, response, "unversioned", "/go/api/feed/pipelines.xml", nil,
+                            "20.1.0", "20.4.0", "Pipelines Feed")
     @pipelines = pipeline_history_service.latestInstancesForConfiguredPipelines(current_user)
   end
 
   def stage_feed
+    add_deprecation_headers(request, response, "unversioned", "/go/api/feed/pipelines/#{params[:name]}/stages.xml", nil,
+                            "20.1.0", "20.4.0", "Stages Feed")
+
     @title = @pipeline_name = params[:name]
     if !go_config_service.hasPipelineNamed(CaseInsensitiveString.new(@pipeline_name))
       render_error_response "Pipeline not found", 404, true

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/api/pipelines_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/api/pipelines_controller.rb
@@ -58,6 +58,9 @@ class Api::PipelinesController < Api::ApiController
   end
 
   def status
+    add_deprecation_headers(request, response, "unversioned", nil,
+                            "v1", "20.1.0", "20.4.0", "Pipeline Status")
+
     pipeline_name = params[:pipeline_name]
     result = HttpOperationResult.new
 

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/api/stages_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/api/stages_controller.rb
@@ -18,8 +18,12 @@ java_import 'org.springframework.dao.DataRetrievalFailureException'
 
 class Api::StagesController < Api::ApiController
   include ApplicationHelper
+  include DeprecatedApiHelper
 
   def index
+    add_deprecation_headers(request, response, "unversioned", "/go/api/feed/pipelines/:pipeline_name/:pipeline_counter/:stage_name/:stage_counter.xml",
+                            nil, "20.1.0", "20.4.0", "Stage Feed")
+
     return render_not_found unless number?(params[:id])
 
     stage_id = Integer(params[:id])

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/api_v1/notification_filters_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/api_v1/notification_filters_controller.rb
@@ -16,9 +16,11 @@
 
 module ApiV1
   class NotificationFiltersController < ApiV1::BaseController
+    include DeprecatedApiHelper
     before_action :check_user_and_404
     before_action :load_current_user
     before_action :check_filter_params, only: :create
+    before_action :deprecation_headers_action
 
     def index
       render_user_notification_filters
@@ -42,6 +44,10 @@ module ApiV1
     end
 
     private
+
+    def deprecation_headers_action
+      add_deprecation_headers(request, response, "v1", nil, "v2", "20.1.0", "20.4.0", "Notification Filter")
+    end
 
     def render_user_notification_filters
       render DEFAULT_FORMAT => NotificationFiltersRepresenter.new(@user_to_operate.notificationFilters).to_hash

--- a/server/src/main/webapp/WEB-INF/rails/app/helpers/deprecated_api_helper.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/helpers/deprecated_api_helper.rb
@@ -18,11 +18,13 @@ module DeprecatedApiHelper
 
   def add_deprecation_headers(request, response, deprecated_api_version, successor_api_url, successor_api_version, deprecated_in, removal_in, entity_name)
     version_text = "unversioned".eql?(deprecated_api_version) ? "unversioned API" : "API version #{deprecated_api_version}"
-    successor_api_url = (successor_api_url == nil || successor_api_url.blank?) ? request.url: "#{request.protocol}#{request.host}#{successor_api_url}"
+    successor_api_url = (successor_api_url == nil || successor_api_url.blank?) ? request.url : "#{request.protocol}#{request.host}#{successor_api_url}"
+    successor_mimetype = successor_api_version ? "Accept=\"application/vnd.go.cd.#{successor_api_version}+json\"; " : nil
+    successor_api_version_text = successor_api_version ? "Version #{successor_api_version}" : "Newer version"
 
     changelog_url = "https://api.gocd.org/#{deprecated_in}/#api-changelog"
-    link = "<#{successor_api_url}>; Accept=\"application/vnd.go.cd.#{successor_api_version}+json\"; rel=\"successor-version\""
-    warning = "299 GoCD/v#{deprecated_in} \"The #{entity_name} #{version_text} has been deprecated in GoCD Release v#{deprecated_in}. This version will be removed in GoCD Release v#{removal_in}. Version #{successor_api_version} of the API is available, and users are encouraged to use it\""
+    link = "<#{successor_api_url}>; #{successor_mimetype}rel=\"successor-version\""
+    warning = "299 GoCD/v#{deprecated_in} \"The #{entity_name} #{version_text} has been deprecated in GoCD Release v#{deprecated_in}. This version will be removed in GoCD Release v#{removal_in}. #{successor_api_version_text} of the API is available, and users are encouraged to use it\""
 
     response.set_header("X-GoCD-API-Deprecated-In", "v#{deprecated_in}")
     response.set_header("X-GoCD-API-Removal-In", "v#{removal_in}")

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/agents_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/agents_controller_spec.rb
@@ -27,6 +27,21 @@ describe Api::AgentsController do
   describe "job_run_history" do
     include APIModelMother
 
+    it "should add deprecation API headers" do
+      expect(@job_instance_service).to receive(:totalCompletedJobsCountOn).with('uuid').and_return(10)
+      expect(@job_instance_service).to receive(:completedJobsOnAgent).with('uuid', anything, anything, anything).and_return(create_agent_job_run_history_model)
+
+      get :job_run_history, params:{:uuid => 'uuid', :offset => '5', :no_layout => true}
+
+      expect(response).to be_ok
+      expect(response.headers["X-GoCD-API-Deprecated-In"]).to eq('v19.12.0')
+      expect(response.headers["X-GoCD-API-Removal-In"]).to eq('v20.3.0')
+      expect(response.headers["X-GoCD-API-Deprecation-Info"]).to eq("https://api.gocd.org/19.12.0/#api-changelog")
+      expect(response.headers["Link"]).to eq('<http://test.host/api/agents/uuid/job_run_history/5>; Accept="application/vnd.go.cd.v1+json"; rel="successor-version"')
+      expect(response.headers["Warning"]).to eq('299 GoCD/v19.12.0 "The Agent Job Run History unversioned API has been deprecated in GoCD Release v19.12.0. This version will be removed in GoCD Release v20.3.0. Version v1 of the API is available, and users are encouraged to use it"')
+    end
+
+
     it "should resolve routes" do
       expect(:get => "/api/agents/1234/job_run_history").to route_to({:controller => 'api/agents', :action => 'job_run_history', :uuid => '1234', :offset => '0', :no_layout => true})
       expect(:get => "/api/agents/1234/job_run_history/1").to route_to({:controller => 'api/agents', :action => 'job_run_history', :uuid => '1234', :offset => '1', :no_layout => true})

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/jobs_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/jobs_controller_spec.rb
@@ -87,6 +87,23 @@ describe Api::JobsController do
   describe "history" do
     include APIModelMother
 
+    it "should add deprecation API headers" do
+      loser = Username.new(CaseInsensitiveString.new("loser"))
+      expect(controller).to receive(:current_user).and_return(loser)
+      expect(@job_instance_service).to receive(:getJobHistoryCount).and_return(10)
+      expect(@job_instance_service).to receive(:findJobHistoryPage).with('pipeline', 'stage', 'job', anything, "loser", anything).and_return([create_job_model])
+
+      get :history, params: {:pipeline_name => 'pipeline', :stage_name => 'stage', :job_name => 'job', :offset => '5', :no_layout => true}
+      expect(response).to be_ok
+
+      expect(response.headers["X-GoCD-API-Deprecated-In"]).to eq('v20.1.0')
+      expect(response.headers["X-GoCD-API-Removal-In"]).to eq('v20.4.0')
+      expect(response.headers["X-GoCD-API-Deprecation-Info"]).to eq("https://api.gocd.org/20.1.0/#api-changelog")
+      expect(response.headers["Link"]).to eq('<http://test.host/api/jobs/pipeline/stage/job/history/5>; Accept="application/vnd.go.cd.v1+json"; rel="successor-version"')
+      expect(response.headers["Warning"]).to eq('299 GoCD/v20.1.0 "The Job History unversioned API has been deprecated in GoCD Release v20.1.0. This version will be removed in GoCD Release v20.4.0. Version v1 of the API is available, and users are encouraged to use it"')
+    end
+
+
     it "should render history json" do
       loser = Username.new(CaseInsensitiveString.new("loser"))
       expect(controller).to receive(:current_user).and_return(loser)

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/jobs_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/jobs_controller_spec.rb
@@ -45,6 +45,24 @@ describe Api::JobsController do
     expect(:get => "/api/jobs/blah_id.xml").to route_to(:id => "blah_id", :action => "index", :controller => 'api/jobs', :format => "xml", :no_layout => true)
   end
 
+  it "should add deprecation API headers" do
+    job = job_instance('job')
+
+    allow(@xml_api_service).to receive(:write).with(JobXmlViewModel.new(job), "http://test.host/go").and_return(:dom)
+
+    expect(@job_instance_service).to receive(:buildById).with(1).and_return(job)
+    fake_template_presence 'api/jobs/index', 'some data'
+
+    get 'index', params: {:id => "1", :format => "xml", :no_layout => true}
+    expect(response).to be_ok
+
+    expect(response.headers["X-GoCD-API-Deprecated-In"]).to eq('v20.1.0')
+    expect(response.headers["X-GoCD-API-Removal-In"]).to eq('v20.4.0')
+    expect(response.headers["X-GoCD-API-Deprecation-Info"]).to eq("https://api.gocd.org/20.1.0/#api-changelog")
+    expect(response.headers["Link"]).to eq('<http://test.host/go/api/feed/pipelines/:pipeline_name/:pipeline_counter/:stage_name/:stage_counter/:job_name.xml>; rel="successor-version"')
+    expect(response.headers["Warning"]).to eq('299 GoCD/v20.1.0 "The Job Feed unversioned API has been deprecated in GoCD Release v20.1.0. This version will be removed in GoCD Release v20.4.0. Newer version of the API is available, and users are encouraged to use it"')
+  end
+
   it "should load job and properties based on passed on id param" do
     job = job_instance('job')
 

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/pipeline_groups_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/pipeline_groups_controller_spec.rb
@@ -35,6 +35,21 @@ describe Api::PipelineGroupsController do
       expect(:get => "/api/config/pipeline_groups").to route_to(:controller => "api/pipeline_groups", :action => "list_configs", :no_layout=>true)
     end
 
+    it "should add deprecation API headers" do
+      loser = Username.new(CaseInsensitiveString.new("loser"))
+      expect(controller).to receive(:current_user).and_return(loser)
+      expect(@pipeline_configs_service).to receive(:getGroupsForUser).with("loser").and_return([create_pipeline_group_config_model])
+
+      get :list_configs, params:{:no_layout => true}
+
+      expect(response).to be_ok
+      expect(response.headers["X-GoCD-API-Deprecated-In"]).to eq('v19.12.0')
+      expect(response.headers["X-GoCD-API-Removal-In"]).to eq('v20.3.0')
+      expect(response.headers["X-GoCD-API-Deprecation-Info"]).to eq("https://api.gocd.org/19.12.0/#api-changelog")
+      expect(response.headers["Link"]).to eq('<http://test.host/go/api/admin/pipeline_groups>; Accept="application/vnd.go.cd.v1+json"; rel="successor-version"')
+      expect(response.headers["Warning"]).to eq('299 GoCD/v19.12.0 "The Pipeline Groups Config Listing unversioned API has been deprecated in GoCD Release v19.12.0. This version will be removed in GoCD Release v20.3.0. Version v1 of the API is available, and users are encouraged to use it"')
+    end
+
     it "should render pipeline group list json" do
       loser = Username.new(CaseInsensitiveString.new("loser"))
       expect(controller).to receive(:current_user).and_return(loser)

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/pipelines_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/pipelines_controller_spec.rb
@@ -199,6 +199,20 @@ describe Api::PipelinesController do
   end
 
   describe "pipeline_instance" do
+    it "should add deprecation API headers" do
+      pipeline = PipelineInstanceModel.createPipeline("pipeline", 1, "label", BuildCause.createWithEmptyModifications(), stage_history_for("blah-stage"))
+      expect(@pipeline_history_service).to receive(:load).with(10, "user", anything).and_return(pipeline)
+
+      get :pipeline_instance, params:{:id => '10', :name => "pipeline", :format => "xml", :no_layout => true}
+
+      expect(response).to be_ok
+      expect(response.headers["X-GoCD-API-Deprecated-In"]).to eq('v20.1.0')
+      expect(response.headers["X-GoCD-API-Removal-In"]).to eq('v20.4.0')
+      expect(response.headers["X-GoCD-API-Deprecation-Info"]).to eq("https://api.gocd.org/20.1.0/#api-changelog")
+      expect(response.headers["Link"]).to eq('<http://test.host/go/api/feed/pipelines/pipeline/10.xml>; rel="successor-version"')
+      expect(response.headers["Warning"]).to eq('299 GoCD/v20.1.0 "The Pipeline Feed unversioned API has been deprecated in GoCD Release v20.1.0. This version will be removed in GoCD Release v20.4.0. Newer version of the API is available, and users are encouraged to use it"')
+    end
+
     it "should load pipeline by id" do
       pipeline = PipelineInstanceModel.createPipeline("pipeline", 1, "label", BuildCause.createWithEmptyModifications(), stage_history_for("blah-stage"))
       expect(@pipeline_history_service).to receive(:load).with(10, "user", anything).and_return(pipeline)
@@ -261,6 +275,19 @@ describe Api::PipelinesController do
   end
 
   describe "pipelines" do
+    it "should add deprecation API headers" do
+      expect(@pipeline_history_service).to receive(:latestInstancesForConfiguredPipelines).with("user").and_return(:pipeline_instance)
+
+      get :pipelines, params:{:format => "xml", :no_layout => true}
+
+      expect(response).to be_ok
+      expect(response.headers["X-GoCD-API-Deprecated-In"]).to eq('v20.1.0')
+      expect(response.headers["X-GoCD-API-Removal-In"]).to eq('v20.4.0')
+      expect(response.headers["X-GoCD-API-Deprecation-Info"]).to eq("https://api.gocd.org/20.1.0/#api-changelog")
+      expect(response.headers["Link"]).to eq('<http://test.host/go/api/feed/pipelines.xml>; rel="successor-version"')
+      expect(response.headers["Warning"]).to eq('299 GoCD/v20.1.0 "The Pipelines Feed unversioned API has been deprecated in GoCD Release v20.1.0. This version will be removed in GoCD Release v20.4.0. Newer version of the API is available, and users are encouraged to use it"')
+    end
+
     it "should assign pipeline_configs and latest instance of each pipeline configured" do
       expect(@pipeline_history_service).to receive(:latestInstancesForConfiguredPipelines).with("user").and_return(:pipeline_instance)
       get :pipelines, params:{:format => "xml", :no_layout => true}
@@ -290,6 +317,19 @@ describe Api::PipelinesController do
 
     it "should answer for /api/pipelines/foo/stages.xml" do
       expect(:get => '/api/pipelines/foo/stages.xml').to route_to(:controller => "api/pipelines", :action => "stage_feed", :format=>"xml", :name => 'foo', :no_layout => true)
+    end
+
+    it "should add deprecation API headers" do
+      expect(Feed).to receive(:new).with(@user, an_instance_of(PipelineStagesFeedService::PipelineStageFeedResolver), an_instance_of(HttpLocalizedOperationResult), have_key(:controller)).and_return(:stage_feed)
+      expect(@go_config_service).to receive(:hasPipelineNamed).with(CaseInsensitiveString.new('pipeline')).and_return(true)
+      get 'stage_feed', params:{:format => "xml", :no_layout => true, :name => 'pipeline'}
+
+      expect(response).to be_ok
+      expect(response.headers["X-GoCD-API-Deprecated-In"]).to eq('v20.1.0')
+      expect(response.headers["X-GoCD-API-Removal-In"]).to eq('v20.4.0')
+      expect(response.headers["X-GoCD-API-Deprecation-Info"]).to eq("https://api.gocd.org/20.1.0/#api-changelog")
+      expect(response.headers["Link"]).to eq('<http://test.host/go/api/feed/pipelines/pipeline/stages.xml>; rel="successor-version"')
+      expect(response.headers["Warning"]).to eq('299 GoCD/v20.1.0 "The Stages Feed unversioned API has been deprecated in GoCD Release v20.1.0. This version will be removed in GoCD Release v20.4.0. Newer version of the API is available, and users are encouraged to use it"')
     end
 
     it "should set the stage feed from the java side" do

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/pipelines_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/pipelines_controller_spec.rb
@@ -125,6 +125,21 @@ describe Api::PipelinesController do
 
   describe "status" do
 
+    it "should add deprecation API headers" do
+      loser = Username.new(CaseInsensitiveString.new("loser"))
+      expect(controller).to receive(:current_user).and_return(loser)
+      expect(@pipeline_history_service).to receive(:getPipelineStatus).with('up42', "loser", anything).and_return(create_pipeline_status_model)
+
+      get :status, params:{:pipeline_name => 'up42', :no_layout => true}
+
+      expect(response).to be_ok
+      expect(response.headers["X-GoCD-API-Deprecated-In"]).to eq('v20.1.0')
+      expect(response.headers["X-GoCD-API-Removal-In"]).to eq('v20.4.0')
+      expect(response.headers["X-GoCD-API-Deprecation-Info"]).to eq("https://api.gocd.org/20.1.0/#api-changelog")
+      expect(response.headers["Link"]).to eq('<http://test.host/api/pipelines/up42/status>; Accept="application/vnd.go.cd.v1+json"; rel="successor-version"')
+      expect(response.headers["Warning"]).to eq('299 GoCD/v20.1.0 "The Pipeline Status unversioned API has been deprecated in GoCD Release v20.1.0. This version will be removed in GoCD Release v20.4.0. Version v1 of the API is available, and users are encouraged to use it"')
+    end
+
     it "should render status json" do
       loser = Username.new(CaseInsensitiveString.new("loser"))
       expect(controller).to receive(:current_user).and_return(loser)

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/stages_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/api/stages_controller_spec.rb
@@ -36,6 +36,21 @@ describe Api::StagesController do
       expect(response.status).to eq(404)
     end
 
+
+    it "should add deprecation API headers" do
+      updated_date = java.util.Date.new
+      stage = StageMother.create_passed_stage("pipeline_name", 100, "blah-stage", 12, "dev", updated_date)
+      expect(@stage_service).to receive(:stageById).with(99).and_return(stage)
+      get 'index', params:{:id => "99", :format => "xml", :no_layout => true}
+
+      expect(response).to be_ok
+      expect(response.headers["X-GoCD-API-Deprecated-In"]).to eq('v20.1.0')
+      expect(response.headers["X-GoCD-API-Removal-In"]).to eq('v20.4.0')
+      expect(response.headers["X-GoCD-API-Deprecation-Info"]).to eq("https://api.gocd.org/20.1.0/#api-changelog")
+      expect(response.headers["Link"]).to eq('<http://test.host/go/api/feed/pipelines/:pipeline_name/:pipeline_counter/:stage_name/:stage_counter.xml>; rel="successor-version"')
+      expect(response.headers["Warning"]).to eq('299 GoCD/v20.1.0 "The Stage Feed unversioned API has been deprecated in GoCD Release v20.1.0. This version will be removed in GoCD Release v20.4.0. Newer version of the API is available, and users are encouraged to use it"')
+    end
+
     it "should load stage data" do
       updated_date = java.util.Date.new
       stage = StageMother.create_passed_stage("pipeline_name", 100, "blah-stage", 12, "dev", updated_date)

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/api_v1/notification_filters_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/api_v1/notification_filters_controller_spec.rb
@@ -29,6 +29,19 @@ describe ApiV1::NotificationFiltersController do
   end
 
   describe "index" do
+    it("should add deprecation headers") do
+      allow(@user).to receive(:notificationFilters).and_return([])
+
+      get_with_api_header(:index)
+
+      expect(response).to be_ok
+      expect(response.headers["X-GoCD-API-Deprecated-In"]).to eq('v20.1.0')
+      expect(response.headers["X-GoCD-API-Removal-In"]).to eq('v20.4.0')
+      expect(response.headers["X-GoCD-API-Deprecation-Info"]).to eq("https://api.gocd.org/20.1.0/#api-changelog")
+      expect(response.headers["Link"]).to eq('<http://test.host/api/notification_filters?format=json>; Accept="application/vnd.go.cd.v2+json"; rel="successor-version"')
+      expect(response.headers["Warning"]).to eq('299 GoCD/v20.1.0 "The Notification Filter API version v1 has been deprecated in GoCD Release v20.1.0. This version will be removed in GoCD Release v20.4.0. Version v2 of the API is available, and users are encouraged to use it"')
+    end
+
     it("returns a list of filters serialized to JSON") do
       allow(@user).to receive(:notificationFilters).and_return([
         filter_for("pipeline1", "defaultStage", "Fails", true, 1),
@@ -47,6 +60,20 @@ describe ApiV1::NotificationFiltersController do
   end
 
   describe "create" do
+    it("should add deprecation headers") do
+      allow(@user).to receive(:notificationFilters).and_return([]) # not verifying this
+      expect(@user_service).to receive(:oldAddNotificationFilter).with(@user.id, filter_for("foo", "bar", "Breaks", false))
+
+      post_with_api_header(:create, params:{pipeline: "foo", stage: "bar", event: "Breaks"})
+
+      expect(response).to be_ok
+      expect(response.headers["X-GoCD-API-Deprecated-In"]).to eq('v20.1.0')
+      expect(response.headers["X-GoCD-API-Removal-In"]).to eq('v20.4.0')
+      expect(response.headers["X-GoCD-API-Deprecation-Info"]).to eq("https://api.gocd.org/20.1.0/#api-changelog")
+      expect(response.headers["Link"]).to eq('<http://test.host/api/notification_filters>; Accept="application/vnd.go.cd.v2+json"; rel="successor-version"')
+      expect(response.headers["Warning"]).to eq('299 GoCD/v20.1.0 "The Notification Filter API version v1 has been deprecated in GoCD Release v20.1.0. This version will be removed in GoCD Release v20.4.0. Version v2 of the API is available, and users are encouraged to use it"')
+    end
+
     it("creates a filter to match any commit") do
       allow(@user).to receive(:notificationFilters).and_return([]) # not verifying this
       expect(@user_service).to receive(:oldAddNotificationFilter).with(@user.id, filter_for("foo", "bar", "Breaks", false))
@@ -76,6 +103,20 @@ describe ApiV1::NotificationFiltersController do
   end
 
   describe "destroy" do
+    it("should add deprecation headers") do
+      allow(@user).to receive(:notificationFilters).and_return([]) # really don't care
+      expect(@user_service).to receive(:removeNotificationFilter).with(@user.id, 5)
+
+      delete_with_api_header(:destroy, params:{id: "5"})
+
+      expect(response).to be_ok
+      expect(response.headers["X-GoCD-API-Deprecated-In"]).to eq('v20.1.0')
+      expect(response.headers["X-GoCD-API-Removal-In"]).to eq('v20.4.0')
+      expect(response.headers["X-GoCD-API-Deprecation-Info"]).to eq("https://api.gocd.org/20.1.0/#api-changelog")
+      expect(response.headers["Link"]).to eq('<http://test.host/api/notification_filters/5>; Accept="application/vnd.go.cd.v2+json"; rel="successor-version"')
+      expect(response.headers["Warning"]).to eq('299 GoCD/v20.1.0 "The Notification Filter API version v1 has been deprecated in GoCD Release v20.1.0. This version will be removed in GoCD Release v20.4.0. Version v2 of the API is available, and users are encouraged to use it"')
+    end
+
     it("destroys a filter") do
       allow(@user).to receive(:notificationFilters).and_return([]) # really don't care
       expect(@user_service).to receive(:removeNotificationFilter).with(@user.id, 5)


### PR DESCRIPTION
Issue: #7713

Deprecation required: https://github.com/gocd/gocd/issues/7713#issuecomment-585212004

- [X] Deprecate unversioned Pipeline Groups config listing API.
- [X] Deprecate unversioned Agent Job Run History API.
- [X] Deprecate Stages API v1.
- [X] Deprecate Job History unversioned API.
- [X] Deprecate Pipeline Status Unversioned API.
- [X] Deprecate Notification Filters API v1.
- [X] Deprecate Template Config API v5.
- [X] Deprecate Template Config API v6.
- [x] Deprecate unversioned Feeds API.
