### PR TITLE
Don't showcase pending agents in edit agents modal

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/agents/spec/agents_test_data.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/agents/spec/agents_test_data.ts
@@ -268,7 +268,7 @@ class AgentJSONBuilder {
   }
 
   private static randomAgentConfigState() {
-    return ["Disabled", "Enabled", "Pending"][this.getRandomIntegerInRange(0, 2)];
+    return ["Disabled", "Enabled"][this.getRandomIntegerInRange(0, 1)];
   }
 
   private static randomAgentState() {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_agents_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_agents_modal.tsx
@@ -17,7 +17,7 @@
 import {MithrilViewComponent} from "jsx/mithril-component";
 import m from "mithril";
 import Stream from "mithril/stream";
-import {Agent, Agents} from "models/agents/agents";
+import {Agent, AgentConfigState, Agents} from "models/agents/agents";
 import {Environments, EnvironmentWithOrigin} from "models/new-environments/environments";
 import {EnvironmentsAPIs} from "models/new-environments/environments_apis";
 import s from "underscore.string";
@@ -46,14 +46,16 @@ export class AgentCheckboxListWidget extends MithrilViewComponent<AgentCheckboxL
     return <div class={styles.pipelinesContainer} data-test-id={s.slugify(vnode.attrs.title)}>
       <div class={styles.header}>{vnode.attrs.title}</div>
       {
-        agents.map((agent: Agent) => {
-          return <div class={styles.pipelineCheckbox} data-test-id={`agent-checkbox-for-${agent.uuid}`}>
-            <CheckboxField label={agent.hostname}
-                           dataTestId={`form-field-input-${agent.uuid}`}
-                           readonly={vnode.attrs.readonly}
-                           property={vnode.attrs.agentSelectedFn(agent)}/>
-          </div>;
-        })
+        agents
+          .filter((agent: Agent) => agent.agentConfigState !== AgentConfigState.Pending)
+          .map((agent: Agent) => {
+            return <div class={styles.pipelineCheckbox} data-test-id={`agent-checkbox-for-${agent.uuid}`}>
+              <CheckboxField label={agent.hostname}
+                             dataTestId={`form-field-input-${agent.uuid}`}
+                             readonly={vnode.attrs.readonly}
+                             property={vnode.attrs.agentSelectedFn(agent)}/>
+            </div>;
+          })
       }
     </div>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_agents_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/spec/edit_agents_modal_spec.tsx
@@ -261,4 +261,21 @@ describe("Edit Agents Modal", () => {
     expect(helper.byTestId("cancel-button")).toBeDisabled();
     expect(helper.byTestId("spinner")).toBeInDOM();
   });
+
+  it('should not render pending agents', () => {
+    helper.unmount();
+
+    agentsJSON._embedded.agents[2].agent_config_state = "Pending";
+    modal                                             = new EditAgentsModal(environment,
+                                                                            environments,
+                                                                            Agents.fromJSON(agentsJSON),
+                                                                            jasmine.createSpy("onSuccessfulSave"));
+
+    helper.mount(() => modal.view());
+    const availableAgentsSection = helper.byTestId(`available-agents`);
+    const agent2Selector         = `agent-checkbox-for-${unassociatedStaticAgent}`;
+
+    expect(availableAgentsSection).toBeInDOM();
+    expect(helper.byTestId(agent2Selector, availableAgentsSection)).not.toBeInDOM();
+  });
 });


### PR DESCRIPTION
Any pending agent cannot be added to an env. Hence, not showcasing them on the edit agents modal on the Environments SPA.


