### PR TITLE
Refactor code for better readability

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/JobConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/JobConfig.java
@@ -52,10 +52,14 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
     @ConfigSubtag
     private ArtifactTypeConfigs artifactTypeConfigs = new ArtifactTypeConfigs();
 
-    @ConfigAttribute(value = "runOnAllAgents", optional = true) private boolean runOnAllAgents = false;
-    @ConfigAttribute(value = "runInstanceCount", optional = true, allowNull = true) private String runInstanceCount;
-    @ConfigAttribute(value = "timeout", optional = true, allowNull = true) private String timeout;
-    @ConfigAttribute(value = "elasticProfileId", optional = true, allowNull = true) private String elasticProfileId;
+    @ConfigAttribute(value = "runOnAllAgents", optional = true)
+    private boolean runOnAllAgents = false;
+    @ConfigAttribute(value = "runInstanceCount", optional = true, allowNull = true)
+    private String runInstanceCount;
+    @ConfigAttribute(value = "timeout", optional = true, allowNull = true)
+    private String timeout;
+    @ConfigAttribute(value = "elasticProfileId", optional = true, allowNull = true)
+    private String elasticProfileId;
 
     private ConfigErrors errors = new ConfigErrors();
     public static final String NAME = "name";
@@ -69,13 +73,13 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
     public static final String DEFAULT_TIMEOUT = "defaultTimeout";
     public static final String OVERRIDE_TIMEOUT = "overrideTimeout";
     public static final String NEVER_TIMEOUT = "neverTimeout";
-	public static final String RUN_TYPE = "runType";
-	public static final String RUN_SINGLE_INSTANCE = "runSingleInstance";
-	public static final String RUN_ON_ALL_AGENTS = "runOnAllAgents";
-	public static final String RUN_MULTIPLE_INSTANCE = "runMultipleInstance";
-	public static final String RUN_INSTANCE_COUNT = "runInstanceCount";
-	public static final String ELASTIC_PROFILE_ID = "elasticProfileId";
-	private static final String JOB_NAME_PATTERN = "[a-zA-Z0-9_\\-.]+";
+    public static final String RUN_TYPE = "runType";
+    public static final String RUN_SINGLE_INSTANCE = "runSingleInstance";
+    public static final String RUN_ON_ALL_AGENTS = "runOnAllAgents";
+    public static final String RUN_MULTIPLE_INSTANCE = "runMultipleInstance";
+    public static final String RUN_INSTANCE_COUNT = "runInstanceCount";
+    public static final String ELASTIC_PROFILE_ID = "elasticProfileId";
+    private static final String JOB_NAME_PATTERN = "[a-zA-Z0-9_\\-.]+";
     private static final Pattern JOB_NAME_PATTERN_REGEX = Pattern.compile(String.format("^(%s)$", JOB_NAME_PATTERN));
 
     public JobConfig() {
@@ -135,7 +139,8 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
         if (variables != null ? !variables.equals(jobConfig.variables) : jobConfig.variables != null) return false;
         if (tasks != null ? !tasks.equals(jobConfig.tasks) : jobConfig.tasks != null) return false;
         if (tabs != null ? !tabs.equals(jobConfig.tabs) : jobConfig.tabs != null) return false;
-        if (resourceConfigs != null ? !resourceConfigs.equals(jobConfig.resourceConfigs) : jobConfig.resourceConfigs != null) return false;
+        if (resourceConfigs != null ? !resourceConfigs.equals(jobConfig.resourceConfigs) : jobConfig.resourceConfigs != null)
+            return false;
         if (artifactTypeConfigs != null ? !artifactTypeConfigs.equals(jobConfig.artifactTypeConfigs) : jobConfig.artifactTypeConfigs != null)
             return false;
         if (runInstanceCount != null ? !runInstanceCount.equals(jobConfig.runInstanceCount) : jobConfig.runInstanceCount != null)
@@ -225,28 +230,33 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
         this.runOnAllAgents = runOnAllAgents;
     }
 
-	public boolean isRunMultipleInstanceType() {
-        Integer runInstanceCountValue = getRunInstanceCountValue();
-        return runInstanceCountValue != null && runInstanceCountValue > 0;
-	}
+    public boolean isRunMultipleInstanceType() {
+        if (isBlank(runInstanceCount)) {
+            return false;
+        }
+        return getRunInstanceCountValue() > 0;
+    }
 
-	public Integer getRunInstanceCountValue() {
-		return isBlank(runInstanceCount) ? null : Integer.valueOf(runInstanceCount);
-	}
+    public int getRunInstanceCountValue() {
+        if (isBlank(runInstanceCount)) {
+            throw new RuntimeException("This job config is a single instance type job.");
+        }
+        return Integer.valueOf(runInstanceCount);
+    }
 
-	public String getRunInstanceCount() {
-		return runInstanceCount;
-	}
+    public String getRunInstanceCount() {
+        return runInstanceCount;
+    }
 
-	public void setRunInstanceCount(Integer runInstanceCount) {
-		setRunInstanceCount(Integer.toString(runInstanceCount));
-	}
+    public void setRunInstanceCount(Integer runInstanceCount) {
+        setRunInstanceCount(Integer.toString(runInstanceCount));
+    }
 
-	public void setRunInstanceCount(String runInstanceCount) {
-		this.runInstanceCount = runInstanceCount;
-	}
+    public void setRunInstanceCount(String runInstanceCount) {
+        this.runInstanceCount = runInstanceCount;
+    }
 
-	public boolean isInstanceOf(String jobInstanceName, boolean ignoreCase) {
+    public boolean isInstanceOf(String jobInstanceName, boolean ignoreCase) {
         return jobTypeConfig().isInstanceOf(jobInstanceName, ignoreCase, CaseInsensitiveString.str(jobName));
     }
 
@@ -257,9 +267,9 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
     private JobTypeConfig jobTypeConfig() {
         if (runOnAllAgents) {
             return new RunOnAllAgentsJobTypeConfig();
-		} else if (isRunMultipleInstanceType()) {
-			return new RunMultipleInstanceJobTypeConfig();
-		} else {
+        } else if (isRunMultipleInstanceType()) {
+            return new RunMultipleInstanceJobTypeConfig();
+        } else {
             return new SingleJobTypeConfig();
         }
     }
@@ -398,7 +408,7 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
                 errors().add(ELASTIC_PROFILE_ID, String.format("No profile defined corresponding to profile_id '%s'", elasticProfileId));
             }
         }
-        if (elasticProfileId != null && isBlank(elasticProfileId)){
+        if (elasticProfileId != null && isBlank(elasticProfileId)) {
             errors().add(ELASTIC_PROFILE_ID, "Must not be a blank string");
         }
         for (ResourceConfig resourceConfig : resourceConfigs) {
@@ -426,7 +436,7 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
 
     public void setConfigAttributes(Object attributes, TaskFactory taskFactory) {
         Map attributesMap = (Map) attributes;
-		if (attributesMap.containsKey(NAME)) {
+        if (attributesMap.containsKey(NAME)) {
             String nameString = (String) attributesMap.get(NAME);
             jobName = nameString == null ? null : new CaseInsensitiveString(nameString);
         }
@@ -474,24 +484,24 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
         }
     }
 
-	private void setJobRunTypeAttribute(Map attributesMap) {
-		if (attributesMap.containsKey(RUN_TYPE)) {
-			this.runOnAllAgents = false;
-			this.runInstanceCount = null;
+    private void setJobRunTypeAttribute(Map attributesMap) {
+        if (attributesMap.containsKey(RUN_TYPE)) {
+            this.runOnAllAgents = false;
+            this.runInstanceCount = null;
 
-			String jobRunType = (String) attributesMap.get(RUN_TYPE);
-			if (RUN_ON_ALL_AGENTS.equals(jobRunType)) {
-				this.runOnAllAgents = true;
-			} else if (RUN_MULTIPLE_INSTANCE.equals(jobRunType)) {
-				String runInstanceCount = (String) attributesMap.get(RUN_INSTANCE_COUNT);
-				if (isBlank(runInstanceCount)) {
-					this.runInstanceCount = null;
-				} else {
-					this.runInstanceCount = runInstanceCount;
-				}
-			}
-		}
-	}
+            String jobRunType = (String) attributesMap.get(RUN_TYPE);
+            if (RUN_ON_ALL_AGENTS.equals(jobRunType)) {
+                this.runOnAllAgents = true;
+            } else if (RUN_MULTIPLE_INSTANCE.equals(jobRunType)) {
+                String runInstanceCount = (String) attributesMap.get(RUN_INSTANCE_COUNT);
+                if (isBlank(runInstanceCount)) {
+                    this.runInstanceCount = null;
+                } else {
+                    this.runInstanceCount = runInstanceCount;
+                }
+            }
+        }
+    }
 
     public void validateNameUniqueness(Map<String, JobConfig> visitedConfigs) {
         if (isBlank(CaseInsensitiveString.str(name()))) return;
@@ -527,13 +537,13 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
         return timeout == null ? DEFAULT_TIMEOUT : timeout.equals("0") ? NEVER_TIMEOUT : OVERRIDE_TIMEOUT;
     }
 
-	public String getRunType() {
-		if (isRunOnAllAgents())
-			return RUN_ON_ALL_AGENTS;
-		if (isRunMultipleInstanceType())
-			return RUN_MULTIPLE_INSTANCE;
-		return RUN_SINGLE_INSTANCE;
-	}
+    public String getRunType() {
+        if (isRunOnAllAgents())
+            return RUN_ON_ALL_AGENTS;
+        if (isRunMultipleInstanceType())
+            return RUN_MULTIPLE_INSTANCE;
+        return RUN_SINGLE_INSTANCE;
+    }
 
     public void injectTasksForTest(Tasks tasks) {
         this.tasks = tasks;

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/JobConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/JobConfigTest.java
@@ -26,19 +26,14 @@ import com.thoughtworks.go.util.ReflectionUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.HashMap;
-import java.util.stream.Stream;
 
 import static com.thoughtworks.go.util.DataStructureUtils.a;
 import static com.thoughtworks.go.util.DataStructureUtils.m;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.*;
 
 class JobConfigTest {
@@ -550,24 +545,24 @@ class JobConfigTest {
     }
 
     @Nested
-    @TestInstance(PER_CLASS)
     class RunInstanceCount {
-        @ParameterizedTest
-        @MethodSource("runInstanceCountTestValues")
-        void shouldReturnNullIfNoInstanceCountIsSet(String instanceCount, Integer instanceCountValue, boolean isRunMultipleType) {
-            JobConfig jobConfig = new JobConfig("plan-name");
-            jobConfig.setRunInstanceCount(instanceCount);
+        @Test
+        void shouldThrowExceptionIsSingleInstanceJobType() {
+            JobConfig jobConfig = new JobConfig("job");
 
-            assertThat(jobConfig.getRunInstanceCountValue()).isEqualTo(instanceCountValue);
-            assertThat(jobConfig.isRunMultipleInstanceType()).isEqualTo(isRunMultipleType);
+            assertThatCode(jobConfig::getRunInstanceCountValue)
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("This job config is a single instance type job.");
+            assertThat(jobConfig.isRunMultipleInstanceType()).isFalse();
         }
 
-        Stream<Arguments> runInstanceCountTestValues() {
-            return Stream.of(
-                    Arguments.of(null, null, false),
-                    Arguments.of("", null, false),
-                    Arguments.of("10", 10, true)
-            );
+        @Test
+        void shouldNotThrowExceptionIfMultipleInstanceJobType() {
+            JobConfig jobConfig = new JobConfig("job");
+            jobConfig.setRunInstanceCount(10);
+
+            assertThat(jobConfig.getRunInstanceCountValue()).isEqualTo(10);
+            assertThat(jobConfig.isRunMultipleInstanceType()).isTrue();
         }
     }
 


### PR DESCRIPTION
Description:
 - the JobConfig should throw exception if `getRunInstanceCountValue` is called for a single instance job type.
  Users should call `isRunMultipleInstanceType` first to confirm if the said job is a multiple instance type.

