### PR TITLE
[Pipeline Config SPA] Do not show Save and Reset Buttons when not required

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/pipeline_config.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/pipeline_config.tsx
@@ -149,6 +149,24 @@ export class PipelineConfigPage<T> extends Page<null, T> {
       return <Spinner/>;
     }
 
+    let saveAndResetButtons: m.Children;
+    if (this.tab().shouldShowSaveAndResetButtons()) {
+      saveAndResetButtons = (
+        <div className={styles.buttonContainer}>
+          <Reset data-test-id={"cancel"}
+                 ajaxOperationMonitor={this.ajaxOperationMonitor}
+                 onclick={this.reset.bind(this)}>
+            RESET
+          </Reset>
+          <Primary data-test-id={"save"}
+                   ajaxOperationMonitor={this.ajaxOperationMonitor}
+                   ajaxOperation={this.save.bind(this)}>
+            SAVE
+          </Primary>
+        </div>
+      );
+    }
+
     return [
       <div key={m.route.param().tab_name}>
         <FlashMessage message={this.flashMessage.message} type={this.flashMessage.type}/>
@@ -171,21 +189,11 @@ export class PipelineConfigPage<T> extends Page<null, T> {
                                                   PipelineConfigPage.routeInfo().params,
                                                   this.ajaxOperationMonitor);
                       }
+                      return <Spinner/>;
                     })
                   }
                   beforeChange={this.onTabChange.bind(this, vnode)}/>
-            <div className={styles.buttonContainer}>
-              <Reset data-test-id={"cancel"}
-                     ajaxOperationMonitor={this.ajaxOperationMonitor}
-                     onclick={this.reset.bind(this)}>
-                RESET
-              </Reset>
-              <Primary data-test-id={"save"}
-                       ajaxOperationMonitor={this.ajaxOperationMonitor}
-                       ajaxOperation={this.save.bind(this)}>
-                SAVE
-              </Primary>
-            </div>
+            {saveAndResetButtons}
           </div>
         </div>
       </div>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
@@ -198,6 +198,10 @@ export class TasksTabContent extends TabContent<Job> {
     return super.content(pipelineConfig, templateConfig, routeParams, ajaxOperationMonitor);
   }
 
+  shouldShowSaveAndResetButtons(): boolean {
+    return false;
+  }
+
   protected renderer(entity: Job, templateConfig: TemplateConfig): m.Children {
     return <TasksWidget pluginInfos={this.pluginInfos}
                         autoSuggestions={this.autoSuggestions}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_tab_content.tsx
@@ -45,6 +45,10 @@ export class MaterialsTabContent extends TabContent<PipelineConfig> {
     }).render();
   }
 
+  public shouldShowSaveAndResetButtons(): boolean {
+    return false;
+  }
+
   protected selectedEntity(pipelineConfig: PipelineConfig, routeParams: PipelineConfigRouteParams): PipelineConfig {
     return pipelineConfig;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stages_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stages_tab_content.tsx
@@ -35,6 +35,10 @@ export class StagesTabContent extends TabContent<PipelineConfig> {
     return "Stages";
   }
 
+  public shouldShowSaveAndResetButtons(): boolean {
+    return false;
+  }
+
   protected selectedEntity(pipelineConfig: PipelineConfig, routeParams: PipelineConfigRouteParams): PipelineConfig {
     return pipelineConfig;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/jobs_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/jobs_tab_content.tsx
@@ -35,6 +35,10 @@ export class JobsTabContent extends TabContent<Stage> {
     return "Jobs";
   }
 
+  public shouldShowSaveAndResetButtons(): boolean {
+    return false;
+  }
+
   protected selectedEntity(pipelineConfig: PipelineConfig, routeParams: PipelineConfigRouteParams): Stage {
     return pipelineConfig.stages().findByName(routeParams.stage_name!)!;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/tab_content.tsx
@@ -61,6 +61,10 @@ export abstract class TabContent<T> {
     this.pageState = PageState.OK;
   }
 
+  public shouldShowSaveAndResetButtons(): boolean {
+    return true;
+  }
+
   protected abstract renderer(entity: T, templateConfig: TemplateConfig): m.Children;
 
   protected abstract selectedEntity(pipelineConfig: PipelineConfig, routeParams: PipelineConfigRouteParams): T;


### PR DESCRIPTION
### Description:

* Add an ability for each tab to specify whether save and reset
  button should be shown.

* Do not show Save and Reset buttons for:
  - Pipeline - Materials Tab
  - Pipeline - Stages Tab
  - Stage    - Jobs Tab
  - Job      - Tasks Tab