### PR TITLE
Update pluggable scm SPA

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm.ts
@@ -84,11 +84,10 @@ export class Scm extends ValidatableMixin {
     this.pluginMetadata = Stream(pluginMetadata);
     this.configuration  = Stream(configuration);
 
-    this.validatePresenceOf("id");
     this.validatePresenceOf("name");
     this.validateFormatOf("name",
                           new RegExp("^[-a-zA-Z0-9_][-a-zA-Z0-9_.]*$"),
-                          {message: "Invalid Id. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period)."});
+                          {message: "Invalid Name. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period)."});
     this.validateMaxLength("name", 255, {message: "The maximum allowed length is 255 characters."});
     this.validateAssociated("pluginMetadata");
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/types_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/types_spec.ts
@@ -203,8 +203,7 @@ describe("Material Types", () => {
 
       expect(isValid).toBeFalse();
 
-      expect(material.errors().count()).toBe(2);
-      expect(material.errors().errorsForDisplay('id')).toBe('Id must be present.');
+      expect(material.errors().count()).toBe(1);
       expect(material.errors().errorsForDisplay('name')).toBe('Name must be present.');
 
       expect(material.pluginMetadata().errors().count()).toBe(1);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms.tsx
@@ -82,7 +82,7 @@ export class PluggableScmsPage extends Page<null, State> {
     vnode.state.onDelete = (scm: Scm, e: MouseEvent) => {
       e.stopPropagation();
 
-      new DeletePluggableScmModal(scm, vnode.state.onSuccessfulSave, onOperationError).render();
+      new DeletePluggableScmModal(scm, vnode.state.onSuccessfulSave).render();
     };
 
     vnode.state.showUsages = (scm: Scm, e: MouseEvent) => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms.tsx
@@ -22,7 +22,6 @@ import {PluggableScmCRUD} from "models/materials/pluggable_scm_crud";
 import {Configurations} from "models/shared/configuration";
 import {ExtensionTypeString, SCMExtensionType} from "models/shared/plugin_infos_new/extension_type";
 import {PluginInfoCRUD} from "models/shared/plugin_infos_new/plugin_info_crud";
-import {v4 as uuidv4} from 'uuid';
 import {ButtonIcon, Primary} from "views/components/buttons";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {HeaderPanel} from "views/components/header_panel";
@@ -30,20 +29,8 @@ import {NoPluginsOfTypeInstalled} from "views/components/no_plugins_installed";
 import {Page, PageState} from "views/pages/page";
 import {PluggableScmsWidget} from "views/pages/pluggable_scms/pluggable_scms_widget";
 import {UsagePackageModal} from "./package_repositories/package_modals";
-import {
-  AddOperation,
-  CloneOperation,
-  DeleteOperation,
-  EditOperation,
-  RequiresPluginInfos,
-  SaveOperation
-} from "./page_operations";
-import {
-  ClonePluggableScmModal,
-  CreatePluggableScmModal,
-  DeletePluggableScmModal,
-  EditPluggableScmModal
-} from "./pluggable_scms/modals";
+import {AddOperation, CloneOperation, DeleteOperation, EditOperation, RequiresPluginInfos, SaveOperation} from "./page_operations";
+import {ClonePluggableScmModal, CreatePluggableScmModal, DeletePluggableScmModal, EditPluggableScmModal} from "./pluggable_scms/modals";
 
 interface State extends RequiresPluginInfos, AddOperation<Scm>, EditOperation<Scm>, CloneOperation<Scm>, DeleteOperation<Scm>, SaveOperation {
   scms: Stream<Scms>;
@@ -73,7 +60,7 @@ export class PluggableScmsPage extends Page<null, State> {
       e.stopPropagation();
 
       const pluginId = vnode.state.pluginInfos()[0].id;
-      const scm      = new Scm(uuidv4(), "", false, new PluginMetadata(pluginId, "1"), new Configurations([]));
+      const scm      = new Scm("", "", false, new PluginMetadata(pluginId, "1"), new Configurations([]));
 
       new CreatePluggableScmModal(scm, vnode.state.pluginInfos(), vnode.state.onSuccessfulSave)
         .render();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/modals.tsx
@@ -162,15 +162,12 @@ export class ClonePluggableScmModal extends PluggableScmModal {
 
 export class DeletePluggableScmModal extends DeleteConfirmModal {
   private readonly onSuccessfulSave: (msg: m.Children) => any;
-  private readonly onOperationError: (errorResponse: ErrorResponse) => any;
 
   constructor(pkgRepo: Scm,
-              onSuccessfulSave: (msg: m.Children) => any,
-              onOperationError: (errorResponse: ErrorResponse) => any) {
+              onSuccessfulSave: (msg: m.Children) => any) {
     super(DeletePluggableScmModal.deleteConfirmationMessage(pkgRepo),
           () => this.delete(pkgRepo), "Are you sure?");
     this.onSuccessfulSave = onSuccessfulSave;
-    this.onOperationError = onOperationError;
   }
 
   private static deleteConfirmationMessage(scm: Scm) {
@@ -184,12 +181,19 @@ export class DeletePluggableScmModal extends DeleteConfirmModal {
       .delete(obj.name())
       .then((result) => {
         result.do(
-          () => this.onSuccessfulSave(
-            <span>The scm <em>{obj.name()}</em> was deleted successfully!</span>
-          ),
-          this.onOperationError
+          () => {
+            this.onSuccessfulSave(
+              <span>The scm <em>{obj.name()}</em> was deleted successfully!</span>
+            );
+            this.close();
+          },
+          (errorResponse: ErrorResponse) => {
+            this.errorMessage = errorResponse.message;
+            if (errorResponse.body) {
+              this.errorMessage = JSON.parse(errorResponse.body).message;
+            }
+          }
         );
-      })
-      .finally(this.close.bind(this));
+      });
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/modals.tsx
@@ -21,7 +21,6 @@ import Stream from "mithril/stream";
 import {Scm, ScmJSON} from "models/materials/pluggable_scm";
 import {PluggableScmCRUD} from "models/materials/pluggable_scm_crud";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
-import {v4 as uuidv4} from 'uuid';
 import {FlashMessageModel, MessageType} from "views/components/flash_message";
 import {Warning} from "views/components/icons";
 import {Size} from "views/components/modal";
@@ -34,29 +33,34 @@ abstract class PluggableScmModal extends EntityModal<Scm> {
   protected readonly originalEntityName: string;
   protected message?: FlashMessageModel;
   private disableId: boolean;
+  private disablePluginId: boolean;
 
   constructor(entity: Scm,
               pluginInfos: PluginInfos,
               onSuccessfulSave: (msg: m.Children) => any,
-              disableId: boolean = false,
-              size: Size         = Size.large) {
+              disableId: boolean       = false,
+              disablePluginId: boolean = true,
+              size: Size               = Size.large) {
     super(entity, pluginInfos, onSuccessfulSave, size);
     this.disableId          = disableId;
+    this.disablePluginId    = disablePluginId;
     this.originalEntityId   = entity.id();
     this.originalEntityName = entity.name();
   }
 
   operationError(errorResponse: any, statusCode: number) {
-    this.errorMessage(errorResponse.message);
     if (errorResponse.body) {
       this.errorMessage(JSON.parse(errorResponse.body).message);
+    } else if (errorResponse.data) {
+      this.entity(Scm.fromJSON(errorResponse.data));
+    } else {
+      this.errorMessage(errorResponse.message);
     }
   }
 
   protected modalBody(): m.Children {
-    return <PluggableScmModalBody pluginInfos={this.pluginInfos}
-                                  scm={this.entity()}
-                                  disableId={this.disableId}
+    return <PluggableScmModalBody pluginInfos={this.pluginInfos} scm={this.entity()}
+                                  disableId={this.disableId} disablePluginId={this.disablePluginId}
                                   pluginIdProxy={this.pluginIdProxy.bind(this)} message={this.message}/>;
   }
 
@@ -93,7 +97,7 @@ export class CreatePluggableScmModal extends PluggableScmModal {
   constructor(entity: Scm,
               pluginInfos: PluginInfos,
               onSuccessfulSave: (msg: m.Children) => any) {
-    super(entity, pluginInfos, onSuccessfulSave);
+    super(entity, pluginInfos, onSuccessfulSave, false, false);
     this.isStale(false);
   }
 
@@ -151,7 +155,7 @@ export class ClonePluggableScmModal extends PluggableScmModal {
   }
 
   fetchCompleted() {
-    this.entity().id(uuidv4());
+    this.entity().id("");
     this.entity().name("");
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_modal_body.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_modal_body.tsx
@@ -32,6 +32,7 @@ interface Attrs {
   pluginInfos: PluginInfos;
   scm: Scm;
   disableId: boolean;
+  disablePluginId: boolean;
   pluginIdProxy: (newPluginId?: string) => any;
   message?: FlashMessageModel;
 }
@@ -58,27 +59,18 @@ export class PluggableScmModalBody extends MithrilViewComponent<Attrs> {
                      readonly={vnode.attrs.disableId}
                      property={vnode.attrs.scm.name}
                      placeholder={"Enter the pluggable scm name"}
-                     errorText={vnode.attrs.scm.errors().errorsForDisplay("name")}
+                     errorText={vnode.attrs.scm.errors().errorsForDisplay("name") || vnode.attrs.scm.errors().errorsForDisplay("scmId")}
                      required={true}/>
 
           <SelectField label="Plugin"
                        property={vnode.attrs.pluginIdProxy.bind(this)}
-                       required={true}
+                       required={true} readonly={vnode.attrs.disablePluginId}
                        errorText={vnode.attrs.scm.errors().errorsForDisplay("pluginId")}>
             <SelectFieldOptions selected={vnode.attrs.scm.pluginMetadata().id()}
                                 items={pluginList}/>
           </SelectField>
         </Form>
       </FormHeader>
-
-      <div>
-        <TextField label="Id"
-                   readonly={vnode.attrs.disableId}
-                   property={vnode.attrs.scm.id}
-                   placeholder={"Enter a unique id for this material"}
-                   helpText={"Each material is associated with an id by which it can be referenced in the pipelines. Once defined, cannot be updated"}
-                   errorText={vnode.attrs.scm.errors().errorsForDisplay("scmId")}/>
-      </div>
 
       <div className="row collapse">
         <AngularPluginNew

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_modal_body_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_modal_body_spec.tsx
@@ -32,16 +32,18 @@ describe('PluggableScmModalBodySpec', () => {
   let pluginInfos: PluginInfos;
   let scm: Scm;
   let disabled: boolean;
+  let disablePluginId: boolean;
 
   beforeEach(() => {
-    scm         = Scm.fromJSON(getPluggableScm());
-    pluginInfos = new PluginInfos(PluginInfo.fromJSON(getScmPlugin()));
-    disabled    = false;
+    scm             = Scm.fromJSON(getPluggableScm());
+    pluginInfos     = new PluginInfos(PluginInfo.fromJSON(getScmPlugin()));
+    disabled        = false;
+    disablePluginId = false;
   });
   afterEach((done) => helper.unmount(done));
 
   function mount(message?: FlashMessageModel) {
-    helper.mount(() => <PluggableScmModalBody scm={scm} pluginInfos={pluginInfos}
+    helper.mount(() => <PluggableScmModalBody scm={scm} pluginInfos={pluginInfos} disablePluginId={disablePluginId}
                                               disableId={disabled} pluginIdProxy={pluginIdProxy} message={message}/>);
   }
 
@@ -53,12 +55,9 @@ describe('PluggableScmModalBodySpec', () => {
     expect(helper.byTestId("form-field-input-name")).toHaveValue(scm.name());
 
     expect(helper.byTestId('form-field-input-plugin')).toBeInDOM();
+    expect(helper.byTestId('form-field-input-plugin')).not.toBeDisabled();
     expect(helper.byTestId("form-field-input-plugin").children.length).toBe(1);
     expect(helper.byTestId("form-field-input-plugin").children[0].textContent).toBe('SCM Plugin');
-
-    expect(helper.byTestId('form-field-input-id')).toBeInDOM();
-    expect(helper.byTestId('form-field-input-id')).not.toBeDisabled();
-    expect(helper.byTestId("form-field-input-id")).toHaveValue(scm.id());
   });
 
   it('should render the name and id as readonly', () => {
@@ -66,7 +65,6 @@ describe('PluggableScmModalBodySpec', () => {
     mount();
 
     expect(helper.byTestId('form-field-input-name')).toBeDisabled();
-    expect(helper.byTestId('form-field-input-id')).toBeDisabled();
   });
 
   it('should call the spy method on plugin change', () => {
@@ -89,6 +87,13 @@ describe('PluggableScmModalBodySpec', () => {
 
     expect(helper.byTestId('flash-message-warning')).toBeInDOM();
     expect(helper.textByTestId('flash-message-warning')).toBe('some message');
+  });
 
+  it('should render plugin as readonly', () => {
+    disablePluginId = true;
+    mount();
+
+    expect(helper.byTestId('form-field-input-plugin')).toBeInDOM();
+    expect(helper.byTestId('form-field-input-plugin')).toBeDisabled();
   });
 });


### PR DESCRIPTION
Issue: https://github.com/gocd/gocd/pull/7919#issuecomment-610483965

Description:
 - removing the id field
 - binding the scmId error to name field
 - corrected the error on invalid name
 - disabled the plugin field on edit/clone scm
 - render the errors on delete on the popup itself