### PR TITLE
Updating url-rewrite for ApiInfo api to move to internal #000

### DIFF
--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -69,8 +69,8 @@
 
   <rule>
     <name>APIs info API</name>
-    <from>^/api/apis(/?)$</from>
-    <to last="true">/spark/api/apis</to>
+    <from>^/api/internal/apis(/?)$</from>
+    <to last="true">/spark/api/internal/apis</to>
   </rule>
 
   <rule>

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/SparkPreFilter.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/SparkPreFilter.java
@@ -47,7 +47,7 @@ public class SparkPreFilter extends SparkFilter {
             "/go/spark/api/plugin_images",
             "/go/spark/api/support",
             "/go/spark/api/v1/health",
-            "/go/spark/api/apis",
+            "/go/spark/api/internal/apis",
             "/go/spark/api/feed",
             "/go/spark/api/webhooks"
         );


### PR DESCRIPTION
* The APIInfo api was moved to internal as part of
  https://github.com/gocd/gocd/commit/361e2a3f2c2d80e18f82539d2c38ed42b6630af9
  Updating url-rewite to use the right url.

Issue: #

Description:

