### PR TITLE
Fix issue with empty destination

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/types_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/types_spec.ts
@@ -210,4 +210,22 @@ describe("Material Types", () => {
       expect(material.pluginMetadata().errors().errorsForDisplay('id')).toBe('Id must be present.');
     });
   });
+
+  describe('Serialization', () => {
+    it('should serialize dependency materials', () => {
+      const dependencyAttrs = new DependencyMaterialAttributes("name", false, "pipeline", "stage", false);
+
+      expect(Object.keys(dependencyAttrs.toJSON())).not.toContain('destination');
+    });
+
+    it('should serialize git materials', () => {
+      const gitAttrs = new GitMaterialAttributes("name", false, "some-url");
+
+      expect(Object.keys(gitAttrs.toJSON())).not.toContain('destination');
+
+      gitAttrs.destination("some-dest");
+      expect(Object.keys(gitAttrs.toJSON())).toContain('destination');
+    });
+  });
+
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
@@ -210,9 +210,15 @@ export abstract class MaterialAttributes extends ValidatableMixin {
   }
 
   toJSON() {
-    const serialized                       = _.assign({}, this);
-    const password: Stream<EncryptedValue> = _.get(serialized, "password");
+    const serialized = _.assign({}, this);
 
+    const destination = _.get(serialized, "destination");
+    if (_.isEmpty(destination) || _.isEmpty(destination())) {
+      // @ts-ignore
+      delete serialized.destination; // collapse empty string as undefined to avoid blowing up
+    }
+
+    const password: Stream<EncryptedValue> = _.get(serialized, "password");
     // remove the password field and setup the password serialization
     if (password) {
       // @ts-ignore
@@ -223,11 +229,6 @@ export abstract class MaterialAttributes extends ValidatableMixin {
       } else {
         return _.assign({}, serialized, {encrypted_password: password().value()});
       }
-    }
-    const destination = _.get(serialized, "destination");
-    if (_.isEmpty(destination())) {
-      // @ts-ignore
-      delete serialized.destination; // collapse empty string as undefined to avoid blowing up
     }
     return serialized;
   }


### PR DESCRIPTION
Description
 - destination if empty should not be send in the api payload

Issue: If destination is set and then removed - the create pipeline calls fails for invalid file path.

Steps to reproduce on master (before this commit):

1. Open up the dashboard 
2. Click on add new pipeline
3. Set a material url
4. Set a `Alternate Checkout Path`.
5. **Now remove the same**
6. Fill out other details and click save + edit full config.

Expected results: the pipeline is created and a page opens up to edit full config
Actual results: the pipeline does not get created and the errors shows invalid file path

