### PR TITLE
[Pipeline Config SPA] Bind plugin config validation errors onto view.

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/mixins/errors_consumer.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/mixins/errors_consumer.ts
@@ -16,6 +16,7 @@
 
 import Stream from "mithril/stream";
 import {Errors} from "models/mixins/errors";
+import {Configuration} from "models/shared/configuration";
 import s from "underscore.string";
 
 /**
@@ -146,9 +147,18 @@ function addErrorsToModel(errors: ErrorMap, model: any, path: string, unmatched:
       if (matchesField) {
         container.errors().add(fieldName, msg);
       } else {
-        unmatched.add(next(path, key), msg);
+        addToUnmatchIfNotPluginProperty(container, unmatched, path, key, msg);
       }
     }
+  }
+}
+
+//todo: Remove this special handling for Configuration class and make Configuration class an ErrorConsumer by containing Errors field.
+function addToUnmatchIfNotPluginProperty(container: any, unmatched: Errors, path: string, key: string, msg: string) {
+  if(container instanceof Configuration) {
+    container.errors!.push(msg);
+  } else {
+    unmatched.add(next(path, key), msg);
   }
 }
 
@@ -170,6 +180,7 @@ function item(model: any, i: number): any {
   if (!model) { return undefined; }
   if (model instanceof Array) { return model[i]; }
   if (model[Symbol.iterator]) { return Array.from(model)[i]; }
+  if (model.get) { return model.get(i); }
   return model;
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/mixins/spec/errors_consumer_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/mixins/spec/errors_consumer_spec.ts
@@ -16,6 +16,8 @@
 
 import Stream from "mithril/stream";
 import {BaseErrorsConsumer, ErrorsConsumer} from "models/mixins/errors_consumer";
+import {Configuration, Configurations} from "models/shared/configuration";
+import {PlainTextValue} from "models/shared/config_value";
 
 describe("ErrorsConsumer", () => {
   describe("consumeErrorsResponse()", () => {
@@ -200,6 +202,24 @@ describe("ErrorsConsumer", () => {
       expect(unmatched.keys()).toEqual(["me.unknown"]);
       expect(unmatched.errorsForDisplay("me.unknown")).toBe("hello.");
     });
+
+    it("should bind errors onto to the configuration object", () => {
+      const model = new DummyWithConfigurations();
+
+      expect(model.config!.get(0).errors).toEqual([]);
+      model.consumeErrorsResponse({config: [{errors: {pluginKey: ["Boom!"]}}]});
+      expect(model.config!.get(0).errors).toEqual(["Boom!"]);
+    });
+
+    class DummyWithConfigurations extends BaseErrorsConsumer {
+      config: Configurations;
+
+      constructor() {
+        super();
+        const config = new Configuration("pluginKey", new PlainTextValue("pluginValue"));
+        this.config  = new Configurations([config]);
+      }
+    }
 
     class Dummy extends BaseErrorsConsumer {
       one: Stream<Sub1> = Stream();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/configuration.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/configuration.ts
@@ -76,22 +76,26 @@ export class Configurations {
     return this.configurations;
   }
 
+  public get(index: number) {
+    return this.configurations[index];
+  }
+
   public asString(): string {
     const configValues = this.configurations
                              .map((config) => `${config.key}=${config.displayValue()}`)
-                             .join(',');
+                             .join(",");
     return `[${configValues}]`;
   }
 }
 
 export class Configuration {
   readonly key: string;
-  readonly errors?: string[];
+  readonly errors: string[];
   private _value: ConfigValue;
 
-  constructor(key: string, value: EncryptedValue | PlainTextValue, errors?: string[]) {
+  constructor(key: string, value: EncryptedValue | PlainTextValue, errors: string[] = []) {
     this.key    = key;
-    this._value  = value;
+    this._value = value;
     this.errors = errors;
   }
 


### PR DESCRIPTION
* Modify ErrorConsumer to treat plugin configuration class special.

Description:
<img width="1042" alt="Screen Shot 2020-04-10 at 11 26 28 AM" src="https://user-images.githubusercontent.com/15275847/78966976-d0c49180-7b1e-11ea-8321-acd425ea8e8d.png">


