### PR TITLE
Make internal resources controller accessible by all normal users

### DIFF
--- a/api/api-internal-resources-v1/src/main/java/com/thoughtworks/go/apiv1/internalresources/InternalResourcesControllerV1.java
+++ b/api/api-internal-resources-v1/src/main/java/com/thoughtworks/go/apiv1/internalresources/InternalResourcesControllerV1.java
@@ -59,7 +59,7 @@ public class InternalResourcesControllerV1 extends ApiController implements Spar
             before("", mimeType, this::setContentType);
             before("/*", mimeType, this::setContentType);
 
-            before("", mimeType, this.apiAuthenticationHelper::checkAdminUserAnd403);
+            before("", mimeType, this.apiAuthenticationHelper::checkUserAnd403);
 
             get("", mimeType, this::index);
         });

--- a/api/api-internal-resources-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalresources/InternalResourcesControllerV1Test.groovy
+++ b/api/api-internal-resources-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalresources/InternalResourcesControllerV1Test.groovy
@@ -19,8 +19,8 @@ import com.thoughtworks.go.api.SecurityTestTrait
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.server.service.AgentService
 import com.thoughtworks.go.server.service.GoConfigService
-import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -50,7 +50,7 @@ class InternalResourcesControllerV1Test implements SecurityServiceTrait, Control
   class Index {
 
     @Nested
-    class Security implements SecurityTestTrait, AdminUserSecurity {
+    class Security implements SecurityTestTrait, NormalUserSecurity {
       @Override
       String getControllerMethodUnderTest() {
         return 'index'


### PR DESCRIPTION
Resources list needs to be accessible on the new pipeline config SPA to provide resource autocompletions, thus following users needs to have access to this API:
- Super Admins
- Pipeline Group Admins
- Template Admins

Did not find any harm in opening up this API for all users as users can find the resources information through Agents SPA/API.