### PR TITLE
Add an annotation that allows API routes to be conditionally mapped to `latest` version via feature-toggle

### DIFF
--- a/api/api-base/src/main/java/com/thoughtworks/go/api/spring/RouteToggle.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/spring/RouteToggle.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.api.spring;
+
+import com.thoughtworks.go.api.ApiVersion;
+import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
+import com.thoughtworks.go.spark.spring.RouteEntry;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
+
+import java.net.URISyntaxException;
+
+class RouteToggle {
+    String prefix;
+    ApiVersion version;
+    String toggleName;
+    boolean descend;
+
+    RouteToggle(String prefix, ApiVersion version, String toggleName, boolean descend) {
+        this.prefix = normalize(prefix);
+        this.version = version;
+        this.descend = descend;
+        if (StringUtils.isBlank((toggleName))) {
+            this.toggleName = version.toString() + "_" + prefix.replaceAll("/", "_");
+        } else {
+            this.toggleName = toggleName;
+        }
+    }
+
+    boolean matches(RouteEntry entry) {
+        return entry.getAcceptedType().equals(version.mimeType()) &&
+                this.withinPath(entry.getPath());
+    }
+
+    boolean isToggleOn(FeatureToggleService s) {
+        return s.isToggleOn(this.toggleName);
+    }
+
+    private boolean withinPath(String path) {
+        return path.equals(this.prefix) || (descend ? path.startsWith(this.prefix + "/") : path.equals(this.prefix + "/"));
+    }
+
+    private String normalize(String path) {
+        try {
+            return new URIBuilder().setPath(path).build().normalize().getPath().replaceAll("/$", "");
+        } catch (URISyntaxException e) {
+            return path;
+        }
+    }
+}

--- a/api/api-base/src/main/java/com/thoughtworks/go/api/spring/RouteToggles.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/spring/RouteToggles.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.api.spring;
+
+import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
+import com.thoughtworks.go.spark.spring.RouteEntry;
+
+import java.util.List;
+
+class RouteToggles {
+    private final List<RouteToggle> matchers;
+    private final FeatureToggleService features;
+
+    RouteToggles(List<RouteToggle> matchers, FeatureToggleService features) {
+        this.matchers = matchers;
+        this.features = features;
+    }
+
+    boolean matches(RouteEntry entry) {
+        return matchers.stream().anyMatch((routeToggle -> routeToggle.matches(entry)));
+    }
+
+    boolean isToggledOn(RouteEntry entry) {
+        return matchers.stream().filter(r -> r.matches(entry)).allMatch(routeToggle -> routeToggle.isToggleOn(features));
+    }
+}

--- a/api/api-base/src/main/java/com/thoughtworks/go/api/spring/ToggleRegisterLatest.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/spring/ToggleRegisterLatest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.api.spring;
+
+import com.thoughtworks.go.api.ApiVersion;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Class-level (i.e., spark controllers) annotation that allows API `latest-version` mime type route registration
+ * to be togglable for a given {@link String} path prefix and {@link ApiVersion}.
+ * <p>
+ * Set the optional `as={@link String}` option to specify a toggle name to bind instead of generating
+ * a toggle key from the path and version. This toggle key need not be unique among controllers; thus, one can
+ * control a set of APIs (usually, related to the same feature) with a single toggle.
+ * <p>
+ * Controller classes can have multiple annotations of this type to specify complex matching patterns against
+ * different path prefixes.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ToggleRegisterLatest {
+    /**
+     * Specifies the path prefix to match routes against
+     *
+     * @return the {@link String} path prefix
+     */
+    String controllerPath();
+
+    /**
+     * Specifies the API version to match routes against
+     *
+     * @return the {@link ApiVersion}
+     */
+    ApiVersion apiVersion();
+
+    /**
+     * Set a toggle key to control this route. This need not be unique among controllers, thus allowing a single
+     * toggle to control groups of APIs.
+     *
+     * @return the {@link String} toggle key name
+     */
+    String as() default "";
+
+    /**
+     * When true, also matches paths under {@link #controllerPath()}. Otherwise, perform exact path match.
+     * This may be useful when the path you want to toggle is an ascendant of an existing API. This is likely
+     * rare, but exists for that reason.
+     * <p>
+     * Defaults to true.
+     *
+     * @return whether or not to include sub paths when matching
+     */
+    boolean includeDescendants() default true;
+}

--- a/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/RerouteLatestApisImplTest.groovy
+++ b/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/RerouteLatestApisImplTest.groovy
@@ -15,179 +15,386 @@
  */
 package com.thoughtworks.go.api.spring
 
+import com.thoughtworks.go.api.ApiVersion
 import com.thoughtworks.go.config.exceptions.HttpException
+import com.thoughtworks.go.http.mocks.HttpRequestBuilder
+import com.thoughtworks.go.http.mocks.MockHttpServletResponse
+import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService
 import com.thoughtworks.go.spark.SparkController
 import com.thoughtworks.go.spark.mocks.TestApplication
 import com.thoughtworks.go.spark.mocks.TestSparkPreFilter
+import com.thoughtworks.go.spark.spring.RouteEntry
 import com.thoughtworks.go.spark.spring.RouteInformationProvider
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
-import spark.ExceptionHandler
-import spark.Filter
-import spark.Route
+import org.springframework.context.ApplicationContext
+import spark.*
 import spark.servlet.SparkFilter
 
 import javax.servlet.FilterConfig
+import java.util.stream.Collectors
 
 import static org.assertj.core.api.Assertions.assertThat
-import static org.mockito.Mockito.mock
-import static org.mockito.Mockito.when
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.mockito.Mockito.*
 import static org.mockito.MockitoAnnotations.initMocks
 import static spark.Spark.*
 
 class RerouteLatestApisImplTest {
+    @Mock
+    Filter apiv11BeforeFilter1
+    @Mock
+    Filter apiv11BeforeFilter2
+    @Mock
+    Filter apiv11AfterFilter1
+    @Mock
+    Filter apiv11AfterFilter2
 
-  @Mock
-  Filter apiv11BeforeFilter1
-  @Mock
-  Filter apiv11BeforeFilter2
-  @Mock
-  Filter apiv11AfterFilter1
-  @Mock
-  Filter apiv11AfterFilter2
+    @Mock
+    ExceptionHandler<HttpException> apiv11ExceptionHandler1
+    @Mock
+    Route apiv11GetMethod
 
-  @Mock
-  ExceptionHandler<HttpException> apiv11ExceptionHandler1
-  @Mock
-  Route apiv11GetMethod
+    @Mock
+    Filter apiv10BeforeFilter1
+    @Mock
+    Filter apiv10BeforeFilter2
+    @Mock
+    Filter apiv10AfterFilter1
+    @Mock
+    Filter apiv10AfterFilter2
+    @Mock
+    ExceptionHandler<HttpException> apiv10ExceptionHandler1
+    @Mock
+    Route apiv10GetMethod
 
-  @Mock
-  Filter apiv10BeforeFilter1
-  @Mock
-  Filter apiv10BeforeFilter2
-  @Mock
-  Filter apiv10AfterFilter1
-  @Mock
-  Filter apiv10AfterFilter2
-  @Mock
-  ExceptionHandler<HttpException> apiv10ExceptionHandler1
-  @Mock
-  Route apiv10GetMethod
+    @Mock
+    Filter apiv1BeforeFilter1
+    @Mock
+    Filter apiv1BeforeFilter2
+    @Mock
+    Route apiv1GetMethod
 
-  @Mock
-  Filter apiv1BeforeFilter1
-  @Mock
-  Filter apiv1BeforeFilter2
-  @Mock
-  Route apiv1GetMethod
+    @Mock
+    ExceptionHandler<Exception> apiv1ExceptionHandler1
 
-  @Mock
-  ExceptionHandler<Exception> apiv1ExceptionHandler1
+    @Mock
+    FeatureToggleService features
 
-  private SparkController controller1
-  private SparkController controller2
-  private SparkController controller3
+    @Mock
+    ApplicationContext context
 
-  private TestApplication testApplication
-  private TestSparkPreFilter preFilter
-  private RouteInformationProvider routeInformationProvider
+    private SparkController controller1
+    private SparkController controller2
+    private SparkController controller3
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-    routeInformationProvider = new RouteInformationProvider()
+    private TestApplication testApplication
+    private TestSparkPreFilter preFilter
+    private RouteInformationProvider routeInformationProvider
 
-    controller1 = new SparkController() {
-      @Override
-      String controllerBasePath() {
-        return "/foo"
-      }
+    @BeforeEach
+    void setUp() {
+        initMocks(this)
+        routeInformationProvider = new RouteInformationProvider()
 
-      @Override
-      void setupRoutes() {
-        path(controllerBasePath(), { ->
-          // some filters
-          before("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11BeforeFilter1)
-          before("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11BeforeFilter2)
+        controller1 = new SparkController() {
+            @Override
+            String controllerBasePath() {
+                return "/foo"
+            }
 
-          get("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11GetMethod)
+            @Override
+            void setupRoutes() {
+                path(controllerBasePath(), { ->
+                    // some filters
+                    before("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11BeforeFilter1)
+                    before("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11BeforeFilter2)
 
-          after("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11AfterFilter1)
-          after("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11AfterFilter2)
+                    get("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11GetMethod)
 
-          // some exception handlers
-          exception(HttpException.class, apiv11ExceptionHandler1)
-        })
-      }
+                    after("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11AfterFilter1)
+                    after("/bar", "application/vnd.go.cd." + "v11" + "+json", apiv11AfterFilter2)
+
+                    // some exception handlers
+                    exception(HttpException.class, apiv11ExceptionHandler1)
+                })
+            }
+        }
+
+        controller2 = new SparkController() {
+            @Override
+            String controllerBasePath() {
+                return "/foo"
+            }
+
+            @Override
+            void setupRoutes() {
+                path(controllerBasePath(), { ->
+                    // some filters
+                    before("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10BeforeFilter1)
+                    before("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10BeforeFilter2)
+
+                    get("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10GetMethod)
+
+                    after("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10AfterFilter2)
+                    after("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10AfterFilter1)
+
+                    // some exception handlers
+                    exception(HttpException.class, apiv10ExceptionHandler1)
+                })
+            }
+        }
+
+        controller3 = new SparkController() {
+            @Override
+            String controllerBasePath() {
+                return "/something-else"
+            }
+
+            @Override
+            void setupRoutes() {
+                path(controllerBasePath(), { ->
+                    // some filters
+                    before("/bar", "application/vnd.go.cd." + "v1" + "+json", apiv1BeforeFilter1)
+                    before("/bar", "application/vnd.go.cd." + "v1" + "+json", apiv1BeforeFilter2)
+
+                    get("/bar", "application/vnd.go.cd." + "v1" + "+json", apiv1GetMethod)
+
+                    // some exception handlers
+                    exception(Exception.class, apiv1ExceptionHandler1)
+                })
+            }
+        }
     }
 
-    controller2 = new SparkController() {
-      @Override
-      String controllerBasePath() {
-        return "/foo"
-      }
 
-      @Override
-      void setupRoutes() {
-        path(controllerBasePath(), { ->
-          // some filters
-          before("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10BeforeFilter1)
-          before("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10BeforeFilter2)
-
-          get("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10GetMethod)
-
-          after("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10AfterFilter2)
-          after("/bar", "application/vnd.go.cd." + "v10" + "+json", apiv10AfterFilter1)
-
-          // some exception handlers
-          exception(HttpException.class, apiv10ExceptionHandler1)
-        })
-      }
+    @AfterEach
+    void tearDown() {
+        if (preFilter != null) {
+            preFilter.destroy()
+        }
+        testApplication = null
+        preFilter = null
     }
 
-    controller3 = new SparkController() {
-      @Override
-      String controllerBasePath() {
-        return "/something-else"
-      }
+    private void createApplication(SparkController... controllers) {
+        testApplication = new TestApplication(controllers)
+        def filterConfig = mock(FilterConfig.class)
+        when(filterConfig.getInitParameter(SparkFilter.APPLICATION_CLASS_PARAM)).thenReturn(TestApplication.class.getName())
 
-      @Override
-      void setupRoutes() {
-        path(controllerBasePath(), { ->
-          // some filters
-          before("/bar", "application/vnd.go.cd." + "v1" + "+json", apiv1BeforeFilter1)
-          before("/bar", "application/vnd.go.cd." + "v1" + "+json", apiv1BeforeFilter2)
-
-          get("/bar", "application/vnd.go.cd." + "v1" + "+json", apiv1GetMethod)
-
-          // some exception handlers
-          exception(Exception.class, apiv1ExceptionHandler1)
-        })
-      }
+        preFilter = new TestSparkPreFilter(testApplication)
+        preFilter.init(filterConfig)
     }
 
-    testApplication = new TestApplication(controller1, controller2, controller3)
+    @Nested
+    class Standard {
+        @BeforeEach
+        void setup() {
+            createApplication(controller1, controller2, controller3)
+        }
 
-    def filterConfig = mock(FilterConfig.class)
-    when(filterConfig.getInitParameter(SparkFilter.APPLICATION_CLASS_PARAM)).thenReturn(TestApplication.class.getName())
+        @Test
+        void routeAssertions() {
+            routeInformationProvider.cacheRouteInformation()
+            assertThat(routeInformationProvider.routes).hasSize(16)
+        }
 
-    preFilter = new TestSparkPreFilter(testApplication)
-    preFilter.init(filterConfig)
-  }
+        @Test
+        void shouldRegisterLatestRoutes() {
+            // original route list
+            RerouteLatestApisImpl rerouteLatestApis = new RerouteLatestApisImpl(routeInformationProvider, features)
+            rerouteLatestApis.setApplicationContext(context)
+            when(context.getBeansWithAnnotation()).thenReturn(Collections.emptyMap())
 
-  @AfterEach
-  void tearDown() {
-    preFilter.destroy()
-  }
+            routeInformationProvider.cacheRouteInformation()
+            assertThat(routeInformationProvider.routes).hasSize(16)
 
-  @Test
-  void routeAssertions() {
-    routeInformationProvider.cacheRouteInformation()
-    assertThat(routeInformationProvider.routes).hasSize(16)
-  }
+            rerouteLatestApis.registerLatest()
+            // add 5 routes for `/foo/bar`
+            // add 3 routes for `/something-else/bar`
+            assertThat(routeInformationProvider.routes).hasSize(24)
+        }
+    }
 
-  @Test
-  void shouldRegisterLatestRoutes() {
-    // original route list
-    RerouteLatestApisImpl rerouteLatestApis = new RerouteLatestApisImpl(routeInformationProvider)
-    routeInformationProvider.cacheRouteInformation()
-    assertThat(routeInformationProvider.routes).hasSize(16)
+    @Nested
+    class RouteToggles {
+        private builder = new HttpRequestBuilder()
 
-    rerouteLatestApis.registerLatest()
-    // add 5 routes for `/foo/bar`
-    // add 3 routes for `/something-else/bar`
-    assertThat(routeInformationProvider.routes).hasSize(24)
-  }
+        @BeforeEach
+        void setup() {
+            controller1 = new TestControllerV1()
+            controller2 = new TestControllerV2()
+            controller3 = new Controller(ApiVersion.v5) {
+                @Override
+                String controllerBasePath() {
+                    return "/foo"
+                }
+
+                @Override
+                void setupRoutes() {
+                    path(controllerPath(), { ->
+                        get("/bar", v.mimeType(), route)
+                    })
+                }
+            }
+            createApplication(controller1, controller2, controller3)
+        }
+
+        @Test
+        void 'ignores annotated controllers when calculating the latest version route alias if matching toggle is off'() {
+            RerouteLatestApisImpl rerouteLatestApis = new RerouteLatestApisImpl(routeInformationProvider, features)
+            rerouteLatestApis.setApplicationContext(context)
+            when(context.getBeansWithAnnotation(ToggleRegisterLatest.class)).thenReturn(
+                    Collections.singletonMap(TestControllerV2.class.name, controller2)
+            )
+
+            when(features.isToggleOn("testv2")).thenReturn(false)
+
+            routeInformationProvider.cacheRouteInformation()
+
+            List<RouteEntry> routes = routeInformationProvider.routes
+
+            // 3 of these are boilerplate routes
+            // 2 from TestController v1
+            // 2 from TestController v2
+            // 1 from the inlined controller
+            assertEquals(8, routes.size())
+
+            // All the routes are registered
+            assertEquals(1, find(routes, "/foo/bar", ApiVersion.v5).size())
+            assertEquals(1, find(routes, "/in_development", ApiVersion.v1).size())
+            assertEquals(1, find(routes, "/in_development/show/:id", ApiVersion.v1).size())
+            assertEquals(1, find(routes, "/in_development", ApiVersion.v2).size())
+            assertEquals(1, find(routes, "/in_development/show/:id", ApiVersion.v2).size())
+
+            rerouteLatestApis.registerLatest()
+
+            // add latest aliases 1 route for inlined
+            // add latest aliases 2 routes for TestController v1
+            assertEquals(11, routes.size())
+
+            verify(features, times(4)).isToggleOn("testv2")
+
+            // Verify we have latest entries
+            assertEquals(1, find(routes, "/foo/bar", ApiVersion.LATEST_VERSION_MIMETYPE).size())
+            assertEquals(1, find(routes, "/in_development", ApiVersion.LATEST_VERSION_MIMETYPE).size())
+            assertEquals(1, find(routes, "/in_development/show/:id", ApiVersion.LATEST_VERSION_MIMETYPE).size())
+
+            // Assert the aliases point to expected versions
+            assertEquals("v5", sendGet("/foo/bar", ApiVersion.LATEST_VERSION_MIMETYPE))
+            assertEquals("v1", sendGet("/in_development", ApiVersion.LATEST_VERSION_MIMETYPE))
+            assertEquals("v1", sendGet("/in_development/show/:id", ApiVersion.LATEST_VERSION_MIMETYPE))
+        }
+
+        @Test
+        void 'considers annotated controllers when calculating the latest version route alias if matching toggle is on'() {
+            RerouteLatestApisImpl rerouteLatestApis = new RerouteLatestApisImpl(routeInformationProvider, features)
+            rerouteLatestApis.setApplicationContext(context)
+            when(context.getBeansWithAnnotation(ToggleRegisterLatest.class)).thenReturn(
+                    Collections.singletonMap(TestControllerV2.class.name, controller2)
+            )
+
+            when(features.isToggleOn("testv2")).thenReturn(true)
+
+            routeInformationProvider.cacheRouteInformation()
+
+            List<RouteEntry> routes = routeInformationProvider.routes
+
+            // 3 of these are boilerplate routes
+            // 2 from TestController v1
+            // 2 from TestController v2
+            // 1 from the inlined controller
+            assertEquals(8, routes.size())
+
+            // All the routes are registered
+            assertEquals(1, find(routes, "/foo/bar", ApiVersion.v5).size())
+            assertEquals(1, find(routes, "/in_development", ApiVersion.v1).size())
+            assertEquals(1, find(routes, "/in_development/show/:id", ApiVersion.v1).size())
+            assertEquals(1, find(routes, "/in_development", ApiVersion.v2).size())
+            assertEquals(1, find(routes, "/in_development/show/:id", ApiVersion.v2).size())
+
+            rerouteLatestApis.registerLatest()
+
+            // add latest aliases 1 route for inlined
+            // add latest aliases 2 routes for TestController v1
+            assertEquals(11, routes.size())
+
+            verify(features, times(4)).isToggleOn("testv2")
+
+            // Verify we have latest entries
+            assertEquals(1, find(routes, "/foo/bar", ApiVersion.LATEST_VERSION_MIMETYPE).size())
+            assertEquals(1, find(routes, "/in_development", ApiVersion.LATEST_VERSION_MIMETYPE).size())
+            assertEquals(1, find(routes, "/in_development/show/:id", ApiVersion.LATEST_VERSION_MIMETYPE).size())
+
+            // Assert the aliases point to expected versions
+            assertEquals("v5", sendGet("/foo/bar", ApiVersion.LATEST_VERSION_MIMETYPE))
+            assertEquals("v2", sendGet("/in_development", ApiVersion.LATEST_VERSION_MIMETYPE))
+            assertEquals("v2", sendGet("/in_development/show/:id", ApiVersion.LATEST_VERSION_MIMETYPE))
+        }
+
+        private List<RouteEntry> find(List<RouteEntry> all, String path, ApiVersion v) {
+            return find(all, path, v.mimeType())
+        }
+
+        private List<RouteEntry> find(List<RouteEntry> all, String path, String mime) {
+            return all.stream().filter({ e ->
+                (path == e.path && mime == e.acceptedType)
+            }).collect(Collectors.toList())
+        }
+
+        private String sendGet(String path, String mime) {
+            def req = builder.withMethod("get").withHeader("accept", mime).withPath(path).build()
+            def res = new MockHttpServletResponse()
+            preFilter.doFilter(req, res, null)
+            return res.contentAsString
+        }
+    }
+
+    private static abstract class Controller implements SparkController {
+        ApiVersion v
+        /** Do NOT use a groovy closure here. It will fail to invoke. */
+        final Route route = new Route() {
+            @Override
+            Object handle(Request request, Response response) throws Exception {
+                return v.name()
+            }
+        }
+
+        Controller(ApiVersion v) {
+            this.v = v
+        }
+    }
+
+    private static class TestControllerV1 extends Controller {
+        TestControllerV1() {
+            this(ApiVersion.v1)
+        }
+
+        protected TestControllerV1(ApiVersion v) {
+            super(v)
+        }
+
+        @Override
+        String controllerBasePath() {
+            return "/in_development"
+        }
+
+        @Override
+        void setupRoutes() {
+            path(controllerPath(), { ->
+                get("", v.mimeType(), this.route)
+                get("/show/:id", v.mimeType(), this.route)
+            })
+        }
+    }
+
+    @ToggleRegisterLatest(controllerPath = "/in_development", apiVersion = ApiVersion.v2, as = "testv2")
+    private static class TestControllerV2 extends TestControllerV1 {
+        TestControllerV2() {
+            super(ApiVersion.v2)
+        }
+    }
 }

--- a/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/RouteToggleTest.java
+++ b/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/RouteToggleTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.api.spring;
+
+import com.thoughtworks.go.api.ApiVersion;
+import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
+import com.thoughtworks.go.spark.spring.RouteEntry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import spark.Route;
+import spark.route.HttpMethod;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+class RouteToggleTest {
+    @Mock
+    FeatureToggleService features;
+
+    @BeforeEach
+    void setup() {
+        initMocks(this);
+    }
+
+    @Test
+    void matchesDescending() {
+        final RouteToggle r = desc("/foo/", ApiVersion.v3, "me");
+        assertTrue(r.matches(entry("/foo", ApiVersion.v3)));
+        assertTrue(r.matches(entry("/foo/", ApiVersion.v3)));
+        assertTrue(r.matches(entry("/foo/bar/baz", ApiVersion.v3)));
+
+        // versions don't match
+        assertFalse(r.matches(entry("/foo", ApiVersion.v1)));
+        assertFalse(r.matches(entry("/foo/", ApiVersion.v1)));
+        assertFalse(r.matches(entry("/foo/bar", ApiVersion.v1)));
+
+        // not path or sub path
+        assertFalse(r.matches(entry("/foobar", ApiVersion.v3)));
+    }
+
+    @Test
+    void matchesExact() {
+        final RouteToggle r = exact("/foo/", ApiVersion.v3, "me");
+        assertTrue(r.matches(entry("/foo", ApiVersion.v3)));
+        assertTrue(r.matches(entry("/foo/", ApiVersion.v3)));
+        assertFalse(r.matches(entry("/foo/bar/baz", ApiVersion.v3)));
+
+        // versions don't match
+        assertFalse(r.matches(entry("/foo", ApiVersion.v1)));
+        assertFalse(r.matches(entry("/foo/", ApiVersion.v1)));
+
+        // not path or sub path
+        assertFalse(r.matches(entry("/foobar", ApiVersion.v3)));
+    }
+
+    @Test
+    void neverMatchesParents() {
+        RouteToggle r = desc("/foo/bar", ApiVersion.v3, "me");
+        assertFalse(r.matches(entry("/foo", ApiVersion.v3)));
+        assertFalse(r.matches(entry("/foo/", ApiVersion.v3)));
+
+        assertTrue(r.matches(entry("/foo/bar", ApiVersion.v3)));
+        assertTrue(r.matches(entry("/foo/bar/", ApiVersion.v3)));
+        assertTrue(r.matches(entry("/foo/bar/baz", ApiVersion.v3)));
+
+        r = exact("/foo/bar", ApiVersion.v3, "me");
+        assertFalse(r.matches(entry("/foo", ApiVersion.v3)));
+        assertFalse(r.matches(entry("/foo/", ApiVersion.v3)));
+
+        assertTrue(r.matches(entry("/foo/bar", ApiVersion.v3)));
+        assertTrue(r.matches(entry("/foo/bar/", ApiVersion.v3)));
+    }
+
+    @Test
+    void isToggleOn() {
+        final RouteToggle r = desc("/foo", ApiVersion.v3, "me");
+
+        assertFalse(r.isToggleOn(features));
+
+        when(features.isToggleOn("me")).thenReturn(true);
+        assertTrue(r.isToggleOn(features));
+
+        verify(features, atLeastOnce()).isToggleOn("me");
+    }
+
+    @Test
+    void generatesToggleNameWhenNotSpecified() {
+        final RouteToggle r = desc("/foo", ApiVersion.v3, "");
+
+        assertFalse(r.isToggleOn(features));
+
+        when(features.isToggleOn("v3__foo")).thenReturn(true);
+        assertTrue(r.isToggleOn(features));
+
+        verify(features, atLeastOnce()).isToggleOn("v3__foo");
+    }
+
+    private RouteToggle desc(String path, ApiVersion v, String name) {
+        return new RouteToggle(path, v, name, true);
+    }
+
+    private RouteToggle exact(String path, ApiVersion v, String name) {
+        return new RouteToggle(path, v, name, false);
+    }
+
+    private RouteEntry entry(String path, ApiVersion v) {
+        return new RouteEntry(HttpMethod.get, path, v.mimeType(), (Route) (rq, rs) -> v.name());
+    }
+}

--- a/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/RouteTogglesTest.java
+++ b/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/RouteTogglesTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.api.spring;
+
+import com.thoughtworks.go.api.ApiVersion;
+import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
+import com.thoughtworks.go.spark.spring.RouteEntry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import spark.Route;
+import spark.route.HttpMethod;
+
+import java.util.Arrays;
+
+import static com.thoughtworks.go.api.ApiVersion.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+class RouteTogglesTest {
+    @Mock
+    FeatureToggleService features;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    void matches() {
+        final RouteToggles rts = new RouteToggles(Arrays.asList(
+                desc("/foo/bar", v5, "one"),
+                desc("/foo/baz", v5, "two"),
+                desc("/ping", v2, "ping")
+        ), features);
+
+        assertTrue(rts.matches(entry("/foo/bar", v5)));
+        assertTrue(rts.matches(entry("/foo/baz", v5)));
+
+        // will not implicitly match parents
+        assertFalse(rts.matches(entry("/foo", v5)));
+
+        // version must match
+        assertFalse(rts.matches(entry("/foo/baz", v2)));
+
+        // ignores anything else
+        assertFalse(rts.matches(entry("/anything", v1)));
+
+        // matches sub paths
+        assertTrue(rts.matches(entry("/ping", v2)));
+        assertTrue(rts.matches(entry("/ping/pong", v2)));
+        assertTrue(rts.matches(entry("/ping/foo", v2)));
+
+        // must be the path or a child, not just prefix
+        assertFalse(rts.matches(entry("/ping-a-ling", v2)));
+    }
+
+    @Test
+    void matchesCanHandleExactPaths() {
+        final RouteToggles rts = new RouteToggles(Arrays.asList(
+                exact("/foo", v5, "a"),
+                exact("/foo/bar", v5, "b"),
+                desc("/foo/bar/baz/quu", v5, "c")
+        ), features);
+
+        // exact matches
+        assertTrue(rts.matches(entry("/foo", v5)));
+        assertTrue(rts.matches(entry("/foo/", v5)));
+        assertTrue(rts.matches(entry("/foo/bar", v5)));
+        assertTrue(rts.matches(entry("/foo/bar/", v5)));
+
+        // baseline failures to show difference from descendant matching
+        assertFalse(rts.matches(entry("/foo/bar/any", v5)));
+        assertFalse(rts.matches(entry("/foo/any", v5)));
+
+        // won't match child paths unless explicitly added
+        assertFalse(rts.matches(entry("/foo/bar/baz", v5)));
+        assertFalse(rts.matches(entry("/foo/bar/baz/", v5)));
+        assertFalse(rts.matches(entry("/foo/bar/baz/any", v5)));
+
+        // does not interfere with descendant matchers of sub paths
+        assertTrue(rts.matches(entry("/foo/bar/baz/quu", v5)));
+        assertTrue(rts.matches(entry("/foo/bar/baz/quu/", v5)));
+        assertTrue(rts.matches(entry("/foo/bar/baz/quu/whatever", v5)));
+    }
+
+    @Test
+    void isToggledOn() {
+        when(features.isToggleOn("one")).thenReturn(true);
+        when(features.isToggleOn("two")).thenReturn(false);
+        when(features.isToggleOn("three")).thenReturn(true);
+
+        RouteToggles rts = new RouteToggles(Arrays.asList(
+                desc("/foo/bar", v5, "one"),
+                desc("/foo/baz", v5, "two")
+        ), features);
+
+        assertTrue(rts.isToggledOn(entry("/foo/bar", v5)));
+        assertFalse(rts.isToggledOn(entry("/foo/baz", v5)));
+
+        // two rules that match are AND'ed together in case you need a compound condition
+        rts = new RouteToggles(Arrays.asList(
+                desc("/foo/bar", v5, "one"),
+                desc("/foo/bar", v5, "two")
+        ), features);
+
+        assertFalse(rts.isToggledOn(entry("/foo/bar", v5)));
+
+        // fine when both toggle keys are true, of course
+        rts = new RouteToggles(Arrays.asList(
+                desc("/foo/bar", v5, "one"),
+                desc("/foo/bar", v5, "three")
+        ), features);
+
+        assertTrue(rts.isToggledOn(entry("/foo/bar", v5)));
+
+        // using exact and desc together allow fine-grained toggling control
+        rts = new RouteToggles(Arrays.asList(
+                desc("/foo", v5, "one"),
+                exact("/foo/bar/baz", v5, "two")
+        ), features);
+
+        assertTrue(rts.isToggledOn(entry("/foo", v5)));
+        assertTrue(rts.isToggledOn(entry("/foo/bar", v5)));
+        assertTrue(rts.isToggledOn(entry("/foo/blah", v5)));
+
+        assertFalse(rts.isToggledOn(entry("/foo/bar/baz", v5)));
+        assertFalse(rts.isToggledOn(entry("/foo/bar/baz/", v5)));
+
+        assertTrue(rts.isToggledOn(entry("/foo/bar/baz/anything", v5)));
+        assertTrue(rts.isToggledOn(entry("/foo/bar/baz/anything/else", v5)));
+    }
+
+    private RouteToggle desc(String path, ApiVersion v, String name) {
+        return new RouteToggle(path, v, name, true);
+    }
+
+    private RouteToggle exact(String path, ApiVersion v, String name) {
+        return new RouteToggle(path, v, name, false);
+    }
+
+    private RouteEntry entry(String path, ApiVersion v) {
+        return new RouteEntry(HttpMethod.get, path, v.mimeType(), (Route) (rq, rs) -> v.name());
+    }
+}

--- a/api/api-config-repos-v4/src/main/java/com/thoughtworks/go/apiv4/configrepos/ConfigReposControllerV4.java
+++ b/api/api-config-repos-v4/src/main/java/com/thoughtworks/go/apiv4/configrepos/ConfigReposControllerV4.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.api.CrudController;
 import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
+import com.thoughtworks.go.api.spring.ToggleRegisterLatest;
 import com.thoughtworks.go.api.util.GsonTransformer;
 import com.thoughtworks.go.api.util.MessageJson;
 import com.thoughtworks.go.apiv4.configrepos.representers.ConfigRepoConfigRepresenterV4;
@@ -54,6 +55,7 @@ import static com.thoughtworks.go.util.CachedDigestUtils.sha256Hex;
 import static java.util.stream.Collectors.toCollection;
 import static spark.Spark.*;
 
+@ToggleRegisterLatest(controllerPath = Routes.ConfigRepos.BASE, apiVersion = ApiVersion.v4, as = "config_repo_v4")
 @Component
 public class ConfigReposControllerV4 extends ApiController implements SparkSpringController, CrudController<ConfigRepoConfig> {
     private final ApiAuthenticationHelper authHelper;

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/support/toggle/FeatureToggleServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/support/toggle/FeatureToggleServiceTest.java
@@ -26,11 +26,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class FeatureToggleServiceTest {
@@ -88,6 +85,23 @@ public class FeatureToggleServiceTest {
         FeatureToggleService service = new FeatureToggleService(repository, goCache);
 
         assertThat(service.isToggleOn("NON_EXISTENT_KEY"), is(false));
+    }
+
+    @Test
+    public void honorTogglesDefinedInInUserTogglesEvenIfNotEnumeratedInAvailableToggles() throws Exception {
+        FeatureToggles existingToggles = new FeatureToggles(
+                new FeatureToggle("key1", "description1", true),
+                new FeatureToggle("key2", "description2", false)
+        );
+
+        when(repository.availableToggles()).thenReturn(existingToggles);
+        when(repository.userToggles()).thenReturn(new FeatureToggles(
+                new FeatureToggle("key3", "whatever", true)
+        ));
+
+        FeatureToggleService service = new FeatureToggleService(repository, goCache);
+
+        assertTrue(service.isToggleOn("key3"));
     }
 
     @Test


### PR DESCRIPTION
Useful for developing new API versions that may not be yet finalized for release. Now you don't really have to revert your code only to undo the revert after release.

Also hides config repo v4 from being aliased as `latest`.

#### Note

Toggling a route will require a restart. It won't hot-update due to how we map `latest` aliases.