### PR TITLE
[Pipeline Config SPA] General Tab Fixes (#7915)

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/pipeline_config.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/pipeline_config.ts
@@ -252,7 +252,12 @@ export class PipelineConfig extends ValidatableMixin {
   }
 
   toPutApiPayload(): any {
-    return JsonUtils.toSnakeCasedObject(this);
+    const json = JsonUtils.toSnakeCasedObject(this);
+    if (_.isEmpty(json.label_template)) {
+      delete json.label_template;
+    }
+
+    return json;
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/spec/pipeline_config_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/spec/pipeline_config_spec.ts
@@ -217,6 +217,20 @@ describe("PipelineConfig model", () => {
     expect(trackingTool.errors().errorsForDisplay("urlPattern")).toBe("URL pattern must be present.");
   });
 
+  it("should serialize pipeline config template", () => {
+    const config = new PipelineConfig("name", defaultMaterials, defaultStages).withGroup("foo");
+    config.labelTemplate("${COUNT}-pipeline");
+
+    expect(config.toPutApiPayload().label_template).toBe("${COUNT}-pipeline");
+  });
+
+  it("should serialize pipeline config template", () => {
+    const config = new PipelineConfig("name", defaultMaterials, defaultStages).withGroup("foo");
+    config.labelTemplate("");
+
+    expect(config.toPutApiPayload().label_template).toEqual(undefined);
+  });
+
   it("create()", (done) => {
     jasmine.Ajax.withMock(() => {
       const config = new PipelineConfig("name", defaultMaterials, defaultStages).withGroup("foo");

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/general_options_tab_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/general_options_tab_spec.tsx
@@ -58,6 +58,7 @@ describe("GeneralOptionsTag", () => {
       const pipelineConfig  = PipelineConfig.fromJSON(PipelineConfigTestData.withTemplate());
       const templateConfig  = new TemplateConfig(pipelineConfig.template()!, []);
       const stageInTemplate = new Stage("StageOne");
+      stageInTemplate.approval().state(false);
       templateConfig.stages(new NameableSet([stageInTemplate]));
       mount(pipelineConfig, templateConfig);
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/general_options_tab.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/general_options_tab.tsx
@@ -48,9 +48,8 @@ export class GeneralOptionsTabContent extends TabContent<PipelineConfig> {
                    errorText={entity.errors().errorsForDisplay("labelTemplate")}
                    helpText={"Customize the label for this pipeline."}
                    docLink={"configuration/pipeline_labeling.html"}
-                   dataTestId={"label-template"}
-                   required={true}/>
-
+                   placeholder={"${COUNT}"}
+                   dataTestId={"label-template"}/>
         {this.getPipelineSchedulingCheckBox(entity, templateConfig)}
       </Form>
 


### PR DESCRIPTION
##### Issue: #7915 

##### Description:

* Make pipeline label template an optional field.
  When user does not specify one, it defaults to ${COUNT}.

* Allow updating Automatic pipeline scheduling checkbox.
