### PR TITLE
Update material editor for supporting packages and scm materials

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -572,4 +572,8 @@ export class SparkRoutes {
   static scmUsagePath(scm_name: string): string {
     return `/go/api/admin/scms/${scm_name}/usages`;
   }
+
+  static pluggableScmSPA() {
+    return '/go/admin/scms';
+  }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/pluggable_scm_crud_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/pluggable_scm_crud_spec.ts
@@ -35,7 +35,7 @@ describe('PluggableScmCRUDSpec', () => {
       expect(scms).toHaveLength(1);
       expect(scms[0].id()).toBe('scm-id');
       expect(scms[0].name()).toBe('pluggable.scm.material.name');
-      expect(scms[0].pluginMetadata().id()).toBe('github.pr');
+      expect(scms[0].pluginMetadata().id()).toBe('scm-plugin-id');
       expect(scms[0].pluginMetadata().version()).toBe('1');
 
       expect(scms[0].configuration().count()).toBe(1);
@@ -60,7 +60,7 @@ describe('PluggableScmCRUDSpec', () => {
 
       expect(packageRepository.id()).toBe('scm-id');
       expect(packageRepository.name()).toBe('pluggable.scm.material.name');
-      expect(packageRepository.pluginMetadata().id()).toBe('github.pr');
+      expect(packageRepository.pluginMetadata().id()).toBe('scm-plugin-id');
       expect(packageRepository.pluginMetadata().version()).toBe('1');
 
       expect(packageRepository.configuration().count()).toBe(1);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
@@ -19,7 +19,18 @@ import {JsonUtils} from "helpers/json_utils";
 import {SparkRoutes} from "helpers/spark_routes";
 import _ from "lodash";
 import Stream from "mithril/stream";
-import {DependencyMaterialAttributesJSON, GitMaterialAttributesJSON, HgMaterialAttributesJSON, MaterialAttributesJSON, MaterialJSON, P4MaterialAttributesJSON, PackageMaterialAttributesJSON, PluggableScmMaterialAttributesJSON, SvnMaterialAttributesJSON, TfsMaterialAttributesJSON,} from "models/materials/serialization";
+import {
+  DependencyMaterialAttributesJSON,
+  GitMaterialAttributesJSON,
+  HgMaterialAttributesJSON,
+  MaterialAttributesJSON,
+  MaterialJSON,
+  P4MaterialAttributesJSON,
+  PackageMaterialAttributesJSON,
+  PluggableScmMaterialAttributesJSON,
+  SvnMaterialAttributesJSON,
+  TfsMaterialAttributesJSON,
+} from "models/materials/serialization";
 import {Errors} from "models/mixins/errors";
 import {ErrorsConsumer} from "models/mixins/errors_consumer";
 import {ErrorMessages} from "models/mixins/error_messages";
@@ -495,7 +506,7 @@ export class PluggableScmMaterialAttributes extends MaterialAttributes {
   filter: Stream<Filter>;
   destination: Stream<string>;
 
-  constructor(name: string, autoUpdate: boolean, ref: string, destination: string, filter: Filter) {
+  constructor(name: string | undefined, autoUpdate: boolean, ref: string, destination: string, filter: Filter) {
     super(name, autoUpdate);
     this.ref         = Stream(ref);
     this.filter      = Stream(filter);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/configuration.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/configuration.ts
@@ -82,6 +82,7 @@ export class Configurations {
 
   public asString(): string {
     const configValues = this.configurations
+                             .filter((config) => config.isEncrypted() === false && !_.isEmpty(config.displayValue()))
                              .map((config) => `${config.key}=${config.displayValue()}`)
                              .join(",");
     return `[${configValues}]`;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.tsx
@@ -17,6 +17,7 @@
 import {ErrorResponse} from "helpers/api_request_builder";
 import m from "mithril";
 import Stream from "mithril/stream";
+import {Scms} from "models/materials/pluggable_scm";
 import {Material} from "models/materials/types";
 import {PackageRepositories} from "models/package_repositories/package_repositories";
 import {Materials} from "models/pipeline_configs/pipeline_config";
@@ -34,15 +35,17 @@ export class MaterialModal extends Modal {
   private readonly errorMessage: Stream<string>;
   private readonly pluginInfos: Stream<PluginInfos>;
   private readonly packageRepositories: Stream<PackageRepositories>;
+  private readonly pluggableScms: Stream<Scms>;
   private readonly pipelineConfigSave: () => Promise<any>;
   private readonly isNew: boolean;
 
-  constructor(title: string, entity: Stream<Material>, materials: Stream<Materials>,
+  constructor(title: string, entity: Stream<Material>, materials: Stream<Materials>, scms: Stream<Scms>,
               packages: Stream<PackageRepositories>, pluginInfos: Stream<PluginInfos>,
               pipelineConfigSave: () => Promise<any>, isNew: boolean) {
     super(Size.large);
     this.__title             = title;
     this.entity              = entity;
+    this.pluggableScms       = scms;
     this.materials           = materials;
     this.packageRepositories = packages;
     this.pluginInfos         = pluginInfos;
@@ -51,16 +54,16 @@ export class MaterialModal extends Modal {
     this.errorMessage        = Stream();
   }
 
-  static forAdd(materials: Stream<Materials>, packageRepositories: Stream<PackageRepositories>,
+  static forAdd(materials: Stream<Materials>, scms: Stream<Scms>, packageRepositories: Stream<PackageRepositories>,
                 pluginInfos: Stream<PluginInfos>, onSuccessfulAdd: () => Promise<any>) {
-    return new MaterialModal("Add material", Stream(new Material("git")), materials, packageRepositories, pluginInfos, onSuccessfulAdd, true);
+    return new MaterialModal("Add material", Stream(new Material("git")), materials, scms, packageRepositories, pluginInfos, onSuccessfulAdd, true);
   }
 
-  static forEdit(material: Material, materials: Stream<Materials>,
+  static forEdit(material: Material, materials: Stream<Materials>, scms: Stream<Scms>,
                  packageRepositories: Stream<PackageRepositories>, pluginInfos: Stream<PluginInfos>,
                  pipelineConfigSave: () => Promise<any>) {
     const title = `Edit material - ${s.capitalize(material.type()!)}`;
-    return new MaterialModal(title, Stream(material), materials, packageRepositories, pluginInfos, pipelineConfigSave, false);
+    return new MaterialModal(title, Stream(material), materials, scms, packageRepositories, pluginInfos, pipelineConfigSave, false);
   }
 
   title(): string {
@@ -71,7 +74,7 @@ export class MaterialModal extends Modal {
     return <div>
       <FlashMessage type={MessageType.alert} message={this.errorMessage()}/>
       <MaterialEditor material={this.entity()} showExtraMaterials={true} disabledMaterialTypeSelection={!this.isNew}
-                      packageRepositories={this.packageRepositories()} pluginInfos={this.pluginInfos()}/>
+                      pluggableScms={this.pluggableScms()} packageRepositories={this.packageRepositories()} pluginInfos={this.pluginInfos()}/>
     </div>;
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_tab_content.tsx
@@ -33,9 +33,9 @@ import {MaterialsWidget} from "./materials_widget";
 
 export class MaterialsTabContent extends TabContent<PipelineConfig> {
   private readonly pluginInfos: Stream<PluginInfos>                 = Stream(new PluginInfos());
-  private readonly packageRepositories: Stream<PackageRepositories> = Stream();
-  private readonly packages: Stream<Packages>                       = Stream();
-  private readonly scmMaterials: Stream<Scms>                       = Stream();
+  private readonly packageRepositories: Stream<PackageRepositories> = Stream(new PackageRepositories());
+  private readonly packages: Stream<Packages>                       = Stream(new Packages());
+  private readonly scmMaterials: Stream<Scms>                       = Stream(new Scms());
 
   constructor() {
     super();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_tab_content.tsx
@@ -29,6 +29,7 @@ import {PluginInfoCRUD} from "models/shared/plugin_infos_new/plugin_info_crud";
 import {FlashMessageModelWithTimeout} from "views/components/flash_message";
 import {PipelineConfigRouteParams} from "views/pages/clicky_pipeline_config/pipeline_config";
 import {TabContent} from "views/pages/clicky_pipeline_config/tabs/tab_content";
+import {PackageRepositoriesPage} from "views/pages/package_repositories";
 import {MaterialsWidget} from "./materials_widget";
 
 export class MaterialsTabContent extends TabContent<PipelineConfig> {
@@ -61,8 +62,9 @@ export class MaterialsTabContent extends TabContent<PipelineConfig> {
   }
 
   protected renderer(entity: PipelineConfig, templateConfig: TemplateConfig, flashMessage: FlashMessageModelWithTimeout, pipelineConfigSave: () => Promise<any>, pipelineConfigReset: () => any) {
+    const mergedPkgRepos = PackageRepositoriesPage.getMergedList(this.packageRepositories, this.packages);
     return <MaterialsWidget materials={entity.materials} pluginInfos={this.pluginInfos} flashMessage={flashMessage}
-                            packageRepositories={this.packageRepositories} packages={this.packages}
+                            packageRepositories={Stream(mergedPkgRepos)} packages={this.packages}
                             scmMaterials={this.scmMaterials} pipelineConfigSave={pipelineConfigSave}/>;
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_widget.tsx
@@ -16,6 +16,7 @@
 
 import {ErrorResponse} from "helpers/api_request_builder";
 import {MithrilViewComponent} from "jsx/mithril-component";
+import _ from "lodash";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {Scms} from "models/materials/pluggable_scm";
@@ -100,30 +101,30 @@ export class MaterialsWidget extends MithrilViewComponent<MaterialsAttrs> {
 
   private getMaterialUrlForDisplay(material: Material, vnode: m.Vnode<MaterialsAttrs, this>) {
     const url = material.materialUrl();
-    if (url.length === 0 && material.type() === "package") {
+    if (url.length === 0 && material.type() === "package" && !_.isEmpty(vnode.attrs.packages())) {
       const attrs   = material.attributes() as PackageMaterialAttributes;
-      const pkgInfo = vnode.attrs.packages().find((pkg) => pkg.id() === attrs.ref())!;
-      return `Repository: ${pkgInfo.packageRepo().name()} - Package: ${pkgInfo.name()} ${pkgInfo.configuration().asString()}`;
+      const pkgInfo = vnode.attrs.packages().find((pkg) => pkg.id() === attrs.ref());
+      return pkgInfo === undefined ? "" : `Repository: ${pkgInfo.packageRepo().name()} - Package: ${pkgInfo.name()} ${pkgInfo.configuration().asString()}`;
     }
-    if (url.length === 0 && material.type() === "plugin") {
+    if (url.length === 0 && material.type() === "plugin" && !_.isEmpty(vnode.attrs.scmMaterials())) {
       const attrs       = material.attributes() as PluggableScmMaterialAttributes;
-      const scmMaterial = vnode.attrs.scmMaterials().find((pkg) => pkg.id() === attrs.ref())!;
-      return `${scmMaterial.name()}: ${scmMaterial.configuration().asString()}`;
+      const scmMaterial = vnode.attrs.scmMaterials().find((pkg) => pkg.id() === attrs.ref());
+      return scmMaterial === undefined ? "" : `${scmMaterial.name()}: ${scmMaterial.configuration().asString()}`;
     }
     return url;
   }
 
   private getMaterialDisplayName(material: Material, vnode: m.Vnode<MaterialsAttrs, this>) {
     const displayName = material.displayName();
-    if (displayName.length === 0 && material.type() === "package") {
+    if (displayName.length === 0 && material.type() === "package" && !_.isEmpty(vnode.attrs.packages())) {
       const attrs   = material.attributes() as PackageMaterialAttributes;
-      const pkgInfo = vnode.attrs.packages().find((pkg) => pkg.id() === attrs.ref())!;
-      return `${pkgInfo.packageRepo().name()}_${pkgInfo.name()}`;
+      const pkgInfo = vnode.attrs.packages().find((pkg) => pkg.id() === attrs.ref());
+      return pkgInfo === undefined ? "" : `${pkgInfo.packageRepo().name()}_${pkgInfo.name()}`;
     }
-    if (displayName.length === 0 && material.type() === "plugin") {
+    if (displayName.length === 0 && material.type() === "plugin" && !_.isEmpty(vnode.attrs.scmMaterials())) {
       const attrs       = material.attributes() as PluggableScmMaterialAttributes;
-      const scmMaterial = vnode.attrs.scmMaterials().find((pkg) => pkg.id() === attrs.ref())!;
-      return scmMaterial.name();
+      const scmMaterial = vnode.attrs.scmMaterials().find((pkg) => pkg.id() === attrs.ref());
+      return scmMaterial === undefined ? "" : scmMaterial.name();
     }
     return displayName;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_widget.tsx
@@ -54,12 +54,12 @@ export class MaterialsWidget extends MithrilViewComponent<MaterialsAttrs> {
 
   private addMaterial(vnode: m.Vnode<MaterialsAttrs, this>, e: MouseEvent) {
     e.stopPropagation();
-    MaterialModal.forAdd(vnode.attrs.materials, vnode.attrs.packageRepositories, vnode.attrs.pluginInfos, vnode.attrs.pipelineConfigSave).render();
+    MaterialModal.forAdd(vnode.attrs.materials, vnode.attrs.scmMaterials, vnode.attrs.packageRepositories, vnode.attrs.pluginInfos, vnode.attrs.pipelineConfigSave).render();
   }
 
   private updateMaterial(vnode: m.Vnode<MaterialsAttrs, this>, materialToUpdate: Material, e: MouseEvent) {
     e.stopPropagation();
-    MaterialModal.forEdit(materialToUpdate, vnode.attrs.materials, vnode.attrs.packageRepositories, vnode.attrs.pluginInfos, vnode.attrs.pipelineConfigSave).render();
+    MaterialModal.forEdit(materialToUpdate, vnode.attrs.materials, vnode.attrs.scmMaterials, vnode.attrs.packageRepositories, vnode.attrs.pluginInfos, vnode.attrs.pipelineConfigSave).render();
   }
 
   private deleteMaterial(vnode: m.Vnode<MaterialsAttrs, this>, materialToRemove: Material, e: MouseEvent) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories.tsx
@@ -18,29 +18,17 @@ import {ErrorResponse} from "helpers/api_request_builder";
 import _ from "lodash";
 import m from "mithril";
 import Stream from "mithril/stream";
-import {
-  Package,
-  PackageRepositories,
-  PackageRepository,
-  PackageRepositorySummary,
-  Packages
-} from "models/package_repositories/package_repositories";
 import {PackagesCRUD} from "models/package_repositories/packages_crud";
+import {Package, PackageRepositories, PackageRepository, PackageRepositorySummary, Packages} from "models/package_repositories/package_repositories";
 import {PackageRepositoriesCRUD} from "models/package_repositories/package_repositories_crud";
 import {ExtensionTypeString, PackageRepoExtensionType} from "models/shared/plugin_infos_new/extension_type";
 import {PluginInfoCRUD} from "models/shared/plugin_infos_new/plugin_info_crud";
 import {ButtonIcon, Primary} from "views/components/buttons";
 import {FlashMessage, MessageType} from "views/components/flash_message";
-import {HeaderPanel} from "views/components/header_panel";
 import {SearchField} from "views/components/forms/input_fields";
+import {HeaderPanel} from "views/components/header_panel";
 import {NoPluginsOfTypeInstalled} from "views/components/no_plugins_installed";
 import configRepoStyles from "views/pages/config_repos/index.scss";
-import {
-  ClonePackageRepositoryModal,
-  CreatePackageRepositoryModal,
-  DeletePackageRepositoryModal,
-  EditPackageRepositoryModal
-} from "views/pages/package_repositories/package_repository_modals";
 import {PackageRepositoriesWidget} from "views/pages/package_repositories/package_repositories_widget";
 import {
   ClonePackageRepositoryModal,
@@ -50,13 +38,7 @@ import {
 } from "views/pages/package_repositories/package_repository_modals";
 import {Page, PageState} from "views/pages/page";
 import {RequiresPluginInfos, SaveOperation} from "views/pages/page_operations";
-import {
-  ClonePackageModal,
-  CreatePackageModal,
-  DeletePackageModal,
-  EditPackageModal,
-  UsagePackageModal
-} from "./package_repositories/package_modals";
+import {ClonePackageModal, CreatePackageModal, DeletePackageModal, EditPackageModal, UsagePackageModal} from "./package_repositories/package_modals";
 
 export class PackageRepoOperations {
   onAdd: (e: MouseEvent) => void                            = () => _.noop;
@@ -99,7 +81,7 @@ export class PackageRepositoriesPage extends Page<null, State> {
         if (completePkg !== undefined) {
           pkg.autoUpdate(completePkg.autoUpdate());
           pkg.configuration(completePkg.configuration());
-          pkg.packageRepo(new PackageRepositorySummary(pkgRepo.repoId(), pkgRepo.name()))
+          pkg.packageRepo(new PackageRepositorySummary(pkgRepo.repoId(), pkgRepo.name()));
         }
       });
     });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_widget.tsx
@@ -37,15 +37,18 @@ export class PackageRepositoryWidget extends MithrilViewComponent<Attrs> {
 
   public static getPkgRepoDetails(packageRepository: PackageRepository) {
     const pkgRepoProperties = packageRepository.configuration() ? packageRepository.configuration()!.asMap() : [];
-    return new Map([
-                     ["Repo Id", packageRepository.repoId()],
-                     ["Plugin Id", packageRepository.pluginMetadata().id()],
-                     ...Array.from(pkgRepoProperties)
-                   ]);
+    const pkgRepoDetails    = new Map([
+                                        ["Repo Id", packageRepository.repoId()],
+                                        ["Plugin Id", packageRepository.pluginMetadata().id()],
+                                        ...Array.from(pkgRepoProperties)
+                                      ]);
+    return pkgRepoDetails;
   }
 
   view(vnode: m.Vnode<Attrs, this>): m.Children | void | null {
-    const header            = <KeyValuePair inline={true} data={PackageRepositoryWidget.headerMap(vnode.attrs.packageRepository)}/>;
+    const header = <KeyValuePair inline={true}
+                                 data={PackageRepositoryWidget.headerMap(vnode.attrs.packageRepository)}/>;
+
     const packageRepository = vnode.attrs.packageRepository;
     const pkgRepoDetails    = PackageRepositoryWidget.getPkgRepoDetails(packageRepository);
     const disabled          = vnode.attrs.disableActions;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_widget.tsx
@@ -64,6 +64,7 @@ export class PackageRepositoryWidget extends MithrilViewComponent<Attrs> {
                  icon={ButtonIcon.ADD}>
         Create Package
       </Secondary>,
+
       <div className={styles.packageRepositoryCrudActions}>
         <IconGroup>
           <Edit data-test-id="package-repo-edit"
@@ -78,7 +79,8 @@ export class PackageRepositoryWidget extends MithrilViewComponent<Attrs> {
                   title={PackageRepositoryWidget.getMsgForOperation(disabled, packageRepository.name(), "delete")}
                   onclick={vnode.attrs.onDelete.bind(vnode.attrs, packageRepository)}/>
         </IconGroup>
-      </div>];
+      </div>
+    ];
 
     return <CollapsiblePanel key={vnode.attrs.packageRepository.repoId()}
                              header={header} error={disabled}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines.tsx
@@ -18,55 +18,77 @@
 import {queryParamAsString} from "helpers/url";
 import _ from "lodash";
 import m from "mithril";
-import {EnvironmentVariablesWidget} from "views/components/environment_variables";
-import {Page, PageState} from "views/pages/page";
-
-// models
-import {PipelineConfigVM} from "views/pages/pipelines/pipeline_config_view_model";
-
+import Stream from "mithril/stream";
+import {Scms} from "models/materials/pluggable_scm";
+import {PluggableScmCRUD} from "models/materials/pluggable_scm_crud";
+import {PackagesCRUD} from "models/package_repositories/packages_crud";
+import {PackageRepositories, Packages} from "models/package_repositories/package_repositories";
+import {PackageRepositoriesCRUD} from "models/package_repositories/package_repositories_crud";
+import {ExtensionTypeString} from "models/shared/plugin_infos_new/extension_type";
+import {PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {PluginInfoCRUD} from "models/shared/plugin_infos_new/plugin_info_crud";
 // components
 import {ConceptDiagram} from "views/components/concept_diagram";
+import {EnvironmentVariablesWidget} from "views/components/environment_variables";
+import {Page, PageState} from "views/pages/page";
 import {PipelineActions} from "views/pages/pipelines/actions";
 import {AdvancedSettings} from "views/pages/pipelines/advanced_settings";
 import {FillableSection} from "views/pages/pipelines/fillable_section";
 import {JobEditor} from "views/pages/pipelines/job_editor";
 import {MaterialEditor} from "views/pages/pipelines/material_editor";
+// models
+import {PipelineConfigVM} from "views/pages/pipelines/pipeline_config_view_model";
 import {PipelineInfoEditor} from "views/pages/pipelines/pipeline_info_editor";
 import {StageEditor} from "views/pages/pipelines/stage_editor";
 import {TaskTerminalField} from "views/pages/pipelines/task_editor";
 import {UserInputPane} from "views/pages/pipelines/user_input_pane";
+import {PackageRepositoriesPage} from "./package_repositories";
 
 const materialImg = require("../../../app/assets/images/concept_diagrams/concept_material.svg");
 const pipelineImg = require("../../../app/assets/images/concept_diagrams/concept_pipeline.svg");
 const stageImg    = require("../../../app/assets/images/concept_diagrams/concept_stage.svg");
 const jobImg      = require("../../../app/assets/images/concept_diagrams/concept_job.svg");
 
-export class PipelineCreatePage extends Page {
+interface State {
+  pluginInfos: Stream<PluginInfos>;
+  packageRepositories: Stream<PackageRepositories>;
+  packages: Stream<Packages>;
+  scmMaterials: Stream<Scms>;
+}
+
+export class PipelineCreatePage extends Page<{}, State> {
   private model = new PipelineConfigVM();
 
   pageName(): string {
     return "Add a New Pipeline";
   }
 
-  oninit(vnode: m.Vnode) {
-    this.pageState = PageState.OK;
+  oninit(vnode: m.Vnode<{}, State>) {
+    super.oninit(vnode);
     const group = queryParamAsString(window.location.search, "group").trim();
 
     if ("" !== group) {
       this.model.pipeline.group(group);
     }
+
+    vnode.state.pluginInfos         = Stream(new PluginInfos());
+    vnode.state.packageRepositories = Stream();
+    vnode.state.packages            = Stream();
+    vnode.state.scmMaterials        = Stream();
   }
 
-  componentToDisplay(vnode: m.Vnode): m.Children {
-    const { pipeline, material, stage, job, isUsingTemplate } = this.model;
-
+  componentToDisplay(vnode: m.Vnode<{}, State>): m.Children {
+    const {pipeline, material, stage, job, isUsingTemplate} = this.model;
+    const mergedPkgRepos                                    = PackageRepositoriesPage.getMergedList(vnode.state.packageRepositories, vnode.state.packages);
     return [
       <FillableSection>
         <UserInputPane heading="Part 1: Material">
-          <MaterialEditor material={material}/>
+          <MaterialEditor material={material} showExtraMaterials={true} pluggableScms={vnode.state.scmMaterials()}
+                          packageRepositories={mergedPkgRepos} pluginInfos={vnode.state.pluginInfos()}/>
         </UserInputPane>
         <ConceptDiagram image={materialImg}>
-          A <strong>material</strong> triggers your pipeline to run. Typically this is a <strong>source repository</strong> or an <strong>upStream pipeline</strong>.
+          A <strong>material</strong> triggers your pipeline to run. Typically this is a <strong>source repository</strong> or an <strong>upStream
+          pipeline</strong>.
         </ConceptDiagram>
       </FillableSection>,
 
@@ -75,14 +97,15 @@ export class PipelineCreatePage extends Page {
           <PipelineInfoEditor pipelineConfig={pipeline} isUsingTemplate={isUsingTemplate}/>
         </UserInputPane>
         <ConceptDiagram image={pipelineImg}>
-          In GoCD, a <strong>pipeline</strong> is a representation of a <strong>workflow</strong>. Pipelines consist of one or more <strong>stages</strong>.
+          In GoCD, a <strong>pipeline</strong> is a representation of a <strong>workflow</strong>. Pipelines consist of one or
+          more <strong>stages</strong>.
         </ConceptDiagram>
       </FillableSection>,
 
       this.model.whenTemplateAbsent(() => [
         <FillableSection>
           <UserInputPane heading="Part 3: Stage Details">
-            <StageEditor stage={stage} />
+            <StageEditor stage={stage}/>
           </UserInputPane>
           <ConceptDiagram image={stageImg}>
             A <strong>stage</strong> is a group of jobs, and a <strong>job</strong> is a piece of work to execute.
@@ -92,13 +115,15 @@ export class PipelineCreatePage extends Page {
         <FillableSection>
           <UserInputPane heading="Part 4: Job and Tasks">
             <JobEditor job={job}/>
-            <TaskTerminalField label="Type your tasks below at the prompt" property={job.tasks} errorText={job.errors().errorsForDisplay("tasks")} required={true}/>
+            <TaskTerminalField label="Type your tasks below at the prompt" property={job.tasks} errorText={job.errors().errorsForDisplay("tasks")}
+                               required={true}/>
             <AdvancedSettings forceOpen={_.some(job.environmentVariables(), (env) => env.errors().hasErrors())}>
               <EnvironmentVariablesWidget environmentVariables={job.environmentVariables()}/>
             </AdvancedSettings>
           </UserInputPane>
           <ConceptDiagram image={jobImg}>
-            A <strong>job</strong> is like a script, where each sequential step is called a <strong>task</strong>. Typically, a task is a single command.
+            A <strong>job</strong> is like a script, where each sequential step is called a <strong>task</strong>. Typically, a task is a single
+            command.
           </ConceptDiagram>
         </FillableSection>
       ]),
@@ -107,7 +132,30 @@ export class PipelineCreatePage extends Page {
     ];
   }
 
-  fetchData(vnode: m.Vnode): Promise<any> {
-    return new Promise(() => null);
+  fetchData(vnode: m.Vnode<{}, State>): Promise<any> {
+    return Promise.all([PluginInfoCRUD.all({type: ExtensionTypeString.PACKAGE_REPO}), PluginInfoCRUD.all({type: ExtensionTypeString.SCM}),
+                         PackageRepositoriesCRUD.all(), PackagesCRUD.all(), PluggableScmCRUD.all()])
+                  .then((result) => {
+                    [result[0], result[1]]
+                      .forEach((apiResult) => apiResult.do((successResponse) => {
+                        vnode.state.pluginInfos().push(...successResponse.body);
+                        this.pageState = PageState.OK;
+                      }, this.setErrorState));
+
+                    result[2].do((successResponse) => {
+                      vnode.state.packageRepositories(successResponse.body);
+                      this.pageState = PageState.OK;
+                    }, this.setErrorState);
+
+                    result[3].do((successResponse) => {
+                      vnode.state.packages(successResponse.body);
+                      this.pageState = PageState.OK;
+                    }, this.setErrorState);
+
+                    result[4].do((successResponse) => {
+                      vnode.state.scmMaterials(successResponse.body);
+                      this.pageState = PageState.OK;
+                    }, this.setErrorState);
+                  });
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss
@@ -70,5 +70,9 @@
     td {
       vertical-align: top;
     }
+
+    .space-between {
+      padding-right: 25px;
+    }
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss
@@ -62,6 +62,13 @@
   }
 }
 
-.form-error-text{
-  color: $form-failed-color;
+.package-fields {
+  table {
+    width:        100%;
+    table-layout: fixed;
+
+    td {
+      vertical-align: top;
+    }
+  }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss
@@ -76,3 +76,12 @@
     }
   }
 }
+
+.material-selection-container {
+  display:     flex;
+  align-items: center;
+
+  .message {
+    margin-left: 10px;
+  }
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss.d.ts
@@ -25,6 +25,7 @@ export const inputSmall: string;
 export const last: string;
 export const lockOpen: string;
 export const open: string;
+export const packageFields: string;
 export const quickAddButton: string;
 export const radioField: string;
 export const radioLabel: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss.d.ts
@@ -32,6 +32,7 @@ export const radioLabel: string;
 export const searchBoxInput: string;
 export const searchBoxWrapper: string;
 export const searchButton: string;
+export const spaceBetween: string;
 export const summary: string;
 export const textArea: string;
 export const textareaFixed: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss.d.ts
@@ -24,6 +24,8 @@ export const inputMedium: string;
 export const inputSmall: string;
 export const last: string;
 export const lockOpen: string;
+export const materialSelectionContainer: string;
+export const message: string;
 export const open: string;
 export const packageFields: string;
 export const quickAddButton: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import {SparkRoutes} from "helpers/spark_routes";
 import {MithrilViewComponent} from "jsx/mithril-component";
+import _ from "lodash";
 import m from "mithril";
 import {Filter} from "models/maintenance_mode/material";
 import {Scms} from "models/materials/pluggable_scm";
@@ -24,15 +26,19 @@ import {
   HgMaterialAttributes,
   Material,
   P4MaterialAttributes,
-  PackageMaterialAttributes, PluggableScmMaterialAttributes,
+  PackageMaterialAttributes,
+  PluggableScmMaterialAttributes,
   SvnMaterialAttributes,
   TfsMaterialAttributes
 } from "models/materials/types";
 import {PackageRepositories} from "models/package_repositories/package_repositories";
-import {ExtensionTypeString} from "models/shared/plugin_infos_new/extension_type";
+import {ExtensionTypeString, PackageRepoExtensionType, SCMExtensionType} from "models/shared/plugin_infos_new/extension_type";
 import {PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {FlashMessage, MessageType} from "views/components/flash_message";
 import {Form, FormBody} from "views/components/forms/form";
 import {Option, SelectField, SelectFieldOptions} from "views/components/forms/input_fields";
+import {Link} from "views/components/link";
+import styles from "./advanced_settings.scss";
 import {DefaultCache, DependencyFields, PackageFields, PluginFields, SuggestionCache} from "./non_scm_material_fields";
 import {GitFields, HgFields, P4Fields, SvnFields, TfsFields} from "./scm_material_fields";
 
@@ -72,10 +78,15 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
     }
 
     return <FormBody>
-      <SelectField label="Material Type" property={vnode.attrs.material.type} required={true}
-                   readonly={vnode.attrs.disabled || vnode.attrs.disabledMaterialTypeSelection}>
-        <SelectFieldOptions selected={vnode.attrs.material.type()} items={supportedMaterials}/>
-      </SelectField>
+      <div className={styles.materialSelectionContainer}>
+        <SelectField label="Material Type" property={vnode.attrs.material.type} required={true}
+                     readonly={vnode.attrs.disabled || vnode.attrs.disabledMaterialTypeSelection}>
+          <SelectFieldOptions selected={vnode.attrs.material.type()} items={supportedMaterials}/>
+        </SelectField>
+        <div className={styles.message}>
+          {this.message(attrs.material, attrs.pluginInfos)}
+        </div>
+      </div>
 
       <Form last={true} compactForm={true}>
         {this.fieldsForType(attrs.material, this.cache, showLocalWorkingCopyOptions, hideTestConnection, attrs.disabled, attrs.packageRepositories, attrs.pluginInfos, attrs.pluggableScms)}
@@ -141,21 +152,53 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
         if (!(material.attributes() instanceof PackageMaterialAttributes)) {
           material.attributes(new PackageMaterialAttributes(undefined, true, ""));
         }
-        packageRepositories = packageRepositories === undefined ? new PackageRepositories() : packageRepositories;
-        pluginInfos         = pluginInfos === undefined ? new PluginInfos()
+        pluginInfos = pluginInfos === undefined ? new PluginInfos()
           : pluginInfos!.filterForExtension(ExtensionTypeString.PACKAGE_REPO);
+        if (_.isEmpty(pluginInfos)) {
+          return <FlashMessage type={MessageType.warning}>
+            There are no Package Repository plugins installed. Please see <Link href={new PackageRepoExtensionType().linkForDocs()} target="_blank"
+                                                                                externalLinkIcon={true}>this page</Link> for a list of supported
+            plugins.
+          </FlashMessage>;
+        }
+        packageRepositories = packageRepositories === undefined ? new PackageRepositories() : packageRepositories;
         return <PackageFields material={material}
                               packageRepositories={packageRepositories} pluginInfos={pluginInfos}/>;
       case "plugin":
         if (!(material.attributes() instanceof PluggableScmMaterialAttributes)) {
           material.attributes(new PluggableScmMaterialAttributes(undefined, true, "", "", new Filter([])));
         }
-        scms        = scms === undefined ? new Scms() : scms;
         pluginInfos = pluginInfos === undefined ? new PluginInfos()
           : pluginInfos!.filterForExtension(ExtensionTypeString.SCM);
+        if (_.isEmpty(pluginInfos)) {
+          return <FlashMessage type={MessageType.warning}>
+            There are no SCM plugins installed. Please see <Link href={new SCMExtensionType().linkForDocs()} target="_blank"
+                                                                 externalLinkIcon={true}>this page</Link> for a list of supported plugins.
+          </FlashMessage>;
+        }
+        scms = scms === undefined ? new Scms() : scms;
         return <PluginFields material={material} showLocalWorkingCopyOptions={showLocalWorkingCopyOptions}
-                              scms={scms} pluginInfos={pluginInfos}/>;
+                             scms={scms} pluginInfos={pluginInfos}/>;
       default:
+        break;
+    }
+  }
+
+  private message(material: Material, pluginInfos?: PluginInfos) {
+    switch (material.type()) {
+      case "package":
+        const packagePlugins = pluginInfos === undefined ? new PluginInfos()
+          : pluginInfos!.filterForExtension(ExtensionTypeString.PACKAGE_REPO);
+        if (!_.isEmpty(packagePlugins)) {
+          return <span data-test-id="package-msg"><Link href={SparkRoutes.packageRepositoriesSPA()}>Create New</Link> or select existing packages below.</span>;
+        }
+        break;
+      case "plugin":
+        const scmPlugins = pluginInfos === undefined ? new PluginInfos()
+          : pluginInfos!.filterForExtension(ExtensionTypeString.SCM);
+        if (!_.isEmpty(scmPlugins)) {
+          return <span data-test-id="plugin-msg"><Link href={SparkRoutes.pluggableScmSPA()}>Create New</Link> or select existing scms below.</span>;
+        }
         break;
     }
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
@@ -16,13 +16,15 @@
 
 import {MithrilViewComponent} from "jsx/mithril-component";
 import m from "mithril";
+import {Filter} from "models/maintenance_mode/material";
+import {Scms} from "models/materials/pluggable_scm";
 import {
   DependencyMaterialAttributes,
   GitMaterialAttributes,
   HgMaterialAttributes,
   Material,
   P4MaterialAttributes,
-  PackageMaterialAttributes,
+  PackageMaterialAttributes, PluggableScmMaterialAttributes,
   SvnMaterialAttributes,
   TfsMaterialAttributes
 } from "models/materials/types";
@@ -31,7 +33,7 @@ import {ExtensionTypeString} from "models/shared/plugin_infos_new/extension_type
 import {PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {Form, FormBody} from "views/components/forms/form";
 import {Option, SelectField, SelectFieldOptions} from "views/components/forms/input_fields";
-import {DefaultCache, DependencyFields, PackageFields, SuggestionCache} from "./non_scm_material_fields";
+import {DefaultCache, DependencyFields, PackageFields, PluginFields, SuggestionCache} from "./non_scm_material_fields";
 import {GitFields, HgFields, P4Fields, SvnFields, TfsFields} from "./scm_material_fields";
 
 interface Attrs {
@@ -45,6 +47,7 @@ interface Attrs {
   showExtraMaterials?: boolean;
   packageRepositories?: PackageRepositories;
   pluginInfos?: PluginInfos;
+  pluggableScms?: Scms;
 }
 
 export class MaterialEditor extends MithrilViewComponent<Attrs> {
@@ -65,6 +68,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
     const supportedMaterials: Array<Option | string> = this.supportedMaterials(scmOnly);
     if (!!attrs.showExtraMaterials) {
       supportedMaterials.push({id: "package", text: "Package"});
+      supportedMaterials.push({id: "plugin", text: "SCM"});
     }
 
     return <FormBody>
@@ -74,7 +78,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
       </SelectField>
 
       <Form last={true} compactForm={true}>
-        {this.fieldsForType(attrs.material, this.cache, showLocalWorkingCopyOptions, hideTestConnection, attrs.disabled, attrs.packageRepositories, attrs.pluginInfos)}
+        {this.fieldsForType(attrs.material, this.cache, showLocalWorkingCopyOptions, hideTestConnection, attrs.disabled, attrs.packageRepositories, attrs.pluginInfos, attrs.pluggableScms)}
       </Form>
     </FormBody>;
   }
@@ -95,7 +99,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
     return options;
   }
 
-  fieldsForType(material: Material, cacheable: SuggestionCache, showLocalWorkingCopyOptions: boolean, hideTestConnection: boolean, disabled?: boolean, packageRepositories?: PackageRepositories, pluginInfos?: PluginInfos): m.Children {
+  fieldsForType(material: Material, cacheable: SuggestionCache, showLocalWorkingCopyOptions: boolean, hideTestConnection: boolean, disabled?: boolean, packageRepositories?: PackageRepositories, pluginInfos?: PluginInfos, scms?: Scms): m.Children {
     switch (material.type()) {
       case "git":
         if (!(material.attributes() instanceof GitMaterialAttributes)) {
@@ -142,6 +146,15 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
           : pluginInfos!.filterForExtension(ExtensionTypeString.PACKAGE_REPO);
         return <PackageFields material={material}
                               packageRepositories={packageRepositories} pluginInfos={pluginInfos}/>;
+      case "plugin":
+        if (!(material.attributes() instanceof PluggableScmMaterialAttributes)) {
+          material.attributes(new PluggableScmMaterialAttributes(undefined, true, "", "", new Filter([])));
+        }
+        scms        = scms === undefined ? new Scms() : scms;
+        pluginInfos = pluginInfos === undefined ? new PluginInfos()
+          : pluginInfos!.filterForExtension(ExtensionTypeString.SCM);
+        return <PluginFields material={material} showLocalWorkingCopyOptions={showLocalWorkingCopyOptions}
+                              scms={scms} pluginInfos={pluginInfos}/>;
       default:
         break;
     }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -358,6 +358,10 @@ export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
             </SelectField>
           </td>
         </tr>
+        <tr>
+          <td>{this.showSelectedPluginConfig(vnode)}</td>
+          <td>{this.showSelectedScmConfig(vnode)}</td>
+        </tr>
       </table>
       {this.advanced(attrs, showLocalWorkingCopyOptions)}
     </div>;
@@ -404,16 +408,16 @@ export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
     if (plugins.length === 1) {
       this.errorMessage       = <FlashMessage type={MessageType.alert}>
         There are no SCM plugins installed. Please see
-        <Link href={new SCMExtensionType().linkForDocs()} target="_blank" externalLinkIcon={true}> this page</Link> for a
-        list of supported plugins.
+        <Link href={new SCMExtensionType().linkForDocs()} target="_blank" externalLinkIcon={true}> this page</Link> for
+        a list of supported plugins.
       </FlashMessage>;
       this.disablePluginField = true;
       this.disableScmField    = true;
     }
+
     if (_.isEmpty(vnode.attrs.scms)) {
       this.errorMessage       = <FlashMessage type={MessageType.alert}>
-        There are no SCMs configured. Go to <Link href={SparkRoutes.pluggableScmSPA()}>Pluggable SCM</Link> to define
-        one.
+        There are no SCMs configured. Go to <Link href={SparkRoutes.pluggableScmSPA()}>Pluggable SCM</Link> to define one.
       </FlashMessage>;
       this.disablePluginField = true;
       this.disableScmField    = true;
@@ -425,6 +429,32 @@ export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
         <Link href={SparkRoutes.pluggableScmSPA()}> Pluggable SCM</Link> to define one.
       </FlashMessage>;
       this.disableScmField = true;
+    }
+  }
+
+  private showSelectedPluginConfig(vnode: m.Vnode<PluginAttrs, PluginState>) {
+    const selectedPlugin = vnode.attrs.pluginInfos.findByPluginId(vnode.state.pluginId());
+    if (selectedPlugin !== undefined) {
+      const data = new Map<string, string | m.Children>([
+                                                          ["Id", selectedPlugin.id],
+                                                          ["Name", selectedPlugin.about.name],
+                                                          ["Description", selectedPlugin.about.description],
+                                                        ]);
+      return <KeyValuePair data-test-id={"selected-plugin-details"} data={data}/>;
+    }
+  }
+
+  private showSelectedScmConfig(vnode: m.Vnode<PluginAttrs, PluginState>) {
+    const attrs       = vnode.attrs.material.attributes() as PluggableScmMaterialAttributes;
+    const selectedScm = vnode.attrs.scms.find((scm) => scm.id() === attrs.ref());
+    if (selectedScm !== undefined) {
+      const scmRepoDetails = new Map([
+                                       ["Id", selectedScm.id()],
+                                       ["Name", selectedScm.name()],
+                                       ["Plugin Id", selectedScm.pluginMetadata().id()],
+                                       ...Array.from(selectedScm.configuration().asMap())
+                                     ]);
+      return <KeyValuePair data-test-id={"selected-scm-details"} data={scmRepoDetails}/>;
     }
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -17,11 +17,22 @@
 import Awesomplete from "awesomplete";
 import {SparkRoutes} from "helpers/spark_routes";
 import {MithrilComponent} from "jsx/mithril-component";
+import _ from "lodash";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {DependencyMaterialAutocomplete, PipelineNameCache} from "models/materials/dependency_autocomplete_cache";
 import {DependencyMaterialAttributes, Material, MaterialAttributes, PackageMaterialAttributes} from "models/materials/types";
+import {Scms} from "models/materials/pluggable_scm";
+import {
+  DependencyMaterialAttributes,
+  Material,
+  MaterialAttributes,
+  PackageMaterialAttributes,
+  PluggableScmMaterialAttributes
+} from "models/materials/types";
 import {PackageRepositories, PackageRepository} from "models/package_repositories/package_repositories";
+import {SCMExtensionType} from "models/shared/plugin_infos_new/extension_type";
+import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
 import {PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {AutocompleteField, SuggestionProvider} from "views/components/forms/autocomplete";
@@ -29,11 +40,13 @@ import {Option, SelectField, SelectFieldOptions, TextField} from "views/componen
 import {KeyValuePair} from "views/components/key_value_pair";
 import {Link} from "views/components/link";
 import {SwitchBtn} from "views/components/switch";
+import * as Tooltip from "views/components/tooltip";
+import {TooltipSize} from "views/components/tooltip";
 import {PackageRepositoryWidget} from "views/pages/package_repositories/package_repository_widget";
 import {PackageWidget} from "views/pages/package_repositories/package_widget";
 import {AdvancedSettings} from "views/pages/pipelines/advanced_settings";
 import styles from "./advanced_settings.scss";
-import {IDENTIFIER_FORMAT_HELP_MESSAGE} from "./messages";
+import {DESTINATION_DIR_HELP_MESSAGE, IDENTIFIER_FORMAT_HELP_MESSAGE} from "./messages";
 
 interface Attrs {
   material: Material;
@@ -287,6 +300,131 @@ export class PackageFields extends MithrilComponent<PackageAttrs, PackageState> 
         return <KeyValuePair data-test-id={"selected-pkg-details"}
                              data={PackageWidget.getPkgDetails(selectedPkg)}/>;
       }
+    }
+  }
+}
+
+interface PluginAttrs {
+  material: Material;
+  scms: Scms;
+  pluginInfos: PluginInfos;
+  showLocalWorkingCopyOptions?: boolean;
+  disabled?: boolean;
+}
+
+interface PluginState {
+  pluginId: Stream<string>;
+  scmsForSelectedPlugin: Stream<Option[]>;
+}
+
+export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
+  readonly defaultScms                = [{id: "", text: "Select a scm"}];
+  private disablePluginField: boolean = false;
+  private disableScmField: boolean    = true;
+  private errorMessage?: m.Children   = undefined;
+
+  oninit(vnode: m.Vnode<PluginAttrs, PluginState>): any {
+    vnode.state.pluginId              = Stream("");
+    vnode.state.scmsForSelectedPlugin = Stream(this.defaultScms);
+  }
+
+  view(vnode: m.Vnode<PluginAttrs, PluginState>): m.Children | void | null {
+    const attrs                           = vnode.attrs.material.attributes() as PluggableScmMaterialAttributes;
+    const plugins: Array<Option | string> = [{id: "", text: "Select a plugin"}];
+    plugins.push(..._.map(vnode.attrs.pluginInfos, (pluginInfo: PluginInfo) => {
+      return {id: pluginInfo.id, text: pluginInfo.about.name};
+    }));
+    const readonly                    = !!vnode.attrs.disabled;
+    const showLocalWorkingCopyOptions = !!vnode.attrs.showLocalWorkingCopyOptions;
+    this.setErrorMessageIfApplicable(vnode, plugins);
+
+    return <div className={styles.packageFields}>
+      {this.errorMessage}
+      <table>
+        <tr>
+          <td>
+            <SelectField property={this.pluginIdProxy.bind(this, vnode)}
+                         label="SCM Plugin"
+                         errorText={attrs.errors().errorsForDisplay("pluginId")}
+                         required={true} readonly={readonly || this.disablePluginField}>
+              <SelectFieldOptions selected={vnode.state.pluginId()} items={plugins}/>
+            </SelectField>
+          </td>
+          <td>
+            <SelectField property={attrs.ref} label="SCM" required={true}
+                         errorText={attrs.errors().errorsForDisplay("ref")}
+                         readonly={readonly || this.disableScmField}>
+              <SelectFieldOptions selected={attrs.ref()} items={vnode.state.scmsForSelectedPlugin()}/>
+            </SelectField>
+          </td>
+        </tr>
+      </table>
+      {this.advanced(attrs, showLocalWorkingCopyOptions)}
+    </div>;
+  }
+
+  private pluginIdProxy(vnode: m.Vnode<PluginAttrs, PluginState>, pluginId?: string): any {
+    if (!pluginId) {
+      return vnode.state.pluginId();
+    }
+
+    vnode.state.pluginId(pluginId);
+    const scmsForPlugin = vnode.attrs.scms
+                               .filter((scm) => scm.pluginMetadata().id() === pluginId)
+                               .map((scm) => {
+                                 return {id: scm.id(), text: scm.name()};
+                               });
+    const scms          = this.defaultScms.concat(...scmsForPlugin);
+    vnode.state.scmsForSelectedPlugin(scms);
+    (vnode.attrs.material.attributes() as PluggableScmMaterialAttributes).ref("");
+    this.disableScmField = false;
+
+    return pluginId;
+  }
+
+  private advanced(attrs: PluggableScmMaterialAttributes, showLocalWorkingCopyOptions: boolean): m.Children {
+    if (showLocalWorkingCopyOptions) {
+      const labelForDestination = [
+        "Alternate Checkout Path",
+        " ",
+        <Tooltip.Help size={TooltipSize.medium} content={DESTINATION_DIR_HELP_MESSAGE}/>
+      ];
+      const forceOpen           = attrs.errors().hasErrors("name") || attrs.errors().hasErrors("destination");
+      return <AdvancedSettings forceOpen={forceOpen}>
+        <TextField label={labelForDestination} property={attrs.destination}
+                   errorText={attrs.errors().errorsForDisplay("destination")}/>
+        <TextField label="Material Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE}
+                   placeholder="A human-friendly label for this material" property={attrs.name}/>
+      </AdvancedSettings>;
+    }
+  }
+
+  private setErrorMessageIfApplicable(vnode: m.Vnode<PluginAttrs, PluginState>, plugins: Array<Option | string>) {
+    this.errorMessage = undefined;
+    if (plugins.length === 1) {
+      this.errorMessage       = <FlashMessage type={MessageType.alert}>
+        There are no SCM plugins installed. Please see
+        <Link href={new SCMExtensionType().linkForDocs()} target="_blank" externalLinkIcon={true}> this page</Link> for a
+        list of supported plugins.
+      </FlashMessage>;
+      this.disablePluginField = true;
+      this.disableScmField    = true;
+    }
+    if (_.isEmpty(vnode.attrs.scms)) {
+      this.errorMessage       = <FlashMessage type={MessageType.alert}>
+        There are no SCMs configured. Go to <Link href={SparkRoutes.pluggableScmSPA()}>Pluggable SCM</Link> to define
+        one.
+      </FlashMessage>;
+      this.disablePluginField = true;
+      this.disableScmField    = true;
+    }
+
+    if (vnode.state.pluginId().length > 0 && vnode.state.scmsForSelectedPlugin().length === 1) {
+      this.errorMessage    = <FlashMessage type={MessageType.alert}>
+        There are no SCMs configured for the selected plugin. Go to
+        <Link href={SparkRoutes.pluggableScmSPA()}> Pluggable SCM</Link> to define one.
+      </FlashMessage>;
+      this.disableScmField = true;
     }
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -31,9 +31,8 @@ import {
   PluggableScmMaterialAttributes
 } from "models/materials/types";
 import {PackageRepositories, PackageRepository} from "models/package_repositories/package_repositories";
-import {SCMExtensionType} from "models/shared/plugin_infos_new/extension_type";
-import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
-import {PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {PackageRepoExtensionType, SCMExtensionType} from "models/shared/plugin_infos_new/extension_type";
+import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {AutocompleteField, SuggestionProvider} from "views/components/forms/autocomplete";
 import {Option, SelectField, SelectFieldOptions, TextField} from "views/components/forms/input_fields";
@@ -220,7 +219,7 @@ export class PackageFields extends MithrilComponent<PackageAttrs, PackageState> 
           </td>
         </tr>
         <tr>
-          <td>{this.showSelectedPkgRepoConfig(vnode)}</td>
+          <td className={styles.spaceBetween}>{this.showSelectedPkgRepoConfig(vnode)}</td>
           <td>{this.showSelectedPkgConfig(vnode)}</td>
         </tr>
       </table>
@@ -229,6 +228,16 @@ export class PackageFields extends MithrilComponent<PackageAttrs, PackageState> 
 
   private setErrorMessageIfApplicable(vnode: m.Vnode<PackageAttrs, PackageState>, packageRepos: Array<Option | string>) {
     this.errorMessage = undefined;
+    if (vnode.attrs.pluginInfos.length === 0) {
+      this.errorMessage        = <FlashMessage type={MessageType.alert}>
+        There are no Package repository plugins installed. Please see
+        <Link href={new PackageRepoExtensionType().linkForDocs()} target="_blank" externalLinkIcon={true}> this page</Link> for
+        a list of supported plugins.
+      </FlashMessage>;
+      this.disablePkgRepoField = true;
+      this.disablePkgField     = true;
+    }
+
     if (packageRepos.length === 1) {
       this.errorMessage        = <FlashMessage type={MessageType.alert}>
         No package repositories defined. Go to <Link href={SparkRoutes.packageRepositoriesSPA()}>Package
@@ -236,6 +245,7 @@ export class PackageFields extends MithrilComponent<PackageAttrs, PackageState> 
       </FlashMessage>;
       this.disablePkgRepoField = true;
     }
+
     if (vnode.state.pkgRepoId().length > 0 && vnode.state.pkgs().length === 1) {
       this.errorMessage    = <FlashMessage type={MessageType.alert}>
         No packages defined for the selected package repository. Go to <Link
@@ -359,7 +369,7 @@ export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
           </td>
         </tr>
         <tr>
-          <td>{this.showSelectedPluginConfig(vnode)}</td>
+          <td className={styles.spaceBetween}>{this.showSelectedPluginConfig(vnode)}</td>
           <td>{this.showSelectedScmConfig(vnode)}</td>
         </tr>
       </table>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -389,8 +389,6 @@ export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
       return <AdvancedSettings forceOpen={forceOpen}>
         <TextField label={labelForDestination} property={attrs.destination}
                    errorText={attrs.errors().errorsForDisplay("destination")}/>
-        <TextField label="Material Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE}
-                   placeholder="A human-friendly label for this material" property={attrs.name}/>
       </AdvancedSettings>;
     }
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -15,13 +15,11 @@
  */
 
 import Awesomplete from "awesomplete";
-import {SparkRoutes} from "helpers/spark_routes";
 import {MithrilComponent} from "jsx/mithril-component";
 import _ from "lodash";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {DependencyMaterialAutocomplete, PipelineNameCache} from "models/materials/dependency_autocomplete_cache";
-import {DependencyMaterialAttributes, Material, MaterialAttributes, PackageMaterialAttributes} from "models/materials/types";
 import {Scms} from "models/materials/pluggable_scm";
 import {
   DependencyMaterialAttributes,
@@ -31,13 +29,11 @@ import {
   PluggableScmMaterialAttributes
 } from "models/materials/types";
 import {PackageRepositories, PackageRepository} from "models/package_repositories/package_repositories";
-import {PackageRepoExtensionType, SCMExtensionType} from "models/shared/plugin_infos_new/extension_type";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {AutocompleteField, SuggestionProvider} from "views/components/forms/autocomplete";
 import {Option, SelectField, SelectFieldOptions, TextField} from "views/components/forms/input_fields";
 import {KeyValuePair} from "views/components/key_value_pair";
-import {Link} from "views/components/link";
 import {SwitchBtn} from "views/components/switch";
 import * as Tooltip from "views/components/tooltip";
 import {TooltipSize} from "views/components/tooltip";
@@ -196,7 +192,7 @@ export class PackageFields extends MithrilComponent<PackageAttrs, PackageState> 
     packageRepos.push(...vnode.attrs.packageRepositories.map((packageRepo) => {
       return {id: packageRepo.repoId(), text: packageRepo.name()};
     }));
-    const readonly                    = !!vnode.attrs.disabled;
+    const readonly = !!vnode.attrs.disabled;
     this.setErrorMessageIfApplicable(vnode, packageRepos);
     return <div className={styles.packageFields}>
       {this.errorMessage}
@@ -228,28 +224,15 @@ export class PackageFields extends MithrilComponent<PackageAttrs, PackageState> 
 
   private setErrorMessageIfApplicable(vnode: m.Vnode<PackageAttrs, PackageState>, packageRepos: Array<Option | string>) {
     this.errorMessage = undefined;
-    if (vnode.attrs.pluginInfos.length === 0) {
-      this.errorMessage        = <FlashMessage type={MessageType.alert}>
-        There are no Package repository plugins installed. Please see
-        <Link href={new PackageRepoExtensionType().linkForDocs()} target="_blank" externalLinkIcon={true}> this page</Link> for
-        a list of supported plugins.
-      </FlashMessage>;
-      this.disablePkgRepoField = true;
-      this.disablePkgField     = true;
-    }
-
     if (packageRepos.length === 1) {
-      this.errorMessage        = <FlashMessage type={MessageType.alert}>
-        No package repositories defined. Go to <Link href={SparkRoutes.packageRepositoriesSPA()}>Package
-        Repositories</Link> to define one.
+      this.errorMessage        = <FlashMessage type={MessageType.warning}>
+        No package repositories defined.
       </FlashMessage>;
       this.disablePkgRepoField = true;
     }
-
     if (vnode.state.pkgRepoId().length > 0 && vnode.state.pkgs().length === 1) {
-      this.errorMessage    = <FlashMessage type={MessageType.alert}>
-        No packages defined for the selected package repository. Go to <Link
-        href={SparkRoutes.packageRepositoriesSPA()}>Package Repositories</Link> to define one.
+      this.errorMessage    = <FlashMessage type={MessageType.warning}>
+        No packages defined for the selected package repository.
       </FlashMessage>;
       this.disablePkgField = true;
     }
@@ -328,10 +311,9 @@ interface PluginState {
 }
 
 export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
-  readonly defaultScms                = [{id: "", text: "Select a scm"}];
-  private disablePluginField: boolean = false;
-  private disableScmField: boolean    = true;
-  private errorMessage?: m.Children   = undefined;
+  readonly defaultScms              = [{id: "", text: "Select a scm"}];
+  private disableScmField: boolean  = true;
+  private errorMessage?: m.Children = undefined;
 
   oninit(vnode: m.Vnode<PluginAttrs, PluginState>): any {
     vnode.state.pluginId              = Stream("");
@@ -356,7 +338,7 @@ export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
             <SelectField property={this.pluginIdProxy.bind(this, vnode)}
                          label="SCM Plugin"
                          errorText={attrs.errors().errorsForDisplay("pluginId")}
-                         required={true} readonly={readonly || this.disablePluginField}>
+                         required={true} readonly={readonly}>
               <SelectFieldOptions selected={vnode.state.pluginId()} items={plugins}/>
             </SelectField>
           </td>
@@ -415,28 +397,9 @@ export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
 
   private setErrorMessageIfApplicable(vnode: m.Vnode<PluginAttrs, PluginState>, plugins: Array<Option | string>) {
     this.errorMessage = undefined;
-    if (plugins.length === 1) {
-      this.errorMessage       = <FlashMessage type={MessageType.alert}>
-        There are no SCM plugins installed. Please see
-        <Link href={new SCMExtensionType().linkForDocs()} target="_blank" externalLinkIcon={true}> this page</Link> for
-        a list of supported plugins.
-      </FlashMessage>;
-      this.disablePluginField = true;
-      this.disableScmField    = true;
-    }
-
-    if (_.isEmpty(vnode.attrs.scms)) {
-      this.errorMessage       = <FlashMessage type={MessageType.alert}>
-        There are no SCMs configured. Go to <Link href={SparkRoutes.pluggableScmSPA()}>Pluggable SCM</Link> to define one.
-      </FlashMessage>;
-      this.disablePluginField = true;
-      this.disableScmField    = true;
-    }
-
     if (vnode.state.pluginId().length > 0 && vnode.state.scmsForSelectedPlugin().length === 1) {
-      this.errorMessage    = <FlashMessage type={MessageType.alert}>
-        There are no SCMs configured for the selected plugin. Go to
-        <Link href={SparkRoutes.pluggableScmSPA()}> Pluggable SCM</Link> to define one.
+      this.errorMessage    = <FlashMessage type={MessageType.warning}>
+        There are no SCMs configured for the selected plugin.
       </FlashMessage>;
       this.disableScmField = true;
     }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_editor_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_editor_spec.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {SparkRoutes} from "helpers/spark_routes";
 import m from "mithril";
 import {
   GitMaterialAttributes,
@@ -23,6 +24,9 @@ import {
   PluggableScmMaterialAttributes
 } from "models/materials/types";
 import {PackageRepositories} from "models/package_repositories/package_repositories";
+import {pluginInfoWithPackageRepositoryExtension} from "models/package_repositories/spec/test_data";
+import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {getScmPlugin} from "views/pages/pluggable_scms/spec/test_data";
 import {TestHelper} from "views/pages/spec/test_helper";
 import {MaterialEditor} from "../material_editor";
 
@@ -89,28 +93,37 @@ describe("AddPipeline: Material Editor", () => {
     expect(helper.byTestId("form-field-label-repository-url").textContent).toBe("Repository URL*");
   });
 
-  it('should render the package options', () => {
-    helper.mount(() => <MaterialEditor material={material} showExtraMaterials={true}
+  it('should render the package options with message', () => {
+    const pluginInfos = new PluginInfos(PluginInfo.fromJSON(pluginInfoWithPackageRepositoryExtension()));
+    helper.mount(() => <MaterialEditor material={material} showExtraMaterials={true} pluginInfos={pluginInfos}
                                        packageRepositories={new PackageRepositories()}/>);
 
     expect(helper.q("label").textContent).toBe("Material Type*");
     expect(helper.textAll("option")).toEqual(["Git", "Mercurial", "Subversion", "Perforce", "Team Foundation Server", "Another Pipeline", "Package", "SCM"]);
 
+    expect(helper.q('span[data-test-id="package-msg"]')).not.toBeInDOM();
     helper.onchange("select", "package");
 
     expect(material.type()).toBe("package");
     expect(material.attributes() instanceof PackageMaterialAttributes).toBe(true);
     expect(material.attributes()!.autoUpdate()).toBeTrue();
     expect((material.attributes() as PackageMaterialAttributes)!.ref()).toBe("");
+
+    const msgElement = helper.q('span[data-test-id="package-msg"]');
+    expect(msgElement).toBeInDOM();
+    expect(msgElement.textContent).toBe('Create New or select existing packages below.');
+    expect(helper.q('a', msgElement)).toHaveAttr('href', SparkRoutes.packageRepositoriesSPA());
   });
 
-  it('should render the scm options', () => {
-    helper.mount(() => <MaterialEditor material={material} showExtraMaterials={true}
+  it('should render the scm options with message', () => {
+    const pluginInfos = new PluginInfos(PluginInfo.fromJSON(getScmPlugin()));
+    helper.mount(() => <MaterialEditor material={material} showExtraMaterials={true} pluginInfos={pluginInfos}
                                        packageRepositories={new PackageRepositories()}/>);
 
     expect(helper.q("label").textContent).toBe("Material Type*");
     expect(helper.textAll("option")).toEqual(["Git", "Mercurial", "Subversion", "Perforce", "Team Foundation Server", "Another Pipeline", "Package", "SCM"]);
 
+    expect(helper.q('span[data-test-id="plugin-msg"]')).not.toBeInDOM();
     helper.onchange("select", "plugin");
 
     expect(material.type()).toBe("plugin");
@@ -121,6 +134,11 @@ describe("AddPipeline: Material Editor", () => {
     expect(attributes.ref()).toBe("");
     expect(attributes.destination()).toBe("");
     expect(attributes.filter().ignore()).toEqual([]);
+
+    const msgElement = helper.q('span[data-test-id="plugin-msg"]');
+    expect(msgElement).toBeInDOM();
+    expect(msgElement.textContent).toBe('Create New or select existing scms below.');
+    expect(helper.q('a', msgElement)).toHaveAttr('href', SparkRoutes.pluggableScmSPA());
   });
 
   it('should disable only material type selection when `disabledMaterialTypeSelection` is set to true', () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_editor_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_editor_spec.tsx
@@ -15,7 +15,13 @@
  */
 
 import m from "mithril";
-import {GitMaterialAttributes, Material, P4MaterialAttributes, PackageMaterialAttributes} from "models/materials/types";
+import {
+  GitMaterialAttributes,
+  Material,
+  P4MaterialAttributes,
+  PackageMaterialAttributes,
+  PluggableScmMaterialAttributes
+} from "models/materials/types";
 import {PackageRepositories} from "models/package_repositories/package_repositories";
 import {TestHelper} from "views/pages/spec/test_helper";
 import {MaterialEditor} from "../material_editor";
@@ -88,7 +94,7 @@ describe("AddPipeline: Material Editor", () => {
                                        packageRepositories={new PackageRepositories()}/>);
 
     expect(helper.q("label").textContent).toBe("Material Type*");
-    expect(helper.textAll("option")).toEqual(["Git", "Mercurial", "Subversion", "Perforce", "Team Foundation Server", "Another Pipeline", "Package"]);
+    expect(helper.textAll("option")).toEqual(["Git", "Mercurial", "Subversion", "Perforce", "Team Foundation Server", "Another Pipeline", "Package", "SCM"]);
 
     helper.onchange("select", "package");
 
@@ -96,6 +102,25 @@ describe("AddPipeline: Material Editor", () => {
     expect(material.attributes() instanceof PackageMaterialAttributes).toBe(true);
     expect(material.attributes()!.autoUpdate()).toBeTrue();
     expect((material.attributes() as PackageMaterialAttributes)!.ref()).toBe("");
+  });
+
+  it('should render the scm options', () => {
+    helper.mount(() => <MaterialEditor material={material} showExtraMaterials={true}
+                                       packageRepositories={new PackageRepositories()}/>);
+
+    expect(helper.q("label").textContent).toBe("Material Type*");
+    expect(helper.textAll("option")).toEqual(["Git", "Mercurial", "Subversion", "Perforce", "Team Foundation Server", "Another Pipeline", "Package", "SCM"]);
+
+    helper.onchange("select", "plugin");
+
+    expect(material.type()).toBe("plugin");
+    expect(material.attributes() instanceof PluggableScmMaterialAttributes).toBe(true);
+    expect(material.attributes()!.autoUpdate()).toBeTrue();
+
+    const attributes = (material.attributes() as PluggableScmMaterialAttributes)!;
+    expect(attributes.ref()).toBe("");
+    expect(attributes.destination()).toBe("");
+    expect(attributes.filter().ignore()).toEqual([]);
   });
 
   it('should disable only material type selection when `disabledMaterialTypeSelection` is set to true', () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -275,18 +275,6 @@ describe('PluginFieldsSpec', () => {
     expect(helper.textAll("option", helper.byTestId('form-field-input-scm'))).toEqual(['Select a scm']);
   });
 
-  it('should render advanced options if showLocalWorkingCopyOptions is set to true', () => {
-    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}
-                                     showLocalWorkingCopyOptions={true}/>);
-
-    assertLabelledInputsPresent(helper, {
-      "scm-plugin":              "SCM Plugin*",
-      "scm":                     "SCM*",
-      "alternate-checkout-path": "Alternate Checkout Path",
-      "material-name":           "Material Name"
-    });
-  });
-
   it('should update scms list when a plugin is selected', () => {
     helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -17,15 +17,23 @@
 import {docsUrl} from "gen/gocd_version";
 import {SparkRoutes} from "helpers/spark_routes";
 import m from "mithril";
-import {DependencyMaterialAttributes, Material, PackageMaterialAttributes} from "models/materials/types";
+import {Filter} from "models/maintenance_mode/material";
+import {Scm, ScmJSON, Scms} from "models/materials/pluggable_scm";
+import {
+  DependencyMaterialAttributes,
+  Material,
+  PackageMaterialAttributes,
+  PluggableScmMaterialAttributes
+} from "models/materials/types";
 import {PackageRepositories, Packages} from "models/package_repositories/package_repositories";
 import {
   getPackageRepository,
   pluginInfoWithPackageRepositoryExtension
 } from "models/package_repositories/spec/test_data";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {PluginInfoJSON} from "models/shared/plugin_infos_new/serialization";
 import {TestHelper} from "views/pages/spec/test_helper";
-import {DependencyFields, PackageFields, SuggestionCache} from "../non_scm_material_fields";
+import {DependencyFields, PackageFields, PluginFields, SuggestionCache} from "../non_scm_material_fields";
 
 describe("AddPipeline: Non-SCM Material Fields", () => {
   const helper = new TestHelper();
@@ -246,4 +254,178 @@ function assertLabelledInputsDisabledOrNot(helper: TestHelper, idsMap: { [key: s
     expect(helper.byTestId(`form-field-input-${id}`)).toBeInDOM();
     expect(helper.byTestId(`form-field-input-${id}`).hasAttribute('readonly')).toBe(idsMap[id]);
   }
+}
+
+describe('PluginFieldsSpec', () => {
+  const helper = new TestHelper();
+  let material: Material;
+  let scms: Scms;
+  let pluginInfos: PluginInfos;
+
+  beforeEach(() => {
+    material    = new Material("plugin", new PluggableScmMaterialAttributes("", false, "", "", new Filter([])));
+    scms        = new Scms(Scm.fromJSON(getPluggableScm()));
+    pluginInfos = new PluginInfos(PluginInfo.fromJSON(getScmPlugin()));
+  });
+  afterEach((done) => helper.unmount(done));
+
+  it('should render plugin structure', () => {
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
+
+    assertLabelledInputsPresent(helper, {
+      "scm-plugin": "SCM Plugin*",
+      "scm":        "SCM*"
+    });
+    assertLabelledInputsDisabledOrNot(helper, {
+      "scm-plugin": false,
+      "scm":        true
+    });
+    expect(helper.textAll("option", helper.byTestId('form-field-input-scm-plugin'))).toEqual(['Select a plugin', 'SCM Plugin']);
+    expect(helper.textAll("option", helper.byTestId('form-field-input-scm'))).toEqual(['Select a scm']);
+  });
+
+  it('should render advanced options if showLocalWorkingCopyOptions is set to true', () => {
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}
+                                     showLocalWorkingCopyOptions={true}/>);
+
+    assertLabelledInputsPresent(helper, {
+      "scm-plugin":              "SCM Plugin*",
+      "scm":                     "SCM*",
+      "alternate-checkout-path": "Alternate Checkout Path",
+      "material-name":           "Material Name"
+    });
+  });
+
+  it('should update scms list when a plugin is selected', () => {
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
+
+    const pluginElement = helper.byTestId('form-field-input-scm-plugin');
+    expect(helper.textAll("option", pluginElement)).toEqual(['Select a plugin', 'SCM Plugin']);
+    expect(helper.textAll("option", helper.byTestId('form-field-input-scm'))).toEqual(['Select a scm']);
+
+    helper.onchange(pluginElement, 'scm-plugin-id');
+
+    assertLabelledInputsDisabledOrNot(helper, {
+      "scm-plugin": false,
+      "scm":        false
+    });
+    expect(helper.textAll("option", helper.byTestId('form-field-input-scm'))).toEqual(['Select a scm', 'pluggable.scm.material.name']);
+  });
+
+  it('should render error if no scms are configured for the selected plugin', () => {
+    scms[0].pluginMetadata().id('some-other-plugin');
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
+
+    assertLabelledInputsDisabledOrNot(helper, {
+      "scm-plugin": false,
+      "scm":        true
+    });
+
+    helper.onchange(helper.byTestId('form-field-input-scm-plugin'), 'scm-plugin-id');
+
+    assertLabelledInputsDisabledOrNot(helper, {
+      "scm-plugin": false,
+      "scm":        true
+    });
+    const errorElement = helper.byTestId('flash-message-alert');
+    expect(errorElement).toBeInDOM();
+    expect(errorElement.textContent).toBe('There are no SCMs configured for the selected plugin. Go to Pluggable SCM to define one.');
+    expect(helper.q('a', errorElement)).toHaveAttr('href', SparkRoutes.pluggableScmSPA());
+  });
+
+  it('should render error if no scm plugins are installed', () => {
+    pluginInfos = new PluginInfos();
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
+
+    assertLabelledInputsDisabledOrNot(helper, {
+      "scm-plugin": true,
+      "scm":        true
+    });
+    const errorElement = helper.byTestId('flash-message-alert');
+    expect(errorElement).toBeInDOM();
+    expect(errorElement.textContent).toBe('There are no SCM plugins installed. Please see this page for a list of supported plugins.');
+    expect(helper.q('a', errorElement)).toHaveAttr('href', 'https://www.gocd.org/plugins/#scm');
+  });
+
+  it('should render error if no scms are configured', () => {
+    scms = new Scms();
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
+
+    assertLabelledInputsDisabledOrNot(helper, {
+      "scm-plugin": true,
+      "scm":        true
+    });
+    const errorElement = helper.byTestId('flash-message-alert');
+    expect(errorElement).toBeInDOM();
+    expect(errorElement.textContent).toBe('There are no SCMs configured. Go to Pluggable SCM to define one.');
+    expect(helper.q('a', errorElement)).toHaveAttr('href', SparkRoutes.pluggableScmSPA());
+  });
+});
+
+function getPluggableScm() {
+  return {
+    id:              "scm-id",
+    name:            "pluggable.scm.material.name",
+    plugin_metadata: {
+      id:      "scm-plugin-id",
+      version: "1"
+    },
+    auto_update:     true,
+    configuration:   [
+      {
+        key:   "url",
+        value: "https://github.com/sample/example.git"
+      }
+    ]
+  } as ScmJSON;
+}
+
+function getScmPlugin() {
+  return {
+    _links:               {
+      self: {
+        href: "http://test-server:8153/go/api/admin/plugin_info/github.pr"
+      },
+      doc:  {
+        href: "https://api.gocd.org/#plugin-info"
+      },
+      find: {
+        href: "http://test-server:8153/go/api/admin/plugin_info/:id"
+      }
+    },
+    id:                   "scm-plugin-id",
+    status:               {
+      state: "active"
+    },
+    plugin_file_location: "/tmp/abc.jar",
+    bundled_plugin:       false,
+    about:                {
+      name:                     "SCM Plugin",
+      version:                  "1.4.0-RC2",
+      target_go_version:        "15.1.0",
+      description:              "Plugin that polls a GitHub repository for pull requests and triggers a build for each of them",
+      target_operating_systems: [],
+      vendor:                   {
+        name: "User",
+        url:  "https://github.com/user/abc"
+      }
+    },
+    extensions:           [{
+      type:         "scm",
+      display_name: "Github",
+      scm_settings: {
+        configurations: [{
+          key:      "url",
+          metadata: {
+            secure:           false,
+            required:         true,
+            part_of_identity: true
+          }
+        }],
+        view:           {
+          template: "<div>some view template</div>"
+        }
+      }
+    }]
+  } as PluginInfoJSON;
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -15,7 +15,6 @@
  */
 
 import {docsUrl} from "gen/gocd_version";
-import {SparkRoutes} from "helpers/spark_routes";
 import m from "mithril";
 import {Filter} from "models/maintenance_mode/material";
 import {Scm, Scms} from "models/materials/pluggable_scm";
@@ -166,10 +165,9 @@ describe('PackageFieldsSpec', () => {
       "package":            true
     });
 
-    const errorElement = helper.byTestId('flash-message-alert');
+    const errorElement = helper.byTestId('flash-message-warning');
     expect(errorElement).toBeInDOM();
-    expect(errorElement.textContent).toBe('No package repositories defined. Go to Package Repositories to define one.');
-    expect(helper.q('a', errorElement)).toHaveAttr('href', SparkRoutes.packageRepositoriesSPA());
+    expect(errorElement.textContent).toBe('No package repositories defined.');
     expect(helper.byTestId('selected-pkg-repo-details')).not.toBeInDOM();
     expect(helper.byTestId('selected-pkg-details')).not.toBeInDOM();
   });
@@ -187,10 +185,9 @@ describe('PackageFieldsSpec', () => {
       "package-repository": false,
       "package":            true
     });
-    const errorElement = helper.byTestId('flash-message-alert');
+    const errorElement = helper.byTestId('flash-message-warning');
     expect(errorElement).toBeInDOM();
-    expect(errorElement.textContent).toBe('No packages defined for the selected package repository. Go to Package Repositories to define one.');
-    expect(helper.q('a', errorElement)).toHaveAttr('href', SparkRoutes.packageRepositoriesSPA());
+    expect(errorElement.textContent).toBe('No packages defined for the selected package repository.');
   });
 
   it('should show selected package details', () => {
@@ -204,24 +201,6 @@ describe('PackageFieldsSpec', () => {
     helper.onchange(helper.byTestId('form-field-input-package'), 'pkg-id');
 
     expect(helper.byTestId('selected-pkg-details')).toBeInDOM();
-  });
-
-  it('should show an error text if no plugins are defined', () => {
-    pluginInfos = new PluginInfos();
-    helper.mount(() => <PackageFields material={material} packageRepositories={packageRepositories}
-                                      pluginInfos={pluginInfos}/>);
-
-    assertLabelledInputsDisabledOrNot(helper, {
-      "package-repository": true,
-      "package":            true
-    });
-
-    const errorElement = helper.byTestId('flash-message-alert');
-    expect(errorElement).toBeInDOM();
-    expect(errorElement.textContent).toBe('There are no Package repository plugins installed. Please see this page for a list of supported plugins.');
-    expect(helper.q('a', errorElement)).toHaveAttr('href', 'https://www.gocd.org/plugins/#package-repo');
-    expect(helper.byTestId('selected-pkg-repo-details')).not.toBeInDOM();
-    expect(helper.byTestId('selected-pkg-details')).not.toBeInDOM();
   });
 });
 
@@ -339,38 +318,9 @@ describe('PluginFieldsSpec', () => {
       "scm-plugin": false,
       "scm":        true
     });
-    const errorElement = helper.byTestId('flash-message-alert');
+    const errorElement = helper.byTestId('flash-message-warning');
     expect(errorElement).toBeInDOM();
-    expect(errorElement.textContent).toBe('There are no SCMs configured for the selected plugin. Go to Pluggable SCM to define one.');
-    expect(helper.q('a', errorElement)).toHaveAttr('href', SparkRoutes.pluggableScmSPA());
-  });
-
-  it('should render error if no scm plugins are installed', () => {
-    pluginInfos = new PluginInfos();
-    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
-
-    assertLabelledInputsDisabledOrNot(helper, {
-      "scm-plugin": true,
-      "scm":        true
-    });
-    const errorElement = helper.byTestId('flash-message-alert');
-    expect(errorElement).toBeInDOM();
-    expect(errorElement.textContent).toBe('There are no SCM plugins installed. Please see this page for a list of supported plugins.');
-    expect(helper.q('a', errorElement)).toHaveAttr('href', 'https://www.gocd.org/plugins/#scm');
-  });
-
-  it('should render error if no scms are configured', () => {
-    scms = new Scms();
-    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
-
-    assertLabelledInputsDisabledOrNot(helper, {
-      "scm-plugin": true,
-      "scm":        true
-    });
-    const errorElement = helper.byTestId('flash-message-alert');
-    expect(errorElement).toBeInDOM();
-    expect(errorElement.textContent).toBe('There are no SCMs configured. Go to Pluggable SCM to define one.');
-    expect(helper.q('a', errorElement)).toHaveAttr('href', SparkRoutes.pluggableScmSPA());
+    expect(errorElement.textContent).toBe('There are no SCMs configured for the selected plugin.');
   });
 
   it('should render plugin configs if a plugin is selected', () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -202,6 +202,15 @@ describe('PackageFieldsSpec', () => {
 
     expect(helper.byTestId('selected-pkg-details')).toBeInDOM();
   });
+
+  it('should pre-populate package config when ref is set', () => {
+    (material.attributes() as PackageMaterialAttributes).ref(packageRepositories[0].packages()[0].id());
+    helper.mount(() => <PackageFields material={material} packageRepositories={packageRepositories}
+                                      pluginInfos={pluginInfos}/>);
+
+    expect(helper.byTestId('selected-pkg-repo-details')).toBeInDOM();
+    expect(helper.byTestId('selected-pkg-details')).toBeInDOM();
+  });
 });
 
 function assertLabelledInputsPresent(helper: TestHelper, idsToLabels: { [key: string]: string }) {
@@ -342,6 +351,14 @@ describe('PluginFieldsSpec', () => {
       "plugin-id": "Plugin Id",
       "url":       "url"
     });
+  });
+
+  it('should pre-populate configs and dropdown if ref is set', () => {
+    (material.attributes()! as PluggableScmMaterialAttributes).ref(scms[0].id());
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
+
+    expect(helper.byTestId('selected-plugin-details')).toBeInDOM();
+    expect(helper.byTestId('selected-scm-details')).toBeInDOM();
   });
 
   function assertConfigsPresent(helper: TestHelper, parentElementSelector: string, idsToValueMap: { [key: string]: string }) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -171,6 +171,7 @@ describe('PackageFieldsSpec', () => {
     expect(errorElement.textContent).toBe('No package repositories defined. Go to Package Repositories to define one.');
     expect(helper.q('a', errorElement)).toHaveAttr('href', SparkRoutes.packageRepositoriesSPA());
     expect(helper.byTestId('selected-pkg-repo-details')).not.toBeInDOM();
+    expect(helper.byTestId('selected-pkg-details')).not.toBeInDOM();
   });
 
   it('should show an error text if no packages are defined for a given package repo', () => {
@@ -181,6 +182,7 @@ describe('PackageFieldsSpec', () => {
     helper.onchange(helper.byTestId('form-field-input-package-repository'), 'pkg-repo-id');
 
     expect(helper.byTestId('selected-pkg-repo-details')).toBeInDOM();
+    expect(helper.byTestId('selected-pkg-details')).not.toBeInDOM();
     assertLabelledInputsDisabledOrNot(helper, {
       "package-repository": false,
       "package":            true
@@ -202,6 +204,24 @@ describe('PackageFieldsSpec', () => {
     helper.onchange(helper.byTestId('form-field-input-package'), 'pkg-id');
 
     expect(helper.byTestId('selected-pkg-details')).toBeInDOM();
+  });
+
+  it('should show an error text if no plugins are defined', () => {
+    pluginInfos = new PluginInfos();
+    helper.mount(() => <PackageFields material={material} packageRepositories={packageRepositories}
+                                      pluginInfos={pluginInfos}/>);
+
+    assertLabelledInputsDisabledOrNot(helper, {
+      "package-repository": true,
+      "package":            true
+    });
+
+    const errorElement = helper.byTestId('flash-message-alert');
+    expect(errorElement).toBeInDOM();
+    expect(errorElement.textContent).toBe('There are no Package repository plugins installed. Please see this page for a list of supported plugins.');
+    expect(helper.q('a', errorElement)).toHaveAttr('href', 'https://www.gocd.org/plugins/#package-repo');
+    expect(helper.byTestId('selected-pkg-repo-details')).not.toBeInDOM();
+    expect(helper.byTestId('selected-pkg-details')).not.toBeInDOM();
   });
 });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -140,6 +140,7 @@ describe('PackageFieldsSpec', () => {
       "package":            false
     });
     expect(helper.textAll("option", helper.byTestId('form-field-input-package'))).toEqual(['Select a package', 'pkg-name']);
+    expect(helper.byTestId('selected-pkg-repo-details')).toBeInDOM();
   });
 
   it('should render plugin not found error message', () => {
@@ -149,6 +150,7 @@ describe('PackageFieldsSpec', () => {
 
     helper.onchange(helper.byTestId('form-field-input-package-repository'), 'pkg-repo-id');
 
+    expect(helper.byTestId('selected-pkg-repo-details')).toBeInDOM();
     const errorElement = helper.q('span[class*="forms__form-error-text"]');
     expect(errorElement).toBeInDOM();
     expect(errorElement.textContent).toBe("Associated plugin 'non-existent-plugin' not found. Please contact the system administrator to install the plugin.");
@@ -168,6 +170,7 @@ describe('PackageFieldsSpec', () => {
     expect(errorElement).toBeInDOM();
     expect(errorElement.textContent).toBe('No package repositories defined. Go to Package Repositories to define one.');
     expect(helper.q('a', errorElement)).toHaveAttr('href', SparkRoutes.packageRepositoriesSPA());
+    expect(helper.byTestId('selected-pkg-repo-details')).not.toBeInDOM();
   });
 
   it('should show an error text if no packages are defined for a given package repo', () => {
@@ -177,6 +180,7 @@ describe('PackageFieldsSpec', () => {
 
     helper.onchange(helper.byTestId('form-field-input-package-repository'), 'pkg-repo-id');
 
+    expect(helper.byTestId('selected-pkg-repo-details')).toBeInDOM();
     assertLabelledInputsDisabledOrNot(helper, {
       "package-repository": false,
       "package":            true
@@ -185,6 +189,19 @@ describe('PackageFieldsSpec', () => {
     expect(errorElement).toBeInDOM();
     expect(errorElement.textContent).toBe('No packages defined for the selected package repository. Go to Package Repositories to define one.');
     expect(helper.q('a', errorElement)).toHaveAttr('href', SparkRoutes.packageRepositoriesSPA());
+  });
+
+  it('should show selected package details', () => {
+    helper.mount(() => <PackageFields material={material} packageRepositories={packageRepositories}
+                                      pluginInfos={pluginInfos}/>);
+
+    helper.onchange(helper.byTestId('form-field-input-package-repository'), 'pkg-repo-id');
+
+    expect(helper.byTestId('selected-pkg-repo-details')).toBeInDOM();
+
+    helper.onchange(helper.byTestId('form-field-input-package'), 'pkg-id');
+
+    expect(helper.byTestId('selected-pkg-details')).toBeInDOM();
   });
 });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -18,20 +18,12 @@ import {docsUrl} from "gen/gocd_version";
 import {SparkRoutes} from "helpers/spark_routes";
 import m from "mithril";
 import {Filter} from "models/maintenance_mode/material";
-import {Scm, ScmJSON, Scms} from "models/materials/pluggable_scm";
-import {
-  DependencyMaterialAttributes,
-  Material,
-  PackageMaterialAttributes,
-  PluggableScmMaterialAttributes
-} from "models/materials/types";
+import {Scm, Scms} from "models/materials/pluggable_scm";
+import {DependencyMaterialAttributes, Material, PackageMaterialAttributes, PluggableScmMaterialAttributes} from "models/materials/types";
 import {PackageRepositories, Packages} from "models/package_repositories/package_repositories";
-import {
-  getPackageRepository,
-  pluginInfoWithPackageRepositoryExtension
-} from "models/package_repositories/spec/test_data";
+import {getPackageRepository, pluginInfoWithPackageRepositoryExtension} from "models/package_repositories/spec/test_data";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
-import {PluginInfoJSON} from "models/shared/plugin_infos_new/serialization";
+import {getPluggableScm, getScmPlugin} from "views/pages/pluggable_scms/spec/test_data";
 import {TestHelper} from "views/pages/spec/test_helper";
 import {DependencyFields, PackageFields, PluginFields, SuggestionCache} from "../non_scm_material_fields";
 
@@ -360,72 +352,50 @@ describe('PluginFieldsSpec', () => {
     expect(errorElement.textContent).toBe('There are no SCMs configured. Go to Pluggable SCM to define one.');
     expect(helper.q('a', errorElement)).toHaveAttr('href', SparkRoutes.pluggableScmSPA());
   });
+
+  it('should render plugin configs if a plugin is selected', () => {
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
+
+    expect(helper.byTestId('selected-plugin-details')).not.toBeInDOM();
+
+    helper.onchange(helper.byTestId('form-field-input-scm-plugin'), 'scm-plugin-id');
+
+    expect(helper.byTestId('selected-plugin-details')).toBeInDOM();
+
+    assertConfigsPresent(helper, 'selected-plugin-details', {
+      id:          "Id",
+      name:        "Name",
+      description: "Description"
+    });
+  });
+
+  it('should render scm configs if selected', () => {
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
+
+    helper.onchange(helper.byTestId('form-field-input-scm-plugin'), 'scm-plugin-id');
+    expect(helper.byTestId('selected-scm-details')).not.toBeInDOM();
+
+    helper.onchange(helper.byTestId('form-field-input-scm'), 'scm-id');
+
+    expect(helper.byTestId('selected-scm-details')).toBeInDOM();
+    assertConfigsPresent(helper, 'selected-scm-details', {
+      "id":        "Id",
+      "name":      "Name",
+      "plugin-id": "Plugin Id",
+      "url":       "url"
+    });
+  });
+
+  function assertConfigsPresent(helper: TestHelper, parentElementSelector: string, idsToValueMap: { [key: string]: string }) {
+    const keys = Object.keys(idsToValueMap);
+    expect(keys.length > 0).toBe(true);
+
+    const parentElement = helper.byTestId(parentElementSelector);
+
+    expect(helper.qa('label[data-test-id*="key-value-key"]', parentElement).length).toBe(keys.length);
+    for (const id of keys) {
+      expect(helper.byTestId(`key-value-key-${id}`, parentElement)).toBeInDOM();
+      expect(helper.byTestId(`key-value-key-${id}`, parentElement).textContent).toBe(idsToValueMap[id]);
+    }
+  }
 });
-
-function getPluggableScm() {
-  return {
-    id:              "scm-id",
-    name:            "pluggable.scm.material.name",
-    plugin_metadata: {
-      id:      "scm-plugin-id",
-      version: "1"
-    },
-    auto_update:     true,
-    configuration:   [
-      {
-        key:   "url",
-        value: "https://github.com/sample/example.git"
-      }
-    ]
-  } as ScmJSON;
-}
-
-function getScmPlugin() {
-  return {
-    _links:               {
-      self: {
-        href: "http://test-server:8153/go/api/admin/plugin_info/github.pr"
-      },
-      doc:  {
-        href: "https://api.gocd.org/#plugin-info"
-      },
-      find: {
-        href: "http://test-server:8153/go/api/admin/plugin_info/:id"
-      }
-    },
-    id:                   "scm-plugin-id",
-    status:               {
-      state: "active"
-    },
-    plugin_file_location: "/tmp/abc.jar",
-    bundled_plugin:       false,
-    about:                {
-      name:                     "SCM Plugin",
-      version:                  "1.4.0-RC2",
-      target_go_version:        "15.1.0",
-      description:              "Plugin that polls a GitHub repository for pull requests and triggers a build for each of them",
-      target_operating_systems: [],
-      vendor:                   {
-        name: "User",
-        url:  "https://github.com/user/abc"
-      }
-    },
-    extensions:           [{
-      type:         "scm",
-      display_name: "Github",
-      scm_settings: {
-        configurations: [{
-          key:      "url",
-          metadata: {
-            secure:           false,
-            required:         true,
-            part_of_identity: true
-          }
-        }],
-        view:           {
-          template: "<div>some view template</div>"
-        }
-      }
-    }]
-  } as PluginInfoJSON;
-}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_widget_spec.tsx
@@ -95,12 +95,12 @@ describe('PluggableScmWidgetSpec', () => {
 
     ['pluggable-scm-edit', 'pluggable-scm-clone'].forEach((key) => {
       expect(helper.byTestId(key)).toBeDisabled();
-      expect(helper.byTestId(key)).toHaveAttr('title', "Plugin 'github.pr' not found!");
+      expect(helper.byTestId(key)).toHaveAttr('title', "Plugin 'scm-plugin-id' not found!");
     });
     expect(helper.byTestId('pluggable-scm-delete')).not.toBeDisabled();
     expect(helper.byTestId('pluggable-scm-usages')).not.toBeDisabled();
     const warningIcon = helper.byTestId('Info Circle-icon');
     expect(warningIcon).toBeInDOM();
-    expect(warningIcon).toHaveAttr('title', "Plugin 'github.pr' was not found!");
+    expect(warningIcon).toHaveAttr('title', "Plugin 'scm-plugin-id' was not found!");
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/test_data.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/test_data.ts
@@ -22,7 +22,7 @@ export function getPluggableScm() {
     id:              "scm-id",
     name:            "pluggable.scm.material.name",
     plugin_metadata: {
-      id:      "github.pr",
+      id:      "scm-plugin-id",
       version: "1"
     },
     auto_update:     true,


### PR DESCRIPTION
Issue: #6737, https://github.com/gocd/gocd/pull/7904#issuecomment-603317125

Description: added support to add reference of a pkg/scm material to the pipeline
Show case error message
1. Packages
 - no package repo plugins are installed
 - no package repositories defined
 - if the selected pkg repo has no valid plugin
 - if there are no pkgs defined for the selected pkg repo
2. Pluggable SCMs
 - no scm plugins are installed
 - no scms defined
 - if there are no scms defined for the selected plugin

Preview:

<img width="1093" alt="Screen Shot 2020-03-27 at 12 34 08 AM" src="https://user-images.githubusercontent.com/41165891/77691211-85f93480-6fca-11ea-80f3-63f775e53bb6.png">

<img width="724" alt="Screen Shot 2020-03-27 at 1 30 29 AM" src="https://user-images.githubusercontent.com/41165891/77691285-9e694f00-6fca-11ea-881d-1bfd3bf11c6b.png">

<img width="858" alt="Screen Shot 2020-03-27 at 1 30 35 AM" src="https://user-images.githubusercontent.com/41165891/77691295-a1643f80-6fca-11ea-8eea-9c4f92c37b42.png">



