### PR TITLE
Improvements to wrapper properties examples

### DIFF
--- a/installers/generic.gradle
+++ b/installers/generic.gradle
@@ -205,17 +205,11 @@ def configureGenericZip(Zip zipTask, InstallerType installerType) {
       rename 'wrapper.conf.in', 'wrapper.conf'
     }
 
-
-    // the example properties file for reference
-    from("include/wrapper-properties.conf.example") {
-      into 'wrapper-config'
-    }
-
     // the actual default config file
     from("include/wrapper-properties-${installerType.baseName}.conf") {
       into 'wrapper-config'
       rename ".*", "wrapper-properties.conf"
-      filter(ConcatFilter, append: file("include/wrapper-properties.conf.example"))
+      filter(ConcatFilter, append: file("include/wrapper-properties.${installerType.baseName}.conf.example"))
     }
 
     from("${extractDeltaPack.outputs.files.singleFile}/wrapper-delta-pack-${project.versions.tanuki}-st/bin") {

--- a/installers/include/additional-properties.conf
+++ b/installers/include/additional-properties.conf
@@ -1,4 +1,5 @@
 
 # Create this file and specify any overrides for environment/jvm args
 #include ../wrapper-config/wrapper-properties.conf
+# (The line above is NOT a comment. It's a "#include" - see: https://wrapper.tanukisoftware.com/doc/english/props-cascading.html)
 

--- a/installers/include/wrapper-properties-go-agent.conf
+++ b/installers/include/wrapper-properties-go-agent.conf
@@ -1,5 +1,4 @@
 # Use this file to configure your GoCD agent
-# See the `wrapper-properties.conf.example` file for the configuration syntax
 
 # setup the GoCD server URL
 wrapper.app.parameter.100=-serverUrl

--- a/installers/include/wrapper-properties-go-server.conf
+++ b/installers/include/wrapper-properties-go-server.conf
@@ -1,2 +1,1 @@
 # Use this file to configure your GoCD server
-# See the `wrapper-properties.conf.example` file for the configuration syntax

--- a/installers/include/wrapper-properties.go-agent.conf.example
+++ b/installers/include/wrapper-properties.go-agent.conf.example
@@ -1,0 +1,40 @@
+# For a detailed description about setting various environment variables, see the page at
+# https://wrapper.tanukisoftware.com/doc/english/props-envvars.html
+
+# For a detailed description about setting JVM options and system properties, see the page at
+# https://wrapper.tanukisoftware.com/doc/english/props-jvm.html
+
+# To understand how properties can be overridden in this file, see the page at:
+# https://wrapper.tanukisoftware.com/doc/english/props-cascading.html
+
+# To use a custom JVM:
+# wrapper.java.command=/path/to/java
+
+# To set any environment variables of your choice use the following syntax
+#set.SOME_ENVIRONMENT_VARIABLE=some-value
+#set.GRADLE_HOME=/path/to/gradle
+#set.M2_HOME=C:\apache-maven-3.2.1
+#set.MAVEN_OPTS=-Xmx1048m -Xms256m -XX:MaxPermSize=312M
+
+# Appending to existing environment variables:
+# This config supports environment variable expansion at run time within the values of any environment variable.
+# To maintain the platform independent nature of this configuration file, the Windows syntax is used for all platforms.
+
+# On windows:
+#set.PATH=..\lib;%PATH%
+
+# On Unix/Linux/macOS. Note that you must use %PATH%, and not $PATH, as you'd normally do on this platform
+#set.PATH=../lib:%PATH%
+
+###### System properties for GoCD agent bootstrapper ######
+# Set any system properties. We recommend that you begin with the index `100` and increment the index for each system property
+#wrapper.java.additional.100=-Dcom.example.enabled=true
+#wrapper.java.additional.101=-Dcom.example.name=bob
+
+# If a property contains quotes, these can be stripped out, but this works only on Unix/Linux/macOS
+#wrapper.java.additional.103=-Dmyapp.data="../MyApp Home"
+#wrapper.java.additional.104.stripquotes=TRUE
+
+###### System properties for GoCD agent ######
+# Set a memory limit of 1GB for the agent process. We recommend that you do not use more than half your system memory.
+#set.AGENT_STARTUP_ARGS=-Xms128m -Xmx1024m -Dsome.java.property=somevalue

--- a/installers/include/wrapper-properties.go-server.conf.example
+++ b/installers/include/wrapper-properties.go-server.conf.example
@@ -1,10 +1,11 @@
-# This is an example configuration file to override any GoCD configuration.
-
 # For a detailed description about setting various environment variables, see the page at
 # https://wrapper.tanukisoftware.com/doc/english/props-envvars.html
 
 # For a detailed description about setting JVM options and system properties, see the page at
 # https://wrapper.tanukisoftware.com/doc/english/props-jvm.html
+
+# To understand how properties can be overridden in this file, see the page at:
+# https://wrapper.tanukisoftware.com/doc/english/props-cascading.html
 
 # To use a custom JVM:
 # wrapper.java.command=/path/to/java

--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -289,13 +289,10 @@ def configureLinuxPackage(DefaultTask packageTask, InstallerType installerType, 
           rename 'wrapper.conf.in', 'wrapper.conf'
         }
 
-        // the example properties file for reference
-        from("include/wrapper-properties.conf.example")
-
         // the actual default config file
         from("include/wrapper-properties-${installerType.baseName}.conf") {
           rename ".*", "wrapper-properties.conf"
-          filter(ConcatFilter, append: file("include/wrapper-properties.conf.example"))
+          filter(ConcatFilter, append: file("include/wrapper-properties.${installerType.baseName}.conf.example"))
         }
       }
 

--- a/installers/windows.gradle
+++ b/installers/windows.gradle
@@ -81,10 +81,14 @@ def configureWindowsFilesystem(Task windowsInstallerTask, InstallerType installe
           include "${installerType.baseName}-${project.goVersion}/bin/*.bat"
         }
 
+        from("include/wrapper-properties.${installerType.baseName}.conf.example") {
+          into "${installerType.baseName}-${project.goVersion}/wrapper-config"
+          rename ".*", "wrapper-properties.conf.example"
+        }
+
         // include the wrapper.conf, but replace the java command
         from(genericZipTree) {
           include "${installerType.baseName}-${project.goVersion}/wrapper-config/wrapper.conf"
-          include "${installerType.baseName}-${project.goVersion}/wrapper-config/wrapper-properties.conf.example"
           filter { String eachLine ->
             if (eachLine == 'wrapper.java.command=java') {
               eachLine = 'wrapper.java.command=jre/bin/java'


### PR DESCRIPTION
Issue: #7698 

Description: This PR tries to make the wrapper.conf and wrapper-properties.conf situation a little clearer.
 
1. Currently, most installers include `wrapper-config/wrapper.conf`, `wrapper-config/wrapper-properties.conf` and `wrapper-config/wrapper-properties.conf.example`. However, in most of these cases (except Windows), the `wrapper-properties.conf` file includes everything inside `wrapper-properties.conf.example`. See: https://github.com/gocd/gocd/blob/fbe640c871dfe4bff5b3e3ddead658e6ca9694a0/installers/generic.gradle#L218

    This PR removes the redundant `wrapper-properties.conf.example` file, except on Windows [See point 3]. The content is in `wrapper-properties.conf`.

2. The `wrapper-properties.conf.example` was often confusing. That's because it was a common file for both agent and server. So, it wouldn't be able to show how to set agent properties properly (which is different from how they are set on the server).

    This PR uses two separate example files (internally) and concatenates the right content into `wrapper-properties.conf` (point 1). 

3. On Windows, the exe is not packaged with a wrapper.properties file. It contains the example file.

    This PR keeps the example file around, but makes it specific to the agent/server as mentioned in point 2.

4. In the agent-specific example content, it is now more clear how to set agent-specific properties and bootstrapper-specific properties. Similarly, the server-specific example content shows the right way to change Xmx.

--------------------------------------

#### The agent-specific wrapper-properties file looks like this:

```config
# Use this file to configure your GoCD agent

# setup the GoCD server URL
wrapper.app.parameter.100=-serverUrl
wrapper.app.parameter.101=https://localhost:8154/go

# For a detailed description about setting various environment variables, see the page at
# https://wrapper.tanukisoftware.com/doc/english/props-envvars.html

# For a detailed description about setting JVM options and system properties, see the page at
# https://wrapper.tanukisoftware.com/doc/english/props-jvm.html

# To understand how properties can be overridden in this file, see the page at:
# https://wrapper.tanukisoftware.com/doc/english/props-cascading.html

# To use a custom JVM:
# wrapper.java.command=/path/to/java

# To set any environment variables of your choice use the following syntax
#set.SOME_ENVIRONMENT_VARIABLE=some-value
#set.GRADLE_HOME=/path/to/gradle
#set.M2_HOME=C:\apache-maven-3.2.1
#set.MAVEN_OPTS=-Xmx1048m -Xms256m -XX:MaxPermSize=312M

# Appending to existing environment variables:
# This config supports environment variable expansion at run time within the values of any environment variable.
# To maintain the platform independent nature of this configuration file, the Windows syntax is used for all platforms.

# On windows:
#set.PATH=..\lib;%PATH%

# On Unix/Linux/macOS. Note that you must use %PATH%, and not $PATH, as you'd normally do on this platform
#set.PATH=../lib:%PATH%

###### System properties for GoCD agent bootstrapper ######
# Set any system properties. We recommend that you begin with the index `100` and increment the index for each system property
#wrapper.java.additional.100=-Dcom.example.enabled=true
#wrapper.java.additional.101=-Dcom.example.name=bob

# If a property contains quotes, these can be stripped out, but this works only on Unix/Linux/macOS
#wrapper.java.additional.103=-Dmyapp.data="../MyApp Home"
#wrapper.java.additional.104.stripquotes=TRUE

###### System properties for GoCD agent ######
# Set a memory limit of 1GB for the agent process. We recommend that you do not use more than half your system memory.
#set.AGENT_STARTUP_ARGS=-Xms128m -Xmx1024m -Dsome.java.property=somevalue
```

#### The server-specific wrapper-properties file looks like this:

```config
# Use this file to configure your GoCD server
# For a detailed description about setting various environment variables, see the page at
# https://wrapper.tanukisoftware.com/doc/english/props-envvars.html

# For a detailed description about setting JVM options and system properties, see the page at
# https://wrapper.tanukisoftware.com/doc/english/props-jvm.html

# To understand how properties can be overridden in this file, see the page at:
# https://wrapper.tanukisoftware.com/doc/english/props-cascading.html

# To use a custom JVM:
# wrapper.java.command=/path/to/java

# To set any environment variables of your choice use the following syntax
#set.SOME_ENVIRONMENT_VARIABLE=some-value
#set.GRADLE_HOME=/path/to/gradle
#set.M2_HOME=C:\apache-maven-3.2.1
#set.MAVEN_OPTS=-Xmx1048m -Xms256m -XX:MaxPermSize=312M

# Appending to existing environment variables:
# This config supports environment variable expansion at run time within the values of any environment variable.
# To maintain the platform independent nature of this configuration file, the Windows syntax is used for all platforms.

# On windows:
#set.PATH=..\lib;%PATH%

# On Unix/Linux/macOS. Note that you must use %PATH%, and not $PATH, as you'd normally do on this platform
#set.PATH=../lib:%PATH%

# Set any system properties. We recommend that you begin with the index `100` and increment the index for each system property
#wrapper.java.additional.100=-Dcom.example.enabled=true
#wrapper.java.additional.101=-Dcom.example.name=bob

# If a property contains quotes, these can be stripped out, but this works only on Unix/Linux/macOS
#wrapper.java.additional.103=-Dmyapp.data="../MyApp Home"
#wrapper.java.additional.104.stripquotes=TRUE

# Set a memory limit of 8GB (usually needed on your GoCD server for large setups). We recommend that you do not use more than half your system memory.
#wrapper.java.additional.105=-Xmx8G
```