### PR TITLE
XML escape `git log` output prior to YAML parsing to protect special characters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,6 +186,7 @@ rootProject.ext.versions = [
   commonsLang           : '2.6',
   commonsLang3          : '3.9',
   commonsPool           : '2.8.0',
+  commonsText           : '1.8',
   dbunit                : '2.7.0',
   ehcache               : '2.10.6',
   felix                 : '5.6.10',

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -22,6 +22,8 @@ dependencies {
   compile group: 'org.springframework', name: 'spring-tx', version: project.versions.spring
   compile group: 'de.skuzzle', name: 'semantic-version', version: project.versions.semanticVersion
   compile group: 'org.yaml', name: 'snakeyaml', version: project.versions.snakeYaml
+  compile group: 'org.apache.commons', name: 'commons-text', version: project.versions.commonsText
+
   compileOnly group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
 

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitLog.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitLog.java
@@ -23,6 +23,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
 
+import static org.apache.commons.text.StringEscapeUtils.unescapeXml;
+
 @Getter
 @Setter
 public class GitLog {
@@ -39,13 +41,13 @@ public class GitLog {
 
     Modification toModification() {
         Modification modification = new Modification(
-                StringUtils.stripToNull(authorName),
-                StringUtils.stripToNull(rawBody),
-                StringUtils.stripToNull(authorEmail),
-                DateUtils.parseISO8601(date),
-                StringUtils.stripToNull(commitHash));
+                StringUtils.stripToNull(unescapeXml(authorName)),
+                StringUtils.stripToNull(unescapeXml(rawBody)),
+                StringUtils.stripToNull(unescapeXml(authorEmail)),
+                DateUtils.parseISO8601(unescapeXml(date)),
+                StringUtils.stripToNull(unescapeXml(commitHash)));
 
-        additionalInfo.put("subject", subject);
+        additionalInfo.put("subject", unescapeXml(subject));
         modification.setAdditionalData(additionalInfo);
         return modification;
     }

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitModificationParser.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitModificationParser.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.commons.text.StringEscapeUtils.escapeXml11;
+
 public class GitModificationParser {
     private Yaml yaml = new Yaml();
 
@@ -31,7 +33,7 @@ public class GitModificationParser {
             return Collections.emptyList();
         }
 
-        List<GitLog> gitLogs = yaml.load(output);
+        List<GitLog> gitLogs = yaml.load(escapeXml11(output));
 
         if (gitLogs.isEmpty()) {
             return Collections.emptyList();

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -818,6 +818,7 @@ task verifyWar(type: VerifyJarTask) {
         "commons-io-${project.versions.commonsIO}.jar",
         "commons-lang-${project.versions.commonsLang}.jar",
         "commons-lang3-${project.versions.commonsLang3}.jar",
+        "commons-text-${project.versions.commonsText}.jar",
         "commons-pool2-${project.versions.commonsPool}.jar",
         "config-api-${project.version}.jar",
         "config-server-${project.version}.jar",


### PR DESCRIPTION
Special characters should not cause exceptions on material check. Currently, the YAML parser blows up when encountering certain non-printable characters in git commit messages.

This PR escapes the `git log` payload prior to YAML parsing so that we avoid these types of exceptions. We unescape the content as we deserialize to `Modification` instances to keep it transparent.

Fixes #7752