### PR TITLE
Send all the selected pipeline group authorizations as is

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/admin_pipelines/admin_pipelines.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/admin_pipelines/admin_pipelines.ts
@@ -78,17 +78,17 @@ export class PipelineGroupViewModel {
   }
 
   getUpdatedPipelineGroup(): PipelineGroup {
+    const viewAccess    = new AuthorizedUsersAndRoles(
+      this.authorizedUsers().filter((user) => !_.isEmpty(user.name()) && user.view()).map((user) => user.name()),
+      this.authorizedRoles().filter((role) => !_.isEmpty(role.name()) && role.view()).map((role) => role.name())
+    );
+    const operateAccess = new AuthorizedUsersAndRoles(
+      this.authorizedUsers().filter((user) => !_.isEmpty(user.name()) && user.operate()).map((user) => user.name()),
+      this.authorizedRoles().filter((role) => !_.isEmpty(role.name()) && role.operate()).map((role) => role.name())
+    );
     const adminAccess   = new AuthorizedUsersAndRoles(
       this.authorizedUsers().filter((user) => !_.isEmpty(user.name()) && user.admin()).map((user) => user.name()),
       this.authorizedRoles().filter((role) => !_.isEmpty(role.name()) && role.admin()).map((role) => role.name())
-    );
-    const operateAccess = new AuthorizedUsersAndRoles(
-      this.authorizedUsers().filter((user) => !_.isEmpty(user.name()) && user.operate() && !user.admin()).map((user) => user.name()),
-      this.authorizedRoles().filter((role) => !_.isEmpty(role.name()) && role.operate() && !role.admin()).map((role) => role.name())
-    );
-    const viewAccess    = new AuthorizedUsersAndRoles(
-      this.authorizedUsers().filter((user) => !_.isEmpty(user.name()) && user.view() && !(user.admin() || user.operate())).map((user) => user.name()),
-      this.authorizedRoles().filter((role) => !_.isEmpty(role.name()) && role.view() && !(role.admin() || role.operate())).map((role) => role.name())
     );
     return new PipelineGroup(this.name(), new Authorization(viewAccess, adminAccess, operateAccess));
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/admin_pipelines/specs/admin_pipelines_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/admin_pipelines/specs/admin_pipelines_spec.ts
@@ -149,12 +149,12 @@ describe('PipelineGroupViewModel', () => {
 
       const updatedPipelineGroup = pipelineGroupViewModel.getUpdatedPipelineGroup();
 
-      expect(updatedPipelineGroup.authorization().view().users()).toEqual([]);
-      expect(updatedPipelineGroup.authorization().operate().users()).toEqual(["user1", "superUser"]);
+      expect(updatedPipelineGroup.authorization().view().users()).toEqual(["user1", "superUser", "admin"]);
+      expect(updatedPipelineGroup.authorization().operate().users()).toEqual(["user1", "superUser", "admin"]);
       expect(updatedPipelineGroup.authorization().admin().users()).toEqual(["admin"]);
 
-      expect(updatedPipelineGroup.authorization().view().roles()).toEqual(["role1"]);
-      expect(updatedPipelineGroup.authorization().operate().roles()).toEqual(["role2"]);
+      expect(updatedPipelineGroup.authorization().view().roles()).toEqual(["role1", "role2", "admin"]);
+      expect(updatedPipelineGroup.authorization().operate().roles()).toEqual(["role2", "admin"]);
       expect(updatedPipelineGroup.authorization().admin().roles()).toEqual(["admin"]);
       expect(updatedPipelineGroup.name()).toEqual(pipelineGroup.name());
     });
@@ -166,8 +166,8 @@ describe('PipelineGroupViewModel', () => {
 
       const updatedPipelineGroup = pipelineGroupViewModel.getUpdatedPipelineGroup();
 
-      expect(updatedPipelineGroup.authorization().view().users()).toEqual(["user1"]);
-      expect(updatedPipelineGroup.authorization().operate().users()).toEqual(["superUser"]);
+      expect(updatedPipelineGroup.authorization().view().users()).toEqual(["user1", "superUser", "admin"]);
+      expect(updatedPipelineGroup.authorization().operate().users()).toEqual(["superUser", "admin"]);
       expect(updatedPipelineGroup.authorization().admin().users()).toEqual(["admin"]);
     });
 
@@ -178,8 +178,8 @@ describe('PipelineGroupViewModel', () => {
 
       const updatedPipelineGroup = pipelineGroupViewModel.getUpdatedPipelineGroup();
 
-      expect(updatedPipelineGroup.authorization().view().roles()).toEqual(["role1"]);
-      expect(updatedPipelineGroup.authorization().operate().roles()).toEqual(["role2"]);
+      expect(updatedPipelineGroup.authorization().view().roles()).toEqual(["role1", "role2", "admin"]);
+      expect(updatedPipelineGroup.authorization().operate().roles()).toEqual(["role2", "admin"]);
       expect(updatedPipelineGroup.authorization().admin().roles()).toEqual(["admin"]);
     });
   });


### PR DESCRIPTION
Issue: #7747 

Description:
 - The pipelines SPA will now send the authorization permissions as is without filtering them. 
