### PR TITLE
Update the materials tab

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/configuration.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/configuration.ts
@@ -84,7 +84,7 @@ export class Configurations {
     const configValues = this.configurations
                              .filter((config) => config.isEncrypted() === false && !_.isEmpty(config.displayValue()))
                              .map((config) => `${config.key}=${config.displayValue()}`)
-                             .join(",");
+                             .join(", ");
     return `[${configValues}]`;
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/index.scss
@@ -91,3 +91,7 @@
 .button-container {
   padding: 15px 0 15px 5px;
 }
+
+.missing-plugin {
+  color: $warning-txt;
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/index.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/index.scss.d.ts
@@ -4,6 +4,7 @@ export const entityConfigContainer: string;
 export const help: string;
 export const mainContainer: string;
 export const materialTab: string;
+export const missingPlugin: string;
 export const navigation: string;
 export const radioLabelWithInlineTextfield: string;
 export const steps: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.tsx
@@ -43,15 +43,16 @@ export class MaterialModal extends Modal {
               packages: Stream<PackageRepositories>, pluginInfos: Stream<PluginInfos>,
               pipelineConfigSave: () => Promise<any>, isNew: boolean) {
     super(Size.large);
-    this.__title             = title;
-    this.entity              = entity;
-    this.pluggableScms       = scms;
-    this.materials           = materials;
-    this.packageRepositories = packages;
-    this.pluginInfos         = pluginInfos;
-    this.pipelineConfigSave  = pipelineConfigSave;
-    this.isNew               = isNew;
-    this.errorMessage        = Stream();
+    this.__title                  = title;
+    this.entity                   = entity;
+    this.pluggableScms            = scms;
+    this.materials                = materials;
+    this.packageRepositories      = packages;
+    this.pluginInfos              = pluginInfos;
+    this.pipelineConfigSave       = pipelineConfigSave;
+    this.isNew                    = isNew;
+    this.errorMessage             = Stream();
+    this.closeModalOnOverlayClick = false;
   }
 
   static forAdd(materials: Stream<Materials>, scms: Stream<Scms>, packageRepositories: Stream<PackageRepositories>,

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/materials_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/materials_widget_spec.tsx
@@ -16,28 +16,40 @@
 
 import m from "mithril";
 import Stream from "mithril/stream";
-import {Scms} from "models/materials/pluggable_scm";
-import {PackageRepositories, Packages} from "models/package_repositories/package_repositories";
+import {Filter} from "models/maintenance_mode/material";
+import {Scm, Scms} from "models/materials/pluggable_scm";
+import {Material, PackageMaterialAttributes, PluggableScmMaterialAttributes} from "models/materials/types";
+import {Package, PackageRepositories, PackageRepository, Packages} from "models/package_repositories/package_repositories";
+import {getPackage, getPackageRepository, pluginInfoWithPackageRepositoryExtension} from "models/package_repositories/spec/test_data";
 import {Materials, PipelineConfig} from "models/pipeline_configs/pipeline_config";
 import {PipelineConfigTestData} from "models/pipeline_configs/spec/test_data";
-import {PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
+import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {FlashMessageModelWithTimeout} from "views/components/flash_message";
 import {MaterialsWidget} from "views/pages/clicky_pipeline_config/tabs/pipeline/materials_widget";
+import {getPluggableScm, getScmPlugin} from "views/pages/pluggable_scms/spec/test_data";
 import {TestHelper} from "views/pages/spec/test_helper";
 
 describe('MaterialsWidgetSpec', () => {
   const helper = new TestHelper();
   let pipelineConfig: PipelineConfig;
+  let pluginInfos: PluginInfos;
+  let pkgRepos: PackageRepositories;
+  let pkgs: Packages;
+  let scms: Scms;
 
   beforeEach(() => {
     pipelineConfig = PipelineConfig.fromJSON(PipelineConfigTestData.withGitMaterial());
+    pkgRepos       = new PackageRepositories();
+    pkgs           = new Packages();
+    scms           = new Scms();
+    pluginInfos    = new PluginInfos();
   });
   afterEach((done) => helper.unmount(done));
 
-  function mount(materials: Stream<Materials> = pipelineConfig.materials, pluginInfos: PluginInfos = new PluginInfos()) {
+  function mount(materials: Stream<Materials> = pipelineConfig.materials) {
     helper.mount(() => <MaterialsWidget materials={materials} pluginInfos={Stream(pluginInfos)}
-                                        packageRepositories={Stream(new PackageRepositories())}
-                                        packages={Stream(new Packages())} scmMaterials={Stream(new Scms())}
+                                        packageRepositories={Stream(pkgRepos)}
+                                        packages={Stream(pkgs)} scmMaterials={Stream(scms)}
                                         pipelineConfigSave={jasmine.createSpy("pipelineConfigSave")}
                                         flashMessage={new FlashMessageModelWithTimeout()}/>);
   }
@@ -57,7 +69,7 @@ describe('MaterialsWidgetSpec', () => {
     const headerRow = helper.byTestId("table-header-row");
     expect(helper.qa("th", headerRow)[0].textContent).toBe("Material Name");
     expect(helper.qa("th", headerRow)[1].textContent).toBe("Type");
-    expect(helper.qa("th", headerRow)[2].textContent).toBe("Url");
+    expect(helper.qa("th", headerRow)[2].textContent).toBe("Url/Description");
 
     const dataRow = helper.byTestId("table-row");
     expect(helper.qa("td", dataRow)).toHaveLength(4);
@@ -73,5 +85,81 @@ describe('MaterialsWidgetSpec', () => {
     expect(deleteMaterialButton).toBeInDOM();
     expect(deleteMaterialButton).toBeDisabled();
     expect(deleteMaterialButton).toHaveAttr('title', 'Cannot delete this material as pipeline should have at least one material');
+  });
+
+  describe('PackageMaterials', () => {
+    it('should render package materials', () => {
+      const pkgRepo     = PackageRepository.fromJSON(getPackageRepository());
+      const pkg         = Package.fromJSON(getPackage());
+      const pluginInfo  = PluginInfo.fromJSON(pluginInfoWithPackageRepositoryExtension());
+      const pkgMaterial = new Material("package", new PackageMaterialAttributes("", false, pkg.id()));
+
+      pluginInfos.push(pluginInfo);
+      pkgRepos.push(pkgRepo);
+      pkgs.push(pkg);
+      pipelineConfig.materials().push(pkgMaterial);
+
+      mount();
+
+      const dataRow = helper.q("tr[data-id='1']");
+      expect(helper.qa("td", dataRow)).toHaveLength(4);
+      expect(helper.qa("td", dataRow)[0].textContent).toBe("pkg-repo-name_pkg-name");
+      expect(helper.qa("td", dataRow)[1].textContent).toBe("Package");
+      expect(helper.qa("td", dataRow)[2].textContent).toBe("Plugin: NPM plugin for package repoRepository: pkg-repo-name [REPO_URL=https://npm.com]Package: pkg-name [PACKAGE_ID=pkg]");
+    });
+
+    it('should render with missing plugin', () => {
+      const pkgRepo     = PackageRepository.fromJSON(getPackageRepository());
+      const pkg         = Package.fromJSON(getPackage());
+      const pkgMaterial = new Material("package", new PackageMaterialAttributes("", false, pkg.id()));
+
+      pkgRepos.push(pkgRepo);
+      pkgs.push(pkg);
+      pipelineConfig.materials().push(pkgMaterial);
+
+      mount();
+
+      const dataRow = helper.q("tr[data-id='1']");
+      expect(helper.qa("td", dataRow)).toHaveLength(4);
+      expect(helper.qa("td", dataRow)[0].textContent).toBe("pkg-repo-name_pkg-name");
+      expect(helper.qa("td", dataRow)[1].textContent).toBe("Package");
+      expect(helper.qa("td", dataRow)[2].textContent).toBe("Plugin: Plugin 'npm' Missing!!!Repository: pkg-repo-name [REPO_URL=https://npm.com]Package: pkg-name [PACKAGE_ID=pkg]");
+    });
+  });
+
+  describe('PluginMaterials', () => {
+    it('should render plugin materials', () => {
+      const scm            = Scm.fromJSON(getPluggableScm());
+      const pluginInfo     = PluginInfo.fromJSON(getScmPlugin());
+      const pluginMaterial = new Material("plugin", new PluggableScmMaterialAttributes("", false, scm.id(), "", new Filter([])));
+
+      scms.push(scm);
+      pluginInfos.push(pluginInfo);
+      pipelineConfig.materials().push(pluginMaterial);
+
+      mount();
+
+      const dataRow = helper.q("tr[data-id='1']");
+      expect(helper.qa("td", dataRow)).toHaveLength(4);
+      expect(helper.qa("td", dataRow)[0].textContent).toBe(scm.name());
+      expect(helper.qa("td", dataRow)[1].textContent).toBe("Github");
+      expect(helper.qa("td", dataRow)[2].textContent).toBe("[url=https://github.com/sample/example.git]");
+    });
+
+    it('should render with missing plugin', () => {
+      const scm            = Scm.fromJSON(getPluggableScm());
+      const pluginMaterial = new Material("plugin", new PluggableScmMaterialAttributes("", false, scm.id(), "", new Filter([])));
+
+      scms.push(scm);
+      pipelineConfig.materials().push(pluginMaterial);
+
+      mount();
+
+      const dataRow = helper.q("tr[data-id='1']");
+      expect(helper.qa("td", dataRow)).toHaveLength(4);
+      expect(helper.qa("td", dataRow)[0].textContent).toBe(scm.name());
+      expect(helper.qa("td", dataRow)[1].textContent).toBe("Plugin");
+      expect(helper.qa("td", dataRow)[2].textContent).toBe("Plugin 'scm-plugin-id' Missing!!![url=https://github.com/sample/example.git]");
+    });
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -52,6 +52,7 @@ interface Attrs {
 
 interface State {
   provider: SuggestionProvider;
+
   stages(): Option[];
 }
 
@@ -180,10 +181,11 @@ export class PackageFields extends MithrilComponent<PackageAttrs, PackageState> 
         return selectedPkg !== undefined;
       });
       if (selectedPkgRepo !== undefined) {
+        this.resetErrorAndWarningFields(vnode);
         vnode.state.pkgRepoId(selectedPkgRepo.repoId());
         vnode.state.pkgs(this.mapAndConcatPackages(selectedPkgRepo));
+        this.setErrorIfPluginNotPresent(vnode, selectedPkgRepo);
       }
-      this.disablePkgField = false;
     }
   }
 
@@ -340,7 +342,7 @@ export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
     }));
     const readonly                    = !!vnode.attrs.disabled;
     const showLocalWorkingCopyOptions = !!vnode.attrs.showLocalWorkingCopyOptions;
-    this.setErrorMessageIfApplicable(vnode, plugins);
+    this.setErrorMessageIfApplicable(vnode);
 
     return <div className={styles.packageFields}>
       {this.errorMessage}
@@ -408,7 +410,7 @@ export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
     }
   }
 
-  private setErrorMessageIfApplicable(vnode: m.Vnode<PluginAttrs, PluginState>, plugins: Array<Option | string>) {
+  private setErrorMessageIfApplicable(vnode: m.Vnode<PluginAttrs, PluginState>) {
     this.errorMessage = undefined;
     if (vnode.state.pluginId().length > 0 && vnode.state.scmsForSelectedPlugin().length === 1) {
       this.errorMessage    = <FlashMessage type={MessageType.warning}>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -211,6 +211,19 @@ describe('PackageFieldsSpec', () => {
     expect(helper.byTestId('selected-pkg-repo-details')).toBeInDOM();
     expect(helper.byTestId('selected-pkg-details')).toBeInDOM();
   });
+
+  it('should pre-populate package config when ref is set with error if plugin is not found', () => {
+    (material.attributes() as PackageMaterialAttributes).ref(packageRepositories[0].packages()[0].id());
+    pluginInfos = new PluginInfos();
+    helper.mount(() => <PackageFields material={material} packageRepositories={packageRepositories}
+                                      pluginInfos={pluginInfos}/>);
+
+    expect(helper.byTestId('selected-pkg-repo-details')).toBeInDOM();
+    expect(helper.byTestId('selected-pkg-details')).toBeInDOM();
+    const errorElement = helper.q('span[class*="forms__form-error-text"]');
+    expect(errorElement).toBeInDOM();
+    expect(errorElement.textContent).toBe("Associated plugin 'npm' not found. Please contact the system administrator to install the plugin.");
+  });
 });
 
 function assertLabelledInputsPresent(helper: TestHelper, idsToLabels: { [key: string]: string }) {


### PR DESCRIPTION
Description:
 - the material add/edit modal cannot be closed on a click outside
 - refactored the materials widget to take into account a missing plugin for package and scm materials

<img width="1356" alt="Screen Shot 2020-04-20 at 10 48 56 AM" src="https://user-images.githubusercontent.com/41165891/79716552-a9c34800-82f4-11ea-9d10-b1d3ab61445f.png">

