### PR TITLE
Render error on popup for pipelines spa

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -40,8 +40,11 @@ export class SparkRoutes {
     }
   }
 
-  static adminPipelineConfigPath(pipelineName: string): string {
-    return `/go/api/admin/pipelines/${pipelineName}`;
+  static adminPipelineConfigPath(pipelineName?: string): string {
+    if (pipelineName) {
+      return `/go/api/admin/pipelines/${pipelineName}`;
+    }
+    return `/go/api/admin/pipelines`;
   }
 
   static adminExtractTemplateFromPipelineConfigPath(pipelineName: string): string {
@@ -59,14 +62,6 @@ export class SparkRoutes {
 
   static createPipelineAsCodePath(): string {
     return `/go/admin/pipelines/as-code`;
-  }
-
-  static pipelineConfigCreatePath(): string {
-    return `/go/api/admin/pipelines`;
-  }
-
-  static getOrUpdatePipelineConfigPath(pipelineName: string): string {
-    return `/go/api/admin/pipelines/${pipelineName}`;
   }
 
   static pipelinePausePath(pipelineName: string): string {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/maintenance_mode/material.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/maintenance_mode/material.ts
@@ -97,6 +97,15 @@ export class Filter {
     const filterPattern = (filter && filter.ignore) ? filter.ignore : [];
     return new Filter(filterPattern);
   }
+
+  toJSON() {
+    if (_.isEmpty(this.ignore())) {
+      return null;
+    }
+    return {
+      ignore: this.ignore()
+    };
+  }
 }
 
 export abstract class MaterialAttributes extends ValidatableMixin {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/maintenance_mode/spec/material_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/maintenance_mode/spec/material_spec.ts
@@ -20,7 +20,8 @@ import {
   MaterialJSON,
   P4MaterialAttributesJSON,
   ScmAttributesJSON,
-  ScmMaterialAttributes, TfsMaterialAttributesJSON
+  ScmMaterialAttributes,
+  TfsMaterialAttributesJSON
 } from "models/maintenance_mode/material";
 
 describe("Material specs", () => {
@@ -148,6 +149,16 @@ describe("Material specs", () => {
       expect(material.attributes().errors().count()).toBe(1);
       expect(material.attributes().errors().keys()).toEqual(["password"]);
     });
+  });
+
+  it('should convert filter into json correctly', () => {
+    const filter = new Filter([]);
+
+    expect(filter.toJSON()).toBeNull();
+
+    filter.ignore(['abc', 'xyz']);
+
+    expect(filter.toJSON()).toEqual({ignore: ['abc', 'xyz']});
   });
 });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/pipeline_config.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/pipeline_config.ts
@@ -191,7 +191,7 @@ export class PipelineConfig extends ValidatableMixin {
   }
 
   static get(pipelineName: string) {
-    return ApiRequestBuilder.GET(SparkRoutes.getOrUpdatePipelineConfigPath(pipelineName), ApiVersion.latest);
+    return ApiRequestBuilder.GET(SparkRoutes.adminPipelineConfigPath(pipelineName), ApiVersion.latest);
   }
 
   static fromJSON(json: PipelineConfigJSON) {
@@ -227,14 +227,14 @@ export class PipelineConfig extends ValidatableMixin {
   }
 
   create(pause: boolean) {
-    return ApiRequestBuilder.POST(SparkRoutes.pipelineConfigCreatePath(), ApiVersion.latest, {
+    return ApiRequestBuilder.POST(SparkRoutes.adminPipelineConfigPath(), ApiVersion.latest, {
       payload: this.toApiPayload(),
       headers: {"X-pause-pipeline": pause.toString(), "X-pause-cause": "Under construction"}
     });
   }
 
   update(etag: string) {
-    return ApiRequestBuilder.PUT(SparkRoutes.getOrUpdatePipelineConfigPath(this.name()), ApiVersion.latest, {
+    return ApiRequestBuilder.PUT(SparkRoutes.adminPipelineConfigPath(this.name()), ApiVersion.latest, {
       payload: this.toPutApiPayload(), etag
     });
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/spec/pipeline_config_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/spec/pipeline_config_spec.ts
@@ -262,7 +262,7 @@ describe("PipelineConfig model", () => {
 });
 
 function stubPipelineCreateSuccess(config: PipelineConfig) {
-  jasmine.Ajax.stubRequest(SparkRoutes.pipelineConfigCreatePath(), undefined, "POST").andReturn({
+  jasmine.Ajax.stubRequest(SparkRoutes.adminPipelineConfigPath(), undefined, "POST").andReturn({
                                                                                                   responseText: JSON.stringify(
                                                                                                     config.toApiPayload()),
                                                                                                   status: 200,

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines.tsx
@@ -36,7 +36,14 @@ import {HeaderPanel} from "views/components/header_panel";
 import {Modal, ModalState} from "views/components/modal";
 import {DeleteConfirmModal} from "views/components/modal/delete_confirm_modal";
 import {Attrs, PipelineGroupsWidget, PipelinesScrollOptions} from "views/pages/admin_pipelines/admin_pipelines_widget";
-import {ClonePipelineConfigModal, CreatePipelineGroupModal, DownloadPipelineModal, ExtractTemplateModal, MoveConfirmModal} from "views/pages/admin_pipelines/modals";
+import {
+  ClonePipelineConfigModal,
+  CreatePipelineGroupModal,
+  DeletePipelineGroupModal,
+  DownloadPipelineModal,
+  ExtractTemplateModal,
+  MoveConfirmModal
+} from "views/pages/admin_pipelines/modals";
 import {Page, PageState} from "views/pages/page";
 import buttonStyle from "views/pages/pipelines/actions.scss";
 import {EditPipelineGroupModal} from "./admin_pipelines/edit_pipeline_group_modal";
@@ -132,7 +139,7 @@ export class AdminPipelinesPage extends Page<null, State> {
                ApiVersion.latest,
                {
                  payload: pipelineToSave,
-                 etag: etag()
+                 etag:    etag()
                })
           .then((apiResult) => {
             apiResult.do(
@@ -177,23 +184,8 @@ export class AdminPipelinesPage extends Page<null, State> {
     };
 
     vnode.state.doDeleteGroup = (group) => {
-      const message = <span>Are you sure you want to delete the pipeline group <em>{group.name()}</em>?</span>;
-
-      const modal: DeleteConfirmModal = new DeleteConfirmModal(message, () => {
-        return ApiRequestBuilder.DELETE(SparkRoutes.pipelineGroupsPath(group.name()), ApiVersion.latest)
-                                .then((result) => {
-                                  result.do(
-                                    () => vnode.state.onSuccessfulSave(
-                                      <span>The pipeline group <em>{group.name()}</em> was deleted successfully!</span>
-                                    ),
-                                    onOperationError
-                                  );
-
-                                })
-                                .finally(modal.close.bind(modal));
-      });
-      modal.render();
-
+      new DeletePipelineGroupModal(group.name(), vnode.state.onSuccessfulSave)
+        .render();
     };
 
     vnode.state.doDeletePipeline = (pipeline) => {
@@ -261,12 +253,12 @@ export class AdminPipelinesPage extends Page<null, State> {
                 ApiVersion.latest,
                 {
                   payload: {
-                    group: newPipelineGroup,
+                    group:    newPipelineGroup,
                     pipeline: pipelineToSave
                   },
                   headers: {
                     "X-pause-pipeline": "true",
-                    "X-pause-cause": "Under construction"
+                    "X-pause-cause":    "Under construction"
                   }
                 })
           .then((apiResult) => {
@@ -302,7 +294,7 @@ export class AdminPipelinesPage extends Page<null, State> {
       const modal         = new DownloadPipelineModal(pipeline, vnode.state.pluginInfos(), (pluginId) => {
         m.request(SparkRoutes.exportPipelinePath(pluginId, pipeline.name()), {
           headers: {
-            "Accept": ApiRequestBuilder.versionHeader(ApiVersion.latest),
+            "Accept":           ApiRequestBuilder.versionHeader(ApiVersion.latest),
             "X-Requested-With": "XMLHttpRequest"
           },
           config(xhr: XMLHttpRequest) {
@@ -396,7 +388,7 @@ export class AdminPipelinesPage extends Page<null, State> {
         return result
           .map((body) => {
             return {
-              etag: result.getEtag(),
+              etag:   result.getEtag(),
               object: JSON.parse(body)
             } as ObjectWithEtag<any>;
           })

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/admin_pipelines_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/admin_pipelines_widget_spec.tsx
@@ -91,7 +91,7 @@ describe("PipelineGroupsWidget", () => {
   });
 
   it("should perform pipeline interactions for pipelines defined in config", () => {
-    const pipelineInXml = new PipelineWithOrigin("in-config", undefined, new Origin(OriginType.GoCD), [], null , []);
+    const pipelineInXml = new PipelineWithOrigin("in-config", undefined, new Origin(OriginType.GoCD), [], null, []);
 
     attrs.pipelineGroups().push(new PipelineGroup("foo", new Pipelines(pipelineInXml)));
 
@@ -221,6 +221,45 @@ describe("PipelineGroupsWidget", () => {
 
       expect(deletePipelineElement).toBeDisabled();
       expect(deletePipelineElement).toHaveAttr('title', "Cannot delete pipeline 'some-pipeline' as pipeline(s) 'pipeline1,pipeline2' depends on it.");
+    });
+
+    it('should render disabled msg for move if pipeline is defined remotely', () => {
+      pipelineJSON.origin.type = OriginType.ConfigRepo;
+      pipelineJSON.origin.id   = 'config-repo-id';
+      attrs.pipelineGroups().push(new PipelineGroup("foo", new Pipelines(PipelineWithOrigin.fromJSON(pipelineJSON))));
+      helper.mount(() => {
+        return <PipelineGroupsWidget {...attrs}/>;
+      });
+
+      const movePipelineElement = helper.byTestId(`move-pipeline-${pipelineJSON.name}`);
+
+      expect(movePipelineElement).toBeDisabled();
+      expect(movePipelineElement).toHaveAttr('title', "Cannot move pipeline 'some-pipeline' as it is defined in configuration repository 'config-repo-id'.");
+    });
+
+    it('should render disabled msg for move if there is only one pipeline grp', () => {
+      attrs.pipelineGroups().push(new PipelineGroup("foo", new Pipelines(PipelineWithOrigin.fromJSON(pipelineJSON))));
+      helper.mount(() => {
+        return <PipelineGroupsWidget {...attrs}/>;
+      });
+
+      const movePipelineElement = helper.byTestId(`move-pipeline-${pipelineJSON.name}`);
+
+      expect(movePipelineElement).toBeDisabled();
+      expect(movePipelineElement).toHaveAttr('title', "Cannot move pipeline 'some-pipeline' as there are no other group(s).");
+    });
+
+    it('should be able to move a pipeline', () => {
+      attrs.pipelineGroups().push(new PipelineGroup("foo", new Pipelines(PipelineWithOrigin.fromJSON(pipelineJSON))));
+      attrs.pipelineGroups().push(new PipelineGroup("bar", new Pipelines()));
+      helper.mount(() => {
+        return <PipelineGroupsWidget {...attrs}/>;
+      });
+
+      const movePipelineElement = helper.byTestId(`move-pipeline-${pipelineJSON.name}`);
+
+      expect(movePipelineElement).not.toBeDisabled();
+      expect(movePipelineElement).toHaveAttr('title', "Move pipeline 'some-pipeline'");
     });
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/modals.tsx
@@ -28,7 +28,7 @@ import {FlashMessage, MessageType} from "views/components/flash_message";
 import {Form, FormBody} from "views/components/forms/form";
 import {SelectField, SelectFieldOptions, TextField} from "views/components/forms/input_fields";
 import {Link} from "views/components/link";
-import {Modal} from "views/components/modal";
+import {Modal, Size} from "views/components/modal";
 import {OperationState} from "../page_operations";
 
 export class MoveConfirmModal extends Modal {
@@ -279,7 +279,7 @@ export class DeletePipelineGroupModal extends Modal {
   private apiService: ApiService<string>;
 
   constructor(pipelineGrpName: string, successCallback: (msg: m.Children) => void, apiService?: ApiService<string>) {
-    super();
+    super(Size.small);
     this.pipelineGrpName = pipelineGrpName;
     this.successCallback = successCallback;
     this.apiService      = apiService ? apiService : new DeletePipelineGroupService(pipelineGrpName);


### PR DESCRIPTION
Issue: #7860

Description: Update pipelines SPA:

 - delete pipeline group will render any error on the popup itself and close only on success
 - disabled the move pipeline button if there is only one pipeline grp - added the disabled msg on the same
 - update the move pipeline modal to show all errors on the modal itself
 - refactored clone pipeline modal to show all errors on the modal itself
