### PR TITLE
Enhance Pipeline config spa toggle

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/RedirectToPipelineConfigSPAToggle.java
+++ b/server/src/main/java/com/thoughtworks/go/server/RedirectToPipelineConfigSPAToggle.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.server;
+
+import com.thoughtworks.go.server.service.support.toggle.Toggles;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class RedirectToPipelineConfigSPAToggle {
+    public void redirect(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        if (Toggles.isToggleOn(Toggles.NEW_PIPELINE_CONFIG_SPA)) {
+            String pipelineOrTemplate = request.getRequestURI().split("/")[3];
+            String pipelineOrTemplateName = request.getRequestURI().split("/")[4];
+            response.sendRedirect("/go/admin/" + pipelineOrTemplate + "/" + pipelineOrTemplateName + "/edit");
+        }
+    }
+}

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -53,7 +53,7 @@
     },
     {
       "key": "new_pipeline_config_spa",
-      "description": "When enabled, provides an option on the pipeline config rails page to use the quick edit SPA.",
+      "description": "When enabled, redirects to pipeline config spa.",
       "value": false
     }
   ]

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
@@ -29,7 +29,6 @@ module Admin
 
     before_action :load_config_for_edit, :only => [:new, :create]
     before_action :load_template_list, :only => [:new, :create]
-    before_action :load_new_spa_toggle_value
 
     load_pipeline_except_for :update, :new, :create, :clone, :save_clone
 
@@ -278,10 +277,6 @@ module Admin
     def load_autocomplete_suggestions
       load_group_list()
       assert_load :pipeline_stages_json, pipeline_stages_json(go_config_service.getCurrentConfig(), current_user, security_service, params)
-    end
-
-    def load_new_spa_toggle_value
-      @should_show_new_spa_link = feature_toggle_service.isToggleOn(Toggles.NEW_PIPELINE_CONFIG_SPA)
     end
   end
 end

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/templates_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/templates_controller.rb
@@ -21,7 +21,6 @@ class Admin::TemplatesController < AdminController
   before_action :check_admin_or_template_admin_and_403, only: [:edit]
   before_action :load_cruise_config, :only => [:edit, :edit_permissions]
   before_action :autocomplete_for_permissions, :only => [:edit_permissions]
-  before_action :load_new_spa_toggle_value
 
   layout "admin", :except => [:create]
 
@@ -77,9 +76,5 @@ class Admin::TemplatesController < AdminController
   def autocomplete_for_permissions
     @autocomplete_users = user_service.allUsernames().to_json
     @autocomplete_roles = user_service.allRoleNames().to_json
-  end
-
-  def load_new_spa_toggle_value
-    @should_show_new_spa_link = feature_toggle_service.isToggleOn(Toggles.NEW_PIPELINE_CONFIG_SPA)
   end
 end

--- a/server/src/main/webapp/WEB-INF/rails/app/views/layouts/pipelines/_breadcrumb_top.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/layouts/pipelines/_breadcrumb_top.html.erb
@@ -8,11 +8,9 @@
     <div id="pause_info_and_controls" class="admin_pause_info_and_controls clear_float">
       <%= render :partial => "shared/pause_info_and_control.html", :locals => {:scope => {:pause_info => @pause_info, :pipeline_name => @pipeline.name()}} %>
     </div>
-    <% if @should_show_new_spa_link %>
-      <a class="link_as_button primary quick_edit_button" href="/go/admin/pipelines/<%= @pipeline.name() %>/edit">
-        Quick Edit
-      </a>
-    <% end %>
+    <a class="link_as_button primary quick_edit_button" href="/go/admin/pipelines/<%= @pipeline.name() %>/edit">
+      Quick Edit
+    </a>
   </div>
 </div>
 <% if @is_config_repo_pipeline %>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/layouts/templates/_breadcrumb_top.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/layouts/templates/_breadcrumb_top.html.erb
@@ -4,10 +4,8 @@
       <li><%= link_to 'Templates', spark_url_for({url_builder: controller}, SparkRoutes::AdminTemplates::SPA_BASE) -%></li>
       <li class='last'><h1 class='wrapped_word'><%= @pipeline.name() -%> </h1></li>
     </ul>
-    <% if @should_show_new_spa_link %>
-      <a class="link_as_button primary quick_edit_button" href="/go/admin/templates/<%= @pipeline.name() %>/edit">
-        Quick Edit
-      </a>
-    <% end %>
+    <a class="link_as_button primary quick_edit_button" href="/go/admin/templates/<%= @pipeline.name() %>/edit">
+      Quick Edit
+    </a>
   </div>
 </div>

--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -998,6 +998,12 @@
   </rule>
 
   <rule>
+    <name>Redirect to Pipeline Config SPA</name>
+    <from>/admin/(pipelines|templates)/([^/]+)/(.*?)?$</from>
+    <run class="com.thoughtworks.go.server.RedirectToPipelineConfigSPAToggle" method="redirect"/>
+  </rule>
+
+  <rule>
     <name>Rails UI</name>
     <note>
       Prepends 'rails/' to Rails urls, so that the request does not go through Java at all

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/ClickyPipelineConfigController.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/ClickyPipelineConfigController.java
@@ -56,9 +56,6 @@ public class ClickyPipelineConfigController implements SparkController {
     }
 
     public ModelAndView index(Request request, Response response) {
-        if (!featureToggleService.isToggleOn(Toggles.NEW_PIPELINE_CONFIG_SPA)) {
-            throw authenticationHelper.renderNotFoundResponse("The page you are looking for is not found.");
-        }
         String pipelineName = request.params("pipeline_name");
         Map<Object, Object> object = new HashMap<>() {{
             put("viewTitle", "Pipeline");

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ClickyPipelineConfigControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ClickyPipelineConfigControllerTest.groovy
@@ -74,7 +74,6 @@ class ClickyPipelineConfigControllerTest implements ControllerTrait<ClickyPipeli
 
   @Test
   void "should add pipeline name in page meta"() {
-    when(featureToggleService.isToggleOn(Toggles.NEW_PIPELINE_CONFIG_SPA)).thenReturn(true)
     def pipelineName = "up42"
     def request = mock(Request)
     when(request.params("pipeline_name")).thenReturn(pipelineName)
@@ -84,15 +83,5 @@ class ClickyPipelineConfigControllerTest implements ControllerTrait<ClickyPipeli
 
     assertThat(model.get("meta") as Map<String, Object>)
       .containsEntry("pipelineName", pipelineName)
-  }
-
-  @Test
-  void 'should return 404 when toggle is off'() {
-    when(featureToggleService.isToggleOn(Toggles.NEW_PIPELINE_CONFIG_SPA)).thenReturn(false)
-    def request = mock(Request)
-
-    assertThatCode({ controller.index(request, null) })
-      .isInstanceOf(HaltException)
-      .satisfies({ HaltException ex -> assertThat(ex.statusCode()).isEqualTo(404) })
   }
 }


### PR DESCRIPTION
#### Always render the new pipeline config spa
* Regardless of the pipeline config spa toggle, serve the new pipeline
      config spa.

* Show the 'quick edit' button to go to the pipelines and templates
      spa from the old rails pages, regardless of the toggle value.

#### Redirect to new pipeline config spa and templates spa when SPA toggle is enabled

----

### Behavior

#### 1. When Pipeline Config SPA Toggle is Off:
  - render rails based pipeline config page
  - render rails based template config page
  - show 'quick edit' button on the rails pages to go to the new config spa.

#### 1. When Pipeline Config SPA Toggle is On:
  - render pipeline config spa. (Can not toggle back to the rails page as a redirect is setup from rails url to spa url)
  - render template config spa. (Can not toggle back to the rails page as a redirect is setup from rails url to spa url)


---

### Problems:

1. When toggle is enabled, following redirect is added:
  - `/go/admin/pipelines/<pipeline_name>/**` => `/go/admin/pipelines/<pipeline_name>/edit`
  - `/go/admin/templates/<template_name>/**` => `/go/admin/templates/<template_name>/edit`

This would cause any tab of the rails page to redirect to General tab of the SPA.
Example:
A user going to tasks tab of the job using the url `https://example.gocd.org/go/admin/pipelines/pipeline_name/stages/stage_name/job/job_name/tasks` will be redirected to pipeline general tab at `https://example.gocd.org/go/admin/pipelines/pipeline_name/edit` url.

Its highly unlikely that GoCD application has links to stages and jobs (because of pipeline using templates has stage and job link construction problems).



