### PR TITLE
Allowing linking to individual scm panel on the pluggable scm spa

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/pluggable_scms.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/pluggable_scms.tsx
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-import {SinglePageAppBase} from "helpers/spa_base";
+import {RoutedSinglePageApp} from "helpers/spa_base";
 import {PluggableScmsPage} from "views/pages/pluggable_scms";
 
-export class PluggableScmsSPA extends SinglePageAppBase {
+export class PluggableScmsSPA extends RoutedSinglePageApp {
   constructor() {
-    super(PluggableScmsPage);
+    super({
+            "/":                 PluggableScmsPage,
+            "/:name":            PluggableScmsPage,
+            "/:name/:operation": PluggableScmsPage
+          });
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_widget_spec.tsx
@@ -16,7 +16,7 @@
 
 import m from "mithril";
 import {Scm} from "models/materials/pluggable_scm";
-import {TestHelper} from "views/pages/spec/test_helper";
+import {stubAllMethods, TestHelper} from "views/pages/spec/test_helper";
 import {PluggableScmWidget} from "../pluggable_scm_widget";
 import {getPluggableScm} from "./test_data";
 
@@ -36,9 +36,14 @@ describe('PluggableScmWidgetSpec', () => {
   afterEach((done) => helper.unmount(done));
 
   function mount() {
+    const scrollOptions = {
+      sm:                 stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl", "hasTarget"]),
+      shouldOpenEditView: false
+    };
     helper.mount(() => <PluggableScmWidget scm={scm} disableActions={disableActions}
                                            onEdit={editSpy} onClone={cloneSpy} onDelete={deleteSpy}
-                                           showUsages={usagesSpy}/>);
+                                           showUsages={usagesSpy}
+                                           scrollOptions={scrollOptions}/>);
   }
 
   it('should render scm details and action buttons', () => {


### PR DESCRIPTION
Description:
 - needed as the material editor will allow linking to allow edit of a certain scm

Links:
 - to expand the selected scm: `http://go-server-url:8153/go/admin/scms#!scm-name`
 - to edit the selected scm: `http://go-server-url:8153/go/admin/scms#!scm-name/edit`
