### PR TITLE
Upgrade css-loader to v3.5.1

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -91,7 +91,7 @@
     "babel-loader": "^8.1.0",
     "cache-loader": "^4.1.0",
     "clean-webpack-plugin": "^3.0.0",
-    "css-loader": "^3.5.0",
+    "css-loader": "3.5.1",
     "eslint": "^6.8.0",
     "eslint-loader": "^4.0.0",
     "eslint-plugin-es5": "^1.5.0",

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -2712,10 +2712,10 @@ css-declaration-sorter@^4.0.1:
     postcss "^7.0.1"
     timsort "^0.3.0"
 
-css-loader@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.5.0.tgz#8c68736fbcba1a9b92a288277ba8998b709ac3ae"
-  integrity sha512-zed7D7JNZEq7htpu3H9oBUVWVgI6s8FgigejbVq+dc5zHV3SUPsyYBozXLIC9Eb73ahAYmnVdnn/SAB4WA75AQ==
+css-loader@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.5.1.tgz#db2b2336f4169edb68e6a829ad4fd36552647b77"
+  integrity sha512-0G4CbcZzQ9D1Q6ndOfjFuMDo8uLYMu5vc9Abs5ztyHcKvmil6GJrMiNjzzi3tQvUF+mVRuDg7bE6Oc0Prolgig==
   dependencies:
     camelcase "^5.3.1"
     cssesc "^3.0.0"


### PR DESCRIPTION
GoCD build started failing after upgrading css-loader to v3.5.0.
Links: 
- [Upgrade PR](https://github.com/gocd/gocd/pull/7967)
- [Build Failure](https://build.gocd.org/go/pipelines/value_stream_map/build-linux/4931)

It looks like we're facing issue mentioned [here](https://github.com/webpack-contrib/css-loader/issues/1071), which is fixed as part of [this](https://github.com/webpack-contrib/css-loader/issues/1072) PR.



