### PR TITLE
[Pipeline Config SPA] show global errors from API response

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/flash_message/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/flash_message/index.tsx
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import classnames from "classnames";
+import {ErrorResponse} from "helpers/api_request_builder";
 import {MithrilComponent} from "jsx/mithril-component";
 import _ from "lodash";
 import m from "mithril";
@@ -155,6 +157,19 @@ export class FlashMessageModelWithTimeout extends FlashMessageModel implements F
 
   alert(message: m.Children, onTimeout?: callback) {
     this.setMessage(MessageType.alert, message, onTimeout);
+  }
+
+  consumeErrorResponse(errorResponse: ErrorResponse) {
+    const parsed            = errorResponse.body ? JSON.parse(errorResponse.body!) : {};
+    let message: m.Children = parsed.message ? parsed.message : errorResponse.message;
+
+    if (parsed.data && parsed.data.errors) {
+      message = (<div>{message}
+        <ul>{_.flatten(Object.values(parsed.data.errors)).map(e => <li>{e}</li>)}</ul>
+      </div>);
+    }
+
+    this.setMessage(MessageType.alert, message);
   }
 
   setMessage(type: MessageType, message: m.Children, timeoutCallback?: callback) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/flash_message/spec/index_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/flash_message/spec/index_spec.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ErrorResponse} from "helpers/api_request_builder";
+import m from "mithril";
+import {FlashMessageModelWithTimeout, MessageType} from "views/components/flash_message/index";
+
+describe("Flash Message", () => {
+
+  let flashMessage: FlashMessageModelWithTimeout;
+
+  beforeEach(() => {
+    flashMessage = new FlashMessageModelWithTimeout();
+  });
+
+  it("should set message and type", () => {
+    const message = "Success!";
+    flashMessage.setMessage(MessageType.success, message);
+
+    expect(flashMessage.type).toBe(MessageType.success);
+    expect(flashMessage.message).toBe(message);
+  });
+
+  describe("Consume Error Response", () => {
+    it("should show error message", () => {
+      const message = "top level message";
+
+      const errorResponse: ErrorResponse = {message};
+      flashMessage.consumeErrorResponse(errorResponse);
+
+      expect(flashMessage.type).toBe(MessageType.alert);
+      expect(flashMessage.message).toBe(errorResponse.message);
+    });
+
+    it("should show error message from body when one exists", () => {
+      const message = "message from body";
+
+      const errorResponse: ErrorResponse = {
+        message: "",
+        body: JSON.stringify({message})
+      };
+
+      flashMessage.consumeErrorResponse(errorResponse);
+
+      expect(flashMessage.type).toBe(MessageType.alert);
+      expect(flashMessage.message).toBe(message);
+    });
+
+    it("should show error message from body when both error exists", () => {
+      const topLevelMessage = "message from body";
+      const bodyMessage     = "message from body";
+
+      const errorResponse: ErrorResponse = {
+        message: topLevelMessage,
+        body: JSON.stringify({message: bodyMessage})
+      };
+
+      flashMessage.consumeErrorResponse(errorResponse);
+
+      expect(flashMessage.type).toBe(MessageType.alert);
+      expect(flashMessage.message).toBe(bodyMessage);
+    });
+
+    it("should show any errors that exists at the top level", () => {
+      const data = {
+        errors: {
+          stage: "pipeline save failed because stage 'stage1' does not exists",
+          base: "save failed"
+        }
+      };
+
+      const errorResponse: ErrorResponse = {
+        message: "Something failed",
+        body: JSON.stringify({data})
+      };
+
+      const expectedMessageForDisplay = <div>
+        {errorResponse.message}
+        <ul>
+          <li>{data.errors.stage}</li>
+          <li>{data.errors.base}</li>
+        </ul>
+      </div>;
+
+      flashMessage.consumeErrorResponse(errorResponse);
+      expect(flashMessage.type).toBe(MessageType.alert);
+      expect(flashMessage.message).toEqual(expectedMessageForDisplay);
+    });
+  });
+});

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
@@ -238,8 +238,7 @@ export class TasksWidget extends MithrilComponent<Attrs, State> {
       vnode.attrs.flashMessage.setMessage(MessageType.success, `Task deleted successfully.`);
     }).catch((errorResponse: ErrorResponse) => {
       vnode.attrs.tasks().splice(taskIndex, 0, taskToDelete);
-      const msg = errorResponse.body ? JSON.parse(errorResponse.body).message : errorResponse.message;
-      vnode.attrs.flashMessage.setMessage(MessageType.alert, msg);
+      vnode.attrs.flashMessage.consumeErrorResponse(errorResponse);
     }).finally(m.redraw.sync);
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stages_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stages_tab_content.tsx
@@ -185,8 +185,7 @@ export class StagesWidget extends MithrilComponent<Attrs, State> {
       vnode.attrs.flashMessage.setMessage(MessageType.success, `Stage '${stageToDelete.name()}' deleted successfully.`);
     }).catch((errorResponse: ErrorResponse) => {
       vnode.attrs.stages().add(stageToDelete);
-      const msg = errorResponse.body ? JSON.parse(errorResponse.body).message : errorResponse.message;
-      vnode.attrs.flashMessage.setMessage(MessageType.alert, msg);
+      vnode.attrs.flashMessage.consumeErrorResponse(errorResponse);
     }).finally(m.redraw.sync);
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/jobs_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/jobs_tab_content.tsx
@@ -181,8 +181,7 @@ export class JobsWidget extends MithrilComponent<Attrs, State> {
       vnode.attrs.flashMessage.setMessage(MessageType.success, `Job '${jobToDelete.name()}' deleted successfully.`);
     }).catch((errorResponse: ErrorResponse) => {
       vnode.attrs.jobs().add(jobToDelete);
-      const msg = errorResponse.body ? JSON.parse(errorResponse.body).message : errorResponse.message;
-      vnode.attrs.flashMessage.setMessage(MessageType.alert, msg);
+      vnode.attrs.flashMessage.consumeErrorResponse(errorResponse);
     }).finally(m.redraw.sync);
   }
 }


### PR DESCRIPTION
#### Description:

* Pipeline config API validation errors are bound to the API response
  field. But, rarely, it could happen that few errors are global
  errors and can not be bound to any of the pipeline config API field.
  Such errors are shown as the top level errors in the API response.

* Show pipeline config API global validation errors as part of the
  flash message.

---

* As part of the pipeline config SPA, the SPA will try to re-implement some of these validations on the client side too, to avoid users running into these validation errors, but as pipeline config depends on many other GoCD entities, its possible that the SPA might miss some of these validations.

<img width="1440" alt="Screen Shot 2020-04-07 at 12 51 34 PM" src="https://user-images.githubusercontent.com/15275847/78642469-6a4a3400-78d0-11ea-8d36-841b1955d73b.png">


**Note:** The error messages shown in the screenshot are just for demo purpose. 
These errors are caused due to deletion of stage which has dependent downstream pipelines. On SPA, the delete button of such stage is disabled.

