### PR TITLE
Minor improvements

### DIFF
--- a/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/CompareControllerV1.java
+++ b/api/api-compare-v1/src/main/java/com/thoughtworks/go/apiv1/compare/CompareControllerV1.java
@@ -19,12 +19,12 @@ import com.thoughtworks.go.api.ApiController;
 import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv1.compare.representers.ComparisonRepresenter;
-import com.thoughtworks.go.config.exceptions.BadRequestException;
 import com.thoughtworks.go.config.exceptions.UnprocessableEntityException;
 import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.server.service.ChangesetService;
 import com.thoughtworks.go.server.service.PipelineService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import com.thoughtworks.go.spark.DeprecatedAPI;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +38,7 @@ import java.util.List;
 import static spark.Spark.*;
 
 @Component
+@DeprecatedAPI(deprecatedApiVersion = ApiVersion.v1, successorApiVersion = ApiVersion.v2, deprecatedIn = "20.2.0", removalIn = "20.5.0", entityName = "Compare Pipelines")
 public class CompareControllerV1 extends ApiController implements SparkSpringController {
 
     private final ApiAuthenticationHelper apiAuthenticationHelper;

--- a/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/CompareControllerV1Test.groovy
+++ b/api/api-compare-v1/src/test/groovy/com/thoughtworks/go/apiv1/compare/CompareControllerV1Test.groovy
@@ -28,6 +28,7 @@ import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult
 import com.thoughtworks.go.serverhealth.HealthStateScope
 import com.thoughtworks.go.serverhealth.HealthStateType
 import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.DeprecatedApiTrait
 import com.thoughtworks.go.spark.PipelineAccessSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import org.junit.jupiter.api.BeforeEach
@@ -42,7 +43,7 @@ import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.when
 import static org.mockito.MockitoAnnotations.initMocks
 
-class CompareControllerV1Test implements SecurityServiceTrait, ControllerTrait<CompareControllerV1> {
+class CompareControllerV1Test implements SecurityServiceTrait, ControllerTrait<CompareControllerV1>, DeprecatedApiTrait {
 
   @Mock
   private ChangesetService changesetService

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfigSaveValidationContext.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfigSaveValidationContext.java
@@ -301,4 +301,17 @@ public class PipelineConfigSaveValidationContext implements ValidationContext {
     public RulesValidationContext getRulesValidationContext() {
         return null;
     }
+
+    @Override
+    public Map<CaseInsensitiveString, Boolean> getPipelineToMaterialAutoUpdateMapByFingerprint(String fingerprint) {
+        Map<CaseInsensitiveString, Boolean> map = new HashMap<>();
+        getCruiseConfig().getAllPipelineConfigs().forEach(pipeline -> {
+            pipeline.materialConfigs().stream()
+                    .filter(materialConfig -> materialConfig.getFingerprint().equals(fingerprint))
+                    .findFirst()
+                    .ifPresent(expectedMaterialConfig -> map.put(pipeline.name(), expectedMaterialConfig.isAutoUpdate()));
+
+        });
+        return map;
+    }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
@@ -341,7 +341,7 @@ public abstract class ScmMaterialConfig extends AbstractMaterialConfig implement
         }
         StringBuilder builder = new StringBuilder();
         pipelinesWithThisMaterial.forEach((key, value) -> {
-            builder.append(format("%s (%s), ", key, getAutoUpdateStatus(value)));
+            builder.append(format("%s (%s),\n ", key, getAutoUpdateStatus(value)));
         });
 
         return builder.delete(builder.lastIndexOf(","), builder.length()).toString();

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigRepoConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigRepoConfig.java
@@ -133,7 +133,7 @@ public class ConfigRepoConfig extends RuleAwarePluginProfile implements Cacheabl
         if (material != null) {
             MaterialConfigs allMaterialsByFingerPrint = validationContext.getAllMaterialsByFingerPrint(material.getFingerprint());
             if (allMaterialsByFingerPrint.stream().anyMatch(m -> !m.isAutoUpdate())) {
-                String message = format("The material of type %s (%s) is used elsewhere with a different value for autoUpdate (\"Poll for changes\"). All copies of this material must have autoUpdate enabled or configuration repository must be removed. Config Repository: %s (%s).", material.getTypeForDisplay(), material.getDescription(), getId(), getAutoUpdateStatus(material.isAutoUpdate()));
+                String message = format("The material of type %s (%s) is used elsewhere with a different value for autoUpdate (\"Poll for changes\"). All copies of this material must have autoUpdate enabled or configuration repository must be removed.\n Config Repository: %s (%s).\n", material.getTypeForDisplay(), material.getDescription(), getId(), getAutoUpdateStatus(material.isAutoUpdate()));
                 Map<CaseInsensitiveString, Boolean> pipelinesWithMaterial = validationContext.getPipelineToMaterialAutoUpdateMapByFingerprint(material.getFingerprint());
                 if (!pipelinesWithMaterial.isEmpty()) {
                     message = message.concat(format(" Pipelines: %s", join(pipelinesWithMaterial)));

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/AbstractRuleAwarePluginProfileTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/AbstractRuleAwarePluginProfileTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractRuleAwarePluginProfileTest {
 
@@ -35,17 +35,17 @@ public abstract class AbstractRuleAwarePluginProfileTest {
         RuleAwarePluginProfile profile = newPluginProfile(null, null);
 
         profile.validate(getValidationContext(profile));
-        assertThat(profile.errors().size(), is(2));
-        assertThat(profile.errors().on("pluginId"), is(format("%s cannot have a blank plugin id.", getObjectDescription())));
-        assertThat(profile.errors().on("id"), is(format("%s cannot have a blank id.", getObjectDescription())));
+        assertThat(profile.errors().size()).isEqualTo(2);
+        assertThat(profile.errors().on("pluginId")).isEqualTo(format("%s cannot have a blank plugin id.", getObjectDescription()));
+        assertThat(profile.errors().on("id")).isEqualTo(format("%s cannot have a blank id.", getObjectDescription()));
     }
 
     @Test
     public void shouldValidatePluginIdPattern() throws Exception {
         RuleAwarePluginProfile profile = newPluginProfile("!123", "docker");
         profile.validate(getValidationContext(profile));
-        assertThat(profile.errors().size(), is(1));
-        assertThat(profile.errors().on("id"), is("Invalid id '!123'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."));
+        assertThat(profile.errors().size()).isEqualTo(1);
+        assertThat(profile.errors().on("id")).isEqualTo("Invalid id '!123'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.");
     }
 
     @Test
@@ -56,16 +56,16 @@ public abstract class AbstractRuleAwarePluginProfileTest {
 
         profile.validate(getValidationContext(profile));
 
-        assertThat(profile.errors().size(), is(0));
+        assertThat(profile.errors().size()).isEqualTo(0);
 
         ConfigurationProperty configProp1 = profile.getConfiguration().get(0);
         ConfigurationProperty configProp2 = profile.getConfiguration().get(1);
 
-        assertThat(configProp1.errors().size(), is(1));
-        assertThat(configProp2.errors().size(), is(1));
+        assertThat(configProp1.errors().size()).isEqualTo(1);
+        assertThat(configProp2.errors().size()).isEqualTo(1);
 
-        assertThat(configProp1.errors().on("configurationKey"), is(format("Duplicate key 'USERNAME' found for %s 'docker.unit-test'", getObjectDescription())));
-        assertThat(configProp2.errors().on("configurationKey"), is(format("Duplicate key 'USERNAME' found for %s 'docker.unit-test'", getObjectDescription())));
+        assertThat(configProp1.errors().on("configurationKey")).isEqualTo(format("Duplicate key 'USERNAME' found for %s 'docker.unit-test'", getObjectDescription()));
+        assertThat(configProp2.errors().on("configurationKey")).isEqualTo(format("Duplicate key 'USERNAME' found for %s 'docker.unit-test'", getObjectDescription()));
     }
 
     protected ValidationContext getValidationContext(RuleAwarePluginProfile profile) {

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/MaterialConfigsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/MaterialConfigsTest.java
@@ -416,7 +416,7 @@ Above scenario allowed
         pipelineOne.materialConfigs().validate(ConfigSaveValidationContext.forChain(config));
 
         assertThat(pipelineOne.materialConfigs().get(0).errors().on(ScmMaterialConfig.AUTO_UPDATE),
-                is("The material of type Mercurial (http://url1) is used elsewhere with a different value for autoUpdate (\"Poll for changes\"). Those values should be the same. Pipelines: one (auto update disabled), two (auto update enabled)"));
+                is("The material of type Mercurial (http://url1) is used elsewhere with a different value for autoUpdate (\"Poll for changes\"). Those values should be the same. Pipelines: one (auto update disabled),\n two (auto update enabled)"));
     }
 
     @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigRepoConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigRepoConfigTest.java
@@ -32,8 +32,7 @@ import java.util.Arrays;
 
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
 import static com.thoughtworks.go.helper.MaterialConfigsMother.svn;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
@@ -48,7 +47,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
     public void shouldReturnPluginNameWhenSpecified() {
         ConfigRepoConfig config = new ConfigRepoConfig();
         config.setPluginId("myplugin");
-        assertThat(config.getPluginId(), is("myplugin"));
+        assertThat(config.getPluginId()).isEqualTo("myplugin");
     }
 
     @Test
@@ -64,9 +63,8 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(cruiseConfig);
         configRepoConfig.validate(validationContext);
 
-        assertThat(svn.errors().isEmpty(), is(false));
-        assertThat(svn.errors().on("autoUpdate"),
-                is("Configuration repository material 'url' must have autoUpdate enabled."));
+        assertThat(svn.errors().isEmpty()).isFalse();
+        assertThat(svn.errors().on("autoUpdate")).isEqualTo("Configuration repository material 'url' must have autoUpdate enabled.");
     }
 
     @Test
@@ -80,9 +78,8 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(cruiseConfig);
         configRepoConfig1.validate(validationContext);
 
-        assertThat(configRepoConfig1.errors().isEmpty(), is(false));
-        assertThat(configRepoConfig1.errors().on("id"),
-                is("You have defined multiple configuration repositories with the same id - 'id_1'."));
+        assertThat(configRepoConfig1.errors().isEmpty()).isFalse();
+        assertThat(configRepoConfig1.errors().on("id")).isEqualTo("You have defined multiple configuration repositories with the same id - 'id_1'.");
     }
 
     @Test
@@ -92,9 +89,8 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         ConfigRepoConfig configRepo = ConfigRepoConfig.createConfigRepoConfig(null, null, "id_1");
         configRepo.validate(validationContext);
 
-        assertThat(configRepo.errors().isEmpty(), is(false));
-        assertThat(configRepo.errors().on("pluginId"),
-                is("Configuration repository cannot have a blank plugin id."));
+        assertThat(configRepo.errors().isEmpty()).isFalse();
+        assertThat(configRepo.errors().on("pluginId")).isEqualTo("Configuration repository cannot have a blank plugin id.");
     }
 
     @Test
@@ -109,9 +105,8 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(cruiseConfig);
         configRepoConfig1.validate(validationContext);
 
-        assertThat(configRepoConfig1.errors().isEmpty(), is(false));
-        assertThat(configRepoConfig1.errors().on("material"),
-                is("You have defined multiple configuration repositories with the same repository - 'url'."));
+        assertThat(configRepoConfig1.errors().isEmpty()).isFalse();
+        assertThat(configRepoConfig1.errors().on("material")).isEqualTo("You have defined multiple configuration repositories with the same repository - 'url'.");
     }
 
     @Test
@@ -125,7 +120,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(cruiseConfig);
         configRepoConfig.validate(validationContext);
 
-        assertThat(configRepoConfig.getRepo().errors().on("url"), is("URL cannot be blank"));
+        assertThat(configRepoConfig.getRepo().errors().on("url")).isEqualTo("URL cannot be blank");
     }
 
     @Test
@@ -154,8 +149,8 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(cruiseConfig);
 
         configRepoConfig.validateTree(validationContext);
-        assertTrue(configRepoConfig.errors().isEmpty());
-        assertFalse(configRepoConfig.getRepo().errors().isEmpty());
+        assertThat(configRepoConfig.errors().isEmpty()).isTrue();
+        assertThat(configRepoConfig.getRepo().errors().isEmpty()).isFalse();
     }
 
     @Test
@@ -177,9 +172,8 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
 
         configRepoConfig.validate(ConfigSaveValidationContext.forChain(cruiseConfig, new BasicPipelineConfigs(), pipeline1));
 
-        assertThat(svnInConfigRepo.errors().isEmpty(), is(false));
-        assertThat(svnInConfigRepo.errors().on("autoUpdate"),
-                is("The material of type Subversion (url) is used elsewhere with a different value for autoUpdate (\"Poll for changes\"). All copies of this material must have autoUpdate enabled or configuration repository must be removed. Config Repository: id (auto update enabled). Pipelines: badpipe (auto update disabled)"));
+        assertThat(svnInConfigRepo.errors().isEmpty()).isFalse();
+        assertThat(svnInConfigRepo.errors().on("autoUpdate")).isEqualTo("The material of type Subversion (url) is used elsewhere with a different value for autoUpdate (\"Poll for changes\"). All copies of this material must have autoUpdate enabled or configuration repository must be removed.\n Config Repository: id (auto update enabled).\n Pipelines: badpipe (auto update disabled)");
     }
 
     @Test
@@ -188,7 +182,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         MaterialConfig someRepo = git("url", "branch");
         ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin", "id");
 
-        assertThat(config.hasSameMaterial(someRepo), is(true));
+        assertThat(config.hasSameMaterial(someRepo)).isTrue();
     }
 
     @Test
@@ -197,7 +191,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         MaterialConfig someRepo = git("url", "branch1");
         ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin", "id");
 
-        assertThat(config.hasSameMaterial(someRepo), is(false));
+        assertThat(config.hasSameMaterial(someRepo)).isFalse();
     }
 
     @Test
@@ -207,7 +201,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         someRepo.setFolder("someFolder");
         ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin", "id");
 
-        assertThat(config.hasSameMaterial(someRepo), is(true));
+        assertThat(config.hasSameMaterial(someRepo)).isTrue();
     }
 
     @Test
@@ -217,7 +211,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         someRepo.setFolder("someFolder");
         ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin", "id");
 
-        assertThat(config.hasMaterialWithFingerprint(someRepo.getFingerprint()), is(true));
+        assertThat(config.hasMaterialWithFingerprint(someRepo.getFingerprint())).isTrue();
     }
 
     @Test
@@ -226,7 +220,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         GitMaterialConfig someRepo = git("url", "branch1");
         ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(configRepo, "myplugin", "id");
 
-        assertThat(config.hasMaterialWithFingerprint(someRepo.getFingerprint()), is(false));
+        assertThat(config.hasMaterialWithFingerprint(someRepo.getFingerprint())).isFalse();
     }
 
     @Override

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/patterns/_forms.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/patterns/_forms.scss
@@ -272,7 +272,8 @@ label.inline {
 
 
 .material_options .form_error{
-  margin-top: 5px;
+  margin-top:  5px;
+  white-space: pre-wrap;
 }
 
 .checkbox_row * {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/compare/spec/compare_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/compare/spec/compare_spec.ts
@@ -16,9 +16,9 @@
 
 import {Comparison, DependencyRevision, MaterialRevision,} from "../compare";
 import {DependencyRevisionJSON, MaterialRevisionJSON} from "../compare_json";
-import {DependencyMaterialAttributes, GitMaterialAttributes} from "../material";
+import {DependencyMaterialAttributes, GitMaterialAttributes, PackageMaterialAttributes, PluggableScmMaterialAttributes} from "../material";
 import {parseDate} from "../pipeline_instance";
-import {ComparisonData} from "./test_data";
+import {ComparisonData, MaterialData} from "./test_data";
 
 describe('ComparisonModelSpec', () => {
   it('should parse json into object', () => {
@@ -58,5 +58,43 @@ describe('ComparisonModelSpec', () => {
     expect((revision1 as DependencyRevision).revision).toEqual(revisionJSON1.revision);
     expect((revision1 as DependencyRevision).pipelineCounter).toEqual(revisionJSON1.pipeline_counter);
     expect((revision1 as DependencyRevision).completedAt).toEqual(parseDate(revisionJSON1.completed_at));
+  });
+
+  it('should parse json into object with package material', () => {
+    const json               = ComparisonData.compare();
+    json.changes[0].material = MaterialData.package();
+    json.changes.splice(1, 1);
+
+    const comparison = Comparison.fromJSON(json);
+
+    expect(comparison.pipelineName).toEqual(json.pipeline_name);
+    expect(comparison.fromCounter).toEqual(json.from_counter);
+    expect(comparison.toCounter).toEqual(json.to_counter);
+    expect(comparison.isBisect).toEqual(json.is_bisect);
+
+    expect(comparison.changes.length).toEqual(1);
+
+    expect(comparison.changes[0].material.type()).toEqual("package");
+    expect(comparison.changes[0].material.attributes()).toBeInstanceOf(PackageMaterialAttributes);
+    expect(comparison.changes[0].revision.length).toEqual(1);
+  });
+
+  it('should parse json into object with pluggable scm material', () => {
+    const json               = ComparisonData.compare();
+    json.changes[0].material = MaterialData.pluggable();
+    json.changes.splice(1, 1);
+
+    const comparison = Comparison.fromJSON(json);
+
+    expect(comparison.pipelineName).toEqual(json.pipeline_name);
+    expect(comparison.fromCounter).toEqual(json.from_counter);
+    expect(comparison.toCounter).toEqual(json.to_counter);
+    expect(comparison.isBisect).toEqual(json.is_bisect);
+
+    expect(comparison.changes.length).toEqual(1);
+
+    expect(comparison.changes[0].material.type()).toEqual("plugin");
+    expect(comparison.changes[0].material.attributes()).toBeInstanceOf(PluggableScmMaterialAttributes);
+    expect(comparison.changes[0].revision.length).toEqual(1);
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/index.scss
@@ -144,8 +144,9 @@ code {
   font-weight: 600;
 }
 
-.error-wrapper{
+.error-wrapper {
   margin-bottom: $error-message-margin-bottom;
+  white-space:   pre-wrap;
 }
 
 .form-group {


### PR DESCRIPTION
 - deprecated Compare API v1
 - added specs for compare spa to render package and pluggable materials
 - updated the auto_update error message to render pipelines on the next line (https://github.com/gocd/gocd/pull/7708#issuecomment-597869926)
 - updated the ui on config repo modal and materials tab on pipeline config page to recognize \ns
 - updated the PipelineConfigSaveValidationContext to return the list of pipelines given a material fingerprint


