### PR TITLE
[Pipeline Config SPA] Project Management Tab Fixes (#7921)

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/pipeline_config.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/pipeline_config.ts
@@ -17,6 +17,7 @@
 import {ApiRequestBuilder, ApiVersion} from "helpers/api_request_builder";
 import {JsonUtils} from "helpers/json_utils";
 import {SparkRoutes} from "helpers/spark_routes";
+import _ from "lodash";
 import Stream from "mithril/stream";
 import {EnvironmentVariableJSON, EnvironmentVariables} from "models/environment_variables/types";
 import {MaterialJSON} from "models/materials/serialization";
@@ -98,7 +99,7 @@ export class Timer extends ValidatableMixin {
     }
 
     return {
-      spec:            this.spec(),
+      spec: this.spec(),
       only_on_changes: this.onlyOnChanges()
     };
   }
@@ -118,6 +119,13 @@ export class TrackingTool extends ValidatableMixin {
   readonly regex      = Stream<string>();
   readonly urlPattern = Stream<string>();
 
+  constructor() {
+    super();
+
+    this.validatePresenceOf("regex", {condition: () => !_.isEmpty(this.urlPattern())});
+    this.validatePresenceOf("urlPattern", {condition: () => !_.isEmpty(this.regex())});
+  }
+
   static fromJSON(json: TrackingToolJSON) {
     const tracingTool = new TrackingTool();
 
@@ -135,10 +143,10 @@ export class TrackingTool extends ValidatableMixin {
     }
 
     return {
-      type:       "generic",
+      type: "generic",
       attributes: {
         url_pattern: this.urlPattern(),
-        regex:       this.regex()
+        regex: this.regex()
       }
     };
   }
@@ -176,6 +184,8 @@ export class PipelineConfig extends ValidatableMixin {
 
     this.stages = Stream(new NameableSet(stages));
     this.validateAssociated("stages");
+
+    this.validateAssociated("trackingTool");
 
     this.validateChildAttrIsUnique("parameters", "name", {message: "Parameter names must be unique"});
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/spec/pipeline_config_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/spec/pipeline_config_spec.ts
@@ -195,6 +195,28 @@ describe("PipelineConfig model", () => {
     expect(trackingTool.errors().count()).toBe(0);
   });
 
+  it("tracking tool should validate presence of regex when URI is specified", () => {
+    const trackingTool = new TrackingTool();
+    trackingTool.urlPattern("uri");
+
+    const isValid = trackingTool.isValid();
+
+    expect(isValid).toBeFalse();
+    expect(trackingTool.errors().count()).toBe(1);
+    expect(trackingTool.errors().errorsForDisplay("regex")).toBe("Regex must be present.");
+  });
+
+  it("tracking tool should validate presence of URI when regex is specified", () => {
+    const trackingTool = new TrackingTool();
+    trackingTool.regex("some-regex");
+
+    const isValid = trackingTool.isValid();
+
+    expect(isValid).toBeFalse();
+    expect(trackingTool.errors().count()).toBe(1);
+    expect(trackingTool.errors().errorsForDisplay("urlPattern")).toBe("URL pattern must be present.");
+  });
+
   it("create()", (done) => {
     jasmine.Ajax.withMock(() => {
       const config = new PipelineConfig("name", defaultMaterials, defaultStages).withGroup("foo");

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/pipeline_config.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/pipeline_config.tsx
@@ -111,9 +111,9 @@ export class PipelineConfigPage<T> extends Page<null, T> {
     }
 
     return this.pipelineConfig!.update(this.etag()).then((result) => {
-      return result.do(() => {
+      return result.do((successResponse) => {
         this.flashMessage.setMessage(MessageType.success, "Saved Successfully!");
-        this.onSuccess.bind(this, result);
+        this.onSuccess(result, successResponse);
       }, this.onFailure.bind(this));
     });
   }


### PR DESCRIPTION
##### Issue: #7921

##### Description: 
* Add client side validations for mandatory fields.
  Do not validation when both url and pattern are not specified.

* Fix pipeline config update 412 error.
  Update pipeline config ETag on every successful save.

* Clear validation errors on successful save.
  Create a new pipeline config object on every successful save.

