### PR TITLE
Update base image for gocd server to alpine 3.11 and centos 8

### DIFF
--- a/settings-docker.gradle
+++ b/settings-docker.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 ThoughtWorks, Inc.
+ * Copyright 2020 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,5 +25,5 @@ Distro.values().each { Distro distro ->
   }
 }
 
-include ":docker:gocd-server:${Distro.centos.projectName(Distro.centos.getVersion('7'))}"
-include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.9'))}"
+include ":docker:gocd-server:${Distro.centos.projectName(Distro.centos.getVersion('8'))}"
+include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.11'))}"


### PR DESCRIPTION
Issue: #000 

Description: Update the base image for docker gocd server to alpine 3.11 and centos 8

@ketan, @GaneshSPatil  - I don't think we wait around for the alpine image to reach EOL before updating the base image, which is a good thing, otherwise, we'd not even have alpine 3.9 which we do today. There is https://hub.docker.com/r/gocd/gocd-server-centos-7 and https://github.com/gocd/docker-gocd-server-centos-7 for centos 7, not sure if those have to be created explicitly for centos 8. I'm unable to verify if everything works as expected with centos 8. If there is no need for a centos 8 server image, then I will change that back to centos 7

