### PR TITLE
Refactor Pipeline Config SPA page mounting

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/clicky_pipeline_config.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/clicky_pipeline_config.tsx
@@ -17,25 +17,12 @@
 import {RoutedSinglePageApp} from "helpers/spa_base";
 import m from "mithril";
 import {PipelineConfigPage} from "views/pages/clicky_pipeline_config/pipeline_config";
-import {EnvironmentVariablesTabContent} from "views/pages/clicky_pipeline_config/tabs/common/environment_variables_tab_content";
-import {ArtifactsTabContent} from "views/pages/clicky_pipeline_config/tabs/job/artifacts_tab_content";
-import {CustomTabTabContent} from "views/pages/clicky_pipeline_config/tabs/job/custom_tab_tab_content";
-import {JobSettingsTabContent} from "views/pages/clicky_pipeline_config/tabs/job/job_settings_tab_content";
-import {TasksTabContent} from "views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content";
-import {GeneralOptionsTabContent} from "views/pages/clicky_pipeline_config/tabs/pipeline/general_options_tab";
-import {MaterialsTabContent} from "views/pages/clicky_pipeline_config/tabs/pipeline/materials_tab_content";
-import {ParametersTabContent} from "views/pages/clicky_pipeline_config/tabs/pipeline/parameters_tab_content";
-import {ProjectManagementTabContent} from "views/pages/clicky_pipeline_config/tabs/pipeline/project_management_tab_content";
-import {StagesTabContent} from "views/pages/clicky_pipeline_config/tabs/pipeline/stages_tab_content";
-import {JobsTabContent} from "views/pages/clicky_pipeline_config/tabs/stage/jobs_tab_content";
-import {PermissionsTabContent} from "views/pages/clicky_pipeline_config/tabs/stage/permissions_tab_content";
-import {StageSettingsTabContent} from "views/pages/clicky_pipeline_config/tabs/stage/stage_settings_tab_content";
 
 class RedirectToGeneralTab extends PipelineConfigPage<any> {
 
   oninit(vnode: m.Vnode<any, any>) {
     const pipelineName = this.getMeta().pipelineName;
-    m.route.set("/" + pipelineName + "/general");
+    m.route.set(pipelineName + "/general");
   }
 }
 
@@ -43,29 +30,12 @@ export class PipelineConfigSPA extends RoutedSinglePageApp {
   constructor() {
     super({
             "/": new RedirectToGeneralTab(),
-            "/:pipeline_name/:tab_name": new PipelineConfigPage(
-              new GeneralOptionsTabContent(),
-              new ProjectManagementTabContent(),
-              new MaterialsTabContent(),
-              new StagesTabContent(),
-              new EnvironmentVariablesTabContent(),
-              new ParametersTabContent()
-            ),
-            "/:pipeline_name/:stage_name/:tab_name": new PipelineConfigPage(
-              new StageSettingsTabContent(),
-              new JobsTabContent(),
-              new EnvironmentVariablesTabContent(),
-              new PermissionsTabContent()
-            ),
-            "/:pipeline_name/:stage_name/:job_name/:tab_name": new PipelineConfigPage(
-              new JobSettingsTabContent(),
-              new TasksTabContent(),
-              new ArtifactsTabContent(),
-              new EnvironmentVariablesTabContent(),
-              new CustomTabTabContent()
-            )
+            "/:pipeline_name/:tab_name": new PipelineConfigPage(),
+            "/:pipeline_name/:stage_name/:tab_name": new PipelineConfigPage(),
+            "/:pipeline_name/:stage_name/:job_name/:tab_name": new PipelineConfigPage()
           });
   }
+
 }
 
 //tslint:disable-next-line

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/job/artifacts_tab_content_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/job/artifacts_tab_content_spec.tsx
@@ -279,7 +279,6 @@ describe("Artifacts Tab", () => {
     helper.mount(() => tab.content(pipelineConfig,
                                    templateConfig,
                                    routeParams,
-                                   true,
                                    Stream<OperationState>(OperationState.UNKNOWN)));
   }
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/job/custom_tab_tab_content_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/job/custom_tab_tab_content_spec.tsx
@@ -145,7 +145,6 @@ describe("Custom Tab Tab Content", () => {
     helper.mount(() => new CustomTabTabContent().content(pipelineConfig,
                                                          templateConfig,
                                                          routeParams,
-                                                         true,
                                                          Stream<OperationState>(OperationState.UNKNOWN)));
   }
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/general_options_tab_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/general_options_tab_spec.tsx
@@ -133,7 +133,6 @@ describe("GeneralOptionsTag", () => {
     helper.mount(() => new GeneralOptionsTabContent().content(pipelineConfig,
                                                               templateConfig,
                                                               routeParams,
-                                                              true,
                                                               Stream<OperationState>(OperationState.UNKNOWN)));
   }
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/materials_tab_content_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/materials_tab_content_spec.tsx
@@ -110,7 +110,6 @@ describe("MaterialsTabContent", () => {
     helper.mount(() => materialTab.content(pipelineConfig,
                                            templateConfig,
                                            routeParams,
-                                           true,
                                            Stream<OperationState>(OperationState.UNKNOWN)));
   }
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/project_management_tab_content_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/project_management_tab_content_spec.tsx
@@ -59,7 +59,6 @@ describe("ProjectManagementTab", () => {
     helper.mount(() => new ProjectManagementTabContent().content(pipelineConfig,
                                                                  templateConfig,
                                                                  routeParams,
-                                                                 true,
                                                                  Stream<OperationState>(OperationState.UNKNOWN)));
   }
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/stage/permissions_tab_content_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/stage/permissions_tab_content_spec.tsx
@@ -251,6 +251,6 @@ describe("Permissions Tab Content", () => {
     pipelineConfig.stages().add(stage);
     const routeParams    = {stage_name: stage.name()} as PipelineConfigRouteParams;
     const templateConfig = new TemplateConfig("foo", []);
-    helper.mount(() => new PermissionsTabContent().content(pipelineConfig, templateConfig, routeParams, true, Stream<OperationState>(OperationState.UNKNOWN)));
+    helper.mount(() => new PermissionsTabContent().content(pipelineConfig, templateConfig, routeParams, Stream<OperationState>(OperationState.UNKNOWN)));
   }
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/stage/stage_settings_tab_content_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/stage/stage_settings_tab_content_spec.tsx
@@ -110,7 +110,6 @@ describe("StageSettingsTab", () => {
     helper.mount(() => new StageSettingsTabContent().content(pipelineConfig,
                                                              templateConfig,
                                                              routeParams,
-                                                             true,
                                                              Stream<OperationState>(OperationState.UNKNOWN)));
   }
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/widgets/navigation_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/widgets/navigation_widget_spec.tsx
@@ -17,7 +17,8 @@
 import m from "mithril";
 import {PipelineConfig} from "models/pipeline_configs/pipeline_config";
 import {PipelineConfigTestData} from "models/pipeline_configs/spec/test_data";
-import {NavigationWidget} from "views/pages/clicky_pipeline_config/widgets/navigation_widget";
+import {PipelineConfigRouteParams, RouteInfo} from "views/pages/clicky_pipeline_config/pipeline_config";
+import {Attrs, NavigationWidget} from "views/pages/clicky_pipeline_config/widgets/navigation_widget";
 import {TestHelper} from "views/pages/spec/test_helper";
 
 describe("PipelineNavigation", () => {
@@ -66,13 +67,70 @@ describe("PipelineNavigation", () => {
     expect(helper.byTestId("tree-node-jobthree")).toHaveText("JobThree");
   });
 
-  function mount(pipelineConfig: PipelineConfig) {
+  it("should answer whether the current route is a pipeline route", () => {
+    mount(PipelineConfig.fromJSON(PipelineConfigTestData.withTwoStages()));
+
     const routeInfo = {
-      route: "up42/general",
-      params: {pipeline_name: pipelineConfig.name(), tab_name: "general"}
+      params: {
+        pipeline_name: "pipeline"
+      }
     };
+
+    // @ts-ignore
+    const vnode = {attrs: {routeInfo}} as m.Vnode<Attrs>;
+
+    expect(NavigationWidget.isPipelineRoute(vnode)).toBeTrue();
+    expect(NavigationWidget.isStageRoute(vnode, "stage")).toBeFalse();
+    expect(NavigationWidget.isJobRoute(vnode, "stage", "job")).toBeFalse();
+  });
+
+  it("should answer whether the current route is a stage route", () => {
+    mount(PipelineConfig.fromJSON(PipelineConfigTestData.withTwoStages()));
+
+    const routeInfo = {
+      params: {
+        pipeline_name: "pipeline",
+        stage_name: "stage"
+      }
+    };
+
+    // @ts-ignore
+    const vnode = {attrs: {routeInfo}} as m.Vnode<Attrs>;
+
+    expect(NavigationWidget.isPipelineRoute(vnode)).toBeFalse();
+    expect(NavigationWidget.isStageRoute(vnode, "stage")).toBeTrue();
+    expect(NavigationWidget.isJobRoute(vnode, "stage", "job")).toBeFalse();
+  });
+
+  it("should answer whether the current route is a job route", () => {
+    mount(PipelineConfig.fromJSON(PipelineConfigTestData.withTwoStages()));
+
+    const routeInfo = {
+      params: {
+        pipeline_name: "pipeline",
+        stage_name: "stage",
+        job_name: "job"
+      }
+    };
+
+    // @ts-ignore
+    const vnode = {attrs: {routeInfo}} as m.Vnode<Attrs>;
+
+    expect(NavigationWidget.isPipelineRoute(vnode)).toBeFalse();
+    expect(NavigationWidget.isStageRoute(vnode, "stage")).toBeFalse();
+    expect(NavigationWidget.isJobRoute(vnode, "stage", "job")).toBeTrue();
+  });
+
+  function mount(pipelineConfig: PipelineConfig, routeInfo?: RouteInfo<PipelineConfigRouteParams>) {
+    if (!routeInfo) {
+      routeInfo = {
+        route: "up42/general",
+        params: {pipeline_name: pipelineConfig.name(), tab_name: "general"}
+      };
+    }
+
     helper.mount(() => <NavigationWidget pipelineConfig={pipelineConfig}
-                                         routeInfo={routeInfo}
+                                         routeInfo={routeInfo!}
                                          changeRoute={changeRoute}/>);
   }
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/common/environment_variables_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/common/environment_variables_tab_content.tsx
@@ -25,7 +25,7 @@ import {TabContent} from "views/pages/clicky_pipeline_config/tabs/tab_content";
 
 export class EnvironmentVariablesTabContent extends TabContent<PipelineConfig | Stage | Job> {
 
-  name(): string {
+  static tabName(): string {
     return "Environment Variables";
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/artifacts_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/artifacts_tab_content.tsx
@@ -52,7 +52,7 @@ export class ArtifactsTabContent extends TabContent<Job> {
     fetchData ? fetchData() : this.fetchData();
   }
 
-  name(): string {
+  static tabName(): string {
     return "Artifacts";
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/custom_tab_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/custom_tab_tab_content.tsx
@@ -32,7 +32,7 @@ import styles from "./custom_tabs.scss";
 
 export class CustomTabTabContent extends TabContent<Job> {
 
-  name(): string {
+  static tabName(): string {
     return "Custom Tabs";
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/job_settings_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/job_settings_tab_content.tsx
@@ -158,7 +158,7 @@ export class JobSettingsTabContent extends TabContent<Job> {
     this.fetchDefaultJobTimeout();
   }
 
-  name(): string {
+  static tabName(): string {
     return "Job Settings";
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
@@ -183,20 +183,19 @@ export class TasksTabContent extends TabContent<Job> {
     this.fetchPluginInfos();
   }
 
-  name(): string {
+  static tabName(): string {
     return "Tasks";
   }
 
   content(pipelineConfig: PipelineConfig,
           templateConfig: TemplateConfig,
           routeParams: PipelineConfigRouteParams,
-          isSelectedTab: boolean,
           ajaxOperationMonitor: Stream<OperationState>): m.Children {
     if (!this.autoSuggestions()) {
       this.fetchUpstreamPipelines(pipelineConfig.name(), routeParams.stage_name!);
     }
 
-    return super.content(pipelineConfig, templateConfig, routeParams, isSelectedTab, ajaxOperationMonitor);
+    return super.content(pipelineConfig, templateConfig, routeParams, ajaxOperationMonitor);
   }
 
   protected renderer(entity: Job, templateConfig: TemplateConfig): m.Children {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/general_options_tab.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/general_options_tab.tsx
@@ -24,7 +24,7 @@ import {PipelineConfigRouteParams} from "views/pages/clicky_pipeline_config/pipe
 import {TabContent} from "views/pages/clicky_pipeline_config/tabs/tab_content";
 
 export class GeneralOptionsTabContent extends TabContent<PipelineConfig> {
-  name(): string {
+  static tabName(): string {
     return "General";
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_tab_content.tsx
@@ -28,6 +28,10 @@ import {TabContent} from "views/pages/clicky_pipeline_config/tabs/tab_content";
 
 export class MaterialsTabContent extends TabContent<PipelineConfig> {
 
+  static tabName(): string {
+    return "Materials";
+  }
+
   addNewMaterial(materials: NameableSet<Material>) {
     MaterialModal.forAdd((material: Material) => {
       materials.add(material);
@@ -39,10 +43,6 @@ export class MaterialsTabContent extends TabContent<PipelineConfig> {
       material.type(updateMaterial.type());
       material.attributes(updateMaterial.attributes());
     }).render();
-  }
-
-  name(): string {
-    return "Materials";
   }
 
   protected selectedEntity(pipelineConfig: PipelineConfig, routeParams: PipelineConfigRouteParams): PipelineConfig {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/parameters_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/parameters_tab_content.tsx
@@ -25,7 +25,7 @@ import {PipelineParametersEditor} from "views/pages/pipelines/parameters_editor"
 export class ParametersTabContent extends TabContent<PipelineConfig> {
   readonly paramList = Stream([] as PipelineParameter[]);
 
-  name(): string {
+  static tabName(): string {
     return "Parameters";
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/project_management_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/project_management_tab_content.tsx
@@ -25,7 +25,8 @@ import {PipelineConfigRouteParams} from "views/pages/clicky_pipeline_config/pipe
 import {TabContent} from "views/pages/clicky_pipeline_config/tabs/tab_content";
 
 export class ProjectManagementTabContent extends TabContent<PipelineConfig> {
-  name() {
+  static tabName(): string {
+
     return "Project Management";
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stages_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stages_tab_content.tsx
@@ -31,7 +31,7 @@ import {TabContent} from "views/pages/clicky_pipeline_config/tabs/tab_content";
 import {TemplateEditor} from "views/pages/pipelines/template_editor";
 
 export class StagesTabContent extends TabContent<PipelineConfig> {
-  name() {
+  static tabName(): string {
     return "Stages";
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/jobs_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/jobs_tab_content.tsx
@@ -31,7 +31,7 @@ import {PipelineConfigRouteParams} from "views/pages/clicky_pipeline_config/pipe
 import {TabContent} from "views/pages/clicky_pipeline_config/tabs/tab_content";
 
 export class JobsTabContent extends TabContent<Stage> {
-  name() {
+  static tabName(): string {
     return "Jobs";
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/permissions_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/permissions_tab_content.tsx
@@ -31,7 +31,7 @@ import styles from "./permissions.scss";
 export class PermissionsTabContent extends TabContent<Stage> {
   private selectedPermission: Stream<string> = Stream();
 
-  name(): string {
+  static tabName(): string {
     return "Permissions";
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/stage_settings_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/stage_settings_tab_content.tsx
@@ -27,7 +27,7 @@ import {StageEditor} from "views/pages/clicky_pipeline_config/widgets/stage_edit
 import styles from "./stage_settings.scss";
 
 export class StageSettingsTabContent extends TabContent<Stage> {
-  name(): string {
+  static tabName(): string {
     return "Stage Settings";
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/tab_content.tsx
@@ -32,29 +32,22 @@ export abstract class TabContent<T> {
   public content(pipelineConfig: PipelineConfig,
                  templateConfig: TemplateConfig,
                  routeParams: PipelineConfigRouteParams,
-                 isSelectedTab: boolean,
                  ajaxOperationMonitor: Stream<OperationState>): m.Children {
     switch (this.pageState) {
       case PageState.FAILED:
-        return <PageLoadError message={`There was a problem fetching ${this.name()} tab`}/>;
+        return <PageLoadError message={`There was a problem fetching current tab`}/>;
       case PageState.LOADING:
         return <Spinner/>;
       case PageState.OK:
-        if (isSelectedTab) {
-          const entity         = this.selectedEntity(pipelineConfig, routeParams) as T;
-          const saveInProgress = ajaxOperationMonitor() === OperationState.IN_PROGRESS;
+        const entity         = this.selectedEntity(pipelineConfig, routeParams) as T;
+        const saveInProgress = ajaxOperationMonitor() === OperationState.IN_PROGRESS;
 
-          return <div class={saveInProgress ? styles.blur : ""}>
-            {saveInProgress ? <Spinner/> : undefined}
-            {this.renderer(entity, templateConfig)}
-          </div>;
-        }
-
-        return <div> Not a selected tab</div>;
+        return <div class={saveInProgress ? styles.blur : ""}>
+          {saveInProgress ? <Spinner/> : undefined}
+          {this.renderer(entity, templateConfig)}
+        </div>;
     }
   }
-
-  public abstract name(): string;
 
   public pageLoadFailure() {
     this.pageState = PageState.FAILED;


### PR DESCRIPTION
#### Description:

* Perform lazy initialization of the tab. Cache the initialized tab to avoid
  re-creating components when user switch between tabs.

* Perform tab specific ajax operations only when the user visits specific tab.

* Select following default tab at each level (instead of first) :
  - Pipeline => General
  - Stage => Stage Settings
  - Job => Tasks

* Fix redirect route to general tab.

* Highlight the selected pipeline/stage/job when any of the tab from the
  mentioned section is selected.

