### PR TITLE
Fix package clone issue

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/package_repositories/package_repositories.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/package_repositories/package_repositories.ts
@@ -149,7 +149,6 @@ export class PackageRepository extends ValidatableMixin {
                           {message: "Invalid Id. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period)."});
     this.validateMaxLength("name", 255, {message: "The maximum allowed length is 255 characters."});
     this.validateAssociated("pluginMetadata");
-    this.validateEach("packages");
   }
 
   static fromJSON(data: PackageRepositoryJSON): PackageRepository {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories.tsx
@@ -30,7 +30,12 @@ import {HeaderPanel} from "views/components/header_panel";
 import {NoPluginsOfTypeInstalled} from "views/components/no_plugins_installed";
 import configRepoStyles from "views/pages/config_repos/index.scss";
 import {PackageRepositoriesWidget} from "views/pages/package_repositories/package_repositories_widget";
-import {ClonePackageRepositoryModal, CreatePackageRepositoryModal, DeletePackageRepositoryModal, EditPackageRepositoryModal} from "views/pages/package_repositories/package_repository_modals";
+import {
+  ClonePackageRepositoryModal,
+  CreatePackageRepositoryModal,
+  DeletePackageRepositoryModal,
+  EditPackageRepositoryModal
+} from "views/pages/package_repositories/package_repository_modals";
 import {Page, PageState} from "views/pages/page";
 import {RequiresPluginInfos, SaveOperation} from "views/pages/page_operations";
 import {ClonePackageModal, CreatePackageModal, DeletePackageModal, EditPackageModal, UsagePackageModal} from "./package_repositories/package_modals";
@@ -206,8 +211,8 @@ export class PackageRepositoriesPage extends Page<null, State> {
 
     vnode.state.packageRepoOperations.onEdit = (pkgRepo: PackageRepository, e: MouseEvent) => {
       e.stopPropagation();
-
-      new EditPackageRepositoryModal(pkgRepo, vnode.state.pluginInfos(), vnode.state.onSuccessfulSave)
+      const copy = new PackageRepository(pkgRepo.repoId(), pkgRepo.name(), pkgRepo.pluginMetadata(), pkgRepo.configuration(), []);
+      new EditPackageRepositoryModal(copy, vnode.state.pluginInfos(), vnode.state.onSuccessfulSave)
         .render();
     };
 
@@ -239,8 +244,8 @@ export class PackageRepositoriesPage extends Page<null, State> {
 
     vnode.state.packageOperations.onEdit = (pkg: Package, e: MouseEvent) => {
       e.stopPropagation();
-
-      new EditPackageModal(pkg, vnode.state.packageRepositories(), vnode.state.pluginInfos(), vnode.state.onSuccessfulSave)
+      const copy = new Package(pkg.id(), pkg.name(), pkg.autoUpdate(), pkg.configuration(), pkg.packageRepo());
+      new EditPackageModal(copy, vnode.state.packageRepositories(), vnode.state.pluginInfos(), vnode.state.onSuccessfulSave)
         .render();
     };
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_modal_body.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_modal_body.tsx
@@ -30,14 +30,12 @@ interface Attrs {
   packageRepositories: PackageRepositories;
   package: Package;
   disableId: boolean;
+  disablePackageRepo: boolean;
   onPackageRepoChange: (newPackageRepo?: PackageRepository) => any;
 }
 
 export class PackageModalBody extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs, this>): m.Children | void | null {
-    const packageRepos = _.map(vnode.attrs.packageRepositories, (pkgRepo: PackageRepository) => {
-      return {id: pkgRepo.repoId(), text: pkgRepo.name()};
-    });
     const msgForNewPkg = vnode.attrs.disableId ? "" : "The new package will be available to be used as material in all pipelines. Other admins might be able to edit this package.";
 
     const selectedPackageRepository = vnode.attrs.packageRepositories.find((repo) => {
@@ -47,6 +45,14 @@ export class PackageModalBody extends MithrilViewComponent<Attrs> {
     const pluginInfo = _.find(vnode.attrs.pluginInfos, (pluginInfo: PluginInfo) => {
       return pluginInfo.id === selectedPackageRepository.pluginMetadata().id();
     })!;
+
+    const packageRepos = vnode.attrs.packageRepositories
+                              .filter((pkgRepo) => {
+                                return pkgRepo.pluginMetadata().id() === selectedPackageRepository.pluginMetadata().id();
+                              })
+                              .map((pkgRepo: PackageRepository) => {
+                                return {id: pkgRepo.repoId(), text: pkgRepo.name()};
+                              });
 
     return <div>
       <FormHeader>
@@ -62,6 +68,7 @@ export class PackageModalBody extends MithrilViewComponent<Attrs> {
           <SelectField label="Package Repository"
                        property={this.packageRepoIdProxy.bind(this, vnode)}
                        required={true}
+                       readonly={vnode.attrs.disablePackageRepo}
                        errorText={vnode.attrs.package.packageRepo().errors().errorsForDisplay("id")}>
             <SelectFieldOptions selected={vnode.attrs.package.packageRepo().id()}
                                 items={packageRepos}/>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_modals.tsx
@@ -33,16 +33,19 @@ abstract class PackageModal extends EntityModal<Package> {
   protected readonly originalEntityId: string;
   protected readonly originalEntityName: string;
   private readonly disableId: boolean;
+  private readonly disablePackageRepo: boolean;
   private readonly packageRepositories: PackageRepositories;
 
   constructor(entity: Package,
               packageRepositories: PackageRepositories,
               pluginInfos: PluginInfos,
               onSuccessfulSave: (msg: m.Children) => any,
-              disableId: boolean = false,
-              size: Size         = Size.large) {
+              disableId: boolean          = false,
+              disablePackageRepo: boolean = true,
+              size: Size                  = Size.large) {
     super(entity, pluginInfos, onSuccessfulSave, size);
     this.disableId           = disableId;
+    this.disablePackageRepo  = disablePackageRepo;
     this.originalEntityId    = entity.id();
     this.originalEntityName  = entity.name();
     this.packageRepositories = packageRepositories;
@@ -59,7 +62,7 @@ abstract class PackageModal extends EntityModal<Package> {
   protected modalBody(): m.Children {
     return <PackageModalBody pluginInfos={this.pluginInfos} packageRepositories={this.packageRepositories}
                              package={this.entity()}
-                             disableId={this.disableId}
+                             disableId={this.disableId} disablePackageRepo={this.disablePackageRepo}
                              onPackageRepoChange={this.onPackageRepoChange.bind(this)}/>;
   }
 
@@ -139,7 +142,7 @@ export class ClonePackageModal extends PackageModal {
               packageRepositories: PackageRepositories,
               pluginInfos: PluginInfos,
               onSuccessfulSave: (msg: m.Children) => any) {
-    super(entity, packageRepositories, pluginInfos, onSuccessfulSave, false);
+    super(entity, packageRepositories, pluginInfos, onSuccessfulSave, false, false);
   }
 
   title(): string {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_modal_body.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_modal_body.tsx
@@ -28,6 +28,7 @@ interface Attrs {
   pluginInfos: PluginInfos;
   packageRepo: PackageRepository;
   disableId: boolean;
+  disablePluginField: boolean;
   pluginIdProxy: (newPluginId?: string) => any;
 }
 
@@ -53,7 +54,7 @@ export class PackageRepositoryModalBody extends MithrilViewComponent<Attrs> {
 
           <SelectField label="Plugin"
                        property={vnode.attrs.pluginIdProxy.bind(this)}
-                       required={true}
+                       required={true} readonly={vnode.attrs.disablePluginField}
                        errorText={vnode.attrs.packageRepo.errors().errorsForDisplay("pluginId")}>
             <SelectFieldOptions selected={vnode.attrs.packageRepo.pluginMetadata().id()}
                                 items={pluginList}/>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_modals.tsx
@@ -32,14 +32,17 @@ abstract class PackageRepositoryModal extends EntityModal<PackageRepository> {
   protected readonly originalEntityId: string;
   protected readonly originalEntityName: string;
   private disableId: boolean;
+  private disablePluginField: boolean;
 
   constructor(entity: PackageRepository,
               pluginInfos: PluginInfos,
               onSuccessfulSave: (msg: m.Children) => any,
-              disableId: boolean = false,
-              size: Size         = Size.large) {
+              disableId: boolean          = false,
+              disablePluginField: boolean = true,
+              size: Size                  = Size.large) {
     super(entity, pluginInfos, onSuccessfulSave, size);
     this.disableId          = disableId;
+    this.disablePluginField = disablePluginField;
     this.originalEntityId   = entity.repoId();
     this.originalEntityName = entity.name();
     this.needsFoundationStyles(false);
@@ -53,9 +56,8 @@ abstract class PackageRepositoryModal extends EntityModal<PackageRepository> {
   }
 
   protected modalBody(): m.Children {
-    return <PackageRepositoryModalBody pluginInfos={this.pluginInfos}
-                                       packageRepo={this.entity()}
-                                       disableId={this.disableId}
+    return <PackageRepositoryModalBody pluginInfos={this.pluginInfos} packageRepo={this.entity()}
+                                       disableId={this.disableId} disablePluginField={this.disablePluginField}
                                        pluginIdProxy={this.pluginIdProxy.bind(this)}/>;
   }
 
@@ -94,7 +96,7 @@ export class CreatePackageRepositoryModal extends PackageRepositoryModal {
   constructor(entity: PackageRepository,
               pluginInfos: PluginInfos,
               onSuccessfulSave: (msg: m.Children) => any) {
-    super(entity, pluginInfos, onSuccessfulSave);
+    super(entity, pluginInfos, onSuccessfulSave, false, false);
     this.isStale(false);
   }
 
@@ -131,7 +133,7 @@ export class EditPackageRepositoryModal extends PackageRepositoryModal {
 
 export class ClonePackageRepositoryModal extends PackageRepositoryModal {
   constructor(entity: PackageRepository, pluginInfos: PluginInfos, onSuccessfulSave: (msg: m.Children) => any) {
-    super(entity, pluginInfos, onSuccessfulSave, false);
+    super(entity, pluginInfos, onSuccessfulSave);
   }
 
   title(): string {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_modal_body_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_modal_body_spec.tsx
@@ -28,20 +28,20 @@ describe('PackageModalBodySpec', () => {
   let packageRepos: PackageRepositories;
   let pkg: Package;
   let disabled: boolean;
+  let disablePackageRepo: boolean;
 
   afterEach((done) => helper.unmount(done));
   beforeEach(() => {
-    pluginInfos  = new PluginInfos(PluginInfo.fromJSON(pluginInfoWithPackageRepositoryExtension()));
-    pkg          = Package.fromJSON(getPackage());
-    packageRepos = new PackageRepositories(PackageRepository.fromJSON(getPackageRepository()));
-    disabled     = false;
+    pluginInfos        = new PluginInfos(PluginInfo.fromJSON(pluginInfoWithPackageRepositoryExtension()));
+    pkg                = Package.fromJSON(getPackage());
+    packageRepos       = new PackageRepositories(PackageRepository.fromJSON(getPackageRepository()));
+    disabled           = false;
+    disablePackageRepo = false;
   });
 
   function mount() {
-    helper.mount(() => <PackageModalBody pluginInfos={pluginInfos}
-                                         packageRepositories={packageRepos}
-                                         package={pkg}
-                                         disableId={disabled}
+    helper.mount(() => <PackageModalBody pluginInfos={pluginInfos} packageRepositories={packageRepos}
+                                         package={pkg} disableId={disabled} disablePackageRepo={disablePackageRepo}
                                          onPackageRepoChange={onPackageRepoChange}/>);
   }
 
@@ -64,6 +64,7 @@ describe('PackageModalBodySpec', () => {
     expect(helper.byTestId("form-field-input-name")).toHaveValue(pkg.name());
 
     expect(helper.byTestId('form-field-input-package-repository')).toBeInDOM();
+    expect(helper.byTestId('form-field-input-package-repository')).not.toBeDisabled();
     expect(helper.byTestId("form-field-input-package-repository").children[0].textContent).toBe(pkg.packageRepo().name());
   });
 
@@ -71,7 +72,7 @@ describe('PackageModalBodySpec', () => {
     const pkgRepo = PackageRepository.default();
     pkgRepo.repoId('new-repo-id');
     pkgRepo.name('new-repo-name');
-
+    pkgRepo.pluginMetadata().id("npm");
     packageRepos.push(pkgRepo);
     mount();
 
@@ -87,5 +88,13 @@ describe('PackageModalBodySpec', () => {
     expect(helper.byTestId('flash-message-info')).not.toBeInDOM();
     expect(helper.byTestId('form-field-input-id')).toBeDisabled();
     expect(helper.byTestId('form-field-input-name')).toBeDisabled();
+  });
+
+  it('should render the package repo as readonly', () => {
+    disablePackageRepo = true;
+    mount();
+
+    expect(helper.byTestId('form-field-input-package-repository')).toBeInDOM();
+    expect(helper.byTestId('form-field-input-package-repository')).toBeDisabled();
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_repository_modal_body_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_repository_modal_body_spec.tsx
@@ -31,18 +31,19 @@ describe('PackageRepositoryModalBodySpec', () => {
   let pluginInfos: PluginInfos;
   let packageRepo: PackageRepository;
   let disabled: boolean;
+  let disablePluginField: boolean;
 
   afterEach((done) => helper.unmount(done));
   beforeEach(() => {
-    pluginInfos = new PluginInfos(PluginInfo.fromJSON(pluginInfoWithPackageRepositoryExtension()));
-    packageRepo = PackageRepository.fromJSON(getPackageRepository());
-    disabled    = false;
+    pluginInfos        = new PluginInfos(PluginInfo.fromJSON(pluginInfoWithPackageRepositoryExtension()));
+    packageRepo        = PackageRepository.fromJSON(getPackageRepository());
+    disabled           = false;
+    disablePluginField = false;
   });
 
   function mount() {
-    helper.mount(() => <PackageRepositoryModalBody pluginInfos={pluginInfos}
-                                                   packageRepo={packageRepo}
-                                                   disableId={disabled}
+    helper.mount(() => <PackageRepositoryModalBody pluginInfos={pluginInfos} packageRepo={packageRepo}
+                                                   disableId={disabled} disablePluginField={disablePluginField}
                                                    pluginIdProxy={pluginIdProxy}/>);
   }
 
@@ -58,6 +59,7 @@ describe('PackageRepositoryModalBodySpec', () => {
     expect(helper.byTestId("form-field-input-name")).toHaveValue(packageRepo.name());
 
     expect(helper.byTestId('form-field-input-plugin')).toBeInDOM();
+    expect(helper.byTestId('form-field-input-plugin')).not.toBeDisabled();
     expect(helper.byTestId("form-field-input-plugin").children.length).toBe(1);
     expect(helper.byTestId("form-field-input-plugin").children[0].textContent).toBe('NPM plugin for package repo');
   });
@@ -82,5 +84,13 @@ describe('PackageRepositoryModalBodySpec', () => {
     helper.onchange(helper.byTestId("form-field-input-plugin"), "new-plugin-id");
 
     expect(spy).toHaveBeenCalled();
+  });
+
+  it('should render the plugin field as disabled', () => {
+    disablePluginField = true;
+    mount();
+
+    expect(helper.byTestId('form-field-input-plugin')).toBeInDOM();
+    expect(helper.byTestId('form-field-input-plugin')).toBeDisabled();
   });
 });


### PR DESCRIPTION
Issue: #7975, https://github.com/gocd/gocd/pull/7940#issuecomment-610739973

Description:
 - Fixed silent failure on client side while cloning a package repo - issue was that individual packages were also validated which failed. Since, there was no client side binding, the error were not represented - removed the package validation from package repo model.
 - disabled the plugin field during edit/clone of package repository
 - disabled the package repo field during creation as it should be within the context of package repo
 - disabled the package repo field during edit as you cannot update the package repo of a package
 - during clone of package repo - only show the repos which belong to the same plugin
