### PR TITLE
Add scm spa endpoint to authorize filter chain

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
@@ -75,6 +75,7 @@ public class AuthorizeFilterChain extends FilterChainProxy {
                 .addAuthorityFilterChain("/admin/package_definitions/**", genericAccessDeniedHandler, ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR)
 
                 .addAuthorityFilterChain("/admin/environments/**", genericAccessDeniedHandler, ROLE_USER)
+                .addAuthorityFilterChain("/admin/scms/**", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/admin/config_repos/**", genericAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/admin/elastic_agents/**", genericAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/admin/admin/elastic_profiles/**", genericAccessDeniedHandler, ROLE_USER)


### PR DESCRIPTION
The Pluggable SCM can be viewed by super admin or group admin.

