### PR TITLE
Toggling back to the old comparison spa for the release

### DIFF
--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -48,8 +48,8 @@
     },
     {
       "key": "show_old_comparison_spa",
-      "description": "Switch to the old comparison SPA. Default is false.",
-      "value": false
+      "description": "Switch to the old comparison SPA. Default is true.",
+      "value": true
     },
     {
       "key": "new_pipeline_config_spa",


### PR DESCRIPTION
Issue: 
There are quite a few issues pending on the new Comparison SPA. Hence, decided to toggle back to the old page and moved this to next release.
