### PR TITLE
Use ephemeral auto register keys for elastic agents #000

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -231,6 +231,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<Long> HSTS_HEADER_MAX_AGE = new GoLongSystemProperty("gocd.hsts.header.max.age", ONE_YEAR);
     public static GoSystemProperty<Boolean> HSTS_HEADER_INCLUDE_SUBDOMAINS = new GoBooleanSystemProperty("gocd.hsts.header.include.subdomains", false);
     public static GoSystemProperty<Boolean> HSTS_HEADER_PRELOAD = new GoBooleanSystemProperty("gocd.hsts.header.preload", false);
+    public static GoSystemProperty<Long> EPHEMERAL_AUTO_REGISTER_KEY_EXPIRY = new GoLongSystemProperty("gocd.ephemeral.auto.register.key.expiry.millis", 30 * 60 *1000L);
 
     private final static Map<String, String> GIT_ALLOW_PROTOCOL;
 
@@ -922,6 +923,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public Optional<String> wrapperConfigDirPath() {
         return Optional.ofNullable(System.getenv("WRAPPER_CONF_DIR"));
+    }
+
+    public long getEphemeralAutoRegisterKeyExpiryInMillis() {
+        return EPHEMERAL_AUTO_REGISTER_KEY_EXPIRY.getValue();
     }
 
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/EphemeralAutoRegisterKeyService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EphemeralAutoRegisterKeyService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.apache.commons.collections4.map.PassiveExpiringMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import static java.util.UUID.randomUUID;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@Service
+public class EphemeralAutoRegisterKeyService {
+    private PassiveExpiringMap<String, String> keyStore;
+
+    @Autowired
+    public EphemeralAutoRegisterKeyService(SystemEnvironment systemEnvironment) {
+        keyStore = new PassiveExpiringMap<>(systemEnvironment.getEphemeralAutoRegisterKeyExpiryInMillis(), MILLISECONDS);
+    }
+
+    public String autoRegisterKey() {
+        String uuid = randomUUID().toString();
+        keyStore.put(uuid, uuid);
+
+        return uuid;
+    }
+
+    public boolean validateAndRevoke(String autoRegisterKey) {
+        if (keyStore.containsKey(autoRegisterKey)) {
+            keyStore.remove(autoRegisterKey);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/EphemeralAutoRegisterKeyServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/EphemeralAutoRegisterKeyServiceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static java.lang.Thread.sleep;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class EphemeralAutoRegisterKeyServiceTest {
+    @Mock
+    SystemEnvironment systemEnvironment;
+    EphemeralAutoRegisterKeyService service;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+        service = new EphemeralAutoRegisterKeyService(systemEnvironment);
+    }
+
+    @Nested
+    class autoRegisterKey {
+        @Test
+        void shouldGenerateANewAutoRegisterKey() {
+            String autoRegisterKey = service.autoRegisterKey();
+
+            assertThat(autoRegisterKey).isNotBlank();
+        }
+    }
+
+    @Nested
+    class validateAndRevoke {
+        @Test
+        void shouldBeAValidKeyIfCheckingForValidityForTheFirstTime() {
+            when(systemEnvironment.getEphemeralAutoRegisterKeyExpiryInMillis()).thenReturn(10000L);
+
+            service = new EphemeralAutoRegisterKeyService(systemEnvironment);
+
+            String autoRegisterKey = service.autoRegisterKey();
+
+            assertThat(service.validateAndRevoke(autoRegisterKey)).isTrue();
+        }
+
+        @Test
+        void shouldRevokeKeyOnceValidated() {
+            when(systemEnvironment.getEphemeralAutoRegisterKeyExpiryInMillis()).thenReturn(10000L);
+
+            service = new EphemeralAutoRegisterKeyService(systemEnvironment);
+
+            String autoRegisterKey = service.autoRegisterKey();
+
+            assertThat(service.validateAndRevoke(autoRegisterKey)).isTrue();
+            assertThat(service.validateAndRevoke(autoRegisterKey)).isFalse();
+        }
+
+        @Test
+        void shouldNotBeValidIfKeyIsExpired() throws InterruptedException {
+            when(systemEnvironment.getEphemeralAutoRegisterKeyExpiryInMillis()).thenReturn(1L);
+
+            service = new EphemeralAutoRegisterKeyService(systemEnvironment);
+
+            String autoRegisterKey = service.autoRegisterKey();
+
+            sleep(10L);
+            assertThat(service.validateAndRevoke(autoRegisterKey)).isFalse();
+        }
+    }
+}

--- a/server/src/test-integration/java/com/thoughtworks/go/server/controller/AgentRegistrationControllerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/controller/AgentRegistrationControllerIntegrationTest.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.domain.AgentConfigStatus;
 import com.thoughtworks.go.domain.AgentInstance;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 import com.thoughtworks.go.server.service.AgentService;
+import com.thoughtworks.go.server.service.EphemeralAutoRegisterKeyService;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.util.UuidGenerator;
 import org.junit.jupiter.api.AfterEach;
@@ -66,6 +67,8 @@ public class AgentRegistrationControllerIntegrationTest {
     private AgentService agentService;
     @Autowired
     private UuidGenerator uuidGenerator;
+    @Autowired
+    EphemeralAutoRegisterKeyService ephemeralAutoRegisterKeyService;
 
     static final Cloner CLONER = new Cloner();
     private Properties original;
@@ -96,7 +99,7 @@ public class AgentRegistrationControllerIntegrationTest {
 
     @Test
     public void shouldRegisterElasticAgent() {
-        String autoRegisterKey = goConfigService.serverConfig().getAgentAutoRegisterKey();
+        String autoRegisterKey = ephemeralAutoRegisterKeyService.autoRegisterKey();
         String uuid = UUID.randomUUID().toString();
         String elasticAgentId = UUID.randomUUID().toString();
         MockHttpServletRequest request = new MockHttpServletRequest();
@@ -123,7 +126,6 @@ public class AgentRegistrationControllerIntegrationTest {
 
     @Test
     public void shouldNotRegisterElasticAgentWithDuplicateElasticAgentID() {
-        String autoRegisterKey = goConfigService.serverConfig().getAgentAutoRegisterKey();
         String uuid = UUID.randomUUID().toString();
         String elasticAgentId = UUID.randomUUID().toString();
         MockHttpServletRequest request = new MockHttpServletRequest();
@@ -133,7 +135,7 @@ public class AgentRegistrationControllerIntegrationTest {
                 "sandbox",
                 "100",
                 "Alpine Linux v3.5",
-                autoRegisterKey,
+                ephemeralAutoRegisterKeyService.autoRegisterKey(),
                 "",
                 "",
                 "hostname",
@@ -149,7 +151,7 @@ public class AgentRegistrationControllerIntegrationTest {
                 "sandbox",
                 "100",
                 "Alpine Linux v3.5",
-                autoRegisterKey,
+                ephemeralAutoRegisterKeyService.autoRegisterKey(),
                 "",
                 "",
                 "hostname",


### PR DESCRIPTION
* The ephemeral keys are short lived and expire based on the system
  property 'gocd.ephemeral.auto.register.key.expiry.millis' defaulted to
  30 mins.
* The ephemeral keys can be used only once, the keys will be revoked upon
  validation.
* Elastic agents can only register using the ephemeral keys, non-elastic
  agents continue to use the autoRegisterKey.

