### PR TITLE
Send response body when submitted Pipeline JSON has duplicate job name error (#7822)

### DIFF
--- a/api/api-shared-v10/src/main/java/com/thoughtworks/go/apiv10/admin/shared/representers/stages/StageRepresenter.java
+++ b/api/api-shared-v10/src/main/java/com/thoughtworks/go/apiv10/admin/shared/representers/stages/StageRepresenter.java
@@ -78,7 +78,7 @@ public class StageRepresenter {
         JobConfigs allJobs = new JobConfigs();
         jsonReader.readArrayIfPresent("jobs", jobs -> {
             jobs.forEach(job -> {
-                allJobs.add(JobRepresenter.fromJSON(new JsonReader(job.getAsJsonObject())));
+                allJobs.addJobWithoutValidityAssertion(JobRepresenter.fromJSON(new JsonReader(job.getAsJsonObject())));
             });
         });
 

--- a/api/api-shared-v10/src/test/groovy/com/thoughtworks/go/apiv10/shared/representers/stages/StageRepresenterTest.groovy
+++ b/api/api-shared-v10/src/test/groovy/com/thoughtworks/go/apiv10/shared/representers/stages/StageRepresenterTest.groovy
@@ -150,6 +150,16 @@ class StageRepresenterTest  {
       assertEquals(JobConfigMother.jobConfig(), stageConfig.getJobs().first())
     }
 
+    @Test
+    void 'should not fail to deserialize stage config which has duplicate jobs'() {
+      def jsonReader = GsonTransformer.instance.jsonReaderFrom([
+        jobs: [jobHash, jobHash]
+      ])
+
+      def stageConfig = StageRepresenter.fromJSON(jsonReader)
+      assertEquals(stageConfig.getJobs().size(), 2)
+    }
+
     def jobHash =
     [
       name:                  'defaultJob',


### PR DESCRIPTION
Issue: #7822

Description:
* Do not validate submitted payload while deserializing