### PR TITLE
Update Package Repositories SPA

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_modal_body.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_modal_body.tsx
@@ -69,6 +69,15 @@ export class PackageModalBody extends MithrilViewComponent<Attrs> {
         </Form>
       </FormHeader>
 
+      <div>
+        <TextField label="Id"
+                   readonly={vnode.attrs.disableId}
+                   property={vnode.attrs.package.id}
+                   placeholder={"Enter a unique id for this package"}
+                   helpText={"Each package is associated with an id by which it can be referenced in the pipelines. Once defined, cannot be updated"}
+                   errorText={vnode.attrs.package.errors().errorsForDisplay("id")}/>
+      </div>
+
       <PluginView pluginSettings={(pluginInfo.extensions[0] as PackageRepoExtension).packageSettings}
                   configurations={vnode.attrs.package.configuration()}/>
     </div>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_modals.tsx
@@ -22,6 +22,7 @@ import {PackagesCRUD} from "models/package_repositories/packages_crud";
 import {Package, PackageRepositories, PackageRepository, PackageUsages} from "models/package_repositories/package_repositories";
 import {PackageJSON} from "models/package_repositories/package_repositories_json";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {v4 as uuidv4} from 'uuid';
 import {Link} from "views/components/link";
 import {EntityModal} from "views/components/modal/entity_modal";
 import {Modal, Size} from "views/components/modal";
@@ -146,6 +147,7 @@ export class ClonePackageModal extends PackageModal {
   }
 
   fetchCompleted() {
+    this.entity().id(uuidv4());
     this.entity().name("");
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_modal_body.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_modal_body.tsx
@@ -41,24 +41,34 @@ export class PackageRepositoryModalBody extends MithrilViewComponent<Attrs> {
       return pluginInfo.id === vnode.attrs.pluginIdProxy();
     })!;
 
-    return <div><FormHeader>
-      <Form>
-        <TextField label="Name"
-                   readonly={vnode.attrs.disableId}
-                   property={vnode.attrs.packageRepo.name}
-                   placeholder={"Enter the package repository name"}
-                   errorText={vnode.attrs.packageRepo.errors().errorsForDisplay("name")}
-                   required={true}/>
+    return <div>
+      <FormHeader>
+        <Form>
+          <TextField label="Name"
+                     readonly={vnode.attrs.disableId}
+                     property={vnode.attrs.packageRepo.name}
+                     placeholder={"Enter the package repository name"}
+                     errorText={vnode.attrs.packageRepo.errors().errorsForDisplay("name")}
+                     required={true}/>
 
-        <SelectField label="Plugin"
-                     property={vnode.attrs.pluginIdProxy.bind(this)}
-                     required={true}
-                     errorText={vnode.attrs.packageRepo.errors().errorsForDisplay("pluginId")}>
-          <SelectFieldOptions selected={vnode.attrs.packageRepo.pluginMetadata().id()}
-                              items={pluginList}/>
-        </SelectField>
-      </Form>
-    </FormHeader>
+          <SelectField label="Plugin"
+                       property={vnode.attrs.pluginIdProxy.bind(this)}
+                       required={true}
+                       errorText={vnode.attrs.packageRepo.errors().errorsForDisplay("pluginId")}>
+            <SelectFieldOptions selected={vnode.attrs.packageRepo.pluginMetadata().id()}
+                                items={pluginList}/>
+          </SelectField>
+        </Form>
+      </FormHeader>
+
+      <div>
+        <TextField label="Repo Id"
+                   readonly={vnode.attrs.disableId}
+                   property={vnode.attrs.packageRepo.repoId}
+                   placeholder={"Enter a unique id for this package repository"}
+                   helpText={"Each package repository is associated with an id. Once defined it cannot be updated"}
+                   errorText={vnode.attrs.packageRepo.errors().errorsForDisplay("repoId")}/>
+      </div>
 
       <PluginView pluginSettings={(selectedPluginInfo.extensions[0] as PackageRepoExtension).repositorySettings}
                   configurations={vnode.attrs.packageRepo.configuration()}/>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_modals.tsx
@@ -22,6 +22,7 @@ import {PackageRepository} from "models/package_repositories/package_repositorie
 import {PackageRepositoriesCRUD} from "models/package_repositories/package_repositories_crud";
 import {PackageRepositoryJSON} from "models/package_repositories/package_repositories_json";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {v4 as uuidv4} from 'uuid';
 import {Size} from "views/components/modal";
 import {DeleteConfirmModal} from "views/components/modal/delete_confirm_modal";
 import {EntityModal} from "views/components/modal/entity_modal";
@@ -41,6 +42,13 @@ abstract class PackageRepositoryModal extends EntityModal<PackageRepository> {
     this.disableId          = disableId;
     this.originalEntityId   = entity.repoId();
     this.originalEntityName = entity.name();
+  }
+
+  operationError(errorResponse: any, statusCode: number) {
+    this.errorMessage(errorResponse.message);
+    if (errorResponse.data) {
+      this.entity(this.parseJsonToEntity(errorResponse.data));
+    }
   }
 
   protected modalBody(): m.Children {
@@ -136,6 +144,7 @@ export class ClonePackageRepositoryModal extends PackageRepositoryModal {
   }
 
   fetchCompleted() {
+    this.entity().repoId(uuidv4());
     this.entity().name("");
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_widget.tsx
@@ -16,6 +16,7 @@
 import {MithrilViewComponent} from "jsx/mithril-component";
 import m from "mithril";
 import {PackageRepository} from "models/package_repositories/package_repositories";
+import s from "underscore.string";
 import {ButtonIcon, Secondary} from "views/components/buttons";
 import {CollapsiblePanel} from "views/components/collapsible_panel";
 import {Clone, Delete, Edit, IconGroup} from "views/components/icons";
@@ -44,22 +45,27 @@ export class PackageRepositoryWidget extends MithrilViewComponent<Attrs> {
                                         ["Plugin Id", packageRepository.pluginMetadata().id()],
                                         ...Array.from(pkgRepoProperties)
                                       ]);
+    const disabled          = vnode.attrs.disableActions;
     const actionButtons     = [
       <Secondary onclick={vnode.attrs.packageOperations.onAdd.bind(vnode.attrs, packageRepository)}
                  data-test-id={"package-create"}
-                 disabled={vnode.attrs.disableActions}
+                 disabled={disabled}
+                 title={PackageRepositoryWidget.getMsgForOperation(disabled, packageRepository.name(), "create package for")}
                  icon={ButtonIcon.ADD}>
         Create Package
       </Secondary>,
       <div className={styles.packageRepositoryCrudActions}>
         <IconGroup>
           <Edit data-test-id="package-repo-edit"
-                disabled={vnode.attrs.disableActions}
+                disabled={disabled}
+                title={PackageRepositoryWidget.getMsgForOperation(disabled, packageRepository.name(), "edit")}
                 onclick={vnode.attrs.onEdit.bind(vnode.attrs, packageRepository)}/>
           <Clone data-test-id="package-repo-clone"
-                 disabled={vnode.attrs.disableActions}
+                 disabled={disabled}
+                 title={PackageRepositoryWidget.getMsgForOperation(disabled, packageRepository.name(), "clone")}
                  onclick={vnode.attrs.onClone.bind(vnode.attrs, packageRepository)}/>
           <Delete data-test-id="package-repo-delete"
+                  title={PackageRepositoryWidget.getMsgForOperation(disabled, packageRepository.name(), "delete")}
                   onclick={vnode.attrs.onDelete.bind(vnode.attrs, packageRepository)}/>
         </IconGroup>
       </div>];
@@ -71,7 +77,7 @@ export class PackageRepositoryWidget extends MithrilViewComponent<Attrs> {
                              dataTestId={"package-repository-panel"}>
       <ConfigurationDetailsWidget header={"Package Repository configuration"} data={pkgRepoDetails}/>
       <PackagesWidget packages={vnode.attrs.packageRepository.packages}
-                      disableActions={vnode.attrs.disableActions}
+                      disableActions={disabled}
                       packageOperations={vnode.attrs.packageOperations}/>
     </CollapsiblePanel>;
   }
@@ -81,5 +87,12 @@ export class PackageRepositoryWidget extends MithrilViewComponent<Attrs> {
     map.set("Name", packageRepository.name());
     map.set("Plugin Id", packageRepository.pluginMetadata().id());
     return map;
+  }
+
+  private static getMsgForOperation(disabled: boolean, pkgRepoName: string, operation: "edit" | "clone" | "delete" | "create package for"): string | undefined {
+    if (disabled && operation !== "delete") {
+      return "Plugin not found!";
+    }
+    return `${s.capitalize(operation)} package repository '${pkgRepoName}'`;
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_widget.tsx
@@ -16,6 +16,7 @@
 import {MithrilViewComponent} from "jsx/mithril-component";
 import m from "mithril";
 import {Package} from "models/package_repositories/package_repositories";
+import s from "underscore.string";
 import {CollapsiblePanel} from "views/components/collapsible_panel";
 import {Clone, Delete, Edit, IconGroup, Usage} from "views/components/icons";
 import {KeyValuePair, KeyValueTitle} from "views/components/key_value_pair";
@@ -29,30 +30,44 @@ interface Attrs extends EditOperation<Package>, CloneOperation<Package>, DeleteO
 
 export class PackageWidget extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs, this>): m.Children | void | null {
-    const title         = <span data-test-id="package-id">{vnode.attrs.package.name()}</span>;
+    const pkgName       = vnode.attrs.package.name();
+    const title         = <span data-test-id="package-id">{pkgName}</span>;
     const pkgProperties = vnode.attrs.package.configuration() ? vnode.attrs.package.configuration()!.asMap() : [];
     const pkgDetails    = new Map([
-                                    ["Name", vnode.attrs.package.name()],
+                                    ["Id", vnode.attrs.package.id()],
+                                    ["Name", pkgName],
                                     ["Auto Update", vnode.attrs.package.autoUpdate() + ""],
                                     ...Array.from(pkgProperties)
                                   ]);
+    const disabled      = vnode.attrs.disableActions;
 
     const actionButtons = [
       <IconGroup>
         <Edit data-test-id="package-edit"
-              disabled={vnode.attrs.disableActions}
+              disabled={disabled}
+              title={PackageWidget.getMsgForOperation(disabled, pkgName, "edit")}
               onclick={vnode.attrs.onEdit.bind(vnode.attrs, vnode.attrs.package)}/>
         <Clone data-test-id="package-clone"
-               disabled={vnode.attrs.disableActions}
+               disabled={disabled}
+               title={PackageWidget.getMsgForOperation(disabled, pkgName, "clone")}
                onclick={vnode.attrs.onClone.bind(vnode.attrs, vnode.attrs.package)}/>
         <Delete data-test-id="package-delete"
+                title={PackageWidget.getMsgForOperation(disabled, pkgName, "delete")}
                 onclick={vnode.attrs.onDelete.bind(vnode.attrs, vnode.attrs.package)}/>
         <Usage data-test-id="package-usages"
+               title={PackageWidget.getMsgForOperation(disabled, pkgName, "show usages for")}
                onclick={vnode.attrs.showUsages.bind(vnode.attrs, vnode.attrs.package)}/>
       </IconGroup>];
     return <CollapsiblePanel key={vnode.attrs.package.id()} dataTestId={"package-panel"} actions={actionButtons}
                              header={<KeyValueTitle image={null} title={title}/>}>
       <KeyValuePair data={pkgDetails}/>
     </CollapsiblePanel>;
+  }
+
+  private static getMsgForOperation(disabled: boolean, pkgName: string, operation: "edit" | "clone" | "delete" | "show usages for"): string | undefined {
+    if (disabled && (operation === "edit" || operation === "clone")) {
+      return "Plugin not found!";
+    }
+    return `${s.capitalize(operation)} package '${pkgName}'`;
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_modal_body_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_modal_body_spec.tsx
@@ -52,8 +52,12 @@ describe('PackageModalBodySpec', () => {
     expect(helper.textByTestId('flash-message-info')).toBe('The new package will be available to be used as material in all pipelines. Other admins might be able to edit this package.');
   });
 
-  it('should render input fields for name and package repo', () => {
+  it('should render input fields for id, name and package repo', () => {
     mount();
+
+    expect(helper.byTestId('form-field-input-id')).toBeInDOM();
+    expect(helper.byTestId('form-field-input-id')).not.toBeDisabled();
+    expect(helper.byTestId("form-field-input-id")).toHaveValue(pkg.id());
 
     expect(helper.byTestId('form-field-input-name')).toBeInDOM();
     expect(helper.byTestId('form-field-input-name')).not.toBeDisabled();
@@ -76,11 +80,12 @@ describe('PackageModalBodySpec', () => {
     expect(onPackageRepoChange).toHaveBeenCalledWith(pkgRepo);
   });
 
-  it('should not render the msg and make the name as readonly', () => {
+  it('should not render the msg and make the id and name as readonly', () => {
     disabled = true;
     mount();
 
     expect(helper.byTestId('flash-message-info')).not.toBeInDOM();
+    expect(helper.byTestId('form-field-input-id')).toBeDisabled();
     expect(helper.byTestId('form-field-input-name')).toBeDisabled();
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_repository_modal_body_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_repository_modal_body_spec.tsx
@@ -46,8 +46,12 @@ describe('PackageRepositoryModalBodySpec', () => {
                                                    pluginIdProxy={pluginIdProxy}/>);
   }
 
-  it('should render input fields for name and package repo', () => {
+  it('should render input fields for id, name and package repo', () => {
     mount();
+
+    expect(helper.byTestId('form-field-input-repo-id')).toBeInDOM();
+    expect(helper.byTestId('form-field-input-repo-id')).not.toBeDisabled();
+    expect(helper.byTestId("form-field-input-repo-id")).toHaveValue(packageRepo.repoId());
 
     expect(helper.byTestId('form-field-input-name')).toBeInDOM();
     expect(helper.byTestId('form-field-input-name')).not.toBeDisabled();
@@ -58,10 +62,11 @@ describe('PackageRepositoryModalBodySpec', () => {
     expect(helper.byTestId("form-field-input-plugin").children[0].textContent).toBe('NPM plugin for package repo');
   });
 
-  it('should render the name as readonly', () => {
+  it('should render the id and name as readonly', () => {
     disabled = true;
     mount();
 
+    expect(helper.byTestId('form-field-input-repo-id')).toBeDisabled();
     expect(helper.byTestId('form-field-input-name')).toBeDisabled();
   });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_repository_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_repository_widget_spec.tsx
@@ -62,10 +62,18 @@ describe('PackageRepositoryWidgetSpec', () => {
     expect(helper.byTestId('configuration-details-widget')).toBeInDOM();
     expect(helper.byTestId('packages-widget')).toBeInDOM();
 
-    expect(helper.byTestId('package-create')).toBeInDOM();
-    expect(helper.byTestId('package-repo-edit')).toBeInDOM();
-    expect(helper.byTestId('package-repo-clone')).toBeInDOM();
-    expect(helper.byTestId('package-repo-delete')).toBeInDOM();
+    const buttonKeys: { [key: string]: string } = {
+      'package-create':      "Create package for package repository 'pkg-repo-name'",
+      'package-repo-edit':   "Edit package repository 'pkg-repo-name'",
+      'package-repo-clone':  "Clone package repository 'pkg-repo-name'",
+      'package-repo-delete': "Delete package repository 'pkg-repo-name'"
+    };
+    Object.keys(buttonKeys)
+          .forEach((key) => {
+            expect(helper.byTestId(key)).toBeInDOM();
+            expect(helper.byTestId(key)).not.toBeDisabled();
+            expect(helper.byTestId(key)).toHaveAttr('title', buttonKeys[key]);
+          });
   });
 
   it('should give a call to the callbacks on relevant button clicks', () => {
@@ -84,4 +92,14 @@ describe('PackageRepositoryWidgetSpec', () => {
     expect(onPkgRepoDelete).toHaveBeenCalled();
   });
 
+  it('should disabled action buttons when disabled is set to true', () => {
+    disableActions = true;
+    mount();
+
+    ['package-create', 'package-repo-edit', 'package-repo-clone'].forEach((key) => {
+      expect(helper.byTestId(key)).toBeDisabled();
+      expect(helper.byTestId(key)).toHaveAttr('title', "Plugin not found!");
+    });
+    expect(helper.byTestId('package-repo-delete')).not.toBeDisabled();
+  });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_widget_spec.tsx
@@ -44,18 +44,32 @@ describe('PackageWidgetSpec', () => {
                                       showUsages={onShowUsages}/>);
   }
 
-  it('should render package information', () => {
+  it('should render package information and action buttons', () => {
     mount();
 
     expect(helper.byTestId('package-panel')).toBeInDOM();
     expect(helper.textByTestId('package-id')).toBe(pkg.name());
 
     const configElements = helper.qa('li');
-    expect(configElements.length).toBe(3);
+    expect(configElements.length).toBe(4);
 
-    expect(configElements[0].textContent).toBe('Namepkg-name');
-    expect(configElements[1].textContent).toBe('Auto Updatetrue');
-    expect(configElements[2].textContent).toBe('PACKAGE_IDpkg');
+    expect(configElements[0].textContent).toBe('Idpkg-id');
+    expect(configElements[1].textContent).toBe('Namepkg-name');
+    expect(configElements[2].textContent).toBe('Auto Updatetrue');
+    expect(configElements[3].textContent).toBe('PACKAGE_IDpkg');
+
+    const buttonKeys: { [key: string]: string } = {
+      'package-edit':   "Edit package 'pkg-name'",
+      'package-clone':  "Clone package 'pkg-name'",
+      'package-delete': "Delete package 'pkg-name'",
+      'package-usages': "Show usages for package 'pkg-name'"
+    };
+    Object.keys(buttonKeys)
+          .forEach((key) => {
+            expect(helper.byTestId(key)).toBeInDOM();
+            expect(helper.byTestId(key)).not.toBeDisabled();
+            expect(helper.byTestId(key)).toHaveAttr('title', buttonKeys[key]);
+          });
   });
 
   it('should give a call to the callbacks on relevant button clicks', () => {
@@ -72,6 +86,18 @@ describe('PackageWidgetSpec', () => {
 
     helper.clickByTestId('package-usages');
     expect(onShowUsages).toHaveBeenCalled();
+  });
+
+  it('should disabled action buttons when disabled is set to true', () => {
+    disableActions = true;
+    mount();
+
+    ['package-edit', 'package-clone'].forEach((key) => {
+      expect(helper.byTestId(key)).toBeDisabled();
+      expect(helper.byTestId(key)).toHaveAttr('title', "Plugin not found!");
+    });
+    expect(helper.byTestId('package-delete')).not.toBeDisabled();
+    expect(helper.byTestId('package-usages')).not.toBeDisabled();
   });
 
 });


### PR DESCRIPTION
Issue: #7333 

Description:

 - Added field for updating `id` during add/clone for package repo and package
 - showing `id` as part of configuration for both
 - updated title when actions buttons are disabled

