### PR TITLE
Update the material editor for supporting SCM materials

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -573,4 +573,8 @@ export class SparkRoutes {
   static scmUsagePath(scm_name: string): string {
     return `/go/api/admin/scms/${scm_name}/usages`;
   }
+
+  static pluggableScmSPA() {
+    return '/go/admin/scms';
+  }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
@@ -19,7 +19,18 @@ import {JsonUtils} from "helpers/json_utils";
 import {SparkRoutes} from "helpers/spark_routes";
 import _ from "lodash";
 import Stream from "mithril/stream";
-import {DependencyMaterialAttributesJSON, GitMaterialAttributesJSON, HgMaterialAttributesJSON, MaterialAttributesJSON, MaterialJSON, P4MaterialAttributesJSON, PackageMaterialAttributesJSON, PluggableScmMaterialAttributesJSON, SvnMaterialAttributesJSON, TfsMaterialAttributesJSON,} from "models/materials/serialization";
+import {
+  DependencyMaterialAttributesJSON,
+  GitMaterialAttributesJSON,
+  HgMaterialAttributesJSON,
+  MaterialAttributesJSON,
+  MaterialJSON,
+  P4MaterialAttributesJSON,
+  PackageMaterialAttributesJSON,
+  PluggableScmMaterialAttributesJSON,
+  SvnMaterialAttributesJSON,
+  TfsMaterialAttributesJSON,
+} from "models/materials/serialization";
 import {ErrorMessages} from "models/mixins/error_messages";
 import {Errors} from "models/mixins/errors";
 import {ErrorsConsumer} from "models/mixins/errors_consumer";
@@ -527,7 +538,7 @@ export class PluggableScmMaterialAttributes extends MaterialAttributes {
   filter: Stream<Filter>;
   destination: Stream<string>;
 
-  constructor(name: string, autoUpdate: boolean, ref: string, destination: string, filter: Filter) {
+  constructor(name: string | undefined, autoUpdate: boolean, ref: string, destination: string, filter: Filter) {
     super(name, autoUpdate);
     this.ref         = Stream(ref);
     this.filter      = Stream(filter);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.tsx
@@ -16,6 +16,7 @@
 
 import m from "mithril";
 import Stream from "mithril/stream";
+import {Scms} from "models/materials/pluggable_scm";
 import {Material} from "models/materials/types";
 import {PackageRepositories} from "models/package_repositories/package_repositories";
 import {PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
@@ -32,31 +33,33 @@ export class MaterialModal extends Modal {
   private readonly errorMessage: Stream<string>;
   private readonly pluginInfos: Stream<PluginInfos>;
   private readonly packageRepositories: Stream<PackageRepositories>;
+  private readonly pluggableScms: Stream<Scms>;
   private readonly onSuccessfulAdd: (material: Material) => Promise<any>;
 
-  constructor(title: string, entity: Stream<Material>,
+  constructor(title: string, entity: Stream<Material>, scms: Stream<Scms>,
               packages: Stream<PackageRepositories>, pluginInfos: Stream<PluginInfos>,
               onSuccessfulAdd: (material: Material) => Promise<any>) {
     super(Size.large);
     this.__title             = title;
     this.entity              = entity;
+    this.pluggableScms       = scms;
     this.packageRepositories = packages;
     this.pluginInfos         = pluginInfos;
     this.onSuccessfulAdd     = onSuccessfulAdd;
     this.errorMessage        = Stream();
   }
 
-  static forAdd(packageRepositories: Stream<PackageRepositories>, pluginInfos: Stream<PluginInfos>,
+  static forAdd(scms: Stream<Scms>, packageRepositories: Stream<PackageRepositories>, pluginInfos: Stream<PluginInfos>,
                 onSuccessfulAdd: (material: Material) => Promise<any>) {
-    return new MaterialModal("Add material", Stream(new Material("git")), packageRepositories, pluginInfos, onSuccessfulAdd);
+    return new MaterialModal("Add material", Stream(new Material("git")), scms, packageRepositories, pluginInfos, onSuccessfulAdd);
   }
 
-  static forEdit(material: Material,
+  static forEdit(material: Material, scms: Stream<Scms>,
                  packageRepositories: Stream<PackageRepositories>, pluginInfos: Stream<PluginInfos>,
                  onSuccessfulAdd: (material: Material) => Promise<any>) {
     const title          = `Edit material - ${s.capitalize(material.type()!)}`;
     const copyOfMaterial = Stream(new Material(material.type(), material.attributes()));
-    return new MaterialModal(title, copyOfMaterial, packageRepositories, pluginInfos, onSuccessfulAdd);
+    return new MaterialModal(title, copyOfMaterial, scms, packageRepositories, pluginInfos, onSuccessfulAdd);
   }
 
   title(): string {
@@ -66,7 +69,7 @@ export class MaterialModal extends Modal {
   body(): m.Children {
     return <div>
       <FlashMessage type={MessageType.alert} message={this.errorMessage()}/>
-      <MaterialEditor material={this.entity()} showExtraMaterials={true}
+      <MaterialEditor material={this.entity()} showExtraMaterials={true} pluggableScms={this.pluggableScms()}
                       packageRepositories={this.packageRepositories()} pluginInfos={this.pluginInfos()}/>
     </div>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_widget.tsx
@@ -57,7 +57,7 @@ export class MaterialsWidget extends MithrilViewComponent<MaterialsAttrs> {
 
   private addMaterial(vnode: m.Vnode<MaterialsAttrs, this>, e: MouseEvent) {
     e.stopPropagation();
-    MaterialModal.forAdd(vnode.attrs.packageRepositories, vnode.attrs.pluginInfos, vnode.attrs.onMaterialAdd).render();
+    MaterialModal.forAdd(vnode.attrs.scmMaterials, vnode.attrs.packageRepositories, vnode.attrs.pluginInfos, vnode.attrs.onMaterialAdd).render();
   }
 
   private tableData(vnode: m.Vnode<MaterialsAttrs, this>) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss
@@ -62,6 +62,13 @@
   }
 }
 
-.form-error-text{
-  color: $form-failed-color;
+.package-fields {
+  table {
+    width:        100%;
+    table-layout: fixed;
+
+    td {
+      vertical-align: top;
+    }
+  }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss.d.ts
@@ -25,6 +25,7 @@ export const inputSmall: string;
 export const last: string;
 export const lockOpen: string;
 export const open: string;
+export const packageFields: string;
 export const quickAddButton: string;
 export const radioField: string;
 export const radioLabel: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -17,23 +17,30 @@
 import Awesomplete from "awesomplete";
 import {SparkRoutes} from "helpers/spark_routes";
 import {MithrilComponent} from "jsx/mithril-component";
+import _ from "lodash";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {DependencyMaterialAutocomplete, PipelineNameCache} from "models/materials/dependency_autocomplete_cache";
+import {Scms} from "models/materials/pluggable_scm";
 import {
   DependencyMaterialAttributes,
   Material,
   MaterialAttributes,
-  PackageMaterialAttributes
+  PackageMaterialAttributes,
+  PluggableScmMaterialAttributes
 } from "models/materials/types";
 import {PackageRepositories, PackageRepository} from "models/package_repositories/package_repositories";
-import {PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {SCMExtensionType} from "models/shared/plugin_infos_new/extension_type";
+import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {FlashMessage, MessageType} from "views/components/flash_message";
 import {AutocompleteField, SuggestionProvider} from "views/components/forms/autocomplete";
 import {Option, SelectField, SelectFieldOptions, TextField} from "views/components/forms/input_fields";
 import {Link} from "views/components/link";
 import {SwitchBtn} from "views/components/switch";
+import * as Tooltip from "views/components/tooltip";
+import {TooltipSize} from "views/components/tooltip";
 import {AdvancedSettings} from "views/pages/pipelines/advanced_settings";
-import {IDENTIFIER_FORMAT_HELP_MESSAGE} from "./messages";
+import {DESTINATION_DIR_HELP_MESSAGE, IDENTIFIER_FORMAT_HELP_MESSAGE} from "./messages";
 import styles from "./advanced_settings.scss";
 
 interface Attrs {
@@ -234,6 +241,131 @@ export class PackageFields extends MithrilComponent<PackageAttrs, PackageState> 
     if (pluginInfo === undefined) {
       vnode.attrs.material.attributes()!
         .errors().add("pkgRepo", `Associated plugin '${selectedPkgRepo.pluginMetadata().id()}' not found. Please contact the system administrator to install the plugin.`)
+    }
+  }
+}
+
+interface PluginAttrs {
+  material: Material;
+  scms: Scms;
+  pluginInfos: PluginInfos;
+  showLocalWorkingCopyOptions?: boolean;
+  disabled?: boolean;
+}
+
+interface PluginState {
+  pluginId: Stream<string>;
+  scmsForSelectedPlugin: Stream<Option[]>;
+}
+
+export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
+  readonly defaultScms                = [{id: "", text: "Select a scm"}];
+  private disablePluginField: boolean = false;
+  private disableScmField: boolean    = true;
+  private errorMessage?: m.Children   = undefined;
+
+  oninit(vnode: m.Vnode<PluginAttrs, PluginState>): any {
+    vnode.state.pluginId              = Stream("");
+    vnode.state.scmsForSelectedPlugin = Stream(this.defaultScms);
+  }
+
+  view(vnode: m.Vnode<PluginAttrs, PluginState>): m.Children | void | null {
+    const attrs                           = vnode.attrs.material.attributes() as PluggableScmMaterialAttributes;
+    const plugins: Array<Option | string> = [{id: "", text: "Select a plugin"}];
+    plugins.push(..._.map(vnode.attrs.pluginInfos, (pluginInfo: PluginInfo) => {
+      return {id: pluginInfo.id, text: pluginInfo.about.name};
+    }));
+    const readonly                    = !!vnode.attrs.disabled;
+    const showLocalWorkingCopyOptions = !!vnode.attrs.showLocalWorkingCopyOptions;
+    this.setErrorMessageIfApplicable(vnode, plugins);
+
+    return <div className={styles.packageFields}>
+      {this.errorMessage}
+      <table>
+        <tr>
+          <td>
+            <SelectField property={this.pluginIdProxy.bind(this, vnode)}
+                         label="SCM Plugin"
+                         errorText={attrs.errors().errorsForDisplay("pluginId")}
+                         required={true} readonly={readonly || this.disablePluginField}>
+              <SelectFieldOptions selected={vnode.state.pluginId()} items={plugins}/>
+            </SelectField>
+          </td>
+          <td>
+            <SelectField property={attrs.ref} label="SCM" required={true}
+                         errorText={attrs.errors().errorsForDisplay("ref")}
+                         readonly={readonly || this.disableScmField}>
+              <SelectFieldOptions selected={attrs.ref()} items={vnode.state.scmsForSelectedPlugin()}/>
+            </SelectField>
+          </td>
+        </tr>
+      </table>
+      {this.advanced(attrs, showLocalWorkingCopyOptions)}
+    </div>;
+  }
+
+  private pluginIdProxy(vnode: m.Vnode<PluginAttrs, PluginState>, pluginId?: string): any {
+    if (!pluginId) {
+      return vnode.state.pluginId();
+    }
+
+    vnode.state.pluginId(pluginId);
+    const scmsForPlugin = vnode.attrs.scms
+                               .filter((scm) => scm.pluginMetadata().id() === pluginId)
+                               .map((scm) => {
+                                 return {id: scm.id(), text: scm.name()};
+                               });
+    const scms          = this.defaultScms.concat(...scmsForPlugin);
+    vnode.state.scmsForSelectedPlugin(scms);
+    (vnode.attrs.material.attributes() as PluggableScmMaterialAttributes).ref("");
+    this.disableScmField = false;
+
+    return pluginId;
+  }
+
+  private advanced(attrs: PluggableScmMaterialAttributes, showLocalWorkingCopyOptions: boolean): m.Children {
+    if (showLocalWorkingCopyOptions) {
+      const labelForDestination = [
+        "Alternate Checkout Path",
+        " ",
+        <Tooltip.Help size={TooltipSize.medium} content={DESTINATION_DIR_HELP_MESSAGE}/>
+      ];
+      const forceOpen           = attrs.errors().hasErrors("name") || attrs.errors().hasErrors("destination");
+      return <AdvancedSettings forceOpen={forceOpen}>
+        <TextField label={labelForDestination} property={attrs.destination}
+                   errorText={attrs.errors().errorsForDisplay("destination")}/>
+        <TextField label="Material Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE}
+                   placeholder="A human-friendly label for this material" property={attrs.name}/>
+      </AdvancedSettings>;
+    }
+  }
+
+  private setErrorMessageIfApplicable(vnode: m.Vnode<PluginAttrs, PluginState>, plugins: Array<Option | string>) {
+    this.errorMessage = undefined;
+    if (plugins.length === 1) {
+      this.errorMessage       = <FlashMessage type={MessageType.alert}>
+        There are no SCM plugins installed. Please see
+        <Link href={new SCMExtensionType().linkForDocs()} target="_blank" externalLinkIcon={true}> this page</Link> for a
+        list of supported plugins.
+      </FlashMessage>;
+      this.disablePluginField = true;
+      this.disableScmField    = true;
+    }
+    if (_.isEmpty(vnode.attrs.scms)) {
+      this.errorMessage       = <FlashMessage type={MessageType.alert}>
+        There are no SCMs configured. Go to <Link href={SparkRoutes.pluggableScmSPA()}>Pluggable SCM</Link> to define
+        one.
+      </FlashMessage>;
+      this.disablePluginField = true;
+      this.disableScmField    = true;
+    }
+
+    if (vnode.state.pluginId().length > 0 && vnode.state.scmsForSelectedPlugin().length === 1) {
+      this.errorMessage    = <FlashMessage type={MessageType.alert}>
+        There are no SCMs configured for the selected plugin. Go to
+        <Link href={SparkRoutes.pluggableScmSPA()}> Pluggable SCM</Link> to define one.
+      </FlashMessage>;
+      this.disableScmField = true;
     }
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -35,6 +35,7 @@ import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_inf
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {AutocompleteField, SuggestionProvider} from "views/components/forms/autocomplete";
 import {Option, SelectField, SelectFieldOptions, TextField} from "views/components/forms/input_fields";
+import {KeyValuePair} from "views/components/key_value_pair";
 import {Link} from "views/components/link";
 import {SwitchBtn} from "views/components/switch";
 import * as Tooltip from "views/components/tooltip";
@@ -299,6 +300,10 @@ export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
             </SelectField>
           </td>
         </tr>
+        <tr>
+          <td>{this.showSelectedPluginConfig(vnode)}</td>
+          <td>{this.showSelectedScmConfig(vnode)}</td>
+        </tr>
       </table>
       {this.advanced(attrs, showLocalWorkingCopyOptions)}
     </div>;
@@ -345,16 +350,16 @@ export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
     if (plugins.length === 1) {
       this.errorMessage       = <FlashMessage type={MessageType.alert}>
         There are no SCM plugins installed. Please see
-        <Link href={new SCMExtensionType().linkForDocs()} target="_blank" externalLinkIcon={true}> this page</Link> for a
-        list of supported plugins.
+        <Link href={new SCMExtensionType().linkForDocs()} target="_blank" externalLinkIcon={true}> this page</Link> for
+        a list of supported plugins.
       </FlashMessage>;
       this.disablePluginField = true;
       this.disableScmField    = true;
     }
+
     if (_.isEmpty(vnode.attrs.scms)) {
       this.errorMessage       = <FlashMessage type={MessageType.alert}>
-        There are no SCMs configured. Go to <Link href={SparkRoutes.pluggableScmSPA()}>Pluggable SCM</Link> to define
-        one.
+        There are no SCMs configured. Go to <Link href={SparkRoutes.pluggableScmSPA()}>Pluggable SCM</Link> to define one.
       </FlashMessage>;
       this.disablePluginField = true;
       this.disableScmField    = true;
@@ -366,6 +371,32 @@ export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
         <Link href={SparkRoutes.pluggableScmSPA()}> Pluggable SCM</Link> to define one.
       </FlashMessage>;
       this.disableScmField = true;
+    }
+  }
+
+  private showSelectedPluginConfig(vnode: m.Vnode<PluginAttrs, PluginState>) {
+    const selectedPlugin = vnode.attrs.pluginInfos.findByPluginId(vnode.state.pluginId());
+    if (selectedPlugin !== undefined) {
+      const data = new Map<string, string | m.Children>([
+                                                          ["Id", selectedPlugin.id],
+                                                          ["Name", selectedPlugin.about.name],
+                                                          ["Description", selectedPlugin.about.description],
+                                                        ]);
+      return <KeyValuePair data-test-id={"selected-plugin-details"} data={data}/>;
+    }
+  }
+
+  private showSelectedScmConfig(vnode: m.Vnode<PluginAttrs, PluginState>) {
+    const attrs       = vnode.attrs.material.attributes() as PluggableScmMaterialAttributes;
+    const selectedScm = vnode.attrs.scms.find((scm) => scm.id() === attrs.ref());
+    if (selectedScm !== undefined) {
+      const scmRepoDetails = new Map([
+                                       ["Id", selectedScm.id()],
+                                       ["Name", selectedScm.name()],
+                                       ["Plugin Id", selectedScm.pluginMetadata().id()],
+                                       ...Array.from(selectedScm.configuration().asMap())
+                                     ]);
+      return <KeyValuePair data-test-id={"selected-scm-details"} data={scmRepoDetails}/>;
     }
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_editor_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_editor_spec.tsx
@@ -15,7 +15,13 @@
  */
 
 import m from "mithril";
-import {GitMaterialAttributes, Material, P4MaterialAttributes, PackageMaterialAttributes} from "models/materials/types";
+import {
+  GitMaterialAttributes,
+  Material,
+  P4MaterialAttributes,
+  PackageMaterialAttributes,
+  PluggableScmMaterialAttributes
+} from "models/materials/types";
 import {PackageRepositories} from "models/package_repositories/package_repositories";
 import {TestHelper} from "views/pages/spec/test_helper";
 import {MaterialEditor} from "../material_editor";
@@ -88,7 +94,7 @@ describe("AddPipeline: Material Editor", () => {
                                        packageRepositories={new PackageRepositories()}/>);
 
     expect(helper.q("label").textContent).toBe("Material Type*");
-    expect(helper.textAll("option")).toEqual(["Git", "Mercurial", "Subversion", "Perforce", "Team Foundation Server", "Another Pipeline", "Package"]);
+    expect(helper.textAll("option")).toEqual(["Git", "Mercurial", "Subversion", "Perforce", "Team Foundation Server", "Another Pipeline", "Package", "SCM"]);
 
     helper.onchange("select", "package");
 
@@ -96,5 +102,24 @@ describe("AddPipeline: Material Editor", () => {
     expect(material.attributes() instanceof PackageMaterialAttributes).toBe(true);
     expect(material.attributes()!.autoUpdate()).toBeTrue();
     expect((material.attributes() as PackageMaterialAttributes)!.ref()).toBe("");
+  });
+
+  it('should render the scm options', () => {
+    helper.mount(() => <MaterialEditor material={material} showExtraMaterials={true}
+                                       packageRepositories={new PackageRepositories()}/>);
+
+    expect(helper.q("label").textContent).toBe("Material Type*");
+    expect(helper.textAll("option")).toEqual(["Git", "Mercurial", "Subversion", "Perforce", "Team Foundation Server", "Another Pipeline", "Package", "SCM"]);
+
+    helper.onchange("select", "plugin");
+
+    expect(material.type()).toBe("plugin");
+    expect(material.attributes() instanceof PluggableScmMaterialAttributes).toBe(true);
+    expect(material.attributes()!.autoUpdate()).toBeTrue();
+
+    const attributes = (material.attributes() as PluggableScmMaterialAttributes)!;
+    expect(attributes.ref()).toBe("");
+    expect(attributes.destination()).toBe("");
+    expect(attributes.filter().ignore()).toEqual([]);
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -17,15 +17,23 @@
 import {docsUrl} from "gen/gocd_version";
 import {SparkRoutes} from "helpers/spark_routes";
 import m from "mithril";
-import {DependencyMaterialAttributes, Material, PackageMaterialAttributes} from "models/materials/types";
+import {
+  DependencyMaterialAttributes,
+  Material,
+  PackageMaterialAttributes,
+  PluggableScmMaterialAttributes
+} from "models/materials/types";
 import {PackageRepositories, Packages} from "models/package_repositories/package_repositories";
 import {
   getPackageRepository,
   pluginInfoWithPackageRepositoryExtension
 } from "models/package_repositories/spec/test_data";
+import {Filter} from "models/maintenance_mode/material";
+import {Scm, ScmJSON, Scms} from "models/materials/pluggable_scm";
+import {PluginInfoJSON} from "models/shared/plugin_infos_new/serialization";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {TestHelper} from "views/pages/spec/test_helper";
-import {DependencyFields, PackageFields, SuggestionCache} from "../non_scm_material_fields";
+import {DependencyFields, PackageFields, PluginFields, SuggestionCache} from "../non_scm_material_fields";
 
 describe("AddPipeline: Non-SCM Material Fields", () => {
   const helper = new TestHelper();
@@ -203,4 +211,188 @@ function assertIgnoreForSchedulingSwitchPresent(helper: TestHelper) {
 
 function assertIgnoreForSchedulingSwitchAbsent(helper: TestHelper) {
   expect(helper.byTestId('material-ignore-for-scheduling')).not.toBeInDOM();
+}
+
+function assertLabelledInputsDisabledOrNot(helper: TestHelper, idsMap: { [key: string]: boolean }) {
+  const keys = Object.keys(idsMap);
+  expect(keys.length > 0).toBe(true);
+
+  for (const id of keys) {
+    expect(helper.byTestId(`form-field-input-${id}`)).toBeInDOM();
+    expect(helper.byTestId(`form-field-input-${id}`).hasAttribute('readonly')).toBe(idsMap[id]);
+  }
+}
+
+describe('PluginFieldsSpec', () => {
+  const helper = new TestHelper();
+  let material: Material;
+  let scms: Scms;
+  let pluginInfos: PluginInfos;
+
+  beforeEach(() => {
+    material    = new Material("plugin", new PluggableScmMaterialAttributes("", false, "", "", new Filter([])));
+    scms        = new Scms(Scm.fromJSON(getPluggableScm()));
+    pluginInfos = new PluginInfos(PluginInfo.fromJSON(getScmPlugin()));
+  });
+  afterEach((done) => helper.unmount(done));
+
+  it('should render plugin structure', () => {
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
+
+    assertLabelledInputsPresent(helper, {
+      "scm-plugin": "SCM Plugin*",
+      "scm":        "SCM*"
+    });
+    assertLabelledInputsDisabledOrNot(helper, {
+      "scm-plugin": false,
+      "scm":        true
+    });
+    expect(helper.textAll("option", helper.byTestId('form-field-input-scm-plugin'))).toEqual(['Select a plugin', 'SCM Plugin']);
+    expect(helper.textAll("option", helper.byTestId('form-field-input-scm'))).toEqual(['Select a scm']);
+  });
+
+  it('should render advanced options if showLocalWorkingCopyOptions is set to true', () => {
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}
+                                     showLocalWorkingCopyOptions={true}/>);
+
+    assertLabelledInputsPresent(helper, {
+      "scm-plugin":              "SCM Plugin*",
+      "scm":                     "SCM*",
+      "alternate-checkout-path": "Alternate Checkout Path",
+      "material-name":           "Material Name"
+    });
+  });
+
+  it('should update scms list when a plugin is selected', () => {
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
+
+    const pluginElement = helper.byTestId('form-field-input-scm-plugin');
+    expect(helper.textAll("option", pluginElement)).toEqual(['Select a plugin', 'SCM Plugin']);
+    expect(helper.textAll("option", helper.byTestId('form-field-input-scm'))).toEqual(['Select a scm']);
+
+    helper.onchange(pluginElement, 'scm-plugin-id');
+
+    assertLabelledInputsDisabledOrNot(helper, {
+      "scm-plugin": false,
+      "scm":        false
+    });
+    expect(helper.textAll("option", helper.byTestId('form-field-input-scm'))).toEqual(['Select a scm', 'pluggable.scm.material.name']);
+  });
+
+  it('should render error if no scms are configured for the selected plugin', () => {
+    scms[0].pluginMetadata().id('some-other-plugin');
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
+
+    assertLabelledInputsDisabledOrNot(helper, {
+      "scm-plugin": false,
+      "scm":        true
+    });
+
+    helper.onchange(helper.byTestId('form-field-input-scm-plugin'), 'scm-plugin-id');
+
+    assertLabelledInputsDisabledOrNot(helper, {
+      "scm-plugin": false,
+      "scm":        true
+    });
+    const errorElement = helper.byTestId('flash-message-alert');
+    expect(errorElement).toBeInDOM();
+    expect(errorElement.textContent).toBe('There are no SCMs configured for the selected plugin. Go to Pluggable SCM to define one.');
+    expect(helper.q('a', errorElement)).toHaveAttr('href', SparkRoutes.pluggableScmSPA());
+  });
+
+  it('should render error if no scm plugins are installed', () => {
+    pluginInfos = new PluginInfos();
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
+
+    assertLabelledInputsDisabledOrNot(helper, {
+      "scm-plugin": true,
+      "scm":        true
+    });
+    const errorElement = helper.byTestId('flash-message-alert');
+    expect(errorElement).toBeInDOM();
+    expect(errorElement.textContent).toBe('There are no SCM plugins installed. Please see this page for a list of supported plugins.');
+    expect(helper.q('a', errorElement)).toHaveAttr('href', 'https://www.gocd.org/plugins/#scm');
+  });
+
+  it('should render error if no scms are configured', () => {
+    scms = new Scms();
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms}/>);
+
+    assertLabelledInputsDisabledOrNot(helper, {
+      "scm-plugin": true,
+      "scm":        true
+    });
+    const errorElement = helper.byTestId('flash-message-alert');
+    expect(errorElement).toBeInDOM();
+    expect(errorElement.textContent).toBe('There are no SCMs configured. Go to Pluggable SCM to define one.');
+    expect(helper.q('a', errorElement)).toHaveAttr('href', SparkRoutes.pluggableScmSPA());
+  });
+});
+
+function getPluggableScm() {
+  return {
+    id:              "scm-id",
+    name:            "pluggable.scm.material.name",
+    plugin_metadata: {
+      id:      "scm-plugin-id",
+      version: "1"
+    },
+    auto_update:     true,
+    configuration:   [
+      {
+        key:   "url",
+        value: "https://github.com/sample/example.git"
+      }
+    ]
+  } as ScmJSON;
+}
+
+function getScmPlugin() {
+  return {
+    _links:               {
+      self: {
+        href: "http://test-server:8153/go/api/admin/plugin_info/github.pr"
+      },
+      doc:  {
+        href: "https://api.gocd.org/#plugin-info"
+      },
+      find: {
+        href: "http://test-server:8153/go/api/admin/plugin_info/:id"
+      }
+    },
+    id:                   "scm-plugin-id",
+    status:               {
+      state: "active"
+    },
+    plugin_file_location: "/tmp/abc.jar",
+    bundled_plugin:       false,
+    about:                {
+      name:                     "SCM Plugin",
+      version:                  "1.4.0-RC2",
+      target_go_version:        "15.1.0",
+      description:              "Plugin that polls a GitHub repository for pull requests and triggers a build for each of them",
+      target_operating_systems: [],
+      vendor:                   {
+        name: "User",
+        url:  "https://github.com/user/abc"
+      }
+    },
+    extensions:           [{
+      type:         "scm",
+      display_name: "Github",
+      scm_settings: {
+        configurations: [{
+          key:      "url",
+          metadata: {
+            secure:           false,
+            required:         true,
+            part_of_identity: true
+          }
+        }],
+        view:           {
+          template: "<div>some view template</div>"
+        }
+      }
+    }]
+  } as PluginInfoJSON;
 }


### PR DESCRIPTION
Issue:  #6737
GoCD PRs to wait for: #7919, #7920

Description: for supporting selection of pluggable scms as material

Preview when no scm plugins are installed: 

<img width="1100" alt="Screen Shot 2020-03-27 at 9 55 22 PM" src="https://user-images.githubusercontent.com/41165891/77851361-6e05f880-71f6-11ea-8f8c-33ee7c3eec9f.png">

General Preview:

![scm-materials](https://user-images.githubusercontent.com/41165891/77851403-a7d6ff00-71f6-11ea-9717-1df75d7d6d2c.gif)


