### PR TITLE
Allow defaulting group permissions to deny if no group auth setup

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -226,7 +226,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     private static GoSystemProperty<Boolean> GO_PLUGIN_CLASSLOADER_OLD = new GoBooleanSystemProperty("gocd.plugins.classloader.old", false);
     public static final GoSystemProperty<String> LOADING_PAGE = new GoStringSystemProperty("loading.page.resource.path", "/loading_pages/new.loading.page.html");
     public static GoSystemProperty<Long> NOTIFICATION_PLUGIN_MESSAGES_TTL = new GoLongSystemProperty("plugins.notification.message.ttl.millis", 2 * 60 * 1000L);
-    public static final GoSystemProperty<Boolean> ALLOW_EVERYONE_TO_VIEW_OPERATE_GROUPS_WITH_NO_GROUP_AUTHORIZATION_SETUP = new GoBooleanSystemProperty("allow.everyone.to.view.operate.groups.with.no.authorization.setup", true);
+    public static final GoSystemProperty<Boolean> ALLOW_EVERYONE_TO_VIEW_OPERATE_GROUPS_WITH_NO_GROUP_AUTHORIZATION_SETUP = new GoBooleanSystemProperty("allow.everyone.to.view.operate.groups.with.no.authorization.setup", false);
 
     public static GoSystemProperty<Boolean> ENABLE_HSTS_HEADER = new GoBooleanSystemProperty("gocd.enable.hsts.header", false);
     public static GoSystemProperty<Long> HSTS_HEADER_MAX_AGE = new GoLongSystemProperty("gocd.hsts.header.max.age", ONE_YEAR);

--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -226,6 +226,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     private static GoSystemProperty<Boolean> GO_PLUGIN_CLASSLOADER_OLD = new GoBooleanSystemProperty("gocd.plugins.classloader.old", false);
     public static final GoSystemProperty<String> LOADING_PAGE = new GoStringSystemProperty("loading.page.resource.path", "/loading_pages/new.loading.page.html");
     public static GoSystemProperty<Long> NOTIFICATION_PLUGIN_MESSAGES_TTL = new GoLongSystemProperty("plugins.notification.message.ttl.millis", 2 * 60 * 1000L);
+    public static final GoSystemProperty<Boolean> ALLOW_EVERYONE_TO_VIEW_OPERATE_GROUPS_WITH_NO_GROUP_AUTHORIZATION_SETUP = new GoBooleanSystemProperty("allow.everyone.to.view.operate.groups.with.no.authorization.setup", true);
 
     public static GoSystemProperty<Boolean> ENABLE_HSTS_HEADER = new GoBooleanSystemProperty("gocd.enable.hsts.header", false);
     public static GoSystemProperty<Long> HSTS_HEADER_MAX_AGE = new GoLongSystemProperty("gocd.hsts.header.max.age", ONE_YEAR);

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BasicPipelineConfigs.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BasicPipelineConfigs.java
@@ -231,8 +231,8 @@ public class BasicPipelineConfigs extends BaseCollection<PipelineConfig> impleme
     }
 
     @Override
-    public boolean hasViewPermission(final CaseInsensitiveString username, UserRoleMatcher userRoleMatcher) {
-        return !hasAuthorizationDefined() || authorization.hasViewPermission(username, userRoleMatcher);
+    public boolean hasViewPermission(final CaseInsensitiveString username, UserRoleMatcher userRoleMatcher, boolean everyoneIsAllowedToViewIfNoAuthIsDefined) {
+        return (!hasAuthorizationDefined() && everyoneIsAllowedToViewIfNoAuthIsDefined) || authorization.hasViewPermission(username, userRoleMatcher);
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BasicPipelineConfigs.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BasicPipelineConfigs.java
@@ -246,8 +246,8 @@ public class BasicPipelineConfigs extends BaseCollection<PipelineConfig> impleme
     }
 
     @Override
-    public boolean hasOperatePermission(final CaseInsensitiveString username, UserRoleMatcher userRoleMatcher) {
-        return !hasAuthorizationDefined() || authorization.hasOperatePermission(username, userRoleMatcher);
+    public boolean hasOperatePermission(final CaseInsensitiveString username, UserRoleMatcher userRoleMatcher, boolean everyoneIsAllowedToOperateIfNoAuthIsDefined) {
+        return (!hasAuthorizationDefined() && everyoneIsAllowedToOperateIfNoAuthIsDefined) || authorization.hasOperatePermission(username, userRoleMatcher);
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfigs.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfigs.java
@@ -76,7 +76,7 @@ public interface PipelineConfigs extends Iterable<PipelineConfig>, Cloneable, Va
 
     void setAuthorization(Authorization authorization);
 
-    boolean hasViewPermission(CaseInsensitiveString username, UserRoleMatcher userRoleMatcher);
+    boolean hasViewPermission(CaseInsensitiveString username, UserRoleMatcher userRoleMatcher, boolean everyoneIsAllowedToViewIfNoAuthIsDefined);
 
     boolean hasViewPermissionDefined();
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfigs.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfigs.java
@@ -82,7 +82,7 @@ public interface PipelineConfigs extends Iterable<PipelineConfig>, Cloneable, Va
 
     boolean hasOperationPermissionDefined();
 
-    boolean hasOperatePermission(CaseInsensitiveString username, UserRoleMatcher userRoleMatcher);
+    boolean hasOperatePermission(CaseInsensitiveString username, UserRoleMatcher userRoleMatcher, boolean everyoneIsAllowedToOperateIfNoAuthIsDefined);
 
     boolean hasAuthorizationDefined();
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/merge/MergePipelineConfigs.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/merge/MergePipelineConfigs.java
@@ -604,8 +604,8 @@ public class MergePipelineConfigs implements PipelineConfigs {
 
 
     @Override
-    public boolean hasViewPermission(CaseInsensitiveString username, UserRoleMatcher userRoleMatcher) {
-        return this.getAuthorizationPart().hasViewPermission(username, userRoleMatcher);
+    public boolean hasViewPermission(CaseInsensitiveString username, UserRoleMatcher userRoleMatcher, boolean everyoneIsAllowedToViewIfNoAuthIsDefined) {
+        return this.getAuthorizationPart().hasViewPermission(username, userRoleMatcher, everyoneIsAllowedToViewIfNoAuthIsDefined);
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/merge/MergePipelineConfigs.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/merge/MergePipelineConfigs.java
@@ -625,8 +625,8 @@ public class MergePipelineConfigs implements PipelineConfigs {
     }
 
     @Override
-    public boolean hasOperatePermission(CaseInsensitiveString username, UserRoleMatcher userRoleMatcher) {
-        return this.getAuthorizationPart().hasOperatePermission(username, userRoleMatcher);
+    public boolean hasOperatePermission(CaseInsensitiveString username, UserRoleMatcher userRoleMatcher, boolean everyoneIsAllowedToOperateIfNoAuthIsDefined) {
+        return this.getAuthorizationPart().hasOperatePermission(username, userRoleMatcher, everyoneIsAllowedToOperateIfNoAuthIsDefined);
     }
 
     @Override

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigsTestBase.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigsTestBase.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.remote.FileConfigOrigin;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.domain.config.Admin;
@@ -87,8 +86,13 @@ public abstract class PipelineConfigsTestBase {
     }
 
     @Test
-    public void shouldReturnTrueForOperatePermissionIfAuthorizationIsNotDefined() {
-        assertThat(createEmpty().hasOperatePermission(new CaseInsensitiveString("anyone"), null), is(true));
+    public void shouldReturnTrueForOperatePermissionIfAuthorizationIsNotDefined_AndDefaultPermissionForGroupsWithNoAuthIsToAllowAll() {
+        assertThat(createEmpty().hasOperatePermission(new CaseInsensitiveString("anyone"), null, true), is(true));
+    }
+
+    @Test
+    public void shouldReturnTrueForOperatePermissionIfAuthorizationIsNotDefined_AndDefaultPermissionForGroupsWithNoAuthIsToDeny() {
+        assertThat(createEmpty().hasOperatePermission(new CaseInsensitiveString("anyone"), null, false), is(false));
     }
 
     @Test
@@ -159,21 +163,21 @@ public abstract class PipelineConfigsTestBase {
     public void shouldReturnFalseIfOperatePermissionIsNotDefined() {
         PipelineConfigs group = createWithPipeline(PipelineConfigMother.pipelineConfig("pipeline1"));
         group.getAuthorization().getViewConfig().add(new AdminUser(new CaseInsensitiveString("jez")));
-        assertThat(group.hasOperatePermission(new CaseInsensitiveString("jez"), null), is(false));
+        assertThat(group.hasOperatePermission(new CaseInsensitiveString("jez"), null, true), is(false));
     }
 
     @Test
     public void shouldReturnFalseIfUserDoesNotHaveOperatePermission() {
         PipelineConfigs group = createWithPipeline(PipelineConfigMother.pipelineConfig("pipeline1"));
         group.getAuthorization().getOperationConfig().add(new AdminUser(new CaseInsensitiveString("jez")));
-        assertThat(group.hasOperatePermission(new CaseInsensitiveString("anyone"), null), is(false));
+        assertThat(group.hasOperatePermission(new CaseInsensitiveString("anyone"), null, true), is(false));
     }
 
     @Test
     public void shouldReturnTrueIfUserHasOperatePermission() {
         PipelineConfigs group = createWithPipeline(PipelineConfigMother.pipelineConfig("pipeline1"));
         group.getAuthorization().getOperationConfig().add(new AdminUser(new CaseInsensitiveString("jez")));
-        assertThat(group.hasOperatePermission(new CaseInsensitiveString("jez"), null), is(true));
+        assertThat(group.hasOperatePermission(new CaseInsensitiveString("jez"), null, true), is(true));
     }
 
     @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigsTestBase.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigsTestBase.java
@@ -59,30 +59,30 @@ public abstract class PipelineConfigsTestBase {
     }
 
     @Test
-    public void shouldReturnTrueIfAuthorizationIsNotDefined() {
-        assertThat(createEmpty().hasViewPermission(new CaseInsensitiveString("anyone"), null), is(true));
+    public void shouldUseDefaultViewPermissionsForViewersOfAGroupIfAuthorizationIsNotDefined() {
+        assertThat(createEmpty().hasViewPermission(new CaseInsensitiveString("anyone"), null, true), is(true));
+        assertThat(createEmpty().hasViewPermission(new CaseInsensitiveString("anyone"), null, false), is(false));
     }
-
 
     @Test
     public void shouldReturnFalseIfViewPermissionIsNotDefined() {
         PipelineConfigs group = createWithPipeline(PipelineConfigMother.pipelineConfig("pipeline1"));
         group.getAuthorization().getOperationConfig().add(new AdminUser(new CaseInsensitiveString("jez")));
-        assertThat(group.hasViewPermission(new CaseInsensitiveString("jez"), null), is(false));
+        assertThat(group.hasViewPermission(new CaseInsensitiveString("jez"), null, true), is(false));
     }
 
     @Test
     public void shouldReturnFalseIfUserDoesNotHaveViewPermission() {
         PipelineConfigs group = createWithPipeline(PipelineConfigMother.pipelineConfig("pipeline1"));
         group.getAuthorization().getViewConfig().add(new AdminUser(new CaseInsensitiveString("jez")));
-        assertThat(group.hasViewPermission(new CaseInsensitiveString("anyone"), null), is(false));
+        assertThat(group.hasViewPermission(new CaseInsensitiveString("anyone"), null, true), is(false));
     }
 
     @Test
     public void shouldReturnTrueIfUserHasViewPermission() {
         PipelineConfigs group = createWithPipeline(PipelineConfigMother.pipelineConfig("pipeline1"));
         group.getAuthorization().getViewConfig().add(new AdminUser(new CaseInsensitiveString("jez")));
-        assertThat(group.hasViewPermission(new CaseInsensitiveString("jez"), null), is(true));
+        assertThat(group.hasViewPermission(new CaseInsensitiveString("jez"), null, true), is(true));
     }
 
     @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/merge/MergePipelineConfigsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/merge/MergePipelineConfigsTest.java
@@ -198,12 +198,15 @@ public class MergePipelineConfigsTest extends PipelineConfigsTestBase {
     }
 
     @Test
-    public void shouldReturnTrueForOperatePermissionIfAuthorizationIsNotDefined_When2ConfigParts() {
+    public void shouldUseDefaultPermissionsForOperatePermissionIfAuthorizationIsNotDefined_When2ConfigParts() {
         BasicPipelineConfigs filePart = new BasicPipelineConfigs();
         filePart.setOrigin(new FileConfigOrigin());
 
         assertThat(new MergePipelineConfigs(filePart, new BasicPipelineConfigs())
-                .hasOperatePermission(new CaseInsensitiveString("anyone"), null), is(true));
+                .hasOperatePermission(new CaseInsensitiveString("anyone"), null, true), is(true));
+
+        assertThat(new MergePipelineConfigs(filePart, new BasicPipelineConfigs())
+                .hasOperatePermission(new CaseInsensitiveString("anyone"), null, false), is(false));
     }
 
     @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/merge/MergePipelineConfigsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/merge/MergePipelineConfigsTest.java
@@ -163,12 +163,13 @@ public class MergePipelineConfigsTest extends PipelineConfigsTestBase {
     }
 
     @Test
-    public void shouldReturnTrueIfAuthorizationIsNotDefined_When2ConfigParts() {
+    public void shouldUseDefaultPermissionsForViewPermissionIfAuthorizationIsNotDefined_When2ConfigParts() {
         BasicPipelineConfigs filePart = new BasicPipelineConfigs();
         filePart.setOrigin(new FileConfigOrigin());
 
         MergePipelineConfigs merge = new MergePipelineConfigs(new BasicPipelineConfigs(), filePart);
-        assertThat(merge.hasViewPermission(new CaseInsensitiveString("anyone"), null), is(true));
+        assertThat(merge.hasViewPermission(new CaseInsensitiveString("anyone"), null, true), is(true));
+        assertThat(merge.hasViewPermission(new CaseInsensitiveString("anyone"), null, false), is(false));
     }
 
     @Test
@@ -194,7 +195,7 @@ public class MergePipelineConfigsTest extends PipelineConfigsTestBase {
                 new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig("pipeline1")),
                 new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig("pipeline2")), filePart);
         group.getAuthorization().getOperationConfig().add(new AdminUser(new CaseInsensitiveString("jez")));
-        assertThat(group.hasViewPermission(new CaseInsensitiveString("jez"), null), is(false));
+        assertThat(group.hasViewPermission(new CaseInsensitiveString("jez"), null, true), is(false));
     }
 
     @Test

--- a/server/src/main/java/com/thoughtworks/go/server/service/SecurityService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/SecurityService.java
@@ -99,7 +99,7 @@ public class SecurityService {
         }
 
         PipelineConfigs group = cruiseConfig.getGroups().findGroup(groupName);
-        return isUserAdminOfGroup(username, group) || group.hasOperatePermission(username, new UserRoleMatcherImpl(cruiseConfig.server().security()));
+        return isUserAdminOfGroup(username, group) || group.hasOperatePermission(username, new UserRoleMatcherImpl(cruiseConfig.server().security()), true);
     }
 
     public boolean hasOperatePermissionForStage(String pipelineName, String stageName, String username) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/SecurityService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/SecurityService.java
@@ -105,7 +105,8 @@ public class SecurityService {
         }
 
         PipelineConfigs group = cruiseConfig.getGroups().findGroup(groupName);
-        return isUserAdminOfGroup(username, group) || group.hasOperatePermission(username, new UserRoleMatcherImpl(cruiseConfig.server().security()), true);
+        boolean everyoneIsAllowedToOperateIfNoAuthIsDefined = systemEnvironment.get(ALLOW_EVERYONE_TO_VIEW_OPERATE_GROUPS_WITH_NO_GROUP_AUTHORIZATION_SETUP);
+        return isUserAdminOfGroup(username, group) || group.hasOperatePermission(username, new UserRoleMatcherImpl(cruiseConfig.server().security()), everyoneIsAllowedToOperateIfNoAuthIsDefined);
     }
 
     public boolean hasOperatePermissionForStage(String pipelineName, String stageName, String username) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/SecurityService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/SecurityService.java
@@ -55,7 +55,7 @@ public class SecurityService {
         }
 
         PipelineConfigs group = cruiseConfig.getGroups().findGroup(pipelineGroupName);
-        return isUserAdminOfGroup(username, group) || group.hasViewPermission(username, new UserRoleMatcherImpl(cruiseConfig.server().security()));
+        return isUserAdminOfGroup(username, group) || group.hasViewPermission(username, new UserRoleMatcherImpl(cruiseConfig.server().security()), true);
     }
 
     private boolean isUserAdminOfGroup(final CaseInsensitiveString userName, PipelineConfigs group) {

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/permissions.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/permissions.html.erb
@@ -25,7 +25,7 @@
             <div class="form_item">
                 <div class="inherited_permissions<%= " hidden" if stage_has_auth_defined %>">
                     <% unless @pipeline_group && @pipeline_group.hasOperationPermissionDefined() %>
-                        <div class="no_permissions_message information">There are no operate permissions configured for this stage nor its pipeline group. All Go users can operate on this stage.</div>
+                        <div class="no_permissions_message information">There is no authorization configured for this stage nor its pipeline group. Only GoCD administrators can operate this stage.</div>
                     <% else %>
                         <%= render :partial => "users_and_roles_from_group.html", :locals => {:scope => {:pipeline_group => @pipeline_group, :form => f}} %>
                     <% end %>

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/SecurityServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/SecurityServiceTest.java
@@ -19,6 +19,7 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.policy.*;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,8 +37,9 @@ public class SecurityServiceTest {
     @Before
     public void setUp() {
         goConfigService = mock(GoConfigService.class);
+        SystemEnvironment systemEnvironment = mock(SystemEnvironment.class);
         when(goConfigService.security()).thenReturn(new SecurityConfig());
-        securityService = new SecurityService(goConfigService);
+        securityService = new SecurityService(goConfigService, systemEnvironment);
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ChangesetServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ChangesetServiceIntegrationTest.java
@@ -593,6 +593,8 @@ public class ChangesetServiceIntegrationTest {
         DependencyMaterial dependencyMaterial = MaterialsMother.dependencyMaterial("upstream", "stage");
         PipelineConfig downstream = configHelper.addPipeline("downstream", "stage", dependencyMaterial.config(), "job");
 
+        configHelper.setViewPermissionForGroup(BasicPipelineConfigs.DEFAULT_GROUP, CaseInsensitiveString.str(user.getUsername()));
+
         //Schedule grandfather
         List<MaterialRevision> revisionsForGrandfather1 = new ArrayList<>();
         addRevisionWith2Mods(revisionsForGrandfather1, svn);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/SecurityServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/SecurityServiceIntegrationTest.java
@@ -137,6 +137,20 @@ public class SecurityServiceIntegrationTest {
     }
 
     @Test
+    public void userShouldNotHaveOperatePermissionToGroupWithNoAuth_WhenDefaultPermissionIsToDeny() {
+        withDefaultGroupPermission(false, (o) -> {
+            assertThat(securityService.hasOperatePermissionForGroup(new CaseInsensitiveString(OPERATOR), GROUP_NAME), is(false));
+        });
+    }
+
+    @Test
+    public void userShouldHaveOperatePermissionToGroupWithNoAuth_WhenDefaultPermissionIsToAllow() {
+        withDefaultGroupPermission(true, (o) -> {
+            assertThat(securityService.hasOperatePermissionForGroup(new CaseInsensitiveString(OPERATOR), GROUP_NAME), is(true));
+        });
+    }
+
+    @Test
     public void shouldGiveTheGroupsModifiableByAdmin() {
         configHelper.addAdmins("admin");
         configHelper.addPipelineWithGroup("newGroup", "newPipeline", "newStage", "newJob");
@@ -282,8 +296,6 @@ public class SecurityServiceIntegrationTest {
         configHelper.addAuthorizedUserForStage(PIPELINE_NAME, STAGE_NAME, OPERATOR);
         assertThat(securityService.hasOperatePermissionForStage(PIPELINE_NAME, STAGE_NAME, ADMIN), is(true));
     }
-
-
 
     @Test public void shouldReturnAllPipelinesThatUserHasViewPermissionsFor() throws Exception {
         configHelper.onTearDown();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/StageApprovalAuthorizationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/StageApprovalAuthorizationTest.java
@@ -139,16 +139,6 @@ public class StageApprovalAuthorizationTest {
     }
 
     @Test
-    public void shouldAuthorizeAnyUserIfNoAuthorizationDefinedForAutoApproval() throws Exception {
-        CONFIG_HELPER.addSecurityWithAdminConfig();
-        StageConfig stage = StageConfigMother.custom("ft", Approval.automaticApproval());
-        PipelineConfig pipeline = CONFIG_HELPER.addStageToPipeline(PIPELINE_NAME, stage);
-
-        assertThat("Cruise should not have permission on ft stage unless configured with permission",
-                securityService.hasOperatePermissionForStage(CaseInsensitiveString.str(pipeline.name()), CaseInsensitiveString.str(stage.name()), "cruise"), is(true));
-    }
-
-    @Test
     public void shouldAuthorizeUserCruiseIfUserIsAuthorisedToOperateAutoStage() throws Exception {
         CONFIG_HELPER.addSecurityWithAdminConfig();
         CONFIG_HELPER.setOperatePermissionForStage(PIPELINE_NAME, STAGE_NAME, "cruise");
@@ -157,5 +147,4 @@ public class StageApprovalAuthorizationTest {
         assertThat(securityService.hasOperatePermissionForStage(CaseInsensitiveString.str(pipeline.name()), CaseInsensitiveString.str(stage.name()), "cruise"), is(true));
         assertThat(securityService.hasOperatePermissionForStage(PIPELINE_NAME, STAGE_NAME, "anyone"), is(false));
     }
-
 }

--- a/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
+++ b/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
@@ -742,13 +742,20 @@ public class GoConfigFileHelper {
     }
 
     public void addAuthorizedUserForStage(String pipelineName, String stageName, String... users) {
-        configureStageAsManualApproval(pipelineName, stageName);
+        CaseInsensitiveString pipeline = new CaseInsensitiveString(pipelineName);
+        CaseInsensitiveString stage = new CaseInsensitiveString(stageName);
+
+        if (!currentConfig().stageConfigByName(pipeline, stage).getApproval().isManual()) {
+            configureStageAsManualApproval(pipelineName, stageName);
+        }
+
         CruiseConfig cruiseConfig = loadForEdit();
-        StageConfig stageConfig = cruiseConfig.stageConfigByName(new CaseInsensitiveString(pipelineName), new CaseInsensitiveString(stageName));
+        StageConfig stageConfig = cruiseConfig.stageConfigByName(pipeline, stage);
         Approval approval = stageConfig.getApproval();
         for (String user : users) {
             approval.getAuthConfig().add(new AdminUser(new CaseInsensitiveString(user)));
         }
+
         writeConfigFile(cruiseConfig);
     }
 


### PR DESCRIPTION
Issue: #4940

1. By default: All pipeline groups with no authorization setup can no longer be viewed and operated by everyone. They can only be viewed and operated by GoCD system administrators.

2. For now (for the next few releases), it is possible to set a system property, to go back to the old behaviour. The property is: `allow.everyone.to.view.operate.groups.with.no.authorization.setup`. It can be set using `-Dallow.everyone.to.view.operate.groups.with.no.authorization.setup=Y` in `wrapper-properties.conf` (use the appropriate syntax though).

- [x] Functional test changes: https://github.com/gocd/ruby-functional-tests/pull/651
- [x] Documentation changes: https://github.com/gocd/docs.go.cd/pull/437