### PR TITLE
Fix the error on unauthorized access to scm spa

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
@@ -75,7 +75,7 @@ public class AuthorizeFilterChain extends FilterChainProxy {
                 .addAuthorityFilterChain("/admin/package_definitions/**", genericAccessDeniedHandler, ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR)
 
                 .addAuthorityFilterChain("/admin/environments/**", genericAccessDeniedHandler, ROLE_USER)
-                .addAuthorityFilterChain("/admin/scms/**", apiAccessDeniedHandler, ROLE_USER)
+                .addAuthorityFilterChain("/admin/scms/**", genericAccessDeniedHandler, ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR)
                 .addAuthorityFilterChain("/admin/config_repos/**", genericAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/admin/elastic_agents/**", genericAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/admin/admin/elastic_profiles/**", genericAccessDeniedHandler, ROLE_USER)


### PR DESCRIPTION
Description:
The earlier PR rendered the error as if the request was an API - added necessary headers.
But the endpoint is an SPA - only the generic error is enough. This PR makes that change
