### PR TITLE
Update Package Repo SPA

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/package_repositories/package_repositories.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/package_repositories/package_repositories.ts
@@ -64,7 +64,6 @@ export class Package extends ValidatableMixin {
     this.packageRepo   = Stream(packageRepo);
     this.errors(errors);
 
-    this.validatePresenceOf("id");
     this.validatePresenceOf("name");
     this.validateFormatOf("name",
                           new RegExp("^[-a-zA-Z0-9_][-a-zA-Z0-9_.]*$"),
@@ -144,7 +143,6 @@ export class PackageRepository extends ValidatableMixin {
     this.packages       = Stream(packages);
     this.errors((errors));
 
-    this.validatePresenceOf("repoId");
     this.validatePresenceOf("name");
     this.validateFormatOf("name",
                           new RegExp("^[-a-zA-Z0-9_][-a-zA-Z0-9_.]*$"),

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/package_repositories/spec/package_repositories_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/package_repositories/spec/package_repositories_spec.ts
@@ -32,18 +32,6 @@ describe('PackageRepositoriesModelSpec', () => {
       expect(pkg.packageRepo().errors().keys()).toEqual(["id"]);
     });
 
-    it("should validate presence of id", () => {
-      const packageJSON = getPackage();
-      delete packageJSON.id;
-      const pkg = Package.fromJSON(packageJSON);
-
-      const isValid = pkg.isValid();
-
-      expect(isValid).toBe(false);
-      expect(pkg.errors().count()).toEqual(1);
-      expect(pkg.errors().keys()).toEqual(["id"]);
-    });
-
     it("should validate presence of name", () => {
       const packageJSON = getPackage();
       delete packageJSON.name;
@@ -92,18 +80,6 @@ describe('PackageRepositoriesModelSpec', () => {
     expect(isValid).toBe(false);
     expect(packageRepository.pluginMetadata().errors().count()).toEqual(1);
     expect(packageRepository.pluginMetadata().errors().keys()).toEqual(["id"]);
-  });
-
-  it("should validate presence of repoId", () => {
-    const packageRepositoryJSON = getPackageRepository();
-    delete packageRepositoryJSON.repo_id;
-    const packageRepository = PackageRepository.fromJSON(packageRepositoryJSON);
-
-    const isValid = packageRepository.isValid();
-
-    expect(isValid).toBe(false);
-    expect(packageRepository.errors().count()).toEqual(1);
-    expect(packageRepository.errors().keys()).toEqual(["repoId"]);
   });
 
   it("should validate presence of name", () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/delete_confirm_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/delete_confirm_modal.tsx
@@ -16,13 +16,15 @@
 import m from "mithril";
 import Stream from "mithril/stream";
 import * as Buttons from "views/components/buttons";
+import {FlashMessage, MessageType} from "views/components/flash_message";
 import {Modal, Size} from "views/components/modal";
-import {OperationState} from "../../pages/page_operations";
+import {OperationState} from "views/pages/page_operations";
 
 export class DeleteConfirmModal extends Modal {
   private readonly message: m.Children;
   private readonly modalTitle: string;
   private readonly ondelete: () => Promise<any>;
+  protected errorMessage?: string;
   private operationState: Stream<OperationState> = Stream<OperationState>(OperationState.UNKNOWN);
 
   constructor(message: m.Children, ondelete: () => Promise<any>, title = "Are you sure?") {
@@ -33,6 +35,9 @@ export class DeleteConfirmModal extends Modal {
   }
 
   body(): m.Children {
+    if (this.errorMessage !== undefined) {
+      return <FlashMessage type={MessageType.alert} message={this.errorMessage}/>;
+    }
     return <div>{this.message}</div>;
   }
 
@@ -41,6 +46,12 @@ export class DeleteConfirmModal extends Modal {
   }
 
   buttons(): m.ChildArray {
+    if (this.errorMessage !== undefined) {
+      return [
+        <Buttons.Primary ajaxOperationMonitor={this.operationState} data-test-id='button-no-delete'
+                         onclick={this.close.bind(this)}>OK</Buttons.Primary>
+      ];
+    }
     return [
       <Buttons.Danger data-test-id='button-delete'
                       ajaxOperationMonitor={this.operationState}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/entity_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/entity_modal.tsx
@@ -37,7 +37,8 @@ export abstract class EntityModal<T extends ValidatableMixin> extends Modal {
   protected readonly onSuccessfulSave: (msg: m.Children) => any;
   protected readonly isStale                      = Stream(true);
   protected readonly etag: Stream<string>         = Stream();
-  protected ajaxOperationMonitor = Stream<OperationState>(OperationState.UNKNOWN);
+  protected ajaxOperationMonitor                  = Stream<OperationState>(OperationState.UNKNOWN);
+  protected needsFoundationStyles                 = Stream(true);
 
   constructor(entity: T,
               pluginInfos: PluginInfos,
@@ -73,7 +74,10 @@ export abstract class EntityModal<T extends ValidatableMixin> extends Modal {
       </div> : null;
     return [
       flashMessage,
-      <div className={foundationClassNames(foundationStyles.foundationGridHax, foundationStyles.foundationFormHax)}>
+      <div className={foundationClassNames({
+                                             [foundationStyles.foundationGridHax]: this.needsFoundationStyles(),
+                                             [foundationStyles.foundationFormHax]: this.needsFoundationStyles()
+                                           })}>
         {this.modalBody()}
       </div>
     ];

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories.tsx
@@ -23,7 +23,6 @@ import {Package, PackageRepositories, PackageRepository, PackageRepositorySummar
 import {PackageRepositoriesCRUD} from "models/package_repositories/package_repositories_crud";
 import {ExtensionTypeString, PackageRepoExtensionType} from "models/shared/plugin_infos_new/extension_type";
 import {PluginInfoCRUD} from "models/shared/plugin_infos_new/plugin_info_crud";
-import {v4 as uuidv4} from 'uuid';
 import {ButtonIcon, Primary} from "views/components/buttons";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {SearchField} from "views/components/forms/input_fields";
@@ -200,7 +199,6 @@ export class PackageRepositoriesPage extends Page<null, State> {
 
       const pluginId          = vnode.state.pluginInfos()[0].id;
       const packageRepository = PackageRepository.default();
-      packageRepository.repoId(uuidv4());
       packageRepository.pluginMetadata().id(pluginId);
       new CreatePackageRepositoryModal(packageRepository, vnode.state.pluginInfos(), vnode.state.onSuccessfulSave)
         .render();
@@ -222,7 +220,7 @@ export class PackageRepositoriesPage extends Page<null, State> {
     vnode.state.packageRepoOperations.onDelete = (pkgRepo: PackageRepository, e: MouseEvent) => {
       e.stopPropagation();
 
-      new DeletePackageRepositoryModal(pkgRepo, vnode.state.onSuccessfulSave, this.onOperationError(vnode))
+      new DeletePackageRepositoryModal(pkgRepo, vnode.state.onSuccessfulSave)
         .render();
     };
   }
@@ -235,7 +233,6 @@ export class PackageRepositoriesPage extends Page<null, State> {
 
       const pkg = Package.default();
       pkg.packageRepo().id(packageRepo.repoId());
-      pkg.id(uuidv4());
       new CreatePackageModal(pkg, vnode.state.packageRepositories(), vnode.state.pluginInfos(), vnode.state.onSuccessfulSave)
         .render();
     };
@@ -257,7 +254,7 @@ export class PackageRepositoriesPage extends Page<null, State> {
     vnode.state.packageOperations.onDelete = (pkg: Package, e: MouseEvent) => {
       e.stopPropagation();
 
-      new DeletePackageModal(pkg, vnode.state.onSuccessfulSave, this.onOperationError(vnode))
+      new DeletePackageModal(pkg, vnode.state.onSuccessfulSave)
         .render();
     };
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_widget.tsx
@@ -34,17 +34,20 @@ interface Attrs extends EditOperation<PackageRepository>, CloneOperation<Package
 }
 
 export class PackageRepositoryWidget extends MithrilViewComponent<Attrs> {
-  view(vnode: m.Vnode<Attrs, this>): m.Children | void | null {
-    const header = <KeyValuePair inline={true}
-                                 data={PackageRepositoryWidget.headerMap(vnode.attrs.packageRepository)}/>;
 
-    const packageRepository = vnode.attrs.packageRepository;
+  public static getPkgRepoDetails(packageRepository: PackageRepository) {
     const pkgRepoProperties = packageRepository.configuration() ? packageRepository.configuration()!.asMap() : [];
-    const pkgRepoDetails    = new Map([
-                                        ["Name", packageRepository.name()],
-                                        ["Plugin Id", packageRepository.pluginMetadata().id()],
-                                        ...Array.from(pkgRepoProperties)
-                                      ]);
+    return new Map([
+                     ["Repo Id", packageRepository.repoId()],
+                     ["Plugin Id", packageRepository.pluginMetadata().id()],
+                     ...Array.from(pkgRepoProperties)
+                   ]);
+  }
+
+  view(vnode: m.Vnode<Attrs, this>): m.Children | void | null {
+    const header            = <KeyValuePair inline={true} data={PackageRepositoryWidget.headerMap(vnode.attrs.packageRepository)}/>;
+    const packageRepository = vnode.attrs.packageRepository;
+    const pkgRepoDetails    = PackageRepositoryWidget.getPkgRepoDetails(packageRepository);
     const disabled          = vnode.attrs.disableActions;
     const actionButtons     = [
       <Secondary onclick={vnode.attrs.packageOperations.onAdd.bind(vnode.attrs, packageRepository)}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_widget.tsx
@@ -29,36 +29,41 @@ interface Attrs extends EditOperation<Package>, CloneOperation<Package>, DeleteO
 }
 
 export class PackageWidget extends MithrilViewComponent<Attrs> {
+
+  public static getPkgDetails(pkg: Package) {
+    const pkgProperties = pkg.configuration() ? pkg.configuration()!.asMap() : [];
+    return new Map([
+                     ["Id", pkg.id()],
+                     ["Name", pkg.name()],
+                     ["Auto Update", pkg.autoUpdate() + ""],
+                     ...Array.from(pkgProperties)
+                   ]);
+  }
+
   view(vnode: m.Vnode<Attrs, this>): m.Children | void | null {
-    const pkgName       = vnode.attrs.package.name();
-    const title         = <span data-test-id="package-id">{pkgName}</span>;
-    const pkgProperties = vnode.attrs.package.configuration() ? vnode.attrs.package.configuration()!.asMap() : [];
-    const pkgDetails    = new Map([
-                                    ["Id", vnode.attrs.package.id()],
-                                    ["Name", pkgName],
-                                    ["Auto Update", vnode.attrs.package.autoUpdate() + ""],
-                                    ...Array.from(pkgProperties)
-                                  ]);
-    const disabled      = vnode.attrs.disableActions;
+    const pkg        = vnode.attrs.package;
+    const title      = <span data-test-id="package-id">{pkg.name()}</span>;
+    const pkgDetails = PackageWidget.getPkgDetails(pkg);
+    const disabled   = vnode.attrs.disableActions;
 
     const actionButtons = [
       <IconGroup>
         <Edit data-test-id="package-edit"
               disabled={disabled}
-              title={PackageWidget.getMsgForOperation(disabled, pkgName, "edit")}
-              onclick={vnode.attrs.onEdit.bind(vnode.attrs, vnode.attrs.package)}/>
+              title={PackageWidget.getMsgForOperation(disabled, pkg.name(), "edit")}
+              onclick={vnode.attrs.onEdit.bind(vnode.attrs, pkg)}/>
         <Clone data-test-id="package-clone"
                disabled={disabled}
-               title={PackageWidget.getMsgForOperation(disabled, pkgName, "clone")}
-               onclick={vnode.attrs.onClone.bind(vnode.attrs, vnode.attrs.package)}/>
+               title={PackageWidget.getMsgForOperation(disabled, pkg.name(), "clone")}
+               onclick={vnode.attrs.onClone.bind(vnode.attrs, pkg)}/>
         <Delete data-test-id="package-delete"
-                title={PackageWidget.getMsgForOperation(disabled, pkgName, "delete")}
-                onclick={vnode.attrs.onDelete.bind(vnode.attrs, vnode.attrs.package)}/>
+                title={PackageWidget.getMsgForOperation(disabled, pkg.name(), "delete")}
+                onclick={vnode.attrs.onDelete.bind(vnode.attrs, pkg)}/>
         <Usage data-test-id="package-usages"
-               title={PackageWidget.getMsgForOperation(disabled, pkgName, "show usages for")}
-               onclick={vnode.attrs.showUsages.bind(vnode.attrs, vnode.attrs.package)}/>
+               title={PackageWidget.getMsgForOperation(disabled, pkg.name(), "show usages for")}
+               onclick={vnode.attrs.showUsages.bind(vnode.attrs, pkg)}/>
       </IconGroup>];
-    return <CollapsiblePanel key={vnode.attrs.package.id()} dataTestId={"package-panel"} actions={actionButtons}
+    return <CollapsiblePanel key={pkg.id()} dataTestId={"package-panel"} actions={actionButtons}
                              header={<KeyValueTitle image={null} title={title}/>}>
       <KeyValuePair data={pkgDetails}/>
     </CollapsiblePanel>;


### PR DESCRIPTION
Issue: https://github.com/gocd/gocd/pull/7940#issuecomment-610092587

Description:
 - removed name from config listing - added repo id
 - removed the default setting of repo_id/id - it is a optional attribute and should only be set by the user if required - else the server creates one
 - updated the package repo and package modals to not use foundation hax style - this fixed the reset button placement - it is only for the password field not for the whole form
 - updated the plugin view on change of package repo during package add/edit/clone
 - made sure that the pkg is created wrt to the repo selected
 - all the errors on the package repo/package delete will be shown on the modal itself



