### PR TITLE
Add Pluggable SCM SPA

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -569,4 +569,8 @@ export class SparkRoutes {
   static pipelineStatusApiPath(pipelineName: string) {
     return `/go/api/pipelines/${pipelineName}/status`;
   }
+
+  static scmUsagePath(scm_name: string): string {
+    return `/go/api/admin/scms/${scm_name}/usages`;
+  }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm.ts
@@ -16,6 +16,8 @@
 
 import {Configurations, PropertyJSON} from "models/shared/configuration";
 import Stream from "mithril/stream";
+import {applyMixins} from "models/mixins/mixins";
+import {ValidatableMixin} from "models/mixins/new_validatable_mixin";
 
 export interface ScmsJSON {
   _embedded: EmbeddedJSON;
@@ -38,13 +40,17 @@ export interface PluginMetadataJSON {
   version: string;
 }
 
-class PluginMetadata {
+export class PluginMetadata extends ValidatableMixin {
   id: Stream<string>;
   version: Stream<string>;
 
   constructor(id: string, version: string) {
+    super();
+    ValidatableMixin.call(this);
     this.id      = Stream(id);
     this.version = Stream(version);
+
+    this.validatePresenceOf("id");
   }
 
   static fromJSON(data: PluginMetadataJSON): PluginMetadata {
@@ -52,7 +58,9 @@ class PluginMetadata {
   }
 }
 
-export class Scm {
+applyMixins(PluginMetadata, ValidatableMixin);
+
+export class Scm extends ValidatableMixin {
   id: Stream<string>;
   name: Stream<string>;
   autoUpdate: Stream<boolean>;
@@ -60,17 +68,42 @@ export class Scm {
   configuration: Stream<Configurations>;
 
   constructor(id: string, name: string, autoUpdate: boolean, pluginMetadata: PluginMetadata, configuration: Configurations) {
+    super();
+    ValidatableMixin.call(this);
     this.id             = Stream(id);
     this.name           = Stream(name);
     this.autoUpdate     = Stream(autoUpdate);
     this.pluginMetadata = Stream(pluginMetadata);
     this.configuration  = Stream(configuration);
+
+    this.validatePresenceOf("id");
+    this.validatePresenceOf("name");
+    this.validateFormatOf("name",
+                          new RegExp("^[-a-zA-Z0-9_][-a-zA-Z0-9_.]*$"),
+                          {message: "Invalid Id. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period)."});
+    this.validateMaxLength("name", 255, {message: "The maximum allowed length is 255 characters."});
+    this.validateAssociated("pluginMetadata");
   }
 
   static fromJSON(data: ScmJSON): Scm {
     return new Scm(data.id, data.name, data.auto_update, PluginMetadata.fromJSON(data.plugin_metadata), Configurations.fromJSON(data.configuration));
   }
+
+  toJSON(): object {
+    return {
+      id:              this.id(),
+      name:            this.name(),
+      auto_update:     this.autoUpdate(),
+      plugin_metadata: {
+        id:      this.pluginMetadata().id(),
+        version: this.pluginMetadata().version()
+      },
+      configuration:   this.configuration().toJSON()
+    }
+  }
 }
+
+applyMixins(Scm, ValidatableMixin);
 
 export class Scms extends Array<Scm> {
   constructor(...vals: Scm[]) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm.ts
@@ -25,7 +25,7 @@ interface EmbeddedJSON {
   scms: ScmJSON[];
 }
 
-interface ScmJSON {
+export interface ScmJSON {
   id: string;
   name: string;
   auto_update: boolean;
@@ -52,7 +52,7 @@ class PluginMetadata {
   }
 }
 
-class Scm {
+export class Scm {
   id: Stream<string>;
   name: Stream<string>;
   autoUpdate: Stream<boolean>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm.ts
@@ -16,6 +16,7 @@
 
 import {Configurations, PropertyJSON} from "models/shared/configuration";
 import Stream from "mithril/stream";
+import {Errors, ErrorsJSON} from "models/mixins/errors";
 import {applyMixins} from "models/mixins/mixins";
 import {ValidatableMixin} from "models/mixins/new_validatable_mixin";
 
@@ -33,6 +34,7 @@ export interface ScmJSON {
   auto_update: boolean;
   plugin_metadata: PluginMetadataJSON;
   configuration: PropertyJSON[]
+  errors?: ErrorsJSON;
 }
 
 export interface PluginMetadataJSON {
@@ -95,7 +97,9 @@ export class Scm extends ValidatableMixin {
   }
 
   static fromJSON(data: ScmJSON): Scm {
-    return new Scm(data.id, data.name, data.auto_update, PluginMetadata.fromJSON(data.plugin_metadata), Configurations.fromJSON(data.configuration));
+    const scm = new Scm(data.id, data.name, data.auto_update, PluginMetadata.fromJSON(data.plugin_metadata), Configurations.fromJSON(data.configuration));
+    scm.errors(new Errors(data.errors));
+    return scm;
   }
 
   toJSON(): object {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm.ts
@@ -40,6 +40,15 @@ export interface PluginMetadataJSON {
   version: string;
 }
 
+export interface ScmUsageJSON {
+  group: string;
+  pipeline: string;
+}
+
+export interface ScmUsagesJSON {
+  usages: ScmUsageJSON[];
+}
+
 export class PluginMetadata extends ValidatableMixin {
   id: Stream<string>;
   version: Stream<string>;
@@ -113,5 +122,30 @@ export class Scms extends Array<Scm> {
 
   static fromJSON(data: ScmJSON[]): Scms {
     return new Scms(...data.map((a) => Scm.fromJSON(a)));
+  }
+}
+
+class ScmUsage {
+  group: string;
+  pipeline: string;
+
+  constructor(group: string, pipeline: string) {
+    this.group    = group;
+    this.pipeline = pipeline;
+  }
+
+  static fromJSON(data: ScmUsageJSON): ScmUsage {
+    return new ScmUsage(data.group, data.pipeline);
+  }
+}
+
+export class ScmUsages extends Array<ScmUsage> {
+  constructor(...vals: ScmUsage[]) {
+    super(...vals);
+    Object.setPrototypeOf(this, Object.create(ScmUsages.prototype));
+  }
+
+  static fromJSON(data: ScmUsagesJSON): ScmUsages {
+    return new ScmUsages(...data.usages.map((a) => ScmUsage.fromJSON(a)));
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm_crud.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm_crud.ts
@@ -16,7 +16,7 @@
 
 import {ApiRequestBuilder, ApiResult, ApiVersion, ObjectWithEtag} from "helpers/api_request_builder";
 import {SparkRoutes} from "helpers/spark_routes";
-import {Scm, ScmJSON, Scms, ScmsJSON} from "./pluggable_scm";
+import {Scm, ScmJSON, Scms, ScmsJSON, ScmUsages, ScmUsagesJSON} from "./pluggable_scm";
 
 export class PluggableScmCRUD {
   private static API_VERSION_HEADER = ApiVersion.latest;
@@ -50,6 +50,14 @@ export class PluggableScmCRUD {
   static delete(scmName: string) {
     return ApiRequestBuilder.DELETE(SparkRoutes.pluggableScmPath(scmName), this.API_VERSION_HEADER)
                             .then((result: ApiResult<string>) => result.map((body) => JSON.parse(body)));
+  }
+
+  static usages(id: string) {
+    return ApiRequestBuilder.GET(SparkRoutes.scmUsagePath(id), this.API_VERSION_HEADER)
+                            .then((result: ApiResult<string>) => result.map((response) => {
+                              const usages = JSON.parse(response) as ScmUsagesJSON;
+                              return ScmUsages.fromJSON(usages);
+                            }));
   }
 
   private static extractObjectWithEtag(result: ApiResult<string>) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm_crud.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm_crud.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {ApiRequestBuilder, ApiResult, ApiVersion} from "helpers/api_request_builder";
+import {ApiRequestBuilder, ApiResult, ApiVersion, ObjectWithEtag} from "helpers/api_request_builder";
 import {SparkRoutes} from "helpers/spark_routes";
-import {Scms, ScmsJSON} from "./pluggable_scm";
+import {Scm, ScmJSON, Scms, ScmsJSON} from "./pluggable_scm";
 
 export class PluggableScmCRUD {
   private static API_VERSION_HEADER = ApiVersion.latest;
@@ -27,5 +27,38 @@ export class PluggableScmCRUD {
                               const data = JSON.parse(body) as ScmsJSON;
                               return Scms.fromJSON(data._embedded.scms);
                             }));
+  }
+
+  static get(scmName: string) {
+    return ApiRequestBuilder.GET(SparkRoutes.pluggableScmPath(scmName), this.API_VERSION_HEADER)
+                            .then(this.extractObjectWithEtag);
+  }
+
+  static create(scm: Scm) {
+    return ApiRequestBuilder.POST(SparkRoutes.pluggableScmPath(), this.API_VERSION_HEADER,
+                                  {payload: scm})
+                            .then(this.extractObjectWithEtag)
+  }
+
+  static update(scm: Scm, etag: string) {
+    return ApiRequestBuilder.PUT(SparkRoutes.pluggableScmPath(scm.name()),
+                                 this.API_VERSION_HEADER,
+                                 {payload: scm, etag})
+                            .then(this.extractObjectWithEtag);
+  }
+
+  static delete(scmName: string) {
+    return ApiRequestBuilder.DELETE(SparkRoutes.pluggableScmPath(scmName), this.API_VERSION_HEADER)
+                            .then((result: ApiResult<string>) => result.map((body) => JSON.parse(body)));
+  }
+
+  private static extractObjectWithEtag(result: ApiResult<string>) {
+    return result.map((body) => {
+      const scmJSON = JSON.parse(body) as ScmJSON;
+      return {
+        object: Scm.fromJSON(scmJSON),
+        etag:   result.getEtag()
+      } as ObjectWithEtag<Scm>;
+    });
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/pluggable_scm_crud_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/pluggable_scm_crud_spec.ts
@@ -91,7 +91,7 @@ describe('PluggableScmCRUDSpec', () => {
   });
 
   it("should update a scm", () => {
-    const url = SparkRoutes.pluggableScmPath("scm-id");
+    const url = SparkRoutes.pluggableScmPath("pluggable.scm.material.name");
     jasmine.Ajax.stubRequest(url).andReturn(scmResponse());
 
     const scm = Scm.fromJSON(getPluggableScm());

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/pluggable_scm_crud_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/pluggable_scm_crud_spec.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ApiResult, ObjectWithEtag, SuccessResponse} from "helpers/api_request_builder";
+import {SparkRoutes} from "helpers/spark_routes";
+import {getPluggableScm} from "views/pages/pluggable_scms/spec/test_data";
+import {PluggableScmCRUD} from "../pluggable_scm_crud";
+import {Scm, ScmJSON, Scms} from "../pluggable_scm";
+
+describe('PluggableScmCRUDSpec', () => {
+  beforeEach(() => jasmine.Ajax.install());
+  afterEach(() => jasmine.Ajax.uninstall());
+
+  it("should get all scms", (done) => {
+    const url = SparkRoutes.pluggableScmPath();
+    jasmine.Ajax.stubRequest(url).andReturn(scmsResponse());
+
+    const onResponse = jasmine.createSpy().and.callFake((response: ApiResult<any>) => {
+      const responseJSON = response.unwrap() as SuccessResponse<any>;
+      const scms         = (responseJSON.body as Scms);
+
+      expect(scms).toHaveLength(1);
+      expect(scms[0].id()).toBe('scm-id');
+      expect(scms[0].name()).toBe('pluggable.scm.material.name');
+      expect(scms[0].pluginMetadata().id()).toBe('github.pr');
+      expect(scms[0].pluginMetadata().version()).toBe('1');
+
+      expect(scms[0].configuration().count()).toBe(1);
+      done();
+    });
+
+    PluggableScmCRUD.all().then(onResponse);
+
+    const request = jasmine.Ajax.requests.mostRecent();
+    expect(request.url).toEqual(url);
+    expect(request.method).toEqual("GET");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
+  });
+
+  it('should get the specified smc', (done) => {
+    const url = SparkRoutes.pluggableScmPath("scm-id");
+    jasmine.Ajax.stubRequest(url).andReturn(scmResponse());
+
+    const onResponse = jasmine.createSpy().and.callFake((response: ApiResult<any>) => {
+      const responseJSON      = response.unwrap() as SuccessResponse<any>;
+      const packageRepository = (responseJSON.body as ObjectWithEtag<Scm>).object;
+
+      expect(packageRepository.id()).toBe('scm-id');
+      expect(packageRepository.name()).toBe('pluggable.scm.material.name');
+      expect(packageRepository.pluginMetadata().id()).toBe('github.pr');
+      expect(packageRepository.pluginMetadata().version()).toBe('1');
+
+      expect(packageRepository.configuration().count()).toBe(1);
+      done();
+    });
+
+    PluggableScmCRUD.get("scm-id").then(onResponse);
+
+    const request = jasmine.Ajax.requests.mostRecent();
+    expect(request.url).toEqual(url);
+    expect(request.method).toEqual("GET");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
+  });
+
+  it("should create a new scm", () => {
+    const url = SparkRoutes.pluggableScmPath();
+    jasmine.Ajax.stubRequest(url).andReturn(scmResponse());
+
+    const scm = Scm.fromJSON(getPluggableScm());
+    PluggableScmCRUD.create(scm);
+
+    const request = jasmine.Ajax.requests.mostRecent();
+    expect(request.url).toEqual(url);
+    expect(request.method).toEqual("POST");
+    expect(request.data()).toEqual(toJSON(scm.toJSON()));
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
+  });
+
+  it("should update a scm", () => {
+    const url = SparkRoutes.pluggableScmPath("scm-id");
+    jasmine.Ajax.stubRequest(url).andReturn(scmResponse());
+
+    const scm = Scm.fromJSON(getPluggableScm());
+    PluggableScmCRUD.update(scm, "old-etag");
+
+    const request = jasmine.Ajax.requests.mostRecent();
+    expect(request.url).toEqual(url);
+    expect(request.method).toEqual("PUT");
+    expect(request.data()).toEqual(toJSON(scm.toJSON()));
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
+  });
+
+  it("should delete a scm", () => {
+    const url = SparkRoutes.pluggableScmPath("scm-id");
+    jasmine.Ajax.stubRequest(url).andReturn(deleteScmResponse());
+
+    PluggableScmCRUD.delete("scm-id");
+
+    const request = jasmine.Ajax.requests.mostRecent();
+    expect(request.url).toEqual(url);
+    expect(request.method).toEqual("DELETE");
+    expect(request.data()).toEqual(toJSON({} as ScmJSON));
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual(undefined!);
+    expect(request.requestHeaders["X-GoCD-Confirm"]).toEqual("true");
+  });
+
+  function toJSON(object: any) {
+    return JSON.parse(JSON.stringify(object));
+  }
+
+  function scmsResponse() {
+    const scms = {
+      _embedded: {
+        scms: [getPluggableScm()]
+      }
+    };
+    return {
+      status:          200,
+      responseHeaders: {
+        "Content-Type": "application/vnd.go.cd.v2+json; charset=utf-8",
+      },
+      responseText:    JSON.stringify(scms)
+    };
+  }
+
+  function scmResponse() {
+    return {
+      status:          200,
+      responseHeaders: {
+        "Content-Type": "application/vnd.go.cd.v2+json; charset=utf-8",
+        "ETag":         "some-etag"
+      },
+      responseText:    JSON.stringify(getPluggableScm())
+    };
+  }
+
+  function deleteScmResponse() {
+    return {
+      status:          200,
+      responseHeaders: {
+        "Content-Type": "application/vnd.go.cd.v2+json; charset=utf-8"
+      },
+      responseText:    JSON.stringify({message: "The scm was successfully deleted."})
+    };
+  }
+});

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/types_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/types_spec.ts
@@ -15,8 +15,19 @@
  */
 
 import {Hg} from "models/materials/spec/material_test_data";
-import {DependencyMaterialAttributes, GitMaterialAttributes, HgMaterialAttributes, Material, P4MaterialAttributes, ScmMaterialAttributes, SvnMaterialAttributes, TfsMaterialAttributes} from "models/materials/types";
+import {
+  DependencyMaterialAttributes,
+  GitMaterialAttributes,
+  HgMaterialAttributes,
+  Material,
+  P4MaterialAttributes,
+  ScmMaterialAttributes,
+  SvnMaterialAttributes,
+  TfsMaterialAttributes
+} from "models/materials/types";
 import {DependencyMaterialAttributesJSON} from "../serialization";
+import {PluginMetadata, Scm} from "../pluggable_scm";
+import {Configurations} from "../../shared/configuration";
 
 describe("Material Types", () => {
   describe("Deserialize", () => {
@@ -183,6 +194,21 @@ describe("Material Types", () => {
       expect(material.attributes()!.errors().keys()).toEqual(["url"]);
       expect(material.attributes()!.errors().errorsForDisplay("url"))
         .toBe("URL credentials must be set in either the URL or the username+password fields, but not both.");
+    });
+
+    it('should validate Scm material', () => {
+      const material = new Scm("", "", false, new PluginMetadata("", ""), new Configurations([]));
+
+      const isValid = material.isValid();
+
+      expect(isValid).toBeFalse();
+
+      expect(material.errors().count()).toBe(2);
+      expect(material.errors().errorsForDisplay('id')).toBe('Id must be present.');
+      expect(material.errors().errorsForDisplay('name')).toBe('Name must be present.');
+
+      expect(material.pluginMetadata().errors().count()).toBe(1);
+      expect(material.pluginMetadata().errors().errorsForDisplay('id')).toBe('Id must be present.');
     });
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/pluggable_scms.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/pluggable_scms.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SinglePageAppBase} from "helpers/spa_base";
+import {PluggableScmsPage} from "views/pages/pluggable_scms";
+
+export class PluggableScmsSPA extends SinglePageAppBase {
+  constructor() {
+    super(PluggableScmsPage);
+  }
+}
+
+//tslint:disable-next-line
+new PluggableScmsSPA();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.tsx
@@ -167,6 +167,7 @@ export class SiteMenu extends MithrilViewComponent<Attrs> {
                 <SiteSubNavItem href="/go/admin/config_repos" text="Config Repositories"/>
                 <SiteSubNavItem href="/go/admin/artifact_stores" text="Artifact Stores"/>
                 <SiteSubNavItem href="/go/admin/secret_configs" text="Secret Management"/>
+                <SiteSubNavItem href="/go/admin/scms" text="Pluggable SCMs"/>
               </SiteSubNav>
               <SiteSubNav>
                 <SiteSubNavHeading text="Server configuration"/>
@@ -198,6 +199,7 @@ export class SiteMenu extends MithrilViewComponent<Attrs> {
               <SiteSubNavItem href="/go/admin/package_repositories/new" text="Package Repositories"/>
               <SiteSubNavItem href="/go/admin/config_repos" text="Config Repositories"/>
               <SiteSubNavItem href="/go/admin/elastic_agent_configurations" text="Elastic Agent Configurations"/>
+              <SiteSubNavItem href="/go/admin/scms" text="Pluggable SCMs"/>
             </SiteSubNav>
           </div>
         </SiteNavItem>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/spec/index_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/spec/index_spec.tsx
@@ -60,8 +60,9 @@ describe("Site Menu", () => {
     expect(findMenuItem("/go/admin/security/auth_configs")).toHaveText("Authorization Configuration");
     expect(findMenuItem("/go/admin/security/roles")).toHaveText("Role configuration");
     expect(findMenuItem("/go/admin/admin_access_tokens")).toHaveText("Access Tokens Management");
+    expect(findMenuItem("/go/admin/scms")).toHaveText("Pluggable SCMs");
     expect(helper.qa(`a.${styles.siteNavLink}`)).toHaveLength(4);
-    expect(helper.qa(`a.${styles.siteSubNavLink}`)).toHaveLength(18);
+    expect(helper.qa(`a.${styles.siteSubNavLink}`)).toHaveLength(19);
   });
 
   it("should display the menus for users who can view templates", () => {
@@ -96,6 +97,7 @@ describe("Site Menu", () => {
     expect(findMenuItem("/go/admin/package_repositories/new")).toBeFalsy();
     expect(findMenuItem("/go/admin/security/auth_configs")).toBeFalsy();
     expect(findMenuItem("/go/admin/security/roles")).toBeFalsy();
+    expect(findMenuItem("/go/admin/scms")).toBeFalsy();
     expect(helper.qa(`a.${styles.siteNavLink}`)).toHaveLength(4);
     expect(helper.qa(`a.${styles.siteSubNavLink}`)).toHaveLength(4);
   });
@@ -132,8 +134,9 @@ describe("Site Menu", () => {
     expect(findMenuItem("/go/admin/package_repositories/new")).toHaveText("Package Repositories");
     expect(findMenuItem("/go/admin/security/auth_configs")).toBeFalsy();
     expect(findMenuItem("/go/admin/security/roles")).toBeFalsy();
+    expect(findMenuItem("/go/admin/scms")).toHaveText("Pluggable SCMs");
     expect(helper.qa(`a.${styles.siteNavLink}`)).toHaveLength(4);
-    expect(helper.qa(`a.${styles.siteSubNavLink}`)).toHaveLength(8);
+    expect(helper.qa(`a.${styles.siteSubNavLink}`)).toHaveLength(9);
   });
 
   it("should not show analytics when the attribute is passed as false", () => {
@@ -174,6 +177,7 @@ describe("Site Menu", () => {
     expect(findMenuItem("/go/admin/environments")).toHaveText("Environments");
     expect(findMenuItem("/go/admin/config_repos")).toHaveText("Config Repositories");
     expect(findMenuItem("/go/admin/elastic_agent_configurations")).toHaveText("Elastic Agent Configurations");
+    expect(findMenuItem("/go/admin/scms")).toBeFalsy();
 
     expect(helper.qa(`a.${styles.siteSubNavLink}`)).toHaveLength(3);
   });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import m from "mithril";
+import {Scms} from "models/materials/pluggable_scm";
+import {PluggableScmsWidget} from "views/pages/pluggable_scms/pluggable_scms_widget";
+import {Page} from "views/pages/page";
+
+interface State {
+  dummy?: Scms;
+}
+
+export class PluggableScmsPage extends Page<null, State> {
+  componentToDisplay(vnode: m.Vnode<null, State>): m.Children {
+    return <PluggableScmsWidget/>;
+  }
+
+  pageName(): string {
+    return "SPA Name goes here!";
+  }
+
+  fetchData(vnode: m.Vnode<null, State>): Promise<any> {
+    // to be implemented
+    return Promise.resolve();
+  }
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms.tsx
@@ -15,25 +15,53 @@
  */
 
 import m from "mithril";
+import Stream from "mithril/stream";
 import {Scms} from "models/materials/pluggable_scm";
+import {PluggableScmCRUD} from "models/materials/pluggable_scm_crud";
+import {MessageType} from "views/components/flash_message";
+import {ExtensionTypeString} from "models/shared/plugin_infos_new/extension_type";
+import {PluginInfoCRUD} from "models/shared/plugin_infos_new/plugin_info_crud";
+import {Page, PageState} from "views/pages/page";
 import {PluggableScmsWidget} from "views/pages/pluggable_scms/pluggable_scms_widget";
-import {Page} from "views/pages/page";
+import {RequiresPluginInfos} from "./page_operations";
 
-interface State {
-  dummy?: Scms;
+interface State extends RequiresPluginInfos {
+  scms: Stream<Scms>;
 }
 
 export class PluggableScmsPage extends Page<null, State> {
+  oninit(vnode: m.Vnode<null, State>) {
+    super.oninit(vnode);
+    vnode.state.scms        = Stream();
+    vnode.state.pluginInfos = Stream();
+  }
+
   componentToDisplay(vnode: m.Vnode<null, State>): m.Children {
-    return <PluggableScmsWidget/>;
+    return <PluggableScmsWidget scms={vnode.state.scms} pluginInfos={vnode.state.pluginInfos}/>;
   }
 
   pageName(): string {
-    return "SPA Name goes here!";
+    return "Pluggable SCMs";
   }
 
   fetchData(vnode: m.Vnode<null, State>): Promise<any> {
-    // to be implemented
-    return Promise.resolve();
+    return Promise.all([PluggableScmCRUD.all(), PluginInfoCRUD.all({type: ExtensionTypeString.SCM})])
+                  .then((result) => {
+                    result[0].do((successResponse) => {
+                      vnode.state.scms(successResponse.body);
+                      this.pageState = PageState.OK;
+                    }, (errorResponse) => {
+                      this.flashMessage.setMessage(MessageType.alert, JSON.parse(errorResponse.body!).message);
+                      this.pageState = PageState.FAILED;
+                    });
+
+                    result[1].do((successResponse) => {
+                      vnode.state.pluginInfos(successResponse.body);
+                      this.pageState = PageState.OK;
+                    }, (errorResponse) => {
+                      this.flashMessage.setMessage(MessageType.alert, JSON.parse(errorResponse.body!).message);
+                      this.pageState = PageState.FAILED;
+                    })
+                  });
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/modals.tsx
@@ -21,6 +21,7 @@ import Stream from "mithril/stream";
 import {Scm, ScmJSON} from "models/materials/pluggable_scm";
 import {PluggableScmCRUD} from "models/materials/pluggable_scm_crud";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {v4 as uuidv4} from 'uuid';
 import {Size} from "views/components/modal";
 import {DeleteConfirmModal} from "views/components/modal/delete_confirm_modal";
 import {EntityModal} from "views/components/modal/entity_modal";
@@ -143,7 +144,7 @@ export class ClonePluggableScmModal extends PluggableScmModal {
   }
 
   fetchCompleted() {
-    this.entity().id("");
+    this.entity().id(uuidv4());
     this.entity().name("");
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/modals.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ErrorResponse} from "helpers/api_request_builder";
+import _ from "lodash";
+import m from "mithril";
+import Stream from "mithril/stream";
+import {Scm, ScmJSON} from "models/materials/pluggable_scm";
+import {PluggableScmCRUD} from "models/materials/pluggable_scm_crud";
+import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {Size} from "views/components/modal";
+import {DeleteConfirmModal} from "views/components/modal/delete_confirm_modal";
+import {EntityModal} from "views/components/modal/entity_modal";
+import {FlashMessageModel, MessageType} from "views/components/flash_message";
+import {Warning} from "views/components/icons";
+import {PluggableScmModalBody} from "./pluggable_scm_modal_body";
+
+abstract class PluggableScmModal extends EntityModal<Scm> {
+  protected readonly originalEntityId: string;
+  protected readonly originalEntityName: string;
+  protected message?: FlashMessageModel;
+  private disableId: boolean;
+
+  constructor(entity: Scm,
+              pluginInfos: PluginInfos,
+              onSuccessfulSave: (msg: m.Children) => any,
+              disableId: boolean = false,
+              size: Size         = Size.large) {
+    super(entity, pluginInfos, onSuccessfulSave, size);
+    this.disableId          = disableId;
+    this.originalEntityId   = entity.id();
+    this.originalEntityName = entity.name();
+  }
+
+  protected modalBody(): m.Children {
+    return <PluggableScmModalBody pluginInfos={this.pluginInfos}
+                                  scm={this.entity()}
+                                  disableId={this.disableId}
+                                  pluginIdProxy={this.pluginIdProxy.bind(this)} message={this.message}/>;
+  }
+
+  protected onPluginChange(entity: Stream<Scm>, pluginInfo: PluginInfo): void {
+    const pluginMetadata = entity().pluginMetadata();
+    pluginMetadata.id(pluginInfo.id);
+    entity(new Scm(entity().id(), entity().name(), entity().autoUpdate(), pluginMetadata, entity().configuration()));
+  }
+
+  protected parseJsonToEntity(json: object): Scm {
+    return Scm.fromJSON(json as ScmJSON);
+  }
+
+  protected performFetch(entity: Scm): Promise<any> {
+    return PluggableScmCRUD.get(this.originalEntityName);
+  }
+
+  protected pluginIdProxy(newPluginId?: string): any {
+    if (!newPluginId) {
+      return this.entity().pluginMetadata().id();
+    }
+
+    if (newPluginId !== this.entity().pluginMetadata().id()) {
+      const pluginInfo = _.find(this.pluginInfos, (pluginInfo: PluginInfo) => pluginInfo.id === newPluginId) as PluginInfo;
+      this.onPluginChange(this.entity, pluginInfo);
+    }
+
+    return newPluginId;
+  }
+}
+
+export class CreatePluggableScmModal extends PluggableScmModal {
+
+  constructor(entity: Scm,
+              pluginInfos: PluginInfos,
+              onSuccessfulSave: (msg: m.Children) => any) {
+    super(entity, pluginInfos, onSuccessfulSave);
+    this.isStale(false);
+  }
+
+  title(): string {
+    return "Create a package repository";
+  }
+
+  protected operationPromise(): Promise<any> {
+    return PluggableScmCRUD.create(this.entity());
+  }
+
+  protected successMessage(): m.Children {
+    return <span>The scm <em>{this.entity().name()}</em> was created successfully!</span>;
+  }
+}
+
+export class EditPluggableScmModal extends PluggableScmModal {
+  private readonly warningMsg = <span>
+    <Warning iconOnly={true}/>This is a global copy. All pipelines using this SCM will be affected.
+  </span>;
+
+  constructor(entity: Scm, pluginInfos: PluginInfos, onSuccessfulSave: (msg: m.Children) => any) {
+    super(entity, pluginInfos, onSuccessfulSave, true);
+    this.message = new FlashMessageModel(MessageType.warning, this.warningMsg);
+  }
+
+  title(): string {
+    return `Edit scm ${this.entity().name()}`;
+  }
+
+  operationPromise(): Promise<any> {
+    return PluggableScmCRUD.update(this.entity(), this.etag());
+  }
+
+  successMessage(): m.Children {
+    return <span>The scm <em>{this.entity().name()}</em> was updated successfully!</span>;
+  }
+}
+
+export class ClonePluggableScmModal extends PluggableScmModal {
+  constructor(entity: Scm, pluginInfos: PluginInfos, onSuccessfulSave: (msg: m.Children) => any) {
+    super(entity, pluginInfos, onSuccessfulSave, false);
+  }
+
+  title(): string {
+    return `Clone scm ${this.originalEntityName}`;
+  }
+
+  operationPromise(): Promise<any> {
+    return PluggableScmCRUD.create(this.entity());
+  }
+
+  successMessage(): m.Children {
+    return <span>The scm <em>{this.entity().name()}</em> was created successfully!</span>;
+  }
+
+  fetchCompleted() {
+    this.entity().id("");
+    this.entity().name("");
+  }
+}
+
+export class DeletePluggableScmModal extends DeleteConfirmModal {
+  private readonly onSuccessfulSave: (msg: m.Children) => any;
+  private readonly onOperationError: (errorResponse: ErrorResponse) => any;
+
+  constructor(pkgRepo: Scm,
+              onSuccessfulSave: (msg: m.Children) => any,
+              onOperationError: (errorResponse: ErrorResponse) => any) {
+    super(DeletePluggableScmModal.deleteConfirmationMessage(pkgRepo),
+          () => this.delete(pkgRepo), "Are you sure?");
+    this.onSuccessfulSave = onSuccessfulSave;
+    this.onOperationError = onOperationError;
+  }
+
+  private static deleteConfirmationMessage(scm: Scm) {
+    return <span>
+          Are you sure you want to delete the scm <strong>{scm.name()}</strong>?
+        </span>;
+  }
+
+  private delete(obj: Scm) {
+    return PluggableScmCRUD
+      .delete(obj.name())
+      .then((result) => {
+        result.do(
+          () => this.onSuccessfulSave(
+            <span>The scm <em>{obj.name()}</em> was deleted successfully!</span>
+          ),
+          this.onOperationError
+        );
+      })
+      .finally(this.close.bind(this));
+  }
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_modal_body.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_modal_body.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MithrilViewComponent} from "jsx/mithril-component";
+import _ from "lodash";
+import m from "mithril";
+import Stream from "mithril/stream";
+import {Scm} from "models/materials/pluggable_scm";
+import {ExtensionTypeString} from "models/shared/plugin_infos_new/extension_type";
+import {ScmExtension} from "models/shared/plugin_infos_new/extensions";
+import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {FlashMessage, FlashMessageModel} from "views/components/flash_message";
+import {Form, FormHeader} from "views/components/forms/form";
+import {SelectField, SelectFieldOptions, TextField} from "views/components/forms/input_fields";
+
+const AngularPluginNew = require("views/shared/angular_plugin_new").AngularPluginNew;
+
+interface Attrs {
+  pluginInfos: PluginInfos;
+  scm: Scm;
+  disableId: boolean;
+  pluginIdProxy: (newPluginId?: string) => any;
+  message?: FlashMessageModel;
+}
+
+export class PluggableScmModalBody extends MithrilViewComponent<Attrs> {
+  view(vnode: m.Vnode<Attrs, this>): m.Children | void | null {
+    const pluginList = _.map(vnode.attrs.pluginInfos, (pluginInfo: PluginInfo) => {
+      return {id: pluginInfo.id, text: pluginInfo.about.name};
+    });
+
+    const selectedPluginInfo = _.find(vnode.attrs.pluginInfos, (pluginInfo: PluginInfo) => {
+      return pluginInfo.id === vnode.attrs.pluginIdProxy();
+    })!;
+
+    const mayBeMsg = vnode.attrs.message
+      ? <FlashMessage type={vnode.attrs.message.type} message={vnode.attrs.message.message}/>
+      : undefined;
+    const settings = (selectedPluginInfo.extensionOfType(ExtensionTypeString.SCM) as ScmExtension).scmSettings;
+    return <div>
+      <FormHeader>
+        {mayBeMsg}
+        <Form>
+          <TextField label="Name"
+                     readonly={vnode.attrs.disableId}
+                     property={vnode.attrs.scm.name}
+                     placeholder={"Enter the pluggable scm name"}
+                     errorText={vnode.attrs.scm.errors().errorsForDisplay("name")}
+                     required={true}/>
+
+          <SelectField label="Plugin"
+                       property={vnode.attrs.pluginIdProxy.bind(this)}
+                       required={true}
+                       errorText={vnode.attrs.scm.errors().errorsForDisplay("pluginId")}>
+            <SelectFieldOptions selected={vnode.attrs.scm.pluginMetadata().id()}
+                                items={pluginList}/>
+          </SelectField>
+        </Form>
+      </FormHeader>
+
+      <div className="row collapse">
+        <AngularPluginNew
+          pluginInfoSettings={Stream(settings)}
+          configuration={vnode.attrs.scm.configuration()}
+          key={selectedPluginInfo.id}/>
+      </div>
+    </div>;
+  }
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_modal_body.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_modal_body.tsx
@@ -71,6 +71,15 @@ export class PluggableScmModalBody extends MithrilViewComponent<Attrs> {
         </Form>
       </FormHeader>
 
+      <div>
+        <TextField label="Id"
+                   readonly={vnode.attrs.disableId}
+                   property={vnode.attrs.scm.id}
+                   placeholder={"Enter a unique id for this material"}
+                   helpText={"Each material is associated with an id by which it can be referenced in the pipelines. Once defined, cannot be updated"}
+                   errorText={vnode.attrs.scm.errors().errorsForDisplay("scmId")}/>
+      </div>
+
       <div className="row collapse">
         <AngularPluginNew
           pluginInfoSettings={Stream(settings)}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_widget.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import m from "mithril";
+import {MithrilViewComponent} from "jsx/mithril-component";
+import {Scm} from "models/materials/pluggable_scm";
+import {CollapsiblePanel} from "views/components/collapsible_panel";
+import {KeyValuePair} from "views/components/key_value_pair";
+import {Clone, Delete, Edit, IconGroup} from "views/components/icons";
+
+interface Attrs {
+  scm: Scm;
+  disableActions: boolean;
+}
+
+export class PluggableScmWidget extends MithrilViewComponent<Attrs> {
+  view(vnode: m.Vnode<Attrs, this>): m.Children | void | null {
+    const header = <KeyValuePair inline={true}
+                                 data={PluggableScmWidget.headerMap(vnode.attrs.scm)}/>;
+
+    const scm            = vnode.attrs.scm;
+    const scmRepoDetails = new Map([
+                                     ["Name", scm.name()],
+                                     ["Plugin Id", scm.pluginMetadata().id()],
+                                     ...Array.from(scm.configuration().asMap())
+                                   ]);
+
+    const actionButtons = [
+      <div>
+        <IconGroup>
+          <Edit data-test-id="pluggable-scm-edit"
+                disabled={vnode.attrs.disableActions}/>
+          <Clone data-test-id="pluggable-scm-clone"
+                 disabled={vnode.attrs.disableActions}/>
+          <Delete data-test-id="pluggable-scm-delete"/>
+        </IconGroup>
+      </div>];
+
+    return <CollapsiblePanel key={vnode.attrs.scm.id()}
+                             header={header} actions={actionButtons}
+                             dataTestId={"pluggable-scm-panel"}>
+      <KeyValuePair data-test-id={"pluggable-scm-details"} data={scmRepoDetails}/>
+    </CollapsiblePanel>;
+  }
+
+  private static headerMap(scm: Scm) {
+    const map = new Map();
+    map.set("Name", scm.name());
+    map.set("Plugin Id", scm.pluginMetadata().id());
+    return map;
+  }
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_widget.tsx
@@ -19,12 +19,13 @@ import {MithrilViewComponent} from "jsx/mithril-component";
 import {Scm} from "models/materials/pluggable_scm";
 import {CollapsiblePanel} from "views/components/collapsible_panel";
 import {KeyValuePair} from "views/components/key_value_pair";
-import {Clone, Delete, Edit, IconGroup} from "views/components/icons";
+import {Clone, Delete, Edit, IconGroup, Usage} from "views/components/icons";
 import {CloneOperation, DeleteOperation, EditOperation} from "../page_operations";
 
 interface Attrs extends EditOperation<Scm>, CloneOperation<Scm>, DeleteOperation<Scm> {
   scm: Scm;
   disableActions: boolean;
+  showUsages: (scm: Scm, e: MouseEvent) => void;
 }
 
 export class PluggableScmWidget extends MithrilViewComponent<Attrs> {
@@ -50,6 +51,8 @@ export class PluggableScmWidget extends MithrilViewComponent<Attrs> {
                  onclick={vnode.attrs.onClone.bind(this, scm)}/>
           <Delete data-test-id="pluggable-scm-delete"
                   onclick={vnode.attrs.onDelete.bind(this, scm)}/>
+          <Usage data-test-id="pluggable-scm-usages"
+                 onclick={vnode.attrs.showUsages.bind(this, scm)}/>
         </IconGroup>
       </div>];
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_widget.tsx
@@ -13,14 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import m from "mithril";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import {Scm} from "models/materials/pluggable_scm";
 import {CollapsiblePanel} from "views/components/collapsible_panel";
 import {KeyValuePair} from "views/components/key_value_pair";
 import {Clone, Delete, Edit, IconGroup} from "views/components/icons";
+import {CloneOperation, DeleteOperation, EditOperation} from "../page_operations";
 
-interface Attrs {
+interface Attrs extends EditOperation<Scm>, CloneOperation<Scm>, DeleteOperation<Scm> {
   scm: Scm;
   disableActions: boolean;
 }
@@ -41,10 +43,13 @@ export class PluggableScmWidget extends MithrilViewComponent<Attrs> {
       <div>
         <IconGroup>
           <Edit data-test-id="pluggable-scm-edit"
-                disabled={vnode.attrs.disableActions}/>
+                disabled={vnode.attrs.disableActions}
+                onclick={vnode.attrs.onEdit.bind(this, scm)}/>
           <Clone data-test-id="pluggable-scm-clone"
-                 disabled={vnode.attrs.disableActions}/>
-          <Delete data-test-id="pluggable-scm-delete"/>
+                 disabled={vnode.attrs.disableActions}
+                 onclick={vnode.attrs.onClone.bind(this, scm)}/>
+          <Delete data-test-id="pluggable-scm-delete"
+                  onclick={vnode.attrs.onDelete.bind(this, scm)}/>
         </IconGroup>
       </div>];
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_widget.tsx
@@ -35,6 +35,7 @@ export class PluggableScmWidget extends MithrilViewComponent<Attrs> {
 
     const scm            = vnode.attrs.scm;
     const scmRepoDetails = new Map([
+                                     ["Id", scm.id()],
                                      ["Name", scm.name()],
                                      ["Plugin Id", scm.pluginMetadata().id()],
                                      ...Array.from(scm.configuration().asMap())

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scms_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scms_widget.tsx
@@ -15,15 +15,24 @@
  */
 
 import {MithrilViewComponent} from "jsx/mithril-component";
+import _ from "lodash";
 import m from "mithril";
+import Stream from "mithril/stream";
 import {Scms} from "models/materials/pluggable_scm";
+import {RequiresPluginInfos} from "views/pages/page_operations";
+import {PluggableScmWidget} from "./pluggable_scm_widget";
 
-interface Attrs {
-  dummy?: Scms;
+interface Attrs extends RequiresPluginInfos {
+  scms: Stream<Scms>;
 }
 
 export class PluggableScmsWidget extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs>) {
-    return <div> This is widget</div>;
+    return <div data-test-id="scms">
+      {vnode.attrs.scms().map((scm) => {
+        const pluginInfo = _.find(vnode.attrs.pluginInfos(), {id: scm.pluginMetadata().id()});
+        return <PluggableScmWidget scm={scm} disableActions={pluginInfo === undefined}/>
+      })}
+    </div>;
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scms_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scms_widget.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MithrilViewComponent} from "jsx/mithril-component";
+import m from "mithril";
+import {Scms} from "models/materials/pluggable_scm";
+
+interface Attrs {
+  dummy?: Scms;
+}
+
+export class PluggableScmsWidget extends MithrilViewComponent<Attrs> {
+  view(vnode: m.Vnode<Attrs>) {
+    return <div> This is widget</div>;
+  }
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scms_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scms_widget.tsx
@@ -27,6 +27,7 @@ import {PluggableScmWidget} from "./pluggable_scm_widget";
 
 interface Attrs extends RequiresPluginInfos, EditOperation<Scm>, CloneOperation<Scm>, DeleteOperation<Scm> {
   scms: Stream<Scms>;
+  showUsages: (scm: Scm, e: MouseEvent) => void;
 }
 
 export class PluggableScmsWidget extends MithrilViewComponent<Attrs> {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scms_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scms_widget.tsx
@@ -14,24 +14,39 @@
  * limitations under the License.
  */
 
+import {docsUrl} from "gen/gocd_version";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import _ from "lodash";
 import m from "mithril";
 import Stream from "mithril/stream";
-import {Scms} from "models/materials/pluggable_scm";
-import {RequiresPluginInfos} from "views/pages/page_operations";
+import {Scm, Scms} from "models/materials/pluggable_scm";
+import {Link} from "views/components/link";
+import styles from "views/pages/package_repositories/index.scss";
+import {CloneOperation, DeleteOperation, EditOperation, RequiresPluginInfos} from "views/pages/page_operations";
 import {PluggableScmWidget} from "./pluggable_scm_widget";
 
-interface Attrs extends RequiresPluginInfos {
+interface Attrs extends RequiresPluginInfos, EditOperation<Scm>, CloneOperation<Scm>, DeleteOperation<Scm> {
   scms: Stream<Scms>;
 }
 
 export class PluggableScmsWidget extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs>) {
-    return <div data-test-id="scms">
+    if (!vnode.attrs.scms || _.isEmpty(vnode.attrs.scms())) {
+      return <div className={styles.tips} data-test-id="pluggable-scm-info">
+        <ul>
+          <li>Click on "Create Pluggable Scm" to add new SCM.</li>
+          <li>An SCM can be set up and used as a material in the pipelines. You can read more
+            from <Link target="_blank" href={docsUrl("extension_points/scm_extension.html")}>here</Link>.
+          </li>
+        </ul>
+      </div>
+    }
+    return <div data-test-id="scms-widget">
       {vnode.attrs.scms().map((scm) => {
         const pluginInfo = _.find(vnode.attrs.pluginInfos(), {id: scm.pluginMetadata().id()});
-        return <PluggableScmWidget scm={scm} disableActions={pluginInfo === undefined}/>
+        return <PluggableScmWidget scm={scm}
+                                   disableActions={pluginInfo === undefined}
+                                   {...vnode.attrs}/>
       })}
     </div>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_modal_body_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_modal_body_spec.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import m from "mithril";
+import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {Scm} from "models/materials/pluggable_scm";
+import {TestHelper} from "views/pages/spec/test_helper";
+import {PluggableScmModalBody} from "../pluggable_scm_modal_body";
+import {getPluggableScm, getScmPlugin} from "./test_data";
+import {FlashMessageModel, MessageType} from "../../../components/flash_message";
+
+describe('PluggableScmModalBodySpec', () => {
+  const helper        = new TestHelper();
+  const spy           = jasmine.createSpy("pluginIdProxy");
+  const pluginIdProxy = () => {
+    spy();
+    return "scm-plugin-id"
+  };
+  let pluginInfos: PluginInfos;
+  let scm: Scm;
+  let disabled: boolean;
+
+  beforeEach(() => {
+    scm         = Scm.fromJSON(getPluggableScm());
+    pluginInfos = new PluginInfos(PluginInfo.fromJSON(getScmPlugin()));
+    disabled    = false;
+  });
+  afterEach((done) => helper.unmount(done));
+
+  function mount(message?: FlashMessageModel) {
+    helper.mount(() => <PluggableScmModalBody scm={scm} pluginInfos={pluginInfos}
+                                              disableId={disabled} pluginIdProxy={pluginIdProxy} message={message}/>);
+  }
+
+  it('should render input fields for name, id and plugin', () => {
+    mount();
+
+    expect(helper.byTestId('form-field-input-name')).toBeInDOM();
+    expect(helper.byTestId('form-field-input-name')).not.toBeDisabled();
+    expect(helper.byTestId("form-field-input-name")).toHaveValue(scm.name());
+
+    expect(helper.byTestId('form-field-input-plugin')).toBeInDOM();
+    expect(helper.byTestId("form-field-input-plugin").children.length).toBe(1);
+    expect(helper.byTestId("form-field-input-plugin").children[0].textContent).toBe('SCM Plugin');
+
+    expect(helper.byTestId('form-field-input-id')).toBeInDOM();
+    expect(helper.byTestId('form-field-input-id')).not.toBeDisabled();
+    expect(helper.byTestId("form-field-input-id")).toHaveValue(scm.id());
+  });
+
+  it('should render the name and id as readonly', () => {
+    disabled = true;
+    mount();
+
+    expect(helper.byTestId('form-field-input-name')).toBeDisabled();
+    expect(helper.byTestId('form-field-input-id')).toBeDisabled();
+  });
+
+  it('should call the spy method on plugin change', () => {
+    const json       = getScmPlugin();
+    json.id          = 'new-plugin-id';
+    json.about!.name = 'new-plugin-name';
+    const pluginInfo = PluginInfo.fromJSON(json);
+
+    pluginInfos.push(pluginInfo);
+    mount();
+
+    helper.onchange(helper.byTestId("form-field-input-plugin"), "new-plugin-id");
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should render message when given', () => {
+    const message = new FlashMessageModel(MessageType.warning, "some message");
+    mount(message);
+
+    expect(helper.byTestId('flash-message-warning')).toBeInDOM();
+    expect(helper.textByTestId('flash-message-warning')).toBe('some message');
+
+  });
+});

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_widget_spec.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import m from "mithril";
+import {Scm} from "models/materials/pluggable_scm";
+import {TestHelper} from "views/pages/spec/test_helper";
+import {PluggableScmWidget} from "../pluggable_scm_widget";
+import {getPluggableScm} from "./test_data";
+
+describe('PluggableScmWidgetSpec', () => {
+  const helper = new TestHelper();
+  let scm: Scm;
+  let disableActions: boolean;
+
+  beforeEach(() => {
+    scm            = Scm.fromJSON(getPluggableScm());
+    disableActions = false;
+  });
+  afterEach((done) => helper.unmount(done));
+
+  function mount() {
+    helper.mount(() => <PluggableScmWidget scm={scm} disableActions={disableActions}/>);
+  }
+
+  it('should render scm details and action buttons', () => {
+    mount();
+
+    expect(helper.byTestId('pluggable-scm-panel')).toBeInDOM();
+
+    const headerPanel = helper.byTestId('collapse-header');
+    expect(helper.textByTestId('key-value-key-name', headerPanel)).toBe('Name');
+    expect(helper.textByTestId('key-value-value-name', headerPanel)).toBe(scm.name());
+    expect(helper.textByTestId('key-value-key-plugin-id', headerPanel)).toBe('Plugin Id');
+    expect(helper.textByTestId('key-value-value-plugin-id', headerPanel)).toBe(scm.pluginMetadata().id());
+
+    const scmDetails = helper.byTestId('pluggable-scm-details');
+    expect(helper.textByTestId('key-value-key-name', scmDetails)).toBe('Name');
+    expect(helper.textByTestId('key-value-value-name', scmDetails)).toBe(scm.name());
+    expect(helper.textByTestId('key-value-key-plugin-id', scmDetails)).toBe('Plugin Id');
+    expect(helper.textByTestId('key-value-value-plugin-id', scmDetails)).toBe(scm.pluginMetadata().id());
+    expect(helper.textByTestId('key-value-key-url', scmDetails)).toBe('url');
+    expect(helper.textByTestId('key-value-value-url', scmDetails)).toBe('https://github.com/sample/example.git');
+
+    expect(helper.byTestId('pluggable-scm-edit')).toBeInDOM();
+    expect(helper.byTestId('pluggable-scm-clone')).toBeInDOM();
+    expect(helper.byTestId('pluggable-scm-delete')).toBeInDOM();
+  });
+});

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_widget_spec.tsx
@@ -21,7 +21,10 @@ import {PluggableScmWidget} from "../pluggable_scm_widget";
 import {getPluggableScm} from "./test_data";
 
 describe('PluggableScmWidgetSpec', () => {
-  const helper = new TestHelper();
+  const helper    = new TestHelper();
+  const editSpy   = jasmine.createSpy("onEdit");
+  const cloneSpy  = jasmine.createSpy("onClone");
+  const deleteSpy = jasmine.createSpy("onDelete");
   let scm: Scm;
   let disableActions: boolean;
 
@@ -32,7 +35,8 @@ describe('PluggableScmWidgetSpec', () => {
   afterEach((done) => helper.unmount(done));
 
   function mount() {
-    helper.mount(() => <PluggableScmWidget scm={scm} disableActions={disableActions}/>);
+    helper.mount(() => <PluggableScmWidget scm={scm} disableActions={disableActions}
+                                           onEdit={editSpy} onClone={cloneSpy} onDelete={deleteSpy}/>);
   }
 
   it('should render scm details and action buttons', () => {
@@ -55,7 +59,32 @@ describe('PluggableScmWidgetSpec', () => {
     expect(helper.textByTestId('key-value-value-url', scmDetails)).toBe('https://github.com/sample/example.git');
 
     expect(helper.byTestId('pluggable-scm-edit')).toBeInDOM();
+    expect(helper.byTestId('pluggable-scm-edit')).not.toBeDisabled();
     expect(helper.byTestId('pluggable-scm-clone')).toBeInDOM();
+    expect(helper.byTestId('pluggable-scm-clone')).not.toBeDisabled();
     expect(helper.byTestId('pluggable-scm-delete')).toBeInDOM();
+    expect(helper.byTestId('pluggable-scm-delete')).not.toBeDisabled();
+  });
+
+  it('should give a call to the callbacks on relevant button clicks', () => {
+    mount();
+
+    helper.clickByTestId('pluggable-scm-edit');
+    expect(editSpy).toHaveBeenCalled();
+
+    helper.clickByTestId('pluggable-scm-clone');
+    expect(cloneSpy).toHaveBeenCalled();
+
+    helper.clickByTestId('pluggable-scm-delete');
+    expect(deleteSpy).toHaveBeenCalled();
+  });
+
+  it('should disable edit and clone button', () => {
+    disableActions = true;
+    mount();
+
+    expect(helper.byTestId('pluggable-scm-edit')).toBeDisabled();
+    expect(helper.byTestId('pluggable-scm-clone')).toBeDisabled();
+    expect(helper.byTestId('pluggable-scm-delete')).not.toBeDisabled();
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_widget_spec.tsx
@@ -25,6 +25,7 @@ describe('PluggableScmWidgetSpec', () => {
   const editSpy   = jasmine.createSpy("onEdit");
   const cloneSpy  = jasmine.createSpy("onClone");
   const deleteSpy = jasmine.createSpy("onDelete");
+  const usagesSpy = jasmine.createSpy("showUsages");
   let scm: Scm;
   let disableActions: boolean;
 
@@ -36,7 +37,8 @@ describe('PluggableScmWidgetSpec', () => {
 
   function mount() {
     helper.mount(() => <PluggableScmWidget scm={scm} disableActions={disableActions}
-                                           onEdit={editSpy} onClone={cloneSpy} onDelete={deleteSpy}/>);
+                                           onEdit={editSpy} onClone={cloneSpy} onDelete={deleteSpy}
+                                           showUsages={usagesSpy}/>);
   }
 
   it('should render scm details and action buttons', () => {
@@ -64,6 +66,8 @@ describe('PluggableScmWidgetSpec', () => {
     expect(helper.byTestId('pluggable-scm-clone')).not.toBeDisabled();
     expect(helper.byTestId('pluggable-scm-delete')).toBeInDOM();
     expect(helper.byTestId('pluggable-scm-delete')).not.toBeDisabled();
+    expect(helper.byTestId('pluggable-scm-usages')).toBeInDOM();
+    expect(helper.byTestId('pluggable-scm-usages')).not.toBeDisabled();
   });
 
   it('should give a call to the callbacks on relevant button clicks', () => {
@@ -77,6 +81,9 @@ describe('PluggableScmWidgetSpec', () => {
 
     helper.clickByTestId('pluggable-scm-delete');
     expect(deleteSpy).toHaveBeenCalled();
+
+    helper.clickByTestId('pluggable-scm-usages');
+    expect(usagesSpy).toHaveBeenCalled();
   });
 
   it('should disable edit and clone button', () => {
@@ -86,5 +93,6 @@ describe('PluggableScmWidgetSpec', () => {
     expect(helper.byTestId('pluggable-scm-edit')).toBeDisabled();
     expect(helper.byTestId('pluggable-scm-clone')).toBeDisabled();
     expect(helper.byTestId('pluggable-scm-delete')).not.toBeDisabled();
+    expect(helper.byTestId('pluggable-scm-usages')).not.toBeDisabled();
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_widget_spec.tsx
@@ -53,6 +53,8 @@ describe('PluggableScmWidgetSpec', () => {
     expect(helper.textByTestId('key-value-value-plugin-id', headerPanel)).toBe(scm.pluginMetadata().id());
 
     const scmDetails = helper.byTestId('pluggable-scm-details');
+    expect(helper.textByTestId('key-value-key-id', scmDetails)).toBe('Id');
+    expect(helper.textByTestId('key-value-value-id', scmDetails)).toBe(scm.id());
     expect(helper.textByTestId('key-value-key-name', scmDetails)).toBe('Name');
     expect(helper.textByTestId('key-value-value-name', scmDetails)).toBe(scm.name());
     expect(helper.textByTestId('key-value-key-plugin-id', scmDetails)).toBe('Plugin Id');

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scms_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scms_widget_spec.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {docsUrl} from "gen/gocd_version";
+import m from "mithril";
+import Stream from "mithril/stream";
+import {Scm, Scms} from "models/materials/pluggable_scm";
+import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {TestHelper} from "views/pages/spec/test_helper";
+import {PluggableScmsWidget} from "../pluggable_scms_widget";
+import {getPluggableScm, getScmPlugin} from "./test_data";
+
+describe('PluggableScmsWidgetSpec', () => {
+  const helper = new TestHelper();
+  let scms: Scms;
+  let pluginInfos: PluginInfos;
+
+  beforeEach(() => {
+    scms        = Scms.fromJSON([]);
+    pluginInfos = new PluginInfos(PluginInfo.fromJSON(getScmPlugin()))
+  });
+  afterEach((done) => helper.unmount(done));
+
+  function mount() {
+    helper.mount(() => <PluggableScmsWidget scms={Stream(scms)} pluginInfos={Stream(pluginInfos)}
+                                            onEdit={jasmine.createSpy("onEdit")}
+                                            onClone={jasmine.createSpy("onClone")}
+                                            onDelete={jasmine.createSpy("onDelete")}/>);
+  }
+
+  it('should render info div if repos is empty', () => {
+    mount();
+
+    expect(helper.byTestId('scms-widget')).not.toBeInDOM();
+    const helpInfo = helper.byTestId('pluggable-scm-info');
+    expect(helpInfo).toBeInDOM();
+    expect(helper.qa('li', helpInfo)[0].textContent).toBe('Click on "Create Pluggable Scm" to add new SCM.');
+    expect(helper.qa('li', helpInfo)[1].textContent).toBe('An SCM can be set up and used as a material in the pipelines. You can read more from here.');
+
+    expect(helper.q('a', helpInfo)).toHaveAttr('href', docsUrl("extension_points/scm_extension.html"));
+  });
+
+  it('should render scms if present', () => {
+    scms.push(Scm.fromJSON(getPluggableScm()));
+    mount();
+
+    expect(helper.byTestId('pluggable-scm-info')).not.toBeInDOM();
+    expect(helper.byTestId('scms-widget')).toBeInDOM();
+  });
+});

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scms_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scms_widget_spec.tsx
@@ -38,7 +38,8 @@ describe('PluggableScmsWidgetSpec', () => {
     helper.mount(() => <PluggableScmsWidget scms={Stream(scms)} pluginInfos={Stream(pluginInfos)}
                                             onEdit={jasmine.createSpy("onEdit")}
                                             onClone={jasmine.createSpy("onClone")}
-                                            onDelete={jasmine.createSpy("onDelete")}/>);
+                                            onDelete={jasmine.createSpy("onDelete")}
+                                            showUsages={jasmine.createSpy("showUsages")}/>);
   }
 
   it('should render info div if repos is empty', () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/test_data.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/test_data.ts
@@ -15,6 +15,7 @@
  */
 
 import {ScmJSON} from "models/materials/pluggable_scm";
+import {PluginInfoJSON} from "models/shared/plugin_infos_new/serialization";
 
 export function getPluggableScm() {
   return {
@@ -32,4 +33,82 @@ export function getPluggableScm() {
       }
     ]
   } as ScmJSON;
+}
+
+export function getScmPlugin() {
+  return {
+    _links:               {
+      self: {
+        href: "http://test-server:8153/go/api/admin/plugin_info/github.pr"
+      },
+      doc:  {
+        href: "https://api.gocd.org/#plugin-info"
+      },
+      find: {
+        href: "http://test-server:8153/go/api/admin/plugin_info/:id"
+      }
+    },
+    id:                   "scm-plugin-id",
+    status:               {
+      state: "active"
+    },
+    plugin_file_location: "/tmp/abc.jar",
+    bundled_plugin:       false,
+    about:                {
+      name:                     "SCM Plugin",
+      version:                  "1.4.0-RC2",
+      target_go_version:        "15.1.0",
+      description:              "Plugin that polls a GitHub repository for pull requests and triggers a build for each of them",
+      target_operating_systems: [],
+      vendor:                   {
+        name: "User",
+        url:  "https://github.com/user/abc"
+      }
+    },
+    extensions:           [{
+      type:         "scm",
+      display_name: "Github",
+      scm_settings: {
+        configurations: [{
+          key:      "url",
+          metadata: {
+            secure:           false,
+            required:         true,
+            part_of_identity: true
+          }
+        }, {
+          key:      "username",
+          metadata: {
+            secure:           false,
+            required:         false,
+            part_of_identity: false
+          }
+        }, {
+          key:      "password",
+          metadata: {
+            secure:           true,
+            required:         false,
+            part_of_identity: false
+          }
+        }, {
+          key:      "defaultBranch",
+          metadata: {
+            secure:           false,
+            required:         false,
+            part_of_identity: false
+          }
+        }, {
+          key:      "shallowClone",
+          metadata: {
+            secure:           false,
+            required:         false,
+            part_of_identity: false
+          }
+        }],
+        view:           {
+          template: "<div class=\"form_item_block\">\n    <label>URL:<span class=\"asterisk\">*</span></label>\n    <input type=\"text\" ng-model=\"url\" ng-required=\"true\"/>\n    <span class=\"form_error\" ng-show=\"GOINPUTNAME[url].$error.server\">{{ GOINPUTNAME[url].$error.server }}</span>\n</div>\n<div class=\"form_item_block\">\n    <label>Username:</label>\n    <input type=\"text\" autocomplete=\"new-password\" ng-model=\"username\" ng-required=\"false\"/>\n    <span class=\"form_error\" ng-show=\"GOINPUTNAME[username].$error.server\">{{ GOINPUTNAME[username].$error.server }}</span>\n</div>\n<div class=\"form_item_block\">\n    <label>Password:</label>\n    <input type=\"password\" autocomplete=\"new-password\" ng-model=\"password\" ng-required=\"false\"/>\n    <span class=\"form_error\" ng-show=\"GOINPUTNAME[password].$error.server\">{{ GOINPUTNAME[password].$error.server }}</span>\n</div>\n<div class=\"form_item_block\">\n    <label>Default Branch:</label>\n    <input type=\"text\" ng-model=\"defaultBranch\" ng-required=\"false\"/>\n    <span class=\"form_error\" ng-show=\"GOINPUTNAME[defaultBranch].$error.server\">{{ GOINPUTNAME[defaultBranch].$error.server }}</span>\n</div>\n"
+        }
+      }
+    }]
+  } as PluginInfoJSON;
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/test_data.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/test_data.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ScmJSON} from "models/materials/pluggable_scm";
+
+export function getPluggableScm() {
+  return {
+    id:              "scm-id",
+    name:            "pluggable.scm.material.name",
+    plugin_metadata: {
+      id:      "github.pr",
+      version: "1"
+    },
+    auto_update:     true,
+    configuration:   [
+      {
+        key:   "url",
+        value: "https://github.com/sample/example.git"
+      }
+    ]
+  } as ScmJSON;
+}

--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -24,6 +24,12 @@
 
 <urlrewrite>
   <rule>
+    <name>Pluggable SCMs SPA</name>
+    <from>^/admin/scms(/?)$</from>
+    <to last="true">/spark/admin/scms</to>
+  </rule>
+
+  <rule>
     <name>Internal Dependency Pipelines API</name>
     <from>^/api/internal/pipelines/([^/]+)/([^/]+)/upstream(/?)$</from>
     <to last="true">/spark/api/internal/pipelines/${escape:$1}/${escape:$2}/upstream</to>

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -216,6 +216,8 @@ public class Routes {
         public static final String ID = "/:material_name";
         public static final String USAGES = ID + "/usages";
 
+        public static final String SPA_BASE = "/admin/scms";
+
         public static String find() {
             return BASE + ID;
         }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/PluggableScmsController.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/PluggableScmsController.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.spark.spa;
+import com.thoughtworks.go.spark.Routes;
+import com.thoughtworks.go.spark.SparkController;
+import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper;
+import spark.ModelAndView;
+import spark.Request;
+import spark.Response;
+import spark.TemplateEngine;
+import java.util.HashMap;
+import java.util.Map;
+import static spark.Spark.*;
+
+public class PluggableScmsController implements SparkController {
+  private final SPAAuthenticationHelper authenticationHelper;
+  private final TemplateEngine engine;
+  public PluggableScmsController(SPAAuthenticationHelper authenticationHelper, TemplateEngine engine) {
+    this.authenticationHelper = authenticationHelper;
+    this.engine = engine;
+  }
+
+  @Override
+  public String controllerBasePath() {
+        return Routes.SCM.SPA_BASE;
+  }
+
+  @Override
+  public void setupRoutes() {
+     path(controllerBasePath(), () -> {
+        before("", authenticationHelper::checkAdminUserOrGroupAdminUserAnd403);
+        get("", this::index, engine);
+    });
+  }
+  public ModelAndView index(Request request, Response response) {
+      Map<Object, Object> object = new HashMap<Object, Object>() {{
+          put("viewTitle", "Pluggable SCMs");
+      }};
+      return new ModelAndView(object, null);
+  }
+}

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
@@ -62,6 +62,7 @@ public class SpaControllers implements SparkSpringController {
         LayoutTemplateProvider componentTemplate = () -> COMPONENT_LAYOUT_PATH;
         LayoutTemplateProvider railsCompatibleTemplate = () -> RAILS_COMPATIBLE_PAGE_LAYOUT_PATH;
 
+        sparkControllers.add(new PluggableScmsController(authenticationHelper, templateEngineFactory.create(PluggableScmsController.class, () -> COMPONENT_LAYOUT_PATH)));
         sparkControllers.add(new PackageRepositoriesController(authenticationHelper, templateEngineFactory.create(PackageRepositoriesController.class, () -> COMPONENT_LAYOUT_PATH)));
         sparkControllers.add(new ClickyPipelineConfigController(authenticationHelper, featureToggleService, templateEngineFactory.create(ClickyPipelineConfigController.class, () -> COMPONENT_LAYOUT_PATH)));
         sparkControllers.add(new StatusReportsController(authenticationHelper, templateEngineFactory.create(


### PR DESCRIPTION
Description:
Add a SPA to add/edit/delete a Pluggable SCM material which can be used as a material for any pipeline

Preview:

1. No plugins available

<img width="1674" alt="Screen Shot 2020-03-26 at 4 14 58 PM" src="https://user-images.githubusercontent.com/41165891/77643361-3b08fe00-6f85-11ea-9a12-28cf1593ced9.png">

2. Scm Usages (Currently points to old pipeline config materials edit)

<img width="790" alt="Screen Shot 2020-03-26 at 4 41 13 PM" src="https://user-images.githubusercontent.com/41165891/77643373-3e03ee80-6f85-11ea-8948-f0abdf066201.png">

3. General

![scm-spa](https://user-images.githubusercontent.com/41165891/77643487-74416e00-6f85-11ea-8859-886f07363907.gif)




