### PR TITLE
 Dependency Material name fixes for API's #7737

### DIFF
--- a/api/api-compare-v2/src/main/java/com/thoughtworks/go/apiv2/compare/representers/material/DependencyMaterialRepresenter.java
+++ b/api/api-compare-v2/src/main/java/com/thoughtworks/go/apiv2/compare/representers/material/DependencyMaterialRepresenter.java
@@ -23,7 +23,7 @@ public class DependencyMaterialRepresenter {
     public static void toJSON(OutputWriter jsonWriter, DependencyMaterialConfig dependencyMaterialConfig) {
         jsonWriter.add("pipeline", dependencyMaterialConfig.getPipelineName());
         jsonWriter.add("stage", dependencyMaterialConfig.getStageName());
-        jsonWriter.add("name", dependencyMaterialConfig.getName());
+        jsonWriter.add("name", dependencyMaterialConfig.getNameWithoutDefaults());
         jsonWriter.add("auto_update", dependencyMaterialConfig.isAutoUpdate());
     }
 }

--- a/api/api-compare-v2/src/test/groovy/com/thoughtworks/go/apiv2/compare/representers/material/DependencyMaterialRepresenterTest.groovy
+++ b/api/api-compare-v2/src/test/groovy/com/thoughtworks/go/apiv2/compare/representers/material/DependencyMaterialRepresenterTest.groovy
@@ -47,7 +47,7 @@ class DependencyMaterialRepresenterTest implements MaterialRepresenterTrait {
       attributes  : [
         pipeline   : "pipeline-name",
         stage      : "stage-name",
-        name       : "pipeline-name",
+        name       : null,
         auto_update: true
       ]
     ]
@@ -61,7 +61,7 @@ class DependencyMaterialRepresenterTest implements MaterialRepresenterTrait {
         [
           pipeline   : "",
           stage      : "",
-          name       : "",
+          name       : null,
           auto_update: true
         ],
       errors      : [

--- a/api/api-materials-v1/src/main/java/com/thoughtworks/go/apiv1/materials/representers/materials/DependencyMaterialRepresenter.java
+++ b/api/api-materials-v1/src/main/java/com/thoughtworks/go/apiv1/materials/representers/materials/DependencyMaterialRepresenter.java
@@ -27,7 +27,7 @@ public class DependencyMaterialRepresenter implements MaterialRepresenter<Depend
         return jsonWriter -> {
             jsonWriter.add("pipeline", dependencyMaterialConfig.getPipelineName());
             jsonWriter.add("stage", dependencyMaterialConfig.getStageName());
-            jsonWriter.add("name", dependencyMaterialConfig.getName());
+            jsonWriter.add("name", dependencyMaterialConfig.getNameWithoutDefaults());
             jsonWriter.add("auto_update", dependencyMaterialConfig.isAutoUpdate());
         };
     }

--- a/api/api-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/materials/representers/materials/DependencyMaterialRepresenterTest.groovy
+++ b/api/api-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/materials/representers/materials/DependencyMaterialRepresenterTest.groovy
@@ -47,7 +47,7 @@ class DependencyMaterialRepresenterTest implements MaterialRepresenterTrait<Depe
       attributes : [
         pipeline   : "pipeline-name",
         stage      : "stage-name",
-        name       : "pipeline-name",
+        name       : null,
         auto_update: true
       ]
     ]
@@ -62,7 +62,7 @@ class DependencyMaterialRepresenterTest implements MaterialRepresenterTrait<Depe
         [
           pipeline   : "",
           stage      : "",
-          name       : "",
+          name       : null,
           auto_update: true
         ],
       errors     : [

--- a/api/api-materials-v2/src/main/java/com/thoughtworks/go/apiv2/materials/representers/materials/DependencyMaterialRepresenter.java
+++ b/api/api-materials-v2/src/main/java/com/thoughtworks/go/apiv2/materials/representers/materials/DependencyMaterialRepresenter.java
@@ -27,7 +27,7 @@ public class DependencyMaterialRepresenter implements MaterialRepresenter<Depend
         return jsonWriter -> {
             jsonWriter.add("pipeline", dependencyMaterialConfig.getPipelineName());
             jsonWriter.add("stage", dependencyMaterialConfig.getStageName());
-            jsonWriter.add("name", dependencyMaterialConfig.getName());
+            jsonWriter.add("name", dependencyMaterialConfig.getNameWithoutDefaults());
             jsonWriter.add("auto_update", dependencyMaterialConfig.isAutoUpdate());
             jsonWriter.add("ignore_for_scheduling", dependencyMaterialConfig.ignoreForScheduling());
         };

--- a/api/api-materials-v2/src/test/groovy/com/thoughtworks/go/apiv2/materials/representers/materials/DependencyMaterialRepresenterTest.groovy
+++ b/api/api-materials-v2/src/test/groovy/com/thoughtworks/go/apiv2/materials/representers/materials/DependencyMaterialRepresenterTest.groovy
@@ -47,7 +47,7 @@ class DependencyMaterialRepresenterTest implements MaterialRepresenterTrait<Depe
       attributes : [
         pipeline             : "pipeline-name",
         stage                : "stage-name",
-        name                 : "pipeline-name",
+        name                 : null,
         auto_update          : true,
         ignore_for_scheduling: true
       ]
@@ -63,7 +63,7 @@ class DependencyMaterialRepresenterTest implements MaterialRepresenterTrait<Depe
         [
           pipeline             : "",
           stage                : "",
-          name                 : "",
+          name                 : null,
           auto_update          : true,
           ignore_for_scheduling: false
         ],

--- a/api/api-shared-v1/src/main/java/com/thoughtworks/go/apiv1/shared/representers/materials/DependencyMaterialRepresenter.java
+++ b/api/api-shared-v1/src/main/java/com/thoughtworks/go/apiv1/shared/representers/materials/DependencyMaterialRepresenter.java
@@ -24,7 +24,7 @@ public class DependencyMaterialRepresenter {
     public static void toJSON(OutputWriter jsonWriter, DependencyMaterialConfig dependencyMaterialConfig) {
         jsonWriter.add("pipeline", dependencyMaterialConfig.getPipelineName());
         jsonWriter.add("stage", dependencyMaterialConfig.getStageName());
-        jsonWriter.add("name", dependencyMaterialConfig.getName());
+        jsonWriter.add("name", dependencyMaterialConfig.getNameWithoutDefaults());
         jsonWriter.add("auto_update", dependencyMaterialConfig.isAutoUpdate());
     }
 

--- a/api/api-shared-v1/src/test/groovy/com/thoughtworks/go/apiv1/shared/representers/materials/DependencyMaterialRepresenterTest.groovy
+++ b/api/api-shared-v1/src/test/groovy/com/thoughtworks/go/apiv1/shared/representers/materials/DependencyMaterialRepresenterTest.groovy
@@ -55,7 +55,7 @@ class DependencyMaterialRepresenterTest implements MaterialRepresenterTrait {
     attributes: [
       pipeline: "pipeline-name",
       stage: "stage-name",
-      name: "pipeline-name",
+      name: null,
       auto_update: true
     ]
   ]
@@ -67,7 +67,7 @@ class DependencyMaterialRepresenterTest implements MaterialRepresenterTrait {
     [
       pipeline: "",
       stage: "",
-      name: "",
+      name: null,
       auto_update: true
     ],
     errors: [

--- a/api/api-shared-v10/src/main/java/com/thoughtworks/go/apiv10/admin/shared/representers/materials/DependencyMaterialRepresenter.java
+++ b/api/api-shared-v10/src/main/java/com/thoughtworks/go/apiv10/admin/shared/representers/materials/DependencyMaterialRepresenter.java
@@ -26,7 +26,7 @@ public class DependencyMaterialRepresenter implements MaterialRepresenter<Depend
     public void toJSON(OutputWriter jsonWriter, DependencyMaterialConfig dependencyMaterialConfig) {
         jsonWriter.add("pipeline", dependencyMaterialConfig.getPipelineName());
         jsonWriter.add("stage", dependencyMaterialConfig.getStageName());
-        jsonWriter.add("name", dependencyMaterialConfig.getName());
+        jsonWriter.add("name", dependencyMaterialConfig.getNameWithoutDefaults());
         jsonWriter.add("auto_update", dependencyMaterialConfig.isAutoUpdate());
         jsonWriter.add("ignore_for_scheduling", dependencyMaterialConfig.ignoreForScheduling());
     }

--- a/api/api-shared-v10/src/test/groovy/com/thoughtworks/go/apiv10/shared/representers/materials/DependencyMaterialRepresenterTest.groovy
+++ b/api/api-shared-v10/src/test/groovy/com/thoughtworks/go/apiv10/shared/representers/materials/DependencyMaterialRepresenterTest.groovy
@@ -55,7 +55,7 @@ class DependencyMaterialRepresenterTest implements MaterialRepresenterTrait {
     attributes: [
       pipeline: "pipeline-name",
       stage: "stage-name",
-      name: "pipeline-name",
+      name: null,
       auto_update: true,
       ignore_for_scheduling: true
     ]
@@ -68,7 +68,7 @@ class DependencyMaterialRepresenterTest implements MaterialRepresenterTrait {
     [
       pipeline: "",
       stage: "",
-      name: "",
+      name: null,
       auto_update: true,
       ignore_for_scheduling: true
     ],

--- a/api/api-shared-v9/src/main/java/com/thoughtworks/go/apiv9/admin/shared/representers/materials/DependencyMaterialRepresenter.java
+++ b/api/api-shared-v9/src/main/java/com/thoughtworks/go/apiv9/admin/shared/representers/materials/DependencyMaterialRepresenter.java
@@ -26,7 +26,7 @@ public class DependencyMaterialRepresenter implements MaterialRepresenter<Depend
     public void toJSON(OutputWriter jsonWriter, DependencyMaterialConfig dependencyMaterialConfig) {
         jsonWriter.add("pipeline", dependencyMaterialConfig.getPipelineName());
         jsonWriter.add("stage", dependencyMaterialConfig.getStageName());
-        jsonWriter.add("name", dependencyMaterialConfig.getName());
+        jsonWriter.add("name", dependencyMaterialConfig.getNameWithoutDefaults());
         jsonWriter.add("auto_update", dependencyMaterialConfig.isAutoUpdate());
     }
 

--- a/api/api-shared-v9/src/test/groovy/com/thoughtworks/go/apiv9/shared/representers/materials/DependencyMaterialRepresenterTest.groovy
+++ b/api/api-shared-v9/src/test/groovy/com/thoughtworks/go/apiv9/shared/representers/materials/DependencyMaterialRepresenterTest.groovy
@@ -55,7 +55,7 @@ class DependencyMaterialRepresenterTest implements MaterialRepresenterTrait {
     attributes: [
       pipeline: "pipeline-name",
       stage: "stage-name",
-      name: "pipeline-name",
+      name: null,
       auto_update: true
     ]
   ]
@@ -67,7 +67,7 @@ class DependencyMaterialRepresenterTest implements MaterialRepresenterTrait {
     [
       pipeline: "",
       stage: "",
-      name: "",
+      name: null,
       auto_update: true
     ],
     errors: [

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/dependency/DependencyMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/dependency/DependencyMaterialConfig.java
@@ -85,6 +85,10 @@ public class DependencyMaterialConfig extends AbstractMaterialConfig implements 
         return super.getName() == null ? pipelineName : super.getName();
     }
 
+    public CaseInsensitiveString getNameWithoutDefaults() {
+        return super.getName();
+    }
+
     public String getUserName() {
         return "cruise";
     }

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/serialization/DependencyMaterialConfigTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/serialization/DependencyMaterialConfigTest.java
@@ -27,6 +27,7 @@ import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.util.ConfigElementImplementationRegistryMother;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -196,5 +197,21 @@ class DependencyMaterialConfigTest {
         DependencyMaterialConfig dependencyMaterialConfig = new DependencyMaterialConfig(new CaseInsensitiveString("upstream_stage"), new CaseInsensitiveString("upstream_pipeline"), new CaseInsensitiveString("stage"));
 
         assertThat(dependencyMaterialConfig.getLongDescription()).isEqualTo("upstream_pipeline [ stage ]");
+    }
+
+    @Nested
+    class getNameWithoutDefaults {
+        @Test
+        void shouldNotDefaultToPipelineNameSinceItsUsedToSerializeConfigToJSON() {
+            DependencyMaterialConfig config = new DependencyMaterialConfig(
+                    new CaseInsensitiveString("pipeline_name"), new CaseInsensitiveString("stage_name"));
+
+            assertThat(config.getNameWithoutDefaults()).isNull();
+
+            config = new DependencyMaterialConfig(new CaseInsensitiveString("material_name"),
+                    new CaseInsensitiveString("pipeline_name"), new CaseInsensitiveString("stage_name"));
+
+            assertThat(config.getNameWithoutDefaults()).isEqualTo(new CaseInsensitiveString("material_name"));
+        }
     }
 }


### PR DESCRIPTION
* Fixes #7737. DependencyMaterial representers now rely
 on the actual name of the material instead of defaulting
 to pipeline name.


