### PR TITLE
Do not set 0 as default for runInstanceCount

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/JobConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/JobConfig.java
@@ -226,11 +226,12 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
     }
 
 	public boolean isRunMultipleInstanceType() {
-		return getRunInstanceCountValue() > 0;
+        Integer runInstanceCountValue = getRunInstanceCountValue();
+        return runInstanceCountValue != null && runInstanceCountValue > 0;
 	}
 
 	public Integer getRunInstanceCountValue() {
-		return runInstanceCount == null ? 0 : Integer.valueOf(runInstanceCount);
+		return isBlank(runInstanceCount) ? null : Integer.valueOf(runInstanceCount);
 	}
 
 	public String getRunInstanceCount() {
@@ -431,7 +432,7 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
         }
         if (attributesMap.containsKey("elasticProfileId")) {
             String elasticProfileId = (String) attributesMap.get("elasticProfileId");
-            setElasticProfileId(StringUtils.isBlank(elasticProfileId) ? null : elasticProfileId);
+            setElasticProfileId(isBlank(elasticProfileId) ? null : elasticProfileId);
         }
 
         if (attributesMap.containsKey(TASKS)) {

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/JobConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/JobConfigTest.java
@@ -23,26 +23,29 @@ import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.service.TaskFactory;
 import com.thoughtworks.go.util.DataStructureUtils;
 import com.thoughtworks.go.util.ReflectionUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.HashMap;
+import java.util.stream.Stream;
 
 import static com.thoughtworks.go.util.DataStructureUtils.a;
 import static com.thoughtworks.go.util.DataStructureUtils.m;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.mockito.Mockito.*;
 
-public class JobConfigTest {
-    JobConfig config;
+class JobConfigTest {
+    private JobConfig config;
 
-    @Before
-    public void setup(){
+    @BeforeEach
+    void setup() {
         config = new JobConfig();
         Tasks tasks = mock(Tasks.class);
         config.injectTasksForTest(tasks);
@@ -50,7 +53,7 @@ public class JobConfigTest {
     }
 
     @Test
-    public void shouldCopyAttributeValuesFromAttributeMap() throws Exception {
+    void shouldCopyAttributeValuesFromAttributeMap() throws Exception {
         config = new JobConfig();//override the setup mock
         TaskFactory taskFactory = mock(TaskFactory.class);
         ExecTask emptyExecTask = new ExecTask();
@@ -58,155 +61,155 @@ public class JobConfigTest {
 
         config.setConfigAttributes(DataStructureUtils.m(JobConfig.NAME, "foo-job", JobConfig.TASKS, DataStructureUtils.m(Tasks.TASK_OPTIONS, "exec", "exec",
                 DataStructureUtils.m(Task.TASK_TYPE, "exec", ExecTask.COMMAND, "ls", ExecTask.ARGS, "-la", ExecTask.WORKING_DIR, "/tmp"))), taskFactory);
-        assertThat(config.name(), is(new CaseInsensitiveString("foo-job")));
-        assertThat(config.getTasks().get(0), is(new ExecTask("ls", "-la", "/tmp")));
-        assertThat(config.getTasks().size(), is(1));
+        assertThat(config.name()).isEqualTo(new CaseInsensitiveString("foo-job"));
+        assertThat(config.getTasks().get(0)).isEqualTo(new ExecTask("ls", "-la", "/tmp"));
+        assertThat(config.getTasks().size()).isEqualTo(1);
     }
 
     @Test
-    public void shouldSetTimeoutIfSpecified() throws Exception {
+    void shouldSetTimeoutIfSpecified() throws Exception {
         config.setConfigAttributes(
                 m(JobConfig.NAME, "foo-job", "timeoutType", JobConfig.OVERRIDE_TIMEOUT, JobConfig.TIMEOUT, "100", JobConfig.TASKS, m(Tasks.TASK_OPTIONS, "exec", "exec",
                         m(Task.TASK_TYPE, "exec", ExecTask.COMMAND, "ls", ExecTask.ARGS, "-la", ExecTask.WORKING_DIR, "/tmp"))));
-        assertThat(config.getTimeout(), is("100"));
+        assertThat(config.getTimeout()).isEqualTo("100");
     }
 
     @Test
-    public void shouldClearTimeoutIfSubmittedWithEmptyValue() throws Exception {
+    void shouldClearTimeoutIfSubmittedWithEmptyValue() throws Exception {
         config.setConfigAttributes(
                 m(JobConfig.NAME, "foo-job", "timeoutType", JobConfig.OVERRIDE_TIMEOUT, JobConfig.TIMEOUT, "", JobConfig.TASKS, m(Tasks.TASK_OPTIONS, "exec",
                         "exec", m(Task.TASK_TYPE, "exec", ExecTask.COMMAND, "ls", ExecTask.ARGS, "-la", ExecTask.WORKING_DIR, "/tmp")))
         );
-        assertThat(config.getTimeout(), is(nullValue()));
+        assertThat(config.getTimeout()).isNull();
     }
 
     @Test
-    public void shouldSetTimeoutToZeroIfSubmittedWithNever() throws Exception {
+    void shouldSetTimeoutToZeroIfSubmittedWithNever() throws Exception {
         config.setConfigAttributes(m(JobConfig.NAME, "foo-job", "timeoutType", JobConfig.NEVER_TIMEOUT, JobConfig.TIMEOUT, "100", JobConfig.TASKS, m(Tasks.TASK_OPTIONS, "exec", "exec",
                 m(Task.TASK_TYPE, "exec", ExecTask.COMMAND, "ls", ExecTask.ARGS, "-la", ExecTask.WORKING_DIR, "/tmp"))));
-        assertThat(config.getTimeout(), is("0"));
+        assertThat(config.getTimeout()).isEqualTo("0");
     }
 
     @Test
-    public void shouldSetTimeoutToNullIfSubmittedWithDefault() throws Exception {
+    void shouldSetTimeoutToNullIfSubmittedWithDefault() throws Exception {
         config.setConfigAttributes(m(JobConfig.NAME, "foo-job", "timeoutType", JobConfig.DEFAULT_TIMEOUT, JobConfig.TIMEOUT, "", JobConfig.TASKS, m(Tasks.TASK_OPTIONS, "exec", "exec",
                 m(Task.TASK_TYPE, "exec", ExecTask.COMMAND, "ls", ExecTask.ARGS, "-la", ExecTask.WORKING_DIR, "/tmp"))));
-        assertThat(config.getTimeout(), is(nullValue()));
+        assertThat(config.getTimeout()).isNull();
     }
 
     @Test
-    public void shouldNotSetJobNameIfNotGiven() throws Exception {
+    void shouldNotSetJobNameIfNotGiven() throws Exception {
         JobConfig config = new JobConfig("some-job-name");
         config.setConfigAttributes(m());
-        assertThat(config.name(), is(new CaseInsensitiveString("some-job-name")));
+        assertThat(config.name()).isEqualTo(new CaseInsensitiveString("some-job-name"));
         config.setConfigAttributes(m(JobConfig.NAME, null));
-        assertThat(config.name(), is(nullValue()));
+        assertThat(config.name()).isNull();
     }
 
     @Test
-    public void shouldReturnAntTaskAsDefaultIfNoTasksSpecified() {
+    void shouldReturnAntTaskAsDefaultIfNoTasksSpecified() {
         JobConfig jobConfig = new JobConfig();
-        assertThat(jobConfig.tasks(), org.hamcrest.Matchers.iterableWithSize(1));
+        assertThat(jobConfig.tasks()).hasSize(1);
         Task task = jobConfig.tasks().first();
-        assertThat(task, instanceOf(NullTask.class));
+        assertThat(task).isInstanceOf(NullTask.class);
     }
 
     @Test
-    public void shouldNotSetTasksIfNoTasksGiven() throws Exception {
+    void shouldNotSetTasksIfNoTasksGiven() throws Exception {
         config = new JobConfig();
         AntTask task = new AntTask();
         task.setTarget("hello");
         config.addTask(task);
         config.setConfigAttributes(m());
         AntTask taskAfterUpdate = (AntTask) config.getTasks().get(0);
-        assertThat(taskAfterUpdate.getTarget(), is("hello"));
-        assertThat(config.getTasks().size(), is(1));
+        assertThat(taskAfterUpdate.getTarget()).isEqualTo("hello");
+        assertThat(config.getTasks().size()).isEqualTo(1);
         config.setConfigAttributes(m(JobConfig.TASKS, null));
-        assertThat(config.getTasks().size(), is(0));
+        assertThat(config.getTasks().size()).isEqualTo(0);
     }
 
     @Test
-    public void shouldValidateTheJobName() {
-        assertThat(createJobAndValidate(".name").errors().isEmpty(), is(true));
+    void shouldValidateTheJobName() {
+        assertThat(createJobAndValidate(".name").errors().isEmpty()).isTrue();
         ConfigErrors configErrors = createJobAndValidate("name pavan").errors();
-        assertThat(configErrors.isEmpty(), is(false));
-        assertThat(configErrors.on(JobConfig.NAME), is("Invalid job name 'name pavan'. This must be alphanumeric and may contain underscores and periods. The maximum allowed length is 255 characters."));
-    }
-    @Test
-    public void shouldFailValidationWhenJobNameIsEmpty(){
-        ConfigErrors configErrors = createJobAndValidate(null).errors();
-        assertThat(configErrors.isEmpty(), is(false));
-        assertThat(configErrors.on(JobConfig.NAME), is("Name is a required field"));
+        assertThat(configErrors.isEmpty()).isFalse();
+        assertThat(configErrors.on(JobConfig.NAME)).isEqualTo("Invalid job name 'name pavan'. This must be alphanumeric and may contain underscores and periods. The maximum allowed length is 255 characters.");
     }
 
     @Test
-    public void shouldValidateTheJobNameAgainstHaving_runOnAll() {
+    void shouldFailValidationWhenJobNameIsEmpty() {
+        ConfigErrors configErrors = createJobAndValidate(null).errors();
+        assertThat(configErrors.isEmpty()).isFalse();
+        assertThat(configErrors.on(JobConfig.NAME)).isEqualTo("Name is a required field");
+    }
+
+    @Test
+    void shouldValidateTheJobNameAgainstHaving_runOnAll() {
         String jobName = "a-runOnAll-1";
         ConfigErrors configErrors = createJobAndValidate(jobName).errors();
-        assertThat(configErrors.isEmpty(), is(false));
-        assertThat(configErrors.on(JobConfig.NAME), is(String.format("A job cannot have 'runOnAll' in it's name: %s because it is a reserved keyword", jobName)));
+        assertThat(configErrors.isEmpty()).isFalse();
+        assertThat(configErrors.on(JobConfig.NAME)).isEqualTo(String.format("A job cannot have 'runOnAll' in it's name: %s because it is a reserved keyword", jobName));
     }
 
     @Test
-    public void shouldValidateTheJobNameAgainstHaving_runInstance() {
+    void shouldValidateTheJobNameAgainstHaving_runInstance() {
         String jobName = "a-runInstance-1";
         ConfigErrors configErrors = createJobAndValidate(jobName).errors();
-        assertThat(configErrors.isEmpty(), is(false));
-        assertThat(configErrors.on(JobConfig.NAME), is(String.format("A job cannot have 'runInstance' in it's name: %s because it is a reserved keyword", jobName)));
+        assertThat(configErrors.isEmpty()).isFalse();
+        assertThat(configErrors.on(JobConfig.NAME)).isEqualTo(String.format("A job cannot have 'runInstance' in it's name: %s because it is a reserved keyword", jobName));
     }
 
-	@Test
-	public void shouldValidateAgainstSettingRunInstanceCountToIncorrectValue() {
-		JobConfig jobConfig1 = new JobConfig(new CaseInsensitiveString("test"));
-		jobConfig1.setRunInstanceCount(-1);
+    @Test
+    void shouldValidateAgainstSettingRunInstanceCountToIncorrectValue() {
+        JobConfig jobConfig1 = new JobConfig(new CaseInsensitiveString("test"));
+        jobConfig1.setRunInstanceCount(-1);
 
-		jobConfig1.validate(ConfigSaveValidationContext.forChain(new BasicCruiseConfig()));
+        jobConfig1.validate(ConfigSaveValidationContext.forChain(new BasicCruiseConfig()));
 
-		ConfigErrors configErrors1 = jobConfig1.errors();
-		assertThat(configErrors1.isEmpty(), is(false));
-		assertThat(configErrors1.on(JobConfig.RUN_TYPE), is("'Run Instance Count' cannot be a negative number as it represents number of instances Go needs to spawn during runtime."));
+        ConfigErrors configErrors1 = jobConfig1.errors();
+        assertThat(configErrors1.isEmpty()).isFalse();
+        assertThat(configErrors1.on(JobConfig.RUN_TYPE)).isEqualTo("'Run Instance Count' cannot be a negative number as it represents number of instances Go needs to spawn during runtime.");
 
-		JobConfig jobConfig2 = new JobConfig(new CaseInsensitiveString("test"));
-		ReflectionUtil.setField(jobConfig2, "runInstanceCount", "abcd");
+        JobConfig jobConfig2 = new JobConfig(new CaseInsensitiveString("test"));
+        ReflectionUtil.setField(jobConfig2, "runInstanceCount", "abcd");
 
-		jobConfig2.validate(ConfigSaveValidationContext.forChain(new BasicCruiseConfig()));
+        jobConfig2.validate(ConfigSaveValidationContext.forChain(new BasicCruiseConfig()));
 
-		ConfigErrors configErrors2 = jobConfig2.errors();
-		assertThat(configErrors2.isEmpty(), is(false));
-		assertThat(configErrors2.on(JobConfig.RUN_TYPE), is("'Run Instance Count' should be a valid positive integer as it represents number of instances Go needs to spawn during runtime."));
-	}
-
-	@Test
-	public void shouldValidateAgainstSettingRunOnAllAgentsAndRunInstanceCountSetTogether() {
-		JobConfig jobConfig = new JobConfig(new CaseInsensitiveString("test"));
-		jobConfig.setRunOnAllAgents(true);
-		jobConfig.setRunInstanceCount(10);
-
-		jobConfig.validate(ConfigSaveValidationContext.forChain(new BasicCruiseConfig()));
-
-		ConfigErrors configErrors = jobConfig.errors();
-		assertThat(configErrors.isEmpty(), is(false));
-		assertThat(configErrors.on(JobConfig.RUN_TYPE), is("Job cannot be 'run on all agents' type and 'run multiple instance' type together."));
-	}
+        ConfigErrors configErrors2 = jobConfig2.errors();
+        assertThat(configErrors2.isEmpty()).isFalse();
+        assertThat(configErrors2.on(JobConfig.RUN_TYPE)).isEqualTo("'Run Instance Count' should be a valid positive integer as it represents number of instances Go needs to spawn during runtime.");
+    }
 
     @Test
-    public void shouldValidateEmptyAndNullResources()
-    {
-        PipelineConfig pipelineConfig=PipelineConfigMother.createPipelineConfigWithJobConfigs("pipeline1");
+    void shouldValidateAgainstSettingRunOnAllAgentsAndRunInstanceCountSetTogether() {
+        JobConfig jobConfig = new JobConfig(new CaseInsensitiveString("test"));
+        jobConfig.setRunOnAllAgents(true);
+        jobConfig.setRunInstanceCount(10);
+
+        jobConfig.validate(ConfigSaveValidationContext.forChain(new BasicCruiseConfig()));
+
+        ConfigErrors configErrors = jobConfig.errors();
+        assertThat(configErrors.isEmpty()).isFalse();
+        assertThat(configErrors.on(JobConfig.RUN_TYPE)).isEqualTo("Job cannot be 'run on all agents' type and 'run multiple instance' type together.");
+    }
+
+    @Test
+    void shouldValidateEmptyAndNullResources() {
+        PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfigWithJobConfigs("pipeline1");
         JobConfig jobConfig = JobConfigMother.createJobConfigWithJobNameAndEmptyResources();
-        ValidationContext validationContext=mock(ValidationContext.class);
+        ValidationContext validationContext = mock(ValidationContext.class);
         when(validationContext.getPipeline()).thenReturn(pipelineConfig);
         when(validationContext.getStage()).thenReturn(pipelineConfig.getFirstStageConfig());
         jobConfig.validate(validationContext);
-        assertThat(jobConfig.errors().isEmpty(), is(false));
-        assertThat(jobConfig.errors().getAll().get(0),is("Empty resource name in job \"defaultJob\" of stage \"mingle\" of pipeline \"pipeline1\". If a template is used, please ensure that the resource parameters are defined for this pipeline."));
+        assertThat(jobConfig.errors().isEmpty()).isFalse();
+        assertThat(jobConfig.errors().getAll().get(0)).isEqualTo("Empty resource name in job \"defaultJob\" of stage \"mingle\" of pipeline \"pipeline1\". If a template is used, please ensure that the resource parameters are defined for this pipeline.");
     }
 
     @Test
-    public void shouldValidateAgainstPresenceOfBothResourcesAndElasticProfileId() {
-        PipelineConfig pipelineConfig=PipelineConfigMother.createPipelineConfigWithJobConfigs("pipeline1");
+    void shouldValidateAgainstPresenceOfBothResourcesAndElasticProfileId() {
+        PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfigWithJobConfigs("pipeline1");
         JobConfig jobConfig = JobConfigMother.createJobConfigWithJobNameAndEmptyResources();
-        ValidationContext validationContext=mock(ValidationContext.class);
+        ValidationContext validationContext = mock(ValidationContext.class);
         jobConfig.setElasticProfileId("docker.unit-test");
 
         when(validationContext.getPipeline()).thenReturn(pipelineConfig);
@@ -214,16 +217,16 @@ public class JobConfigTest {
 
         jobConfig.validate(validationContext);
 
-        assertThat(jobConfig.errors().isEmpty(), is(false));
-        assertThat(jobConfig.errors().on(JobConfig.ELASTIC_PROFILE_ID), is("Job cannot have both `resource` and `elasticProfileId`"));
-        assertThat(jobConfig.errors().on(JobConfig.RESOURCES), is("Job cannot have both `resource` and `elasticProfileId`"));
+        assertThat(jobConfig.errors().isEmpty()).isFalse();
+        assertThat(jobConfig.errors().on(JobConfig.ELASTIC_PROFILE_ID)).isEqualTo("Job cannot have both `resource` and `elasticProfileId`");
+        assertThat(jobConfig.errors().on(JobConfig.RESOURCES)).isEqualTo("Job cannot have both `resource` and `elasticProfileId`");
     }
 
     @Test
-    public void shouldValidateElasticProfileId() {
-        PipelineConfig pipelineConfig=PipelineConfigMother.createPipelineConfigWithJobConfigs("pipeline1");
+    void shouldValidateElasticProfileId() {
+        PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfigWithJobConfigs("pipeline1");
         JobConfig jobConfig = JobConfigMother.createJobConfigWithJobNameAndEmptyResources();
-        ValidationContext validationContext=mock(ValidationContext.class);
+        ValidationContext validationContext = mock(ValidationContext.class);
         jobConfig.setResourceConfigs(new ResourceConfigs());
         jobConfig.setElasticProfileId("non-existent-profile-id");
 
@@ -233,47 +236,47 @@ public class JobConfigTest {
 
         jobConfig.validate(validationContext);
 
-        assertThat(jobConfig.errors().isEmpty(), is(false));
-        assertThat(jobConfig.errors().on(JobConfig.ELASTIC_PROFILE_ID), is("No profile defined corresponding to profile_id 'non-existent-profile-id'"));
+        assertThat(jobConfig.errors().isEmpty()).isFalse();
+        assertThat(jobConfig.errors().on(JobConfig.ELASTIC_PROFILE_ID)).isEqualTo("No profile defined corresponding to profile_id 'non-existent-profile-id'");
     }
 
     @Test
-    public void shouldErrorOutIfTwoJobsHaveSameName() {
+    void shouldErrorOutIfTwoJobsHaveSameName() {
         HashMap<String, JobConfig> visitedConfigs = new HashMap<>();
         visitedConfigs.put("defaultJob".toLowerCase(), new JobConfig("defaultJob"));
         JobConfig defaultJob = new JobConfig("defaultJob");
         defaultJob.validateNameUniqueness(visitedConfigs);
 
-        assertThat(defaultJob.errors().isEmpty(), is(false));
-        assertThat(defaultJob.errors().on(JobConfig.NAME), is("You have defined multiple jobs called 'defaultJob'. Job names are case-insensitive and must be unique."));
+        assertThat(defaultJob.errors().isEmpty()).isFalse();
+        assertThat(defaultJob.errors().on(JobConfig.NAME)).isEqualTo("You have defined multiple jobs called 'defaultJob'. Job names are case-insensitive and must be unique.");
 
         JobConfig defaultJobAllLowerCase = new JobConfig("defaultjob");
         defaultJobAllLowerCase.validateNameUniqueness(visitedConfigs);
 
-        assertThat(defaultJobAllLowerCase.errors().isEmpty(), is(false));
-        assertThat(defaultJobAllLowerCase.errors().on(JobConfig.NAME), is("You have defined multiple jobs called 'defaultjob'. Job names are case-insensitive and must be unique."));
+        assertThat(defaultJobAllLowerCase.errors().isEmpty()).isFalse();
+        assertThat(defaultJobAllLowerCase.errors().on(JobConfig.NAME)).isEqualTo("You have defined multiple jobs called 'defaultjob'. Job names are case-insensitive and must be unique.");
     }
 
     @Test
-    public void shouldNotValidateJobNameUniquenessInAbsenceOfName(){
+    void shouldNotValidateJobNameUniquenessInAbsenceOfName() {
         JobConfig job = new JobConfig();
 
         job.validateNameUniqueness(new HashMap<>());
 
-        assertTrue(job.errors().isEmpty());
+        assertThat(job.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void shouldNotValidateJobNameUniquenessIfNameIsEmptyString(){
+    void shouldNotValidateJobNameUniquenessIfNameIsEmptyString() {
         JobConfig job = new JobConfig(" ");
 
         job.validateNameUniqueness(new HashMap<>());
 
-        assertTrue(job.errors().isEmpty());
+        assertThat(job.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void shouldPopulateEnvironmentVariablesFromAttributeMap() {
+    void shouldPopulateEnvironmentVariablesFromAttributeMap() {
         JobConfig jobConfig = new JobConfig();
         HashMap map = new HashMap();
         HashMap valueHashMap = new HashMap();
@@ -289,7 +292,7 @@ public class JobConfigTest {
     }
 
     @Test
-    public void shouldPopulateResourcesFromAttributeMap() {
+    void shouldPopulateResourcesFromAttributeMap() {
         HashMap map = new HashMap();
         String value = "a,  b,c   ,d,e";
         map.put(JobConfig.RESOURCES, value);
@@ -299,106 +302,106 @@ public class JobConfigTest {
 
         jobConfig.setConfigAttributes(map);
 
-        assertThat(jobConfig.resourceConfigs().size(), is(5));
+        assertThat(jobConfig.resourceConfigs().size()).isEqualTo(5);
     }
 
     @Test
-    public void shouldPopulateTabsFromAttributeMap() {
+    void shouldPopulateTabsFromAttributeMap() {
         JobConfig jobConfig = new JobConfig("job-name");
 
         jobConfig.setConfigAttributes(m(JobConfig.TABS, a(m(Tab.NAME, "tab1", Tab.PATH, "path1"), m(Tab.NAME, "tab2", Tab.PATH, "path2"))));
 
-        assertThat(jobConfig.getTabs().size(), is(2));
-        assertThat(jobConfig.getTabs().get(0).getName(), is("tab1"));
-        assertThat(jobConfig.getTabs().get(1).getName(), is("tab2"));
-        assertThat(jobConfig.getTabs().get(0).getPath(), is("path1"));
-        assertThat(jobConfig.getTabs().get(1).getPath(), is("path2"));
+        assertThat(jobConfig.getTabs().size()).isEqualTo(2);
+        assertThat(jobConfig.getTabs().get(0).getName()).isEqualTo("tab1");
+        assertThat(jobConfig.getTabs().get(1).getName()).isEqualTo("tab2");
+        assertThat(jobConfig.getTabs().get(0).getPath()).isEqualTo("path1");
+        assertThat(jobConfig.getTabs().get(1).getPath()).isEqualTo("path2");
     }
 
-	@Test
-	public void shouldSetJobRunTypeCorrectly_forRails4() {
-		// single instance
-		HashMap map1 = new HashMap();
-		map1.put(JobConfig.RUN_TYPE, JobConfig.RUN_SINGLE_INSTANCE);
-		map1.put(JobConfig.RUN_INSTANCE_COUNT, "10"); // should be ignored
-		JobConfig jobConfig1 = new JobConfig();
+    @Test
+    void shouldSetJobRunTypeCorrectly_forRails4() {
+        // single instance
+        HashMap map1 = new HashMap();
+        map1.put(JobConfig.RUN_TYPE, JobConfig.RUN_SINGLE_INSTANCE);
+        map1.put(JobConfig.RUN_INSTANCE_COUNT, "10"); // should be ignored
+        JobConfig jobConfig1 = new JobConfig();
 
-		jobConfig1.setConfigAttributes(map1);
+        jobConfig1.setConfigAttributes(map1);
 
-		assertThat(jobConfig1.isRunOnAllAgents(), is(false));
-		assertThat(jobConfig1.isRunMultipleInstanceType(), is(false));
-		assertThat(jobConfig1.getRunInstanceCount(), is(nullValue()));
+        assertThat(jobConfig1.isRunOnAllAgents()).isFalse();
+        assertThat(jobConfig1.isRunMultipleInstanceType()).isFalse();
+        assertThat(jobConfig1.getRunInstanceCount()).isNull();
 
-		// run on all agents
-		HashMap map2 = new HashMap();
-		map2.put(JobConfig.RUN_TYPE, JobConfig.RUN_ON_ALL_AGENTS);
-		JobConfig jobConfig2 = new JobConfig();
+        // run on all agents
+        HashMap map2 = new HashMap();
+        map2.put(JobConfig.RUN_TYPE, JobConfig.RUN_ON_ALL_AGENTS);
+        JobConfig jobConfig2 = new JobConfig();
 
-		jobConfig2.setConfigAttributes(map2);
+        jobConfig2.setConfigAttributes(map2);
 
-		assertThat(jobConfig2.isRunOnAllAgents(), is(true));
-		assertThat(jobConfig2.isRunMultipleInstanceType(), is(false));
-		assertThat(jobConfig2.getRunInstanceCount(), is(nullValue()));
+        assertThat(jobConfig2.isRunOnAllAgents()).isTrue();
+        assertThat(jobConfig2.isRunMultipleInstanceType()).isFalse();
+        assertThat(jobConfig2.getRunInstanceCount()).isNull();
 
-		// run multiple instance
-		HashMap map3 = new HashMap();
-		map3.put(JobConfig.RUN_TYPE, JobConfig.RUN_MULTIPLE_INSTANCE);
-		map3.put(JobConfig.RUN_INSTANCE_COUNT, "10");
-		JobConfig jobConfig3 = new JobConfig();
+        // run multiple instance
+        HashMap map3 = new HashMap();
+        map3.put(JobConfig.RUN_TYPE, JobConfig.RUN_MULTIPLE_INSTANCE);
+        map3.put(JobConfig.RUN_INSTANCE_COUNT, "10");
+        JobConfig jobConfig3 = new JobConfig();
 
-		jobConfig3.setConfigAttributes(map3);
+        jobConfig3.setConfigAttributes(map3);
 
-		assertThat(jobConfig3.isRunMultipleInstanceType(), is(true));
-		assertThat(jobConfig3.getRunInstanceCountValue(), is(10));
-		assertThat(jobConfig3.isRunOnAllAgents(), is(false));
+        assertThat(jobConfig3.isRunMultipleInstanceType()).isTrue();
+        assertThat(jobConfig3.getRunInstanceCountValue()).isEqualTo(10);
+        assertThat(jobConfig3.isRunOnAllAgents()).isFalse();
 
-		HashMap map4 = new HashMap();
-		map4.put(JobConfig.RUN_TYPE, JobConfig.RUN_MULTIPLE_INSTANCE);
-		map4.put(JobConfig.RUN_INSTANCE_COUNT, "");
-		JobConfig jobConfig4 = new JobConfig();
+        HashMap map4 = new HashMap();
+        map4.put(JobConfig.RUN_TYPE, JobConfig.RUN_MULTIPLE_INSTANCE);
+        map4.put(JobConfig.RUN_INSTANCE_COUNT, "");
+        JobConfig jobConfig4 = new JobConfig();
 
-		jobConfig4.setConfigAttributes(map4);
+        jobConfig4.setConfigAttributes(map4);
 
-		assertThat(jobConfig4.isRunMultipleInstanceType(), is(false));
-		assertThat(jobConfig4.getRunInstanceCount(), is(nullValue()));
-		assertThat(jobConfig4.isRunOnAllAgents(), is(false));
-	}
-
-	@Test
-	public void shouldResetJobRunTypeCorrectly() {
-		HashMap map1 = new HashMap();
-		map1.put(JobConfig.RUN_TYPE, JobConfig.RUN_MULTIPLE_INSTANCE);
-		map1.put(JobConfig.RUN_INSTANCE_COUNT, "10");
-		JobConfig jobConfig = new JobConfig();
-
-		jobConfig.setConfigAttributes(map1);
-
-		assertThat(jobConfig.getRunInstanceCountValue(), is(10));
-		assertThat(jobConfig.isRunMultipleInstanceType(), is(true));
-		assertThat(jobConfig.isRunOnAllAgents(), is(false));
-
-		// should not reset value when correct key not present
-		HashMap map2 = new HashMap();
-
-		jobConfig.setConfigAttributes(map2);
-
-		assertThat(jobConfig.getRunInstanceCountValue(), is(10));
-		assertThat(jobConfig.isRunMultipleInstanceType(), is(true));
-		assertThat(jobConfig.isRunOnAllAgents(), is(false));
-
-		// reset value for same job config
-		HashMap map3 = new HashMap();
-		map3.put(JobConfig.RUN_TYPE, JobConfig.RUN_SINGLE_INSTANCE);
-
-		jobConfig.setConfigAttributes(map3);
-
-		assertThat(jobConfig.isRunMultipleInstanceType(), is(false));
-		assertThat(jobConfig.getRunInstanceCount(), is(nullValue()));
-		assertThat(jobConfig.isRunOnAllAgents(), is(false));
-	}
+        assertThat(jobConfig4.isRunMultipleInstanceType()).isFalse();
+        assertThat(jobConfig4.getRunInstanceCount()).isNull();
+        assertThat(jobConfig4.isRunOnAllAgents()).isFalse();
+    }
 
     @Test
-    public void shouldPopulateArtifactPlansFromAttributeMap() {
+    void shouldResetJobRunTypeCorrectly() {
+        HashMap map1 = new HashMap();
+        map1.put(JobConfig.RUN_TYPE, JobConfig.RUN_MULTIPLE_INSTANCE);
+        map1.put(JobConfig.RUN_INSTANCE_COUNT, "10");
+        JobConfig jobConfig = new JobConfig();
+
+        jobConfig.setConfigAttributes(map1);
+
+        assertThat(jobConfig.getRunInstanceCountValue()).isEqualTo(10);
+        assertThat(jobConfig.isRunMultipleInstanceType()).isTrue();
+        assertThat(jobConfig.isRunOnAllAgents()).isFalse();
+
+        // should not reset value when correct key not present
+        HashMap map2 = new HashMap();
+
+        jobConfig.setConfigAttributes(map2);
+
+        assertThat(jobConfig.getRunInstanceCountValue()).isEqualTo(10);
+        assertThat(jobConfig.isRunMultipleInstanceType()).isTrue();
+        assertThat(jobConfig.isRunOnAllAgents()).isFalse();
+
+        // reset value for same job config
+        HashMap map3 = new HashMap();
+        map3.put(JobConfig.RUN_TYPE, JobConfig.RUN_SINGLE_INSTANCE);
+
+        jobConfig.setConfigAttributes(map3);
+
+        assertThat(jobConfig.isRunMultipleInstanceType()).isFalse();
+        assertThat(jobConfig.getRunInstanceCount()).isNull();
+        assertThat(jobConfig.isRunOnAllAgents()).isFalse();
+    }
+
+    @Test
+    void shouldPopulateArtifactPlansFromAttributeMap() {
         HashMap map = new HashMap();
         HashMap valueHashMap = new HashMap();
         valueHashMap.put("src", "dest");
@@ -413,55 +416,55 @@ public class JobConfigTest {
     }
 
     @Test
-    public void shouldValidateThatTheTimeoutIsAValidNumber() {
+    void shouldValidateThatTheTimeoutIsAValidNumber() {
         JobConfig job = new JobConfig("job");
         job.setTimeout("5.5");
         job.validate(ConfigSaveValidationContext.forChain(new BasicCruiseConfig()));
-        assertThat(job.errors().isEmpty(), is(true));
+        assertThat(job.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void shouldMarkJobInvalidIfTimeoutIsNotAValidNumber() {
+    void shouldMarkJobInvalidIfTimeoutIsNotAValidNumber() {
         JobConfig job = new JobConfig("job");
         job.setTimeout("5.5MN");
         job.validate(ConfigSaveValidationContext.forChain(new BasicCruiseConfig()));
-        assertThat(job.errors().isEmpty(), is(false));
-        assertThat(job.errors().on(JobConfig.TIMEOUT), is("Timeout should be a valid number as it represents number of minutes"));
+        assertThat(job.errors().isEmpty()).isFalse();
+        assertThat(job.errors().on(JobConfig.TIMEOUT)).isEqualTo("Timeout should be a valid number as it represents number of minutes");
     }
 
     @Test
-    public void shouldReturnTimeoutType() {
+    void shouldReturnTimeoutType() {
         JobConfig job = new JobConfig("job");
-        assertThat(job.getTimeoutType(), is(JobConfig.DEFAULT_TIMEOUT));
+        assertThat(job.getTimeoutType()).isEqualTo(JobConfig.DEFAULT_TIMEOUT);
         job.setTimeout("0");
-        assertThat(job.getTimeoutType(), is(JobConfig.NEVER_TIMEOUT));
+        assertThat(job.getTimeoutType()).isEqualTo(JobConfig.NEVER_TIMEOUT);
         job.setTimeout("10");
-        assertThat(job.getTimeoutType(), is(JobConfig.OVERRIDE_TIMEOUT));
+        assertThat(job.getTimeoutType()).isEqualTo(JobConfig.OVERRIDE_TIMEOUT);
     }
 
-	@Test
-	public void shouldReturnRunTypeCorrectly() {
-		JobConfig job = new JobConfig("job");
-		assertThat(job.getRunType(), is(JobConfig.RUN_SINGLE_INSTANCE));
-		job.setRunOnAllAgents(true);
-		assertThat(job.getRunType(), is(JobConfig.RUN_ON_ALL_AGENTS));
-		job.setRunOnAllAgents(false);
-		job.setRunInstanceCount(10);
-		assertThat(job.getRunType(), is(JobConfig.RUN_MULTIPLE_INSTANCE));
-	}
+    @Test
+    void shouldReturnRunTypeCorrectly() {
+        JobConfig job = new JobConfig("job");
+        assertThat(job.getRunType()).isEqualTo(JobConfig.RUN_SINGLE_INSTANCE);
+        job.setRunOnAllAgents(true);
+        assertThat(job.getRunType()).isEqualTo(JobConfig.RUN_ON_ALL_AGENTS);
+        job.setRunOnAllAgents(false);
+        job.setRunInstanceCount(10);
+        assertThat(job.getRunType()).isEqualTo(JobConfig.RUN_MULTIPLE_INSTANCE);
+    }
 
     @Test
-    public void shouldErrorOutWhenTimeoutIsANegativeNumber() {
+    void shouldErrorOutWhenTimeoutIsANegativeNumber() {
         JobConfig jobConfig = new JobConfig("job");
         jobConfig.setTimeout("-1");
         jobConfig.validate(ConfigSaveValidationContext.forChain(new BasicCruiseConfig()));
 
-        assertThat(jobConfig.errors().isEmpty(), is(false));
-        assertThat(jobConfig.errors().on(JobConfig.TIMEOUT), is("Timeout cannot be a negative number as it represents number of minutes"));
+        assertThat(jobConfig.errors().isEmpty()).isFalse();
+        assertThat(jobConfig.errors().on(JobConfig.TIMEOUT)).isEqualTo("Timeout cannot be a negative number as it represents number of minutes");
     }
 
     @Test
-    public void shouldValidateTree(){
+    void shouldValidateTree() {
         ResourceConfigs resourceConfigs = mock(ResourceConfigs.class);
         when(resourceConfigs.iterator()).thenReturn(new ResourceConfigs().iterator());
         ArtifactTypeConfigs artifactTypeConfigs = mock(ArtifactTypeConfigs.class);
@@ -479,12 +482,12 @@ public class JobConfigTest {
         jobConfig.setVariables(variables);
 
         PipelineConfigSaveValidationContext context = PipelineConfigSaveValidationContext.forChain(true, "group", new PipelineConfig(), new StageConfig(), jobConfig);
-        assertThat(jobConfig.validateTree(context), is(true));
+        assertThat(jobConfig.validateTree(context)).isTrue();
 
         ArgumentCaptor<PipelineConfigSaveValidationContext> captor = ArgumentCaptor.forClass(PipelineConfigSaveValidationContext.class);
         verify(tasks).validateTree(captor.capture());
         PipelineConfigSaveValidationContext childContext = captor.getValue();
-        assertThat(childContext.getParent(), is(jobConfig));
+        assertThat(childContext.getParent()).isEqualTo(jobConfig);
         verify(resourceConfigs).validateTree(childContext);
         verify(artifactTypeConfigs).validateTree(childContext);
         verify(tabs).validateTree(childContext);
@@ -492,7 +495,7 @@ public class JobConfigTest {
     }
 
     @Test
-    public void shouldFailValidationIfAnyDescendentIsInvalid(){
+    void shouldFailValidationIfAnyDescendentIsInvalid() {
         ResourceConfigs resourceConfigs = mock(ResourceConfigs.class);
         when(resourceConfigs.iterator()).thenReturn(new ResourceConfigs().iterator());
         ArtifactTypeConfigs artifactTypeConfigs = mock(ArtifactTypeConfigs.class);
@@ -510,12 +513,12 @@ public class JobConfigTest {
         jobConfig.setVariables(variables);
 
         PipelineConfigSaveValidationContext context = PipelineConfigSaveValidationContext.forChain(true, "group", new PipelineConfig(), new StageConfig(), jobConfig);
-        assertThat(jobConfig.validateTree(context), is(false));
+        assertThat(jobConfig.validateTree(context)).isFalse();
 
         ArgumentCaptor<PipelineConfigSaveValidationContext> captor = ArgumentCaptor.forClass(PipelineConfigSaveValidationContext.class);
         verify(tasks).validateTree(captor.capture());
         PipelineConfigSaveValidationContext childContext = captor.getValue();
-        assertThat(childContext.getParent(), is(jobConfig));
+        assertThat(childContext.getParent()).isEqualTo(jobConfig);
         verify(resourceConfigs).validateTree(childContext);
         verify(artifactTypeConfigs).validateTree(childContext);
         verify(tabs).validateTree(childContext);
@@ -523,7 +526,7 @@ public class JobConfigTest {
     }
 
     @Test
-    public void shouldValidateAgainstSettingRunOnAllAgentsForAJobAssignedToElasticAgent() {
+    void shouldValidateAgainstSettingRunOnAllAgentsForAJobAssignedToElasticAgent() {
         JobConfig jobConfig = new JobConfig(new CaseInsensitiveString("test"));
         jobConfig.setRunOnAllAgents(true);
         jobConfig.setElasticProfileId("ubuntu-dev");
@@ -531,12 +534,12 @@ public class JobConfigTest {
         jobConfig.validate(ConfigSaveValidationContext.forChain(new BasicCruiseConfig()));
 
         ConfigErrors configErrors = jobConfig.errors();
-        assertThat(configErrors.isEmpty(), is(false));
-        assertThat(configErrors.on(JobConfig.RUN_TYPE), is("Job cannot be set to 'run on all agents' when assigned to an elastic agent"));
+        assertThat(configErrors.isEmpty()).isFalse();
+        assertThat(configErrors.on(JobConfig.RUN_TYPE)).isEqualTo("Job cannot be set to 'run on all agents' when assigned to an elastic agent");
     }
 
     @Test
-    public void shouldEncryptSecurePropertiesForOnlyFetchExternalArtifactTask() {
+    void shouldEncryptSecurePropertiesForOnlyFetchExternalArtifactTask() {
         JobConfig jobConfig = new JobConfig(new CaseInsensitiveString("job"));
         FetchPluggableArtifactTask mockFetchExternalArtifactTask = mock(FetchPluggableArtifactTask.class);
         jobConfig.addTask(mockFetchExternalArtifactTask);
@@ -544,6 +547,28 @@ public class JobConfigTest {
         jobConfig.encryptSecureProperties(new BasicCruiseConfig(), new PipelineConfig(), jobConfig);
 
         verify(mockFetchExternalArtifactTask).encryptSecureProperties(any(CruiseConfig.class), any(PipelineConfig.class), any(FetchPluggableArtifactTask.class));
+    }
+
+    @Nested
+    @TestInstance(PER_CLASS)
+    class RunInstanceCount {
+        @ParameterizedTest
+        @MethodSource("runInstanceCountTestValues")
+        void shouldReturnNullIfNoInstanceCountIsSet(String instanceCount, Integer instanceCountValue, boolean isRunMultipleType) {
+            JobConfig jobConfig = new JobConfig("plan-name");
+            jobConfig.setRunInstanceCount(instanceCount);
+
+            assertThat(jobConfig.getRunInstanceCountValue()).isEqualTo(instanceCountValue);
+            assertThat(jobConfig.isRunMultipleInstanceType()).isEqualTo(isRunMultipleType);
+        }
+
+        Stream<Arguments> runInstanceCountTestValues() {
+            return Stream.of(
+                    Arguments.of(null, null, false),
+                    Arguments.of("", null, false),
+                    Arguments.of("10", 10, true)
+            );
+        }
     }
 
     private JobConfig createJobAndValidate(final String name) {

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -770,7 +770,7 @@ public class ConfigConverter {
 
         if (jobConfig.isRunOnAllAgents()) {
             job.setRunOnAllAgents(jobConfig.isRunOnAllAgents());
-        } else {
+        } else if (jobConfig.isRunMultipleInstanceType()) {
             job.setRunInstanceCount(jobConfig.getRunInstanceCountValue());
         }
 


### PR DESCRIPTION
Issue: #7676 

Description:
 - If no value is set for runInstanceCount - it should be defaulted to `null` rather than `0`.
    This should be the case when the job is set as run only a single instance.


