### PR TITLE
Pipeline config spa bug fixes

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/authorization/authorization.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/authorization/authorization.ts
@@ -73,8 +73,8 @@ export class AuthorizedUsersAndRoles extends ValidatableMixin {
     }
 
     return {
-      users: this.users(),
-      roles: this.roles()
+      users: this.users().filter(user => !_.isEmpty(user)),
+      roles: this.roles().filter(role => !_.isEmpty(role)),
     };
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/authorization/specs/authorization_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/authorization/specs/authorization_spec.ts
@@ -209,7 +209,21 @@ describe("AuthorizedUsersAndRoles", () => {
 
     const expectedJSON = {users: ["foo_user"], roles: ["foo_role"]};
     expect(actualJSON).toEqual(expectedJSON);
+  });
 
+  it("should not serialize empty values to JSON", () => {
+    const usersAndRoles = new AuthorizedUsersAndRoles(
+      [
+        Stream("foo_user"), Stream("")
+      ],
+      [
+        Stream("foo_role"), Stream("")
+      ]);
+
+    const actualJSON = usersAndRoles.toJSON();
+
+    const expectedJSON = {users: ["foo_user"], roles: ["foo_role"]};
+    expect(actualJSON).toEqual(expectedJSON);
   });
 
   describe("isEmpty", () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/job.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/job.ts
@@ -122,6 +122,10 @@ export class Job extends ValidatableMixin {
   }
 
   toApiPayload() {
+    if (this.tabs()) {
+      this.tabs(this.tabs().filter(t => !_.isEmpty(t.name()) || !_.isEmpty(t.path())));
+    }
+
     const json = JsonUtils.toSnakeCasedObject(this);
 
     json.resources = (json.resources || "")

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/spec/stage_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/spec/stage_spec.ts
@@ -62,6 +62,13 @@ describe("Stage model", () => {
     expect(stage.toApiPayload().approval.type).toBe("success");
   });
 
+  it("should serialize allow_only_on_success as part of api payload", () => {
+    const stage = new Stage("foo", [validJob()]);
+    stage.approval().allowOnlyOnSuccess(false);
+
+    expect(stage.toApiPayload().approval.allow_only_on_success).toBe(false);
+  });
+
   it("adopts errors in server response", () => {
     const stage = new Stage("meow", [
       new Job("scooby", [new ExecTask("whoami", [])], new EnvironmentVariables(new EnvironmentVariable("FOO", "OOF"))),

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/stage.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/stage.ts
@@ -41,13 +41,13 @@ export interface StageJSON {
 export type ApprovalType = "success" | "manual";
 
 class Approval extends ValidatableMixin {
-  readonly type                   = Stream<ApprovalType>("success");
+  readonly type = Stream<ApprovalType>("success");
 
   readonly state: (value?: boolean) => boolean;
   readonly allowOnlyOnSuccess = Stream<boolean>();
   //authorization must be present for server side validations
   //even though it's not editable from the create pipeline page
-  readonly authorization = Stream<AuthorizedUsersAndRoles>(new AuthorizedUsersAndRoles([], []));
+  readonly authorization          = Stream<AuthorizedUsersAndRoles>(new AuthorizedUsersAndRoles([], []));
   private readonly __typeAsStream = Stream<boolean>(true);
 
   constructor() {
@@ -93,6 +93,7 @@ class Approval extends ValidatableMixin {
   toJSON() {
     return {
       type: this.typeAsString(),
+      allow_only_on_success: this.allowOnlyOnSuccess(),
       authorization: JsonUtils.toSnakeCasedObject(this.authorization)
     };
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/pipeline_config.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/pipeline_config.tsx
@@ -279,7 +279,7 @@ export class PipelineConfigPage<T> extends Page<null, T> {
 
   private onFailure(errorResponse: ErrorResponse) {
     const parsed = JSON.parse(errorResponse.body!);
-    this.flashMessage.setMessage(MessageType.alert, parsed.message);
+    this.flashMessage.consumeErrorResponse(errorResponse);
 
     try {
       if (parsed.data) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/pipeline_config.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/pipeline_config.tsx
@@ -38,6 +38,7 @@ import {ParametersTabContent} from "views/pages/clicky_pipeline_config/tabs/pipe
 import {PipelineEnvironmentVariablesTabContent} from "views/pages/clicky_pipeline_config/tabs/pipeline/pipeline_environment_variable_tab_content";
 import {ProjectManagementTabContent} from "views/pages/clicky_pipeline_config/tabs/pipeline/project_management_tab_content";
 import {StagesTabContent} from "views/pages/clicky_pipeline_config/tabs/pipeline/stages_tab_content";
+import {PipelineConfigSPARouteHelper} from "views/pages/clicky_pipeline_config/tabs/route_helper";
 import {JobsTabContent} from "views/pages/clicky_pipeline_config/tabs/stage/jobs_tab_content";
 import {PermissionsTabContent} from "views/pages/clicky_pipeline_config/tabs/stage/permissions_tab_content";
 import {StageEnvironmentVariablesTabContent} from "views/pages/clicky_pipeline_config/tabs/stage/stage_environment_variable_tab_content";
@@ -115,10 +116,11 @@ export class PipelineConfigPage<T> extends Page<null, T> {
       this.flashMessage.setMessage(MessageType.alert, msg);
       return Promise.reject();
     }
-
+    const possibleRenames = PipelineConfigSPARouteHelper.getPossibleRenames(this.pipelineConfig!);
     return this.pipelineConfig!.update(this.etag()).then((result) => {
       return result.do((successResponse) => {
         this.flashMessage.setMessage(MessageType.success, "Saved Successfully!");
+        PipelineConfigSPARouteHelper.updateRouteIfEntityRenamed(possibleRenames);
         this.onSuccess(result, successResponse);
       }, this.onFailure.bind(this));
     });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/stage/permissions_tab_content_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/stage/permissions_tab_content_spec.tsx
@@ -294,6 +294,26 @@ describe("Permissions Tab Content", () => {
     });
   });
 
+  it("should render errors related to users", () => {
+    const stage = Stage.fromJSON(PipelineConfigTestData.stage("Test"));
+    stage.approval().authorization().isInherited(false);
+    stage.approval().authorization()._users.push(Stream("user1"));
+    stage.approval().authorization().errors().add("users", "user 'user1' does not exists");
+    mount(stage);
+
+    expect(helper.byTestId("users-errors")).toContainText("user 'user1' does not exists");
+  });
+
+  it("should render errors related to roles", () => {
+    const stage = Stage.fromJSON(PipelineConfigTestData.stage("Test"));
+    stage.approval().authorization().isInherited(false);
+    stage.approval().authorization()._roles.push(Stream("role1"));
+    stage.approval().authorization().errors().add("roles", "role 'role1' does not exists");
+    mount(stage);
+
+    expect(helper.byTestId("roles-errors")).toContainText("role 'role1' does not exists");
+  });
+
   function mount(stage: Stage) {
     const pipelineConfig = new PipelineConfig();
     pipelineConfig.stages().add(stage);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/custom_tab_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/custom_tab_tab_content.tsx
@@ -58,6 +58,7 @@ export class CustomTabTabContent extends TabContent<Job> {
     const tab = new Tab("", "");
     return tabs.push(tab);
   }
+
   private getAddTabBtn(tabs: Tabs) {
     return (<Secondary small={true} onclick={this.addEmptyTab.bind(null, tabs)}>+ Add</Secondary>);
   }
@@ -80,8 +81,13 @@ export class CustomTabTabContent extends TabContent<Job> {
 
     const tabsView = tabs.map((tab) => {
       return (<div class={styles.tabContainer} data-test-id="tab">
-        <TextField dataTestId={`tab-name-${tab.name()}`} placeholder="name" property={tab.name}/>
-        <TextField dataTestId={`tab-path-${tab.path()}`} placeholder="path" property={tab.path}/>
+        <TextField dataTestId={`tab-name-${tab.name()}`}
+                   errorText={tab.errors().errorsForDisplay("name")}
+                   placeholder="name" property={tab.name}/>
+        <TextField dataTestId={`tab-path-${tab.path()}`}
+                   errorText={tab.errors().errorsForDisplay("path")}
+                   placeholder="path"
+                   property={tab.path}/>
         <Icons.Close data-test-id={`remove-tab-${tab.name()}`}
                      iconOnly={true}
                      onclick={() => this.removeEntity(tab, tabs)}/>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/custom_tabs.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/custom_tabs.scss
@@ -20,8 +20,12 @@
 }
 
 .tab-container {
-  display:     flex;
-  line-height: 35px;
+  display: flex;
+  width:   550px;
+}
+
+.tab-container + div {
+  margin-right: 50px;
 }
 
 .tabs-header {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/route_helper.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/route_helper.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import m from "mithril";
+import {PipelineConfig} from "models/pipeline_configs/pipeline_config";
+import {PipelineConfigRouteParams, RouteInfo} from "views/pages/clicky_pipeline_config/pipeline_config";
+
+export interface OldNewName {
+  old: string;
+  new: string;
+}
+
+export interface PipelineEntityRename {
+  stage?: OldNewName;
+  job?: OldNewName;
+}
+
+export class PipelineConfigSPARouteHelper {
+  static routeInfo(): RouteInfo<PipelineConfigRouteParams> {
+    return {route: m.route.get(), params: m.route.param()};
+  }
+
+  static getPossibleRenames(pipelineConfig: PipelineConfig) {
+    const entityNames: PipelineEntityRename = {};
+
+    const routeInfo = PipelineConfigSPARouteHelper.routeInfo();
+    if (routeInfo.params.stage_name) {
+      const stage = pipelineConfig.stages().items!.find(x => {
+        return x.getOriginalName() === routeInfo.params.stage_name;
+      })!;
+
+      entityNames.stage = {
+        old: stage.getOriginalName(),
+        new: stage.name()
+      };
+    }
+
+    if (routeInfo.params.job_name) {
+      const stage = pipelineConfig.stages().items!.find(stage => {
+        return stage.getOriginalName() === routeInfo.params.stage_name;
+      })!;
+
+      const job = stage.jobs().items!.find(job => {
+        return job.getOriginalName() === routeInfo.params.job_name;
+      })!;
+
+      entityNames.job = {
+        old: job.getOriginalName(),
+        new: job.name()
+      };
+    }
+
+    return entityNames;
+  }
+
+  static updateRouteIfEntityRenamed(entityNames: PipelineEntityRename) {
+    const routeInfo = PipelineConfigSPARouteHelper.routeInfo();
+    let route       = routeInfo.route;
+
+    if (entityNames.stage) {
+      route = route.replace(entityNames.stage.old, entityNames.stage.new);
+    }
+
+    if (entityNames.job) {
+      route = route.replace(entityNames.job.old, entityNames.job.new);
+    }
+
+    m.route.set(route);
+  }
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/permissions_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/permissions_tab_content.tsx
@@ -87,6 +87,9 @@ export class PermissionsTabContent extends TabContent<Stage> {
     return <div data-test-id="users-and-roles">
       <div data-test-id="users">
         <h3>Users</h3>
+        <FlashMessage message={stage.approval().authorization().errors().errorsForDisplay("users")}
+                      dataTestId="users-errors"
+                      type={MessageType.alert}/>
         {
           users.map((user, index) => this.getInputField(
             "username", user, users, index, new RolesSuggestionProvider(Stream([] as string[]), [])
@@ -97,6 +100,9 @@ export class PermissionsTabContent extends TabContent<Stage> {
 
       <div data-test-id="roles">
         <h3>Roles</h3>
+        <FlashMessage message={stage.approval().authorization().errors().errorsForDisplay("roles")}
+                      dataTestId="roles-errors"
+                      type={MessageType.alert}/>
         {
           roles.map((role, index) => this.getInputField(
             "role", role, roles, index, new RolesSuggestionProvider(this.allRoles, roles.map(s => s()))


### PR DESCRIPTION
Description:

* Do not serialize empty values for stage authorization
* Show errors related to stage permissions
* Stage Settings save 'allow only on success'
* Do not show changes popup when user switches between custom tab tabs
* Bind custom tab related errors to fields
* Always show global errors which are not bound to any of the field
* Allow editing stage and job name

