### PR TITLE
Fixing pipeline creation error

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
@@ -89,31 +89,31 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
     switch (material.type()) {
       case "git":
         if (!(material.attributes() instanceof GitMaterialAttributes)) {
-          material.attributes(new GitMaterialAttributes("", true));
+          material.attributes(new GitMaterialAttributes(undefined, true));
         }
         return <GitFields material={material} hideTestConnection={hideTestConnection}
                           showLocalWorkingCopyOptions={showLocalWorkingCopyOptions} disabled={disabled}/>;
       case "hg":
         if (!(material.attributes() instanceof HgMaterialAttributes)) {
-          material.attributes(new HgMaterialAttributes("", true));
+          material.attributes(new HgMaterialAttributes(undefined, true));
         }
         return <HgFields material={material} hideTestConnection={hideTestConnection}
                          showLocalWorkingCopyOptions={showLocalWorkingCopyOptions} disabled={disabled}/>;
       case "svn":
         if (!(material.attributes() instanceof SvnMaterialAttributes)) {
-          material.attributes(new SvnMaterialAttributes("", true));
+          material.attributes(new SvnMaterialAttributes(undefined, true));
         }
         return <SvnFields material={material} hideTestConnection={hideTestConnection}
                           showLocalWorkingCopyOptions={showLocalWorkingCopyOptions} disabled={disabled}/>;
       case "p4":
         if (!(material.attributes() instanceof P4MaterialAttributes)) {
-          material.attributes(new P4MaterialAttributes("", true));
+          material.attributes(new P4MaterialAttributes(undefined, true));
         }
         return <P4Fields material={material} hideTestConnection={hideTestConnection}
                          showLocalWorkingCopyOptions={showLocalWorkingCopyOptions} disabled={disabled}/>;
       case "tfs":
         if (!(material.attributes() instanceof TfsMaterialAttributes)) {
-          material.attributes(new TfsMaterialAttributes("", true));
+          material.attributes(new TfsMaterialAttributes(undefined, true));
         }
         return <TfsFields material={material} hideTestConnection={hideTestConnection}
                           showLocalWorkingCopyOptions={showLocalWorkingCopyOptions} disabled={disabled}/>;
@@ -125,7 +125,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
                                  showLocalWorkingCopyOptions={showLocalWorkingCopyOptions}/>;
       case "package":
         if (!(material.attributes() instanceof PackageMaterialAttributes)) {
-          material.attributes(new PackageMaterialAttributes("", true, ""));
+          material.attributes(new PackageMaterialAttributes(undefined, true, ""));
         }
         packageRepositories = packageRepositories === undefined ? new PackageRepositories() : packageRepositories;
         pluginInfos         = pluginInfos === undefined ? new PluginInfos()

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/pipeline_config_view_model.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/pipeline_config_view_model.ts
@@ -41,7 +41,7 @@ const VANITY_PLUGIN_NAMES: {[key: string]: string} = {
 };
 
 export class PipelineConfigVM {
-  material: Material = new Material("git", new GitMaterialAttributes("", true));
+  material: Material = new Material("git", new GitMaterialAttributes(undefined, true));
   job: Job = new Job("", []);
   stage: Stage = new Stage("", [this.job]);
   pipeline: PipelineConfig = new PipelineConfig("", [this.material], []);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/pipeline_config_view_model_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/pipeline_config_view_model_spec.ts
@@ -79,7 +79,7 @@ describe("PipelineConfig View Model", () => {
       {
         payload: {
           name: "** UNNAMED PIPELINE **",
-          materials: [{attributes: {name: '', auto_update: true, password: ""}, type: "git"}],
+          materials: [{attributes: {auto_update: true, password: ""}, type: "git"}],
           stages: [],
           parameters: []
         }


### PR DESCRIPTION
Setting material name as "" causes the create call to fail - setting them to `undefined`


