### PR TITLE
Update the bisect warning msg

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/comparison_result_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/comparison_result_widget.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
+import {docsUrl} from "gen/gocd_version";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import _ from "lodash";
 import m from "mithril";
 import {Comparison, DependencyRevisions, MaterialRevisions} from "models/compare/compare";
 import {DependencyMaterialAttributes} from "models/compare/material";
 import {InfoCircle} from "views/components/icons";
+import {Link} from "views/components/link";
 import {DependencyRevisionsWidget} from "./dependency_revisions_widget";
 import styles from "./index.scss";
 import {MaterialRevisionsWidget} from "./material_revisions_widget";
@@ -36,8 +38,11 @@ export class ComparisonResultWidget extends MithrilViewComponent<Attrs> {
 
     let warning: m.Child;
     if (vnode.attrs.comparisonResult.isBisect) {
-      warning = <div data-test-id="info-msg" class={styles.infoMsg}><InfoCircle iconOnly={true}/>This comparison involves a pipeline instance
-        that was triggered with a non-sequential material revision.</div>;
+      warning = <div data-test-id="info-msg" class={styles.infoMsg}><InfoCircle iconOnly={true}/>This comparison
+        involves a pipeline instance
+        that was triggered with a non-sequential material revision.
+        <Link href={docsUrl("advanced_usage/compare_pipelines.html")} target="_blank" externalLinkIcon={true}> Learn More</Link>
+      </div>;
     }
 
     return [warning,

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/index.scss
@@ -60,6 +60,7 @@ $dropdown-button-content-z-index: 5;
 
 .warning {
   font-size: 0.725rem;
+  color:     $failed;
 
   i {
     color: $building;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/instance_selection_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/instance_selection_widget.tsx
@@ -36,7 +36,7 @@ export interface InstanceAttrs {
 }
 
 export class InstanceSelectionWidget extends MithrilViewComponent<InstanceAttrs> {
-  readonly showSuggestions: Stream<boolean>             = Stream();
+  readonly showSuggestions: Stream<boolean> = Stream();
 
   static dataTestId(...parts: StringOrNumber[]) {
     return s.slugify(parts.join("-").trim().toLowerCase());
@@ -53,15 +53,19 @@ export class InstanceSelectionWidget extends MithrilViewComponent<InstanceAttrs>
   }
 
   private getStagesOrWarning(vnode: m.Vnode<InstanceAttrs, this>) {
+    let bisectWarningMsg;
     if (vnode.attrs.instance.isBisect()) {
-      return <div data-test-id="warning" class={styles.warning}><Warning iconOnly={true}/>This pipeline instance cannot
-        be used to perform a comparison because it was triggered with a non-sequential material revision.</div>;
+      bisectWarningMsg = <div data-test-id="warning" class={styles.warning}>
+        <Warning iconOnly={true}/>
+        This pipeline instance was triggered with a non-sequential material revision.
+      </div>;
     }
     return <div>
       <StagesWidget stages={vnode.attrs.instance.stages()} onClick={this.onStageClick.bind(this, vnode)}/>
       <span data-test-id="triggered-by" className={styles.label}>
         Triggered by {vnode.attrs.instance.buildCause().getApprover()} on {PipelineInstanceWidget.getTimeToDisplay(vnode.attrs.instance.scheduledDate())}
       </span>
+      {bisectWarningMsg}
     </div>;
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/spec/comparison_result_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/spec/comparison_result_widget_spec.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {docsUrl} from "gen/gocd_version";
 import m from "mithril";
 import {Comparison} from "models/compare/compare";
 import {ComparisonData} from "models/compare/spec/test_data";
@@ -49,9 +50,13 @@ describe('ComparisonResultWidgetSpec', () => {
     comparison.isBisect = true;
     mount(comparison);
 
+    const infoMsgElement = helper.byTestId("info-msg");
+
     expect(helper.byTestId("info-msg")).toBeInDOM();
     expect(helper.byTestId("comparison-result-widget")).toBeInDOM();
-    expect(helper.textByTestId("info-msg")).toBe("This comparison involves a pipeline instance that was triggered with a non-sequential material revision.");
+    expect(infoMsgElement.textContent).toBe("This comparison involves a pipeline instance that was triggered with a non-sequential material revision. Learn More");
+    expect(helper.q('a', infoMsgElement)).toBeInDOM();
+    expect(helper.q('a', infoMsgElement)).toHaveAttr('href', docsUrl('advanced_usage/compare_pipelines.html'));
     expect(helper.byTestId("Info Circle-icon")).toBeInDOM();
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/spec/instance_selection_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/spec/instance_selection_widget_spec.tsx
@@ -60,13 +60,12 @@ describe('InstanceSelectionWidgetSpec', () => {
     expect(helper.textByTestId("triggered-by")).toBe(`Triggered by ${instance.buildCause().getApprover()} on ${timeFormatter.format(instance.scheduledDate())}`);
   });
 
-  it('should render warning msg instead of stages if the instance is a bisect', () => {
+  it('should render warning msg if the instance is a bisect', () => {
     instance.naturalOrder(9.5);
     mount();
 
-    expect(helper.byTestId("stages")).not.toBeInDOM();
     expect(helper.byTestId("warning")).toBeInDOM();
     expect(helper.byTestId("Warning-icon")).toBeInDOM();
-    expect(helper.textByTestId("warning")).toBe("This pipeline instance cannot be used to perform a comparison because it was triggered with a non-sequential material revision.");
+    expect(helper.textByTestId("warning")).toBe("This pipeline instance was triggered with a non-sequential material revision.");
   });
 });


### PR DESCRIPTION
Issue: https://github.com/gocd/gocd/pull/7503#issuecomment-599717827

Description:
  - showcasing stages along with the message that the selected instance is a bisect

<img width="1227" alt="Screen Shot 2020-03-19 at 9 23 40 AM" src="https://user-images.githubusercontent.com/41165891/77030637-44163000-69c5-11ea-864b-dc38e8417c44.png">


### TODO

 - [ ] Update the [docs site](https://docs.gocd.org/current/advanced_usage/compare_pipelines.html) to add explanation related to `bisect` comparison