### PR TITLE
Revert "Toggling back to the old comparison spa for the release"

### DIFF
--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -48,8 +48,8 @@
     },
     {
       "key": "show_old_comparison_spa",
-      "description": "Switch to the old comparison SPA. Default is true.",
-      "value": true
+      "description": "Switch to the old comparison SPA. Default is false.",
+      "value": false
     },
     {
       "key": "new_pipeline_config_spa",


### PR DESCRIPTION
Toggling the comparison spa back to the new one by default

This reverts commit 0cb6660ad91a19a4064e6537374c896506add24a.


