### PR TITLE
Allowing linking to individual repo and package panel on the package repo SPA

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/package_repositories/package_repositories.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/package_repositories/package_repositories.ts
@@ -18,7 +18,14 @@ import Stream from "mithril/stream";
 import {ValidatableMixin} from "models/mixins/new_validatable_mixin";
 import {Errors} from "../mixins/errors";
 import {Configurations} from "../shared/configuration";
-import {PackageJSON, PackageRepositoryJSON, PackageRepositorySummaryJSON, PackageUsageJSON, PackageUsagesJSON, PluginMetadataJSON} from "./package_repositories_json";
+import {
+  PackageJSON,
+  PackageRepositoryJSON,
+  PackageRepositorySummaryJSON,
+  PackageUsageJSON,
+  PackageUsagesJSON,
+  PluginMetadataJSON
+} from "./package_repositories_json";
 
 export class PackageRepositorySummary extends ValidatableMixin {
   id: Stream<string>;
@@ -90,6 +97,10 @@ export class Package extends ValidatableMixin {
       package_repo:  this.packageRepo.toJSON(),
       configuration: this.configuration().toJSON()
     };
+  }
+
+  key() {
+    return `${this.packageRepo().name()}_${this.name()}`;
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/package_repositories/spec/package_repositories_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/package_repositories/spec/package_repositories_spec.ts
@@ -68,6 +68,12 @@ describe('PackageRepositoriesModelSpec', () => {
       expect(pkg.errors().count()).toEqual(1);
       expect(pkg.errors().keys()).toEqual(["name"]);
     });
+
+    it('should return key as concat of package repo name and pkg name', () => {
+      const pkg = Package.fromJSON(getPackage());
+
+      expect(pkg.key()).toBe('pkg-repo-name_pkg-name');
+    });
   });
 
   it("should validate presence of plugin id", () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/package_repositories.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/package_repositories.tsx
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 
-import {SinglePageAppBase} from "helpers/spa_base";
+import {RoutedSinglePageApp} from "helpers/spa_base";
 import {PackageRepositoriesPage} from "views/pages/package_repositories";
 
-export class PackageRepositoriesSPA extends SinglePageAppBase {
+export class PackageRepositoriesSPA extends RoutedSinglePageApp {
   constructor() {
-    super(PackageRepositoriesPage);
+    super({
+            "/":                                                     PackageRepositoriesPage,
+            "/:repo_name":                                           PackageRepositoriesPage,
+            "/:repo_name/:repo_operation":                           PackageRepositoriesPage,
+            "/:repo_name/packages/:package_name":                    PackageRepositoriesPage,
+            "/:repo_name/packages/:package_name/:package_operation": PackageRepositoriesPage
+          });
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories.tsx
@@ -23,13 +23,14 @@ import {Package, PackageRepositories, PackageRepository, PackageRepositorySummar
 import {PackageRepositoriesCRUD} from "models/package_repositories/package_repositories_crud";
 import {ExtensionTypeString, PackageRepoExtensionType} from "models/shared/plugin_infos_new/extension_type";
 import {PluginInfoCRUD} from "models/shared/plugin_infos_new/plugin_info_crud";
+import {AnchorVM} from "views/components/anchor/anchor";
 import {ButtonIcon, Primary} from "views/components/buttons";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {SearchField} from "views/components/forms/input_fields";
 import {HeaderPanel} from "views/components/header_panel";
 import {NoPluginsOfTypeInstalled} from "views/components/no_plugins_installed";
 import configRepoStyles from "views/pages/config_repos/index.scss";
-import {PackageRepositoriesWidget} from "views/pages/package_repositories/package_repositories_widget";
+import {PackageRepoScrollOptions, PackageRepositoriesWidget} from "views/pages/package_repositories/package_repositories_widget";
 import {
   ClonePackageRepositoryModal,
   CreatePackageRepositoryModal,
@@ -64,7 +65,6 @@ interface State extends RequiresPluginInfos, SaveOperation {
 }
 
 export class PackageRepositoriesPage extends Page<null, State> {
-
   public static getMergedList(originalPkgRepos: Stream<PackageRepositories>, pkgs: Stream<Packages>): PackageRepositories {
     const pkgRepos = originalPkgRepos();
 
@@ -110,6 +110,7 @@ export class PackageRepositoriesPage extends Page<null, State> {
   }
 
   componentToDisplay(vnode: m.Vnode<null, State>): m.Children {
+    const scrollOptions = this.parsePackageRepoLink();
     let noPluginMsg;
     if (!this.isPluginInstalled(vnode)) {
       noPluginMsg = <NoPluginsOfTypeInstalled extensionType={new PackageRepoExtensionType()}/>;
@@ -138,7 +139,8 @@ export class PackageRepositoriesPage extends Page<null, State> {
       <PackageRepositoriesWidget packageRepositories={filteredPackageRepos}
                                  pluginInfos={vnode.state.pluginInfos}
                                  packageRepoOperations={vnode.state.packageRepoOperations}
-                                 packageOperations={vnode.state.packageOperations}/>
+                                 packageOperations={vnode.state.packageOperations}
+                                 scrollOptions={scrollOptions}/>
     </div>;
   }
 
@@ -285,4 +287,24 @@ export class PackageRepositoriesPage extends Page<null, State> {
     };
   }
 
+  private parsePackageRepoLink(): PackageRepoScrollOptions {
+    const pkgRepoAnchorVm = new AnchorVM();
+    pkgRepoAnchorVm.setTarget(m.route.param().repo_name || "");
+    const repo_operation = (m.route.param().repo_operation || "").toLowerCase();
+
+    const pkgAnchorVM = new AnchorVM();
+    pkgAnchorVM.setTarget(m.route.param().package_name || "");
+    const pkg_operation = (m.route.param().package_operation || "").toLowerCase();
+
+    return {
+      package_repo_sm: {
+        sm:                 pkgRepoAnchorVm,
+        shouldOpenEditView: repo_operation === "edit"
+      },
+      package_sm:      {
+        sm:                 pkgAnchorVM,
+        shouldOpenEditView: pkg_operation === "edit"
+      }
+    };
+  }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories.tsx
@@ -23,7 +23,7 @@ import {Package, PackageRepositories, PackageRepository, PackageRepositorySummar
 import {PackageRepositoriesCRUD} from "models/package_repositories/package_repositories_crud";
 import {ExtensionTypeString, PackageRepoExtensionType} from "models/shared/plugin_infos_new/extension_type";
 import {PluginInfoCRUD} from "models/shared/plugin_infos_new/plugin_info_crud";
-import {AnchorVM} from "views/components/anchor/anchor";
+import {AnchorVM, ScrollManager} from "views/components/anchor/anchor";
 import {ButtonIcon, Primary} from "views/components/buttons";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {SearchField} from "views/components/forms/input_fields";
@@ -40,6 +40,9 @@ import {
 import {Page, PageState} from "views/pages/page";
 import {RequiresPluginInfos, SaveOperation} from "views/pages/page_operations";
 import {ClonePackageModal, CreatePackageModal, DeletePackageModal, EditPackageModal, UsagePackageModal} from "./package_repositories/package_modals";
+
+const pkgRepoAnchorVm: ScrollManager = new AnchorVM();
+const pkgAnchorVM: ScrollManager     = new AnchorVM();
 
 export class PackageRepoOperations {
   onAdd: (e: MouseEvent) => void                            = () => _.noop;
@@ -110,7 +113,7 @@ export class PackageRepositoriesPage extends Page<null, State> {
   }
 
   componentToDisplay(vnode: m.Vnode<null, State>): m.Children {
-    const scrollOptions = this.parsePackageRepoLink();
+    const scrollOptions = this.parsePackageRepoLink(pkgRepoAnchorVm, pkgAnchorVM);
     let noPluginMsg;
     if (!this.isPluginInstalled(vnode)) {
       noPluginMsg = <NoPluginsOfTypeInstalled extensionType={new PackageRepoExtensionType()}/>;
@@ -287,19 +290,20 @@ export class PackageRepositoriesPage extends Page<null, State> {
     };
   }
 
-  private parsePackageRepoLink(): PackageRepoScrollOptions {
-    const pkgRepoAnchorVm = new AnchorVM();
-    pkgRepoAnchorVm.setTarget(m.route.param().repo_name || "");
+  private parsePackageRepoLink(pkgRepoAnchorVm: ScrollManager, pkgAnchorVM: ScrollManager): PackageRepoScrollOptions {
+    const repo_name = m.route.param().repo_name || "";
+    pkgRepoAnchorVm.setTarget(repo_name);
     const repo_operation = (m.route.param().repo_operation || "").toLowerCase();
 
-    const pkgAnchorVM = new AnchorVM();
-    pkgAnchorVM.setTarget(m.route.param().package_name || "");
+    const pkg_name = m.route.param().package_name || "";
+    pkgAnchorVM.setTarget(`${repo_name}_${pkg_name}`);
     const pkg_operation = (m.route.param().package_operation || "").toLowerCase();
 
     return {
       package_repo_sm: {
-        sm:                 pkgRepoAnchorVm,
-        shouldOpenEditView: repo_operation === "edit"
+        sm:                          pkgRepoAnchorVm,
+        shouldOpenEditView:          repo_operation === "edit",
+        shouldOpenCreatePackageView: repo_operation === "create-package"
       },
       package_sm:      {
         sm:                 pkgAnchorVM,

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repositories_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repositories_widget.tsx
@@ -20,20 +20,37 @@ import _ from "lodash";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {PackageRepositories} from "models/package_repositories/package_repositories";
+import {FlashMessage, MessageType} from "views/components/flash_message";
 import {Link} from "views/components/link";
 import {PackageOperations, PackageRepoOperations} from "views/pages/package_repositories";
 import {RequiresPluginInfos} from "views/pages/page_operations";
 import styles from "./index.scss";
-import {PackageRepositoryWidget} from "./package_repository_widget";
+import {PackageRepositoryScrollOptions, PackageRepositoryWidget} from "./package_repository_widget";
+import {PackageScrollOptions} from "./package_widget";
 
 interface Attrs extends RequiresPluginInfos {
   packageRepositories: Stream<PackageRepositories>;
   packageRepoOperations: PackageRepoOperations;
   packageOperations: PackageOperations;
+  scrollOptions: PackageRepoScrollOptions;
+}
+
+export interface PackageRepoScrollOptions {
+  package_repo_sm: PackageRepositoryScrollOptions;
+  package_sm: PackageScrollOptions;
 }
 
 export class PackageRepositoriesWidget extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs>) {
+    const pkgRepoScrollOptions = vnode.attrs.scrollOptions.package_repo_sm;
+    if (pkgRepoScrollOptions.sm.hasTarget()) {
+      const target           = pkgRepoScrollOptions.sm.getTarget();
+      const hasAnchorElement = vnode.attrs.packageRepositories().some((pkgRepo) => pkgRepo.name() === target);
+      if (!hasAnchorElement) {
+        const msg = `'${target}' package repository has not been set up.`;
+        return <FlashMessage dataTestId="anchor-package-repo-not-present" type={MessageType.alert} message={msg}/>;
+      }
+    }
     if (_.isEmpty(vnode.attrs.packageRepositories())) {
       return <div className={styles.tips} data-test-id="package-repo-info">
         <ul>
@@ -52,7 +69,8 @@ export class PackageRepositoriesWidget extends MithrilViewComponent<Attrs> {
                                         disableActions={pluginInfo === undefined}
                                         onEdit={vnode.attrs.packageRepoOperations.onEdit}
                                         onClone={vnode.attrs.packageRepoOperations.onClone}
-                                        onDelete={vnode.attrs.packageRepoOperations.onDelete}/>;
+                                        onDelete={vnode.attrs.packageRepoOperations.onDelete}
+                                        scrollOptions={vnode.attrs.scrollOptions}/>;
       })}
     </div>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repository_widget.tsx
@@ -40,6 +40,7 @@ interface Attrs extends EditOperation<PackageRepository>, CloneOperation<Package
 export interface PackageRepositoryScrollOptions {
   sm: ScrollManager;
   shouldOpenEditView: boolean;
+  shouldOpenCreatePackageView: boolean;
 }
 
 export class PackageRepositoryWidget extends MithrilViewComponent<Attrs> {
@@ -97,8 +98,19 @@ export class PackageRepositoryWidget extends MithrilViewComponent<Attrs> {
       </div>
     ];
 
+    const onNavigate = () => {
+      const scrollOptions = vnode.attrs.scrollOptions.package_repo_sm;
+      this.expanded(true);
+      if (scrollOptions.sm.getTarget() === packageRepository.name()) {
+        if (scrollOptions.shouldOpenEditView) {
+          vnode.attrs.onEdit(packageRepository, new MouseEvent("click"));
+        } else if (scrollOptions.shouldOpenCreatePackageView) {
+          vnode.attrs.packageOperations.onAdd(packageRepository, new MouseEvent("click"));
+        }
+      }
+    };
     return <Anchor id={packageRepository.name()} sm={vnode.attrs.scrollOptions.package_repo_sm.sm}
-                   onnavigate={() => this.expanded(true)}>
+                   onnavigate={onNavigate}>
       <CollapsiblePanel key={vnode.attrs.packageRepository.repoId()}
                         header={header} error={disabled}
                         actions={[warningIcon, actionButtons]}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_widget.tsx
@@ -54,7 +54,7 @@ export class PackageWidget extends MithrilViewComponent<Attrs> {
     const scrollOptions = vnode.attrs.scrollOptions;
     const pkg           = vnode.attrs.package;
     const linked        = scrollOptions.package_repo_sm.sm.getTarget() === pkg.packageRepo().name()
-                          && scrollOptions.package_sm.sm.getTarget() === pkg.name();
+                          && scrollOptions.package_sm.sm.getTarget() === pkg.key();
 
     this.expanded(linked);
   }
@@ -86,9 +86,12 @@ export class PackageWidget extends MithrilViewComponent<Attrs> {
     const onNavigate    = () => {
       if (scrollOptions.package_repo_sm.sm.getTarget() === pkg.packageRepo().name()) {
         this.expanded(true);
+        if (scrollOptions.package_sm.sm.getTarget() === pkg.key() && scrollOptions.package_sm.shouldOpenEditView) {
+          vnode.attrs.onEdit(pkg, new MouseEvent("click"));
+        }
       }
     };
-    return <Anchor id={pkg.name()} sm={scrollOptions.package_sm.sm}
+    return <Anchor id={pkg.key()} sm={scrollOptions.package_sm.sm}
                    onnavigate={onNavigate}>
       <CollapsiblePanel dataTestId={"package-panel"} actions={actionButtons}
                         header={<KeyValueTitle image={null} title={title}/>}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/packages_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/packages_widget.tsx
@@ -21,16 +21,29 @@ import Stream from "mithril/stream";
 import {Packages} from "models/package_repositories/package_repositories";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {PackageOperations} from "views/pages/package_repositories";
+import {PackageRepoScrollOptions} from "./package_repositories_widget";
 import {PackageWidget} from "./package_widget";
 
 interface Attrs {
+  packageRepoName: string;
   packages: Stream<Packages>;
   packageOperations: PackageOperations;
   disableActions: boolean;
+  scrollOptions: PackageRepoScrollOptions;
 }
 
 export class PackagesWidget extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs, this>): m.Children | void | null {
+    const pkgRepoManager = vnode.attrs.scrollOptions.package_repo_sm.sm;
+    const pkgManager     = vnode.attrs.scrollOptions.package_sm.sm;
+    if (pkgRepoManager.getTarget() === vnode.attrs.packageRepoName && pkgManager.hasTarget()) {
+      const target           = pkgManager.getTarget();
+      const hasAnchorElement = vnode.attrs.packages().some((pkg) => pkg.name() === target);
+      if (!hasAnchorElement) {
+        const msg = `'${target}' package has not been set up.`;
+        return <FlashMessage dataTestId="anchor-package-not-present" type={MessageType.alert} message={msg}/>;
+      }
+    }
     if (_.isEmpty(vnode.attrs.packages())) {
       return <FlashMessage type={MessageType.info}
                            message={"There are no packages defined in this package repository."}/>;
@@ -39,6 +52,7 @@ export class PackagesWidget extends MithrilViewComponent<Attrs> {
       <h4>Packages</h4>
       {vnode.attrs.packages().map((pkg) => {
         return <PackageWidget package={pkg}
+                              scrollOptions={vnode.attrs.scrollOptions}
                               disableActions={vnode.attrs.disableActions}
                               onEdit={vnode.attrs.packageOperations.onEdit}
                               onClone={vnode.attrs.packageOperations.onClone}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/packages_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/packages_widget.tsx
@@ -37,11 +37,14 @@ export class PackagesWidget extends MithrilViewComponent<Attrs> {
     const pkgRepoManager = vnode.attrs.scrollOptions.package_repo_sm.sm;
     const pkgManager     = vnode.attrs.scrollOptions.package_sm.sm;
     if (pkgRepoManager.getTarget() === vnode.attrs.packageRepoName && pkgManager.hasTarget()) {
-      const target           = pkgManager.getTarget();
-      const hasAnchorElement = vnode.attrs.packages().some((pkg) => pkg.name() === target);
-      if (!hasAnchorElement) {
-        const msg = `'${target}' package has not been set up.`;
-        return <FlashMessage dataTestId="anchor-package-not-present" type={MessageType.alert} message={msg}/>;
+      const target        = pkgManager.getTarget();
+      const anchorPkgName = target.split('_')[1];
+      if (!_.isEmpty(anchorPkgName)) {
+        const hasAnchorElement = vnode.attrs.packages().some((pkg) => pkg.key() === target);
+        if (!hasAnchorElement) {
+          const msg = `'${anchorPkgName}' package has not been set up.`;
+          return <FlashMessage dataTestId="anchor-package-not-present" type={MessageType.alert} message={msg}/>;
+        }
       }
     }
     if (_.isEmpty(vnode.attrs.packages())) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_repository_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_repository_widget_spec.tsx
@@ -18,7 +18,8 @@ import m from "mithril";
 import {PackageRepository} from "models/package_repositories/package_repositories";
 import {getPackageRepository} from "models/package_repositories/spec/test_data";
 import {PackageOperations} from "views/pages/package_repositories";
-import {TestHelper} from "views/pages/spec/test_helper";
+import {stubAllMethods, TestHelper} from "views/pages/spec/test_helper";
+import {PackageRepoScrollOptions} from "../package_repositories_widget";
 import {PackageRepositoryWidget} from "../package_repository_widget";
 
 describe('PackageRepositoryWidgetSpec', () => {
@@ -29,10 +30,21 @@ describe('PackageRepositoryWidgetSpec', () => {
   const onPkgRepoDelete = jasmine.createSpy("onDelete");
   let packageRepository: PackageRepository;
   let disableActions: boolean;
+  let scrollOptions: PackageRepoScrollOptions;
 
   beforeEach(() => {
     packageRepository = PackageRepository.fromJSON(getPackageRepository());
     disableActions    = false;
+    scrollOptions     = {
+      package_repo_sm: {
+        sm:                 stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl", "hasTarget"]),
+        shouldOpenEditView: false
+      },
+      package_sm:      {
+        sm:                 stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl", "hasTarget"]),
+        shouldOpenEditView: false
+      }
+    };
   });
   afterEach((done) => helper.unmount(done));
 
@@ -46,7 +58,7 @@ describe('PackageRepositoryWidgetSpec', () => {
                                                 disableActions={disableActions}
                                                 packageOperations={pkgOperations}
                                                 onEdit={onPkgRepoEdit} onClone={onPkgRepoClone}
-                                                onDelete={onPkgRepoDelete}/>);
+                                                onDelete={onPkgRepoDelete} scrollOptions={scrollOptions}/>);
   }
 
   it('should render basic package repo details and action buttons', () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_repository_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_repository_widget_spec.tsx
@@ -37,8 +37,9 @@ describe('PackageRepositoryWidgetSpec', () => {
     disableActions    = false;
     scrollOptions     = {
       package_repo_sm: {
-        sm:                 stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl", "hasTarget"]),
-        shouldOpenEditView: false
+        sm:                          stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl", "hasTarget"]),
+        shouldOpenEditView:          false,
+        shouldOpenCreatePackageView: false
       },
       package_sm:      {
         sm:                 stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl", "hasTarget"]),

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_widget_spec.tsx
@@ -17,7 +17,8 @@
 import m from "mithril";
 import {Package} from "models/package_repositories/package_repositories";
 import {getPackage} from "models/package_repositories/spec/test_data";
-import {TestHelper} from "views/pages/spec/test_helper";
+import {stubAllMethods, TestHelper} from "views/pages/spec/test_helper";
+import {PackageRepoScrollOptions} from "../package_repositories_widget";
 import {PackageWidget} from "../package_widget";
 
 describe('PackageWidgetSpec', () => {
@@ -28,10 +29,21 @@ describe('PackageWidgetSpec', () => {
   const onShowUsages = jasmine.createSpy("showUsages");
   let pkg: Package;
   let disableActions: boolean;
+  let scrollOptions: PackageRepoScrollOptions;
 
   beforeEach(() => {
     pkg            = Package.fromJSON(getPackage());
     disableActions = false;
+    scrollOptions  = {
+      package_repo_sm: {
+        sm:                 stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl", "hasTarget"]),
+        shouldOpenEditView: false
+      },
+      package_sm:      {
+        sm:                 stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl", "hasTarget"]),
+        shouldOpenEditView: false
+      }
+    };
   });
   afterEach((done) => helper.unmount(done));
 
@@ -41,7 +53,7 @@ describe('PackageWidgetSpec', () => {
                                       onEdit={onEdit}
                                       onClone={onClone}
                                       onDelete={onDelete}
-                                      showUsages={onShowUsages}/>);
+                                      showUsages={onShowUsages} scrollOptions={scrollOptions}/>);
   }
 
   it('should render package information and action buttons', () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/packages_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/packages_widget_spec.tsx
@@ -34,8 +34,9 @@ describe('PackagesWidgetSpec', () => {
     packages      = Stream(new Packages());
     scrollOptions = {
       package_repo_sm: {
-        sm:                 stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl", "hasTarget"]),
-        shouldOpenEditView: false
+        sm:                          stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl", "hasTarget"]),
+        shouldOpenEditView:          false,
+        shouldOpenCreatePackageView: false
       },
       package_sm:      {
         sm:                 stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl", "hasTarget"]),
@@ -88,7 +89,7 @@ describe('PackagesWidgetSpec', () => {
     };
     scrollOptions.package_sm.sm      = {
       hasTarget:    jasmine.createSpy().and.callFake(() => true),
-      getTarget:    jasmine.createSpy().and.callFake(() => "non-pkg"),
+      getTarget:    jasmine.createSpy().and.callFake(() => `${pkg.packageRepo().name()}_non-pkg`),
       shouldScroll: jasmine.createSpy(),
       setTarget:    jasmine.createSpy(),
       scrollToEl:   jasmine.createSpy()
@@ -97,5 +98,28 @@ describe('PackagesWidgetSpec', () => {
 
     expect(helper.byTestId("anchor-package-not-present")).toBeInDOM();
     expect(helper.textByTestId("anchor-package-not-present")).toBe("'non-pkg' package has not been set up.");
+  });
+
+  it('should not render error if package name is not set in the anchor', () => {
+    const pkg = Package.fromJSON(getPackage());
+    packages().push(pkg);
+    scrollOptions.package_repo_sm.sm = {
+      hasTarget:    jasmine.createSpy().and.callFake(() => true),
+      getTarget:    jasmine.createSpy().and.callFake(() => pkg.packageRepo().name()),
+      shouldScroll: jasmine.createSpy(),
+      setTarget:    jasmine.createSpy(),
+      scrollToEl:   jasmine.createSpy()
+    };
+    scrollOptions.package_sm.sm      = {
+      hasTarget:    jasmine.createSpy().and.callFake(() => true),
+      getTarget:    jasmine.createSpy().and.callFake(() => `${pkg.packageRepo().name()}_`),
+      shouldScroll: jasmine.createSpy(),
+      setTarget:    jasmine.createSpy(),
+      scrollToEl:   jasmine.createSpy()
+    };
+    mount();
+
+    expect(helper.byTestId("anchor-package-not-present")).not.toBeInDOM();
+    expect(helper.byTestId("packages-widget")).toBeInDOM();
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/packages_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/packages_widget_spec.tsx
@@ -19,17 +19,29 @@ import Stream from "mithril/stream";
 import {Package, Packages} from "models/package_repositories/package_repositories";
 import {getPackage} from "models/package_repositories/spec/test_data";
 import {PackageOperations} from "views/pages/package_repositories";
-import {TestHelper} from "views/pages/spec/test_helper";
+import {stubAllMethods, TestHelper} from "views/pages/spec/test_helper";
 import {PackagesWidget} from "../packages_widget";
+import {PackageRepoScrollOptions} from "../package_repositories_widget";
 
 describe('PackagesWidgetSpec', () => {
   const helper        = new TestHelper();
   const pkgOperations = new PackageOperations();
   let packages: Stream<Packages>;
   let disableActions: boolean;
+  let scrollOptions: PackageRepoScrollOptions;
 
   beforeEach(() => {
-    packages = Stream(new Packages());
+    packages      = Stream(new Packages());
+    scrollOptions = {
+      package_repo_sm: {
+        sm:                 stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl", "hasTarget"]),
+        shouldOpenEditView: false
+      },
+      package_sm:      {
+        sm:                 stubAllMethods(["shouldScroll", "getTarget", "setTarget", "scrollToEl", "hasTarget"]),
+        shouldOpenEditView: false
+      }
+    };
   });
   afterEach((done) => helper.unmount(done));
 
@@ -40,9 +52,9 @@ describe('PackagesWidgetSpec', () => {
     pkgOperations.onDelete   = jasmine.createSpy("onDelete");
     pkgOperations.showUsages = jasmine.createSpy("showUsages");
     disableActions           = false;
-    helper.mount(() => <PackagesWidget packages={packages}
+    helper.mount(() => <PackagesWidget packageRepoName={"pkg-repo-name"} packages={packages}
                                        disableActions={disableActions}
-                                       packageOperations={pkgOperations}/>);
+                                       packageOperations={pkgOperations} scrollOptions={scrollOptions}/>);
   }
 
   it('should render message saying no packages configured', () => {
@@ -62,5 +74,28 @@ describe('PackagesWidgetSpec', () => {
     expect(helper.byTestId('packages-widget')).toBeInDOM();
     expect(helper.q('h4').textContent).toBe('Packages');
     expect(helper.byTestId('package-panel')).toBeInDOM();
+  });
+
+  it('should render error info if the element specified in the anchor does not exist', () => {
+    const pkg = Package.fromJSON(getPackage());
+    packages().push(pkg);
+    scrollOptions.package_repo_sm.sm = {
+      hasTarget:    jasmine.createSpy().and.callFake(() => true),
+      getTarget:    jasmine.createSpy().and.callFake(() => pkg.packageRepo().name()),
+      shouldScroll: jasmine.createSpy(),
+      setTarget:    jasmine.createSpy(),
+      scrollToEl:   jasmine.createSpy()
+    };
+    scrollOptions.package_sm.sm      = {
+      hasTarget:    jasmine.createSpy().and.callFake(() => true),
+      getTarget:    jasmine.createSpy().and.callFake(() => "non-pkg"),
+      shouldScroll: jasmine.createSpy(),
+      setTarget:    jasmine.createSpy(),
+      scrollToEl:   jasmine.createSpy()
+    };
+    mount();
+
+    expect(helper.byTestId("anchor-package-not-present")).toBeInDOM();
+    expect(helper.textByTestId("anchor-package-not-present")).toBe("'non-pkg' package has not been set up.");
   });
 });


### PR DESCRIPTION
Description:
 - needed as the material editor will allow linking to allow edit of a certain package

Links:
 - to expand the selected pkg repo: `http://go-server-url:8153/go/admin/package_repositories#!repo-name`
 - to edit the selected pkg repo: `http://go-server-url:8153/go/admin/package_repositories#!repo-name/edit`
 - to create a new package wrt selected pkg repo: `http://go-server-url:8153/go/admin/package_repositories#!repo-name/create-package`
 - to expand the selected pkg: `http://go-server-url:8153/go/admin/package_repositories#!repo-name/packages/pkg-name`
 - to edit the selected pkg: `http://go-server-url:8153/go/admin/package_repositories#!repo-name/packages/pkg-name/edit`


