### PR TITLE
Continue to build agent image based on debian 8 for now

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -168,7 +168,7 @@ enum Distro implements DistroBehavior {
     @Override
     List<DistroVersion> getSupportedVersions() {
       return [
-        new DistroVersion(version: '8', releaseName: 'jessie', eolDate: parseDate('2020-06-30')),
+        new DistroVersion(version: '8', releaseName: 'jessie', eolDate: parseDate('2020-06-30'), continueToBuild: true),
         new DistroVersion(version: '9', releaseName: 'stretch', eolDate: parseDate('2022-06-30')),
         // No EOL-LTS specified for buster release. Checkout https://wiki.debian.org/DebianReleases for more info
         new DistroVersion(version: '10', releaseName: 'buster', eolDate: parseDate('2024-06-30'))


### PR DESCRIPTION
The Debian 8 based image will reach EOL in June 2020. Hence the builds were failing.

Continue to build them for now.

