### PR TITLE
Fix SPA errors

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/nameable_set.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/nameable_set.ts
@@ -27,7 +27,7 @@ export class NameableSet<T extends Nameable> extends ValidatableMixin implements
   [Symbol.toStringTag]: string = `NameableSet`;
   private readonly _members    = new Map<string, T>(); // preserves insertion order
 
-  constructor(items?: readonly T[] | null) {
+  constructor(readonly items?: T[] | null) {
     super();
     Object.setPrototypeOf(this, Object.create(NameableSet.prototype));
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/template_config.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/template_config.ts
@@ -38,7 +38,7 @@ export class TemplateConfig {
   }
 
   static getTemplate(name: string, onSuccess: (result: TemplateConfig) => void) {
-    ApiRequestBuilder.GET(SparkRoutes.templatesPath(name), ApiVersion.v5)
+    ApiRequestBuilder.GET(SparkRoutes.templatesPath(name), ApiVersion.v7)
                      .then((res) => {
                        res.map((body) => onSuccess(TemplateConfig.fromJSON(JSON.parse(body))));
                      });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity.tsx
@@ -156,10 +156,15 @@ export class PipelineActivityPage extends Page<null, State> implements ResultAwa
   }
 
   protected headerPanel(vnode: m.Vnode<null, State>): any {
-    const title = <PipelinePauseHeader pipelineName={this.pipelineActivity().pipelineName()}
-                                       flashMessage={this.flashMessage}
-                                       shouldShowPauseUnpause={this.pipelineActivity().canPause()}
-                                       shouldShowPipelineSettings={Page.isUserAnAdmin() || Page.isUserAGroupAdmin()}/>;
+    let title: m.Children = <div data-test-id="pipeline-pause-header"/>;
+
+    if (this.pipelineActivity()) {
+      title = <PipelinePauseHeader pipelineName={this.pipelineActivity().pipelineName()}
+                                   flashMessage={this.flashMessage}
+                                   shouldShowPauseUnpause={this.pipelineActivity().canPause()}
+                                   shouldShowPipelineSettings={Page.isUserAnAdmin() || Page.isUserAGroupAdmin()}/>;
+    }
+
     return <HeaderPanel title={title} sectionName={this.pageName()} buttons={
       <SearchField property={this.filterText} label={"Search"}
                    dataTestId={"search-field"}


### PR DESCRIPTION
* Fix console errors on pipeline activity page due to uninitialized
  pipeline activity model.

* Fix loading pipeline config SPA when pipeline is using template.
  Use template config API v7 instead of v5 as v5 has been removed.

* Fix typescript compilation errors from 'pipeline_configs/nameable_set.ts'.