### PR TITLE
Invalidate User Toggles cache on change of value

### DIFF
--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/support/toggle/FeatureToggleServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/support/toggle/FeatureToggleServiceTest.java
@@ -174,11 +174,14 @@ public class FeatureToggleServiceTest {
         FeatureToggleService service = new FeatureToggleService(repository, new StubGoCache(new TestTransactionSynchronizationManager()));
         service.allToggles();
         verify(repository, times(1)).availableToggles();
+        verify(repository, times(1)).userToggles();
 
         service.changeValueOfToggle("key1", false);
         verify(repository, times(1)).availableToggles();
+        verify(repository, times(1)).userToggles();
 
         service.allToggles();
         verify(repository, times(2)).availableToggles();
+        verify(repository, times(2)).userToggles();
     }
 }


### PR DESCRIPTION
* Related to changes introduced as part of #7970
* #7970 introuduced USER_DEF_TOGGLES cache which was not invalidated
  on change of toggles. Hence any changes to toggle was not reflected
  because of the stale cache.

Issue: #

Description:

