### PR TITLE
Fix pipeline config errors on materials tab

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/config/FetchTaskTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/FetchTaskTest.java
@@ -25,26 +25,22 @@ import com.thoughtworks.go.helper.MaterialConfigsMother;
 import com.thoughtworks.go.helper.PipelineTemplateConfigMother;
 import com.thoughtworks.go.helper.StageConfigMother;
 import com.thoughtworks.go.util.ReflectionUtil;
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 import static com.thoughtworks.go.util.DataStructureUtils.m;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.matchers.JUnitMatchers.hasItems;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class FetchTaskTest {
+class FetchTaskTest {
     private PipelineConfig downstream;
     private PipelineConfig upstream;
     private PipelineConfig uppestStream;
     private CruiseConfig config;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         config = GoConfigMother.configWithPipelines("random_pipeline", "uppest_lookalike", "uppest_stream", "upstreams_peer", "upstream", "downstream", "dummy");
 
         PipelineConfig randomPipeline = config.pipelineConfigByName(new CaseInsensitiveString("random_pipeline"));
@@ -69,12 +65,12 @@ public class FetchTaskTest {
     }
 
     @Test
-    public void shouldImplementAbstractFetchArtifact() {
-        assertTrue(new FetchTask() instanceof AbstractFetchTask);
+    void shouldImplementAbstractFetchArtifact() {
+        assertThat(new FetchTask() instanceof AbstractFetchTask).isTrue();
     }
 
     @Test
-    public void validate_shouldErrorWhenReferencingConfigRepositoryPipelineFromFilePipeline() {
+    void validate_shouldErrorWhenReferencingConfigRepositoryPipelineFromFilePipeline() {
         uppestStream.setOrigin(new RepoConfigOrigin());
         downstream.setOrigin(new FileConfigOrigin());
 
@@ -82,56 +78,56 @@ public class FetchTaskTest {
         StageConfig stage = downstream.getStage(new CaseInsensitiveString("stage"));
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, stage, stage.getJobs().first()));
 
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.ARTIFACT_ORIGIN), startsWith("\"downstream :: stage :: job\" tries to fetch artifact from job \"uppest_stream :: uppest-stage2 :: uppest-job2\" which is defined in"));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.ARTIFACT_ORIGIN)).startsWith("\"downstream :: stage :: job\" tries to fetch artifact from job \"uppest_stream :: uppest-stage2 :: uppest-job2\" which is defined in");
 
     }
 
     @Test
-    public void validate_shouldNotErrorWhenReferencingFilePipelineFromConfigRepositoryPipeline() {
+    void validate_shouldNotErrorWhenReferencingFilePipelineFromConfigRepositoryPipeline() {
         uppestStream.setOrigin(new FileConfigOrigin());
         downstream.setOrigin(new RepoConfigOrigin());
 
         FetchTask task = new FetchTask(new CaseInsensitiveString("uppest_stream/upstream"), new CaseInsensitiveString("uppest-stage2"), new CaseInsensitiveString("uppest-job2"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage"))));
 
-        assertThat(task.errors().isEmpty(), is(true));
+        assertThat(task.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void validate_shouldNotErrorWhenReferencingConfigRepositoryPipelineFromConfigRepositoryPipeline() {
+    void validate_shouldNotErrorWhenReferencingConfigRepositoryPipelineFromConfigRepositoryPipeline() {
         uppestStream.setOrigin(new RepoConfigOrigin());
         downstream.setOrigin(new RepoConfigOrigin());
 
         FetchTask task = new FetchTask(new CaseInsensitiveString("uppest_stream/upstream"), new CaseInsensitiveString("uppest-stage2"), new CaseInsensitiveString("uppest-job2"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage"))));
 
-        assertThat(task.errors().isEmpty(), is(true));
+        assertThat(task.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void validate_shouldNotErrorWhenReferencingFilePipelineFromFilePipeline() {
+    void validate_shouldNotErrorWhenReferencingFilePipelineFromFilePipeline() {
         uppestStream.setOrigin(new FileConfigOrigin());
         downstream.setOrigin(new FileConfigOrigin());
 
         FetchTask task = new FetchTask(new CaseInsensitiveString("uppest_stream/upstream"), new CaseInsensitiveString("uppest-stage2"), new CaseInsensitiveString("uppest-job2"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage"))));
 
-        assertThat(task.errors().isEmpty(), is(true));
+        assertThat(task.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void shouldPassValidationWhenSrcAndDestDirectoryAreInsideAgentSandbox() {
+    void shouldPassValidationWhenSrcAndDestDirectoryAreInsideAgentSandbox() {
         StageConfig stage = upstream.getFirstStageConfig();
         JobConfig job = stage.getJobs().get(0);
         FetchTask task = new FetchTask(upstream.name(), stage.name(), job.name(), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(upstream, stage, job));
 
-        assertThat(task.errors().isEmpty(), is(true));
+        assertThat(task.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void shouldFailValidationWhenSrcDirectoryIsOutsideAgentSandbox() {
+    void shouldFailValidationWhenSrcDirectoryIsOutsideAgentSandbox() {
         validateAndAssertIncorrectPath("/src", true, "dest", FetchTask.SRC);
         validateAndAssertIncorrectPath("../src", true, "dest", FetchTask.SRC);
         validateAndAssertIncorrectPath("..", true, "dest", FetchTask.SRC);
@@ -139,14 +135,14 @@ public class FetchTaskTest {
     }
 
     @Test
-    public void shouldFailValidationWhenSrcFileIsOutsideAgentSandbox() {
+    void shouldFailValidationWhenSrcFileIsOutsideAgentSandbox() {
         validateAndAssertIncorrectPath("/src/junk.txt", false, "dest", FetchTask.SRC);
         validateAndAssertIncorrectPath("../junk.txt", false, "dest", FetchTask.SRC);
         validateAndAssertIncorrectPath("first-level/../../../going-back/file.txt", false, "dest", FetchTask.SRC);
     }
 
     @Test
-    public void shouldFailValidationWhenDestDirectoryIsOutsideAgentSandbox() {
+    void shouldFailValidationWhenDestDirectoryIsOutsideAgentSandbox() {
         validateAndAssertIncorrectPath("src", false, "/dest", FetchTask.DEST);
         validateAndAssertIncorrectPath("src", false, "../dest", FetchTask.DEST);
         validateAndAssertIncorrectPath("src", false, "..", FetchTask.DEST);
@@ -154,7 +150,7 @@ public class FetchTaskTest {
     }
 
     @Test
-    public void validate_withinTemplates_shouldPopulateErrorOnSrcFileOrSrcDirOrDestIfIsNotAValidFilePathPattern() {
+    void validate_withinTemplates_shouldPopulateErrorOnSrcFileOrSrcDirOrDestIfIsNotAValidFilePathPattern() {
         String dest = "..";
         String src = "..";
 
@@ -165,12 +161,12 @@ public class FetchTaskTest {
         ValidationContext context = ConfigSaveValidationContext.forChain(config, template, stage, job);
         task.validate(context);
 
-        assertThat(task.errors().isEmpty(), is(false));
+        assertThat(task.errors().isEmpty()).isFalse();
         String messageForSrc = String.format("Task of job '%s' in stage '%s' of template '%s' has src path '%s' which is outside the working directory.", job.name(), stage.name(), template.name(), src);
-        assertThat(task.errors().on(FetchTask.SRC), is(messageForSrc));
+        assertThat(task.errors().on(FetchTask.SRC)).isEqualTo(messageForSrc);
 
         String messageForDest = String.format("Task of job '%s' in stage '%s' of template '%s' has dest path '%s' which is outside the working directory.", job.name(), stage.name(), template.name(), dest);
-        assertThat(task.errors().on(FetchTask.DEST), is(messageForDest));
+        assertThat(task.errors().on(FetchTask.DEST)).isEqualTo(messageForDest);
     }
 
     private void validateAndAssertIncorrectPath(String source, boolean isSourceDir, String destination, String propertyName) {
@@ -184,97 +180,98 @@ public class FetchTaskTest {
         }
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), upstream, stage, job));
 
-        assertThat(task.errors().isEmpty(), is(false));
+        assertThat(task.errors().isEmpty()).isFalse();
         String path = propertyName.equals(FetchTask.SRC) ? source : destination;
         String message = String.format("Task of job '%s' in stage '%s' of pipeline '%s' has %s path '%s' which is outside the working directory.", job.name(), stage.name(), upstream.name(), propertyName, path);
-        assertThat(task.errors().on(propertyName), is(message));
+        assertThat(task.errors().on(propertyName)).isEqualTo(message);
     }
 
     @Test
-    public void validate_shouldPopulateErrorOnSrcFileOrSrcDirOrDestIfIsNotAValidFilePathPattern() {
+    void validate_shouldPopulateErrorOnSrcFileOrSrcDirOrDestIfIsNotAValidFilePathPattern() {
         FetchTask task = new FetchTask(new CaseInsensitiveString(""), new CaseInsensitiveString(""), new CaseInsensitiveString(""), "", "");
         task.validateAttributes(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage")), downstream.getStage(
                 new CaseInsensitiveString("stage")).getJobs().get(0)));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.SRC), is("Should provide either srcdir or srcfile"));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.SRC)).isEqualTo("Should provide either srcdir or srcfile");
     }
 
     @Test
-    public void validate_shouldNotTryAndValidateWhenWithinTemplate() throws Exception {
+    void validate_shouldNotTryAndValidateWhenWithinTemplate() throws Exception {
         FetchTask task = new FetchTask(new CaseInsensitiveString("dummy"), new CaseInsensitiveString("stage"), new CaseInsensitiveString("job"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new TemplatesConfig(), downstream.getStage(new CaseInsensitiveString("stage"))));
-        assertThat(task.errors().isEmpty(), is(true));
+        assertThat(task.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void validate_shouldValidateBlankStageAndJobWhenWithinTemplate() throws Exception {
+    void validate_shouldValidateBlankStageAndJobWhenWithinTemplate() throws Exception {
         FetchTask task = new FetchTask(new CaseInsensitiveString("dummy"), new CaseInsensitiveString(""), new CaseInsensitiveString(""), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new TemplatesConfig(), downstream.getStage(new CaseInsensitiveString("stage"))));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.STAGE), is("Stage is a required field."));
-        assertThat(task.errors().on(FetchTask.JOB), is("Job is a required field."));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.STAGE)).isEqualTo("Stage is a required field.");
+        assertThat(task.errors().on(FetchTask.JOB)).isEqualTo("Job is a required field.");
     }
 
     @Test
-    public void shouldPopulateErrorsIfFetchArtifactFromPipelineThatIsNotDependency() {
+    void shouldPopulateErrorsIfFetchArtifactFromPipelineThatIsNotDependency() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("dummy"), new CaseInsensitiveString("stage"), new CaseInsensitiveString("job"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage"))));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.PIPELINE_NAME), is("Pipeline \"downstream\" tries to fetch artifact from pipeline "
-                + "\"dummy\" which is not an upstream pipeline"));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.PIPELINE_NAME)).isEqualTo("Pipeline \"downstream\" tries to fetch artifact from pipeline "
+                + "\"dummy\" which is not an upstream pipeline");
+        assertThat(downstream.errors().on("base")).isEqualTo("The pipeline contains a fetch artifact task referring to dummy:stage:job but dummy:stage is not added as a material to this pipeline.");
     }
 
     @Test
-    public void shouldPopulateErrorsIfFetchArtifactDoesNotHaveStageAndOrJobDefined() {
+    void shouldPopulateErrorsIfFetchArtifactDoesNotHaveStageAndOrJobDefined() {
         FetchTask task = new FetchTask(new CaseInsensitiveString(""), new CaseInsensitiveString(""), new CaseInsensitiveString(""), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, new StageConfig(), new JobConfig()));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.STAGE), is("Stage is a required field."));
-        assertThat(task.errors().on(FetchTask.JOB), is("Job is a required field."));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.STAGE)).isEqualTo("Stage is a required field.");
+        assertThat(task.errors().on(FetchTask.JOB)).isEqualTo("Job is a required field.");
     }
 
     @Test
-    public void shouldBeValidWhenFetchArtifactIsFromAnyAncestorStage_onTheUpstreamPipeline() {
+    void shouldBeValidWhenFetchArtifactIsFromAnyAncestorStage_onTheUpstreamPipeline() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("uppest_stream/upstream"), new CaseInsensitiveString("uppest-stage2"), new CaseInsensitiveString("uppest-job2"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage"))));
-        assertThat(task.errors().isEmpty(), is(true));
+        assertThat(task.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void shouldBeValidWhenFetchArtifactIsFromAnyAncestorStage_s_predecessorStage__onTheUpstreamPipeline() {
+    void shouldBeValidWhenFetchArtifactIsFromAnyAncestorStage_s_predecessorStage__onTheUpstreamPipeline() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("uppest_stream/upstream"), new CaseInsensitiveString("uppest-stage1"), new CaseInsensitiveString("uppest-job1"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage"))));
-        assertThat(task.errors().isEmpty(), is(true));
+        assertThat(task.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void should_NOT_BeValidWhenFetchArtifactIsFromAnyAncestorStage_s_successorStage_onTheUpstreamPipeline() {
+    void should_NOT_BeValidWhenFetchArtifactIsFromAnyAncestorStage_s_successorStage_onTheUpstreamPipeline() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("uppest_stream/upstream"), new CaseInsensitiveString("uppest-stage3"), new CaseInsensitiveString("uppest-job3"), "src", "dest");
         StageConfig stage = downstream.getStage(new CaseInsensitiveString("stage"));
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, stage, stage.getJobs().first()));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.STAGE), is("\"downstream :: stage :: job\" tries to fetch artifact from stage \"uppest_stream :: uppest-stage3\" which does not complete before \"downstream\" pipeline's dependencies."));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.STAGE)).isEqualTo("\"downstream :: stage :: job\" tries to fetch artifact from stage \"uppest_stream :: uppest-stage3\" which does not complete before \"downstream\" pipeline's dependencies.");
     }
 
     @Test
-    public void should_NOT_BeValidWhen_pathFromAncestor_isInvalid_becauseRefferedPipelineIsNotAnAncestor() {
+    void should_NOT_BeValidWhen_pathFromAncestor_isInvalid_becauseRefferedPipelineIsNotAnAncestor() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("random_pipeline/upstream"), new CaseInsensitiveString("random-stage1"), new CaseInsensitiveString("random-job1"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage"))));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.PIPELINE_NAME), is("Pipeline named 'random_pipeline' exists, but is not an ancestor of 'downstream' as declared in 'random_pipeline/upstream'."));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.PIPELINE_NAME)).isEqualTo("Pipeline named 'random_pipeline' exists, but is not an ancestor of 'downstream' as declared in 'random_pipeline/upstream'.");
     }
 
     @Test
-    public void should_NOT_BeValidWhen_NO_pathFromAncestorIsGiven_butAncestorPipelineIsBeingFetchedFrom() {
+    void should_NOT_BeValidWhen_NO_pathFromAncestorIsGiven_butAncestorPipelineIsBeingFetchedFrom() {
         FetchTask task = new FetchTask(null, new CaseInsensitiveString("uppest-stage3"), new CaseInsensitiveString("uppest-job3"), "src", "dest");
         StageConfig stage = downstream.getStage(new CaseInsensitiveString("stage"));
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, stage, stage.getJobs().get(0)));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.STAGE), is("\"downstream :: stage :: job\" tries to fetch artifact from stage \"downstream :: uppest-stage3\" which does not exist."));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.STAGE)).isEqualTo("\"downstream :: stage :: job\" tries to fetch artifact from stage \"downstream :: uppest-stage3\" which does not exist.");
     }
 
     @Test
-    public void should_BeValidWhen_hasAnAlternatePathToAncestor() {
+    void should_BeValidWhen_hasAnAlternatePathToAncestor() {
         PipelineConfig upstreamsPeer = config.pipelineConfigByName(new CaseInsensitiveString("upstreams_peer"));
         upstreamsPeer.setMaterialConfigs(new MaterialConfigs(MaterialConfigsMother.dependencyMaterialConfig("uppest_stream", "uppest-stage1")));
         upstreamsPeer.add(StageConfigMother.stageConfig("peer-stage", new JobConfigs(new JobConfig("peer-job"))));
@@ -284,15 +281,15 @@ public class FetchTaskTest {
 
         FetchTask task = new FetchTask(new CaseInsensitiveString("uppest_stream/upstream"), new CaseInsensitiveString("uppest-stage1"), new CaseInsensitiveString("uppest-job1"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage"))));
-        assertThat(task.errors().isEmpty(), is(true));
+        assertThat(task.errors().isEmpty()).isTrue();
 
         task = new FetchTask(new CaseInsensitiveString("uppest_stream/upstreams_peer"), new CaseInsensitiveString("uppest-stage1"), new CaseInsensitiveString("uppest-job1"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage"))));
-        assertThat(task.errors().isEmpty(), is(true));
+        assertThat(task.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void should_NOT_BeValidWhen_ImmediateParentDeclaredInPathFromAncestor_isNotAParentPipeline() {
+    void should_NOT_BeValidWhen_ImmediateParentDeclaredInPathFromAncestor_isNotAParentPipeline() {
         PipelineConfig upstreamsPeer = config.pipelineConfigByName(new CaseInsensitiveString("upstreams_peer"));
         upstreamsPeer.setMaterialConfigs(new MaterialConfigs(MaterialConfigsMother.dependencyMaterialConfig("uppest_stream", "uppest-stage1")));
         upstreamsPeer.add(StageConfigMother.stageConfig("peer-stage", new JobConfigs(new JobConfig("peer-job"))));
@@ -303,12 +300,12 @@ public class FetchTaskTest {
         FetchTask task = new FetchTask(new CaseInsensitiveString("upstream/uppest_stream"), new CaseInsensitiveString("up-stage1"), new CaseInsensitiveString("up-job1"), "src", "dest");
         StageConfig stage = downstream.getStage(new CaseInsensitiveString("stage"));
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, stage, stage.getJobs().get(0)));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.PIPELINE_NAME), is("Pipeline named 'uppest_stream' exists, but is not an ancestor of 'downstream' as declared in 'upstream/uppest_stream'."));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.PIPELINE_NAME)).isEqualTo("Pipeline named 'uppest_stream' exists, but is not an ancestor of 'downstream' as declared in 'upstream/uppest_stream'.");
     }
 
     @Test
-    public void should_NOT_BeValidWhen_ImmediateParentDeclaredInPathFromAncestor_isNotAParentPipeline_PipelineConfigValidationContext() {
+    void should_NOT_BeValidWhen_ImmediateParentDeclaredInPathFromAncestor_isNotAParentPipeline_PipelineConfigValidationContext() {
         PipelineConfig upstreamsPeer = config.pipelineConfigByName(new CaseInsensitiveString("upstreams_peer"));
         upstreamsPeer.setMaterialConfigs(new MaterialConfigs(MaterialConfigsMother.dependencyMaterialConfig("uppest_stream", "uppest-stage1")));
         upstreamsPeer.add(StageConfigMother.stageConfig("peer-stage", new JobConfigs(new JobConfig("peer-job"))));
@@ -320,12 +317,12 @@ public class FetchTaskTest {
         StageConfig stage = downstream.getStage(new CaseInsensitiveString("stage"));
 
         task.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", config, downstream, stage, stage.getJobs().get(0)));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.PIPELINE_NAME), is("Pipeline named 'uppest_stream' exists, but is not an ancestor of 'downstream' as declared in 'upstream/uppest_stream'."));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.PIPELINE_NAME)).isEqualTo("Pipeline named 'uppest_stream' exists, but is not an ancestor of 'downstream' as declared in 'upstream/uppest_stream'.");
     }
 
     @Test
-    public void should_NOT_BeValidWhen_stageMayNotHaveRunViaTheGivenPath_evenThoughItMayHaveActuallyRunAccordingToAnAlternatePath() {//TODO: Please fix this if someone cares about this corner case working -jj
+    void should_NOT_BeValidWhen_stageMayNotHaveRunViaTheGivenPath_evenThoughItMayHaveActuallyRunAccordingToAnAlternatePath() {//TODO: Please fix this if someone cares about this corner case working -jj
         PipelineConfig upstreamsPeer = config.pipelineConfigByName(new CaseInsensitiveString("upstreams_peer"));
         upstreamsPeer.setMaterialConfigs(new MaterialConfigs(MaterialConfigsMother.dependencyMaterialConfig("uppest_stream", "uppest-stage1")));
         upstreamsPeer.add(StageConfigMother.stageConfig("peer-stage", new JobConfigs(new JobConfig("peer-job"))));
@@ -335,285 +332,277 @@ public class FetchTaskTest {
 
         FetchTask task = new FetchTask(new CaseInsensitiveString("uppest_stream/upstreams_peer"), new CaseInsensitiveString("uppest-stage1"), new CaseInsensitiveString("uppest-job1"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage")), downstream.getStage(new CaseInsensitiveString("stage")).getJobs().first()));
-        assertThat(task.errors().isEmpty(), is(true));
+        assertThat(task.errors().isEmpty()).isTrue();
 
         task = new FetchTask(new CaseInsensitiveString("uppest_stream/upstreams_peer"), new CaseInsensitiveString("uppest-stage2"), new CaseInsensitiveString("uppest-job2"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage")), downstream.getStage(new CaseInsensitiveString("stage")).getJobs().first()));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.STAGE), is("\"downstream :: stage :: job\" tries to fetch artifact from stage \"uppest_stream :: uppest-stage2\" which does not complete before \"downstream\" pipeline's dependencies."));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.STAGE)).isEqualTo("\"downstream :: stage :: job\" tries to fetch artifact from stage \"uppest_stream :: uppest-stage2\" which does not complete before \"downstream\" pipeline's dependencies.");
     }
 
     @Test
-    public void shouldFailWhenFetchArtifactIsFromAnyStage_AFTER_theDependencyStageOnTheUpstreamPipeline() {
+    void shouldFailWhenFetchArtifactIsFromAnyStage_AFTER_theDependencyStageOnTheUpstreamPipeline() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("upstream"), new CaseInsensitiveString("up-stage2"), new CaseInsensitiveString("up-job2"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage")), downstream.getStage(new CaseInsensitiveString("stage")).getJobs().first()));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.STAGE), is("\"downstream :: stage :: job\" tries to fetch artifact from stage \"upstream :: up-stage2\" which does not complete before \"downstream\" pipeline's dependencies."));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.STAGE)).isEqualTo("\"downstream :: stage :: job\" tries to fetch artifact from stage \"upstream :: up-stage2\" which does not complete before \"downstream\" pipeline's dependencies.");
     }
 
     @Test
-    public void shouldPopulateErrorIfFetchArtifactFromDependentPipelineButStageDoesNotExist() {
+    void shouldPopulateErrorIfFetchArtifactFromDependentPipelineButStageDoesNotExist() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("upstream"), new CaseInsensitiveString("stage-does-not-exist"), new CaseInsensitiveString("job"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage")), downstream.getStage(
                 new CaseInsensitiveString("stage")), downstream.getStage(new CaseInsensitiveString("stage")).getJobs().get(0)));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.STAGE), is("\"downstream :: stage :: job\" tries to fetch artifact from stage "
-                + "\"upstream :: stage-does-not-exist\" which does not exist."));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.STAGE)).isEqualTo("\"downstream :: stage :: job\" tries to fetch artifact from stage "
+                + "\"upstream :: stage-does-not-exist\" which does not exist.");
     }
 
     @Test
-    public void shouldPopulateErrorIfFetchArtifactFromDependentPipelineButJobNotExist() {
+    void shouldPopulateErrorIfFetchArtifactFromDependentPipelineButJobNotExist() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("upstream"), new CaseInsensitiveString("stage"), new CaseInsensitiveString("job-does-not-exist"), "src", "dest");
         StageConfig stage = downstream.getStage(new CaseInsensitiveString("stage"));
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, stage, stage.getJobs().first()));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.JOB), is("\"downstream :: stage :: job\" tries to fetch artifact from job "
-                + "\"upstream :: stage :: job-does-not-exist\" which does not exist."));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.JOB)).isEqualTo("\"downstream :: stage :: job\" tries to fetch artifact from job "
+                + "\"upstream :: stage :: job-does-not-exist\" which does not exist.");
     }
 
     @Test
-    public void shouldBeValidIfFetchArtifactUsingADependantPipeline() {
+    void shouldBeValidIfFetchArtifactUsingADependantPipeline() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("upstream"), new CaseInsensitiveString("up-stage1"), new CaseInsensitiveString("up-job1"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, downstream, downstream.getStage(new CaseInsensitiveString("stage"))));
-        assertThat(task.errors().isEmpty(), is(true));
+        assertThat(task.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void shouldBeValidIfFetchArtifactUsingAStageBeforeCurrentInTheSamePipeline() {
+    void shouldBeValidIfFetchArtifactUsingAStageBeforeCurrentInTheSamePipeline() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("upstream"), new CaseInsensitiveString("stage"), new CaseInsensitiveString("job"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, upstream, upstream.getStage(new CaseInsensitiveString("up-stage1"))));
-        assertThat(task.errors().isEmpty(), is(true));
+        assertThat(task.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void shouldBeValidIfFetchArtifactDoesNotSpecifyPipeline() {
+    void shouldBeValidIfFetchArtifactDoesNotSpecifyPipeline() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("stage"), new CaseInsensitiveString("job"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, upstream, upstream.getStage(new CaseInsensitiveString("up-stage1"))));
-        assertThat(task.errors().isEmpty(), is(true));
+        assertThat(task.errors().isEmpty()).isTrue();
     }
 
     // The Fetch Task is now case insensitive to job names . This behavior has changed from before migration of validations
     // to inside Config Objects for clicky admin. It was earlier Case SENSITIVE. This was done to address #4970
     // -Jake
     @Test
-    public void shouldPopulateErrorsIfFetchArtifactUsingJobNameWithDifferentCase() {
+    void shouldPopulateErrorsIfFetchArtifactUsingJobNameWithDifferentCase() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("upstream"), new CaseInsensitiveString("stage"), new CaseInsensitiveString("JOB"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), downstream, downstream.getStage(new CaseInsensitiveString("stage"))));
-        assertThat(task.errors().isEmpty(), is(true));
+        assertThat(task.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void shouldPopulateErrorIfSrcFileAndSrcDirBothAreDefined() {
+    void shouldPopulateErrorIfSrcFileAndSrcDirBothAreDefined() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("upstream"), new CaseInsensitiveString("stage"), new CaseInsensitiveString("job"), "src_file", "dest");
         task.setSrcdir("src_dir");
         task.validate(ConfigSaveValidationContext.forChain(config, upstream, upstream.getStage(new CaseInsensitiveString("stage"))));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.SRC), is("Only one of srcfile or srcdir is allowed at a time"));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.SRC)).isEqualTo("Only one of srcfile or srcdir is allowed at a time");
     }
 
     @Test
-    public void shouldPopulateErrorIfBothSrcFileAndSrcDirAreNotDefined() {
+    void shouldPopulateErrorIfBothSrcFileAndSrcDirAreNotDefined() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("upstream"), new CaseInsensitiveString("stage"), new CaseInsensitiveString("job"), "src_file", "dest");
         task.setSrcfile(null);
         task.validate(ConfigSaveValidationContext.forChain(config, upstream, upstream.getStage(new CaseInsensitiveString("stage"))));
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.SRC), is("Should provide either srcdir or srcfile"));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.SRC)).isEqualTo("Should provide either srcdir or srcfile");
     }
 
     @Test
-    public void shouldPopulateErrorOnSrcFileOrSrcDirOrDestIfIsNotAValidFilePathPattern() {
+    void shouldPopulateErrorOnSrcFileOrSrcDirOrDestIfIsNotAValidFilePathPattern() {
         FetchTask task = new FetchTask(new CaseInsensitiveString("upstream"), new CaseInsensitiveString("stage"), new CaseInsensitiveString("job"), "..", "..");
         StageConfig stage = upstream.getStage(new CaseInsensitiveString("stage"));
         ValidationContext context = ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), upstream, stage, stage.getJobs().first());
         task.validate(context);
-        assertThat(task.errors().isEmpty(), is(false));
-        assertThat(task.errors().on(FetchTask.SRC), is("Task of job 'job' in stage 'stage' of pipeline 'upstream' has src path '..' which is outside the working directory."));
-        assertThat(task.errors().on(FetchTask.DEST), is("Task of job 'job' in stage 'stage' of pipeline 'upstream' has dest path '..' which is outside the working directory."));
+        assertThat(task.errors().isEmpty()).isFalse();
+        assertThat(task.errors().on(FetchTask.SRC)).isEqualTo("Task of job 'job' in stage 'stage' of pipeline 'upstream' has src path '..' which is outside the working directory.");
+        assertThat(task.errors().on(FetchTask.DEST)).isEqualTo("Task of job 'job' in stage 'stage' of pipeline 'upstream' has dest path '..' which is outside the working directory.");
         task.setSrcfile(null);
         task.setSrcdir("..");
         task.validate(context);
-        assertThat(task.errors().on(FetchTask.SRC), is("Task of job 'job' in stage 'stage' of pipeline 'upstream' has src path '..' which is outside the working directory."));
+        assertThat(task.errors().on(FetchTask.SRC)).isEqualTo("Task of job 'job' in stage 'stage' of pipeline 'upstream' has src path '..' which is outside the working directory.");
     }
 
     @Test
-    public void shouldIndicateSourceIsAFileBasedOnValuePopulated() {
+    void shouldIndicateSourceIsAFileBasedOnValuePopulated() {
         FetchTask fetchTask = new FetchTask();
         fetchTask.setSrcfile("a.txt");
-        assertThat(fetchTask.isSourceAFile(), is(true));
+        assertThat(fetchTask.isSourceAFile()).isTrue();
 
         FetchTask fetchTaskWithDir = new FetchTask();
         fetchTaskWithDir.setSrcdir("/a/b");
-        assertThat(fetchTaskWithDir.isSourceAFile(), is(false));
+        assertThat(fetchTaskWithDir.isSourceAFile()).isFalse();
     }
 
     @Test
-    public void shouldReturnSrcFileWhenSrcFileIsNotEmpty() throws Exception {
+    void shouldReturnSrcFileWhenSrcFileIsNotEmpty() throws Exception {
         FetchTask fetchTask = new FetchTask();
         fetchTask.setSrcfile("a.jar");
-        assertThat(fetchTask.getSrc(), is("a.jar"));
+        assertThat(fetchTask.getSrc()).isEqualTo("a.jar");
     }
 
     @Test
-    public void shouldReturnSrcDirWhenSrcDirIsNotEmpty() throws Exception {
+    void shouldReturnSrcDirWhenSrcDirIsNotEmpty() throws Exception {
         FetchTask fetchTask = new FetchTask();
         fetchTask.setSrcdir("folder");
-        assertThat(fetchTask.getSrc(), is("folder"));
+        assertThat(fetchTask.getSrc()).isEqualTo("folder");
     }
 
     @Test
-    public void shouldNormalizeDest() throws Exception {
+    void shouldNormalizeDest() throws Exception {
         FetchTask fetchTask = new FetchTask(new CaseInsensitiveString("mingle"), new CaseInsensitiveString("dev"), new CaseInsensitiveString("windows-3"), "cruise-output/console.log",
                 "dest\\subfolder");
-        assertThat(fetchTask.getDest(), is("dest/subfolder"));
+        assertThat(fetchTask.getDest()).isEqualTo("dest/subfolder");
     }
 
     @Test
-    public void shouldNormalizeSrcFile() throws Exception {
+    void shouldNormalizeSrcFile() throws Exception {
         FetchTask fetchTask = new FetchTask(new CaseInsensitiveString("mingle"), new CaseInsensitiveString("dev"), new CaseInsensitiveString("windows-3"), "cruise-output\\console.log",
                 "dest\\subfolder");
-        assertThat(fetchTask.getSrc(), is("cruise-output/console.log"));
+        assertThat(fetchTask.getSrc()).isEqualTo("cruise-output/console.log");
     }
 
     @Test
-    public void shouldNormalizeSrcDir() throws Exception {
+    void shouldNormalizeSrcDir() throws Exception {
         FetchTask fetchTask = new FetchTask(new CaseInsensitiveString("mingle"), new CaseInsensitiveString("dev"), new CaseInsensitiveString("windows-3"), "", "dest\\subfolder");
         fetchTask.setSrcdir("testfolder\\subfolder");
-        assertThat(fetchTask.getSrc(), is("testfolder/subfolder"));
+        assertThat(fetchTask.getSrc()).isEqualTo("testfolder/subfolder");
     }
 
     @Test
-    public void describeTestForSrcFile() throws Exception {
+    void describeTestForSrcFile() throws Exception {
         FetchTask fetchTask = new FetchTask(new CaseInsensitiveString("mingle"), new CaseInsensitiveString("dev"), new CaseInsensitiveString("windows-3"), "cruise.zip", "dest\\subfolder");
-        assertThat(fetchTask.describe(),
-                is("fetch artifact [cruise.zip] => [dest/subfolder] from [mingle/dev/windows-3]"));
+        assertThat(fetchTask.describe()).isEqualTo("fetch artifact [cruise.zip] => [dest/subfolder] from [mingle/dev/windows-3]");
     }
 
     @Test
-    public void describeTestForSrcDir() throws Exception {
+    void describeTestForSrcDir() throws Exception {
         FetchTask fetchTask = new FetchTask(new CaseInsensitiveString("mingle"), new CaseInsensitiveString("dev"), new CaseInsensitiveString("windows-3"), "", "dest\\subfolder");
         fetchTask.setSrcdir("cruise-output");
-        assertThat(fetchTask.describe(),
-                is("fetch artifact [cruise-output] => [dest/subfolder] from [mingle/dev/windows-3]"));
+        assertThat(fetchTask.describe()).isEqualTo("fetch artifact [cruise-output] => [dest/subfolder] from [mingle/dev/windows-3]");
     }
 
     @Test
-    public void describeTestForSrcDirAndSrcFile() throws Exception {
+    void describeTestForSrcDirAndSrcFile() throws Exception {
         FetchTask fetchTask = new FetchTask(new CaseInsensitiveString("mingle"), new CaseInsensitiveString("dev"), new CaseInsensitiveString("windows-3"), "cruise.zip", "dest\\subfolder");
         fetchTask.setSrcdir("cruise-output");
-        assertThat(fetchTask.describe(),
-                is("fetch artifact [cruise.zip] => [dest/subfolder] from [mingle/dev/windows-3]"));
+        assertThat(fetchTask.describe()).isEqualTo("fetch artifact [cruise.zip] => [dest/subfolder] from [mingle/dev/windows-3]");
     }
 
     @Test
-    public void shouldUpdateItsAttributesFromAttributeMap() throws Exception {
+    void shouldUpdateItsAttributesFromAttributeMap() throws Exception {
         FetchTask fetchTask = new FetchTask();
         fetchTask.setConfigAttributes(
                 m(FetchTask.PIPELINE_NAME, "pipeline_foo", FetchTask.STAGE, "stage_bar", FetchTask.JOB, "job_baz", FetchTask.SRC, "src_file", FetchTask.DEST, "dest_dir", FetchTask.IS_SOURCE_A_FILE, "1"));
-        assertThat(fetchTask.getTargetPipelineName(), is(new CaseInsensitiveString("pipeline_foo")));
-        assertThat(fetchTask.getStage(), is(new CaseInsensitiveString("stage_bar")));
-        assertThat(fetchTask.getJob().toString(), is("job_baz"));
-        assertThat(fetchTask.getSrcfile(), is("src_file"));
-        assertThat(fetchTask.getSrcdir(), is(nullValue()));
-        assertThat(fetchTask.getDest(), is("dest_dir"));
+        assertThat(fetchTask.getTargetPipelineName()).isEqualTo(new CaseInsensitiveString("pipeline_foo"));
+        assertThat(fetchTask.getStage()).isEqualTo(new CaseInsensitiveString("stage_bar"));
+        assertThat(fetchTask.getJob().toString()).isEqualTo("job_baz");
+        assertThat(fetchTask.getSrcfile()).isEqualTo("src_file");
+        assertThat(fetchTask.getSrcdir()).isNull();
+        assertThat(fetchTask.getDest()).isEqualTo("dest_dir");
         fetchTask.setConfigAttributes(m(FetchTask.PIPELINE_NAME, "", FetchTask.STAGE, "", FetchTask.JOB, "", FetchTask.SRC, "", FetchTask.IS_SOURCE_A_FILE, "1", FetchTask.DEST, ""));
-        assertThat(fetchTask.getTargetPipelineName(), is(new CaseInsensitiveString("")));
-        assertThat(fetchTask.getStage(), is(new CaseInsensitiveString("")));
-        assertThat(fetchTask.getJob().toString(), is(""));
-        assertThat(fetchTask.getSrcfile(), is(nullValue()));
-        assertThat(fetchTask.getSrcdir(), is(nullValue()));
-        assertThat(fetchTask.getDest(), is(""));
+        assertThat(fetchTask.getTargetPipelineName()).isEqualTo(new CaseInsensitiveString(""));
+        assertThat(fetchTask.getStage()).isEqualTo(new CaseInsensitiveString(""));
+        assertThat(fetchTask.getJob().toString()).isEqualTo("");
+        assertThat(fetchTask.getSrcfile()).isNull();
+        assertThat(fetchTask.getSrcdir()).isNull();
+        assertThat(fetchTask.getDest()).isEqualTo("");
     }
 
     @Test
-    public void shouldSetSrcFileToNullIfSrcDirIsDefined() throws Exception {
+    void shouldSetSrcFileToNullIfSrcDirIsDefined() throws Exception {
         FetchTask fetchTask = new FetchTask();
         fetchTask.setConfigAttributes(
                 m(FetchTask.PIPELINE_NAME, "pipeline_foo", FetchTask.STAGE, "stage_bar", FetchTask.JOB, "job_baz", FetchTask.IS_SOURCE_A_FILE, "0", FetchTask.SRC, "src_dir", FetchTask.DEST,
                         "dest_dir"));
 
-        assertThat(fetchTask.getSrcfile(), is(nullValue()));
-        assertThat(fetchTask.getSrcdir(), is("src_dir"));
+        assertThat(fetchTask.getSrcfile()).isNull();
+        assertThat(fetchTask.getSrcdir()).isEqualTo("src_dir");
     }
 
     @Test
-    public void shouldSetSrcFileToNullWhenSrcDirIsUpdated() {
+    void shouldSetSrcFileToNullWhenSrcDirIsUpdated() {
         FetchTask fetchTask = new FetchTask(new CaseInsensitiveString("pname"), new CaseInsensitiveString("sname"), new CaseInsensitiveString("jname"), "sfile", "dest");
         fetchTask.setConfigAttributes(
                 m(FetchTask.PIPELINE_NAME, "pipeline_foo", FetchTask.STAGE, "stage_bar", FetchTask.JOB, "job_baz", FetchTask.IS_SOURCE_A_FILE, "0", FetchTask.SRC, "src_dir", FetchTask.DEST,
                         "dest_dir"));
 
-        assertThat(fetchTask.getSrcfile(), is(nullValue()));
-        assertThat(fetchTask.getSrcdir(), is("src_dir"));
+        assertThat(fetchTask.getSrcfile()).isNull();
+        assertThat(fetchTask.getSrcdir()).isEqualTo("src_dir");
     }
 
     @Test
-    public void shouldNotUpdateItsAttributesFromAttributeMapWhenKeysNotPresent() throws Exception {
+    void shouldNotUpdateItsAttributesFromAttributeMapWhenKeysNotPresent() throws Exception {
         FetchTask fetchTask = new FetchTask();
         fetchTask.setConfigAttributes(
                 m(FetchTask.PIPELINE_NAME, "pipeline_foo", FetchTask.STAGE, "stage_bar", FetchTask.JOB, "job_baz", FetchTask.SRC, "src_file", FetchTask.IS_SOURCE_A_FILE, "1", FetchTask.SRC, "src_file", FetchTask.DEST,
                         "dest_dir"));
         fetchTask.setConfigAttributes(m());
-        assertThat(fetchTask.getTargetPipelineName(), is(new CaseInsensitiveString("pipeline_foo")));
-        assertThat(fetchTask.getStage(), is(new CaseInsensitiveString("stage_bar")));
-        assertThat(fetchTask.getJob().toString(), is("job_baz"));
-        assertThat(fetchTask.getSrcfile(), is("src_file"));
-        assertThat(fetchTask.getSrcdir(), is(nullValue()));
-        assertThat(fetchTask.getDest(), is("dest_dir"));
+        assertThat(fetchTask.getTargetPipelineName()).isEqualTo(new CaseInsensitiveString("pipeline_foo"));
+        assertThat(fetchTask.getStage()).isEqualTo(new CaseInsensitiveString("stage_bar"));
+        assertThat(fetchTask.getJob().toString()).isEqualTo("job_baz");
+        assertThat(fetchTask.getSrcfile()).isEqualTo("src_file");
+        assertThat(fetchTask.getSrcdir()).isNull();
+        assertThat(fetchTask.getDest()).isEqualTo("dest_dir");
     }
 
     @Test
-    public void shouldUpdateDestToNullIfDestIsEmptyInAttributeMap_SoThatItDoesNotGetSerializedInXml() {
+    void shouldUpdateDestToNullIfDestIsEmptyInAttributeMap_SoThatItDoesNotGetSerializedInXml() {
         FetchTask fetchTask = new FetchTask(new CaseInsensitiveString("mingle"), new CaseInsensitiveString("dev"), new CaseInsensitiveString("one"), "", "dest");
         fetchTask.setConfigAttributes(m(FetchTask.DEST, ""));
-        assertThat(fetchTask, is(new FetchTask(new CaseInsensitiveString("mingle"), new CaseInsensitiveString("dev"), new CaseInsensitiveString("one"), "", null)));
+        assertThat(fetchTask).isEqualTo(new FetchTask(new CaseInsensitiveString("mingle"), new CaseInsensitiveString("dev"), new CaseInsensitiveString("one"), "", null));
     }
 
     @Test
-    public void shouldPopulateAllFieldsInReturnedPropertiesForDisplay() {
+    void shouldPopulateAllFieldsInReturnedPropertiesForDisplay() {
         FetchTask fetchTask = new FetchTask(new CaseInsensitiveString("foo-pipeline"), new CaseInsensitiveString("bar-stage"), new CaseInsensitiveString("baz-job"), "quux.c", "bang-file");
-        assertThat(fetchTask.getPropertiesForDisplay(), hasItems(new TaskProperty("Pipeline Name", "foo-pipeline", "pipeline_name"),
-                new TaskProperty("Stage Name", "bar-stage", "stage_name"), new TaskProperty("Job Name", "baz-job", "job_name"),
-                new TaskProperty("Source File", "quux.c", "source_file"), new TaskProperty("Destination", "bang-file", "destination")));
-        assertThat(fetchTask.getPropertiesForDisplay().size(), is(5));
+        assertThat(fetchTask.getPropertiesForDisplay()).contains(new TaskProperty("Pipeline Name", "foo-pipeline", "pipeline_name"), new TaskProperty("Stage Name", "bar-stage", "stage_name"), new TaskProperty("Job Name", "baz-job", "job_name"), new TaskProperty("Source File", "quux.c", "source_file"), new TaskProperty("Destination", "bang-file", "destination"));
+        assertThat(fetchTask.getPropertiesForDisplay().size()).isEqualTo(5);
 
         fetchTask = new FetchTask(new CaseInsensitiveString("foo-pipeline"), new CaseInsensitiveString("bar-stage"), new CaseInsensitiveString("baz-job"), null, "bang-file");
         fetchTask.setSrcdir("foo/src");
-        assertThat(fetchTask.getPropertiesForDisplay(), hasItems(new TaskProperty("Pipeline Name", "foo-pipeline", "pipeline_name"),
-                new TaskProperty("Stage Name", "bar-stage", "stage_name"), new TaskProperty("Job Name", "baz-job", "job_name"),
-                new TaskProperty("Source Directory", "foo/src", "source_directory"), new TaskProperty("Destination", "bang-file", "destination")));
-        assertThat(fetchTask.getPropertiesForDisplay().size(), is(5));
+        assertThat(fetchTask.getPropertiesForDisplay()).contains(new TaskProperty("Pipeline Name", "foo-pipeline", "pipeline_name"), new TaskProperty("Stage Name", "bar-stage", "stage_name"), new TaskProperty("Job Name", "baz-job", "job_name"), new TaskProperty("Source Directory", "foo/src", "source_directory"), new TaskProperty("Destination", "bang-file", "destination"));
+        assertThat(fetchTask.getPropertiesForDisplay().size()).isEqualTo(5);
 
         fetchTask = new FetchTask(new CaseInsensitiveString(null), new CaseInsensitiveString("bar-stage"), new CaseInsensitiveString("baz-job"), null, null);
-        assertThat(fetchTask.getPropertiesForDisplay(), hasItems(new TaskProperty("Stage Name", "bar-stage", "stage_name"), new TaskProperty("Job Name", "baz-job", "job_name")));
-        assertThat(fetchTask.getPropertiesForDisplay().size(), is(2));
+        assertThat(fetchTask.getPropertiesForDisplay()).contains(new TaskProperty("Stage Name", "bar-stage", "stage_name"), new TaskProperty("Job Name", "baz-job", "job_name"));
+        assertThat(fetchTask.getPropertiesForDisplay().size()).isEqualTo(2);
     }
 
     @Test
-    public void shouldCreateChecksumPath() {
+    void shouldCreateChecksumPath() {
         FetchTask fetchTask = new FetchTask(new CaseInsensitiveString("up-pipeline"), new CaseInsensitiveString("bar-stage"), new CaseInsensitiveString("baz-job"), "quux.c", "bang-file");
         String checksumPath = fetchTask.checksumPath();
-        assertThat(checksumPath, is("up-pipeline_bar-stage_baz-job_md5.checksum"));
+        assertThat(checksumPath).isEqualTo("up-pipeline_bar-stage_baz-job_md5.checksum");
     }
 
     @Test
-    public void shouldCreateArtifactDest() {
+    void shouldCreateArtifactDest() {
         FetchTask fetchTask = new FetchTask(new CaseInsensitiveString("up-pipeline"), new CaseInsensitiveString("bar-stage"), new CaseInsensitiveString("baz-job"), "quux.c", "dest-dir");
         File artifactDest = fetchTask.artifactDest("foo-pipeline", "file-name-in-dest");
-        assertThat(artifactDest, is(new File("pipelines/foo-pipeline/dest-dir/file-name-in-dest")));
+        assertThat(artifactDest).isEqualTo(new File("pipelines/foo-pipeline/dest-dir/file-name-in-dest"));
     }
 
     @Test
-    public void shouldNotPopulatePropertyForPipelineWhenPipelineIsNull() {
+    void shouldNotPopulatePropertyForPipelineWhenPipelineIsNull() {
         FetchTask fetchTask = new FetchTask(null, new CaseInsensitiveString("bar-stage"), new CaseInsensitiveString("baz-job"), "quux.c", "bang-file");
         // is null when no pipeline name is specified in config xml (manual entry)
         ReflectionUtil.setField(fetchTask, "pipelineName", null);
-        assertThat(fetchTask.getPropertiesForDisplay(), hasItems(new TaskProperty("Stage Name", "bar-stage", "stage_name"), new TaskProperty("Job Name", "baz-job", "job_name"),
-                new TaskProperty("Source File", "quux.c", "source_file"), new TaskProperty("Destination", "bang-file", "destination")));
-        assertThat(fetchTask.getPropertiesForDisplay().size(), is(4));
+        assertThat(fetchTask.getPropertiesForDisplay()).contains(new TaskProperty("Stage Name", "bar-stage", "stage_name"), new TaskProperty("Job Name", "baz-job", "job_name"), new TaskProperty("Source File", "quux.c", "source_file"), new TaskProperty("Destination", "bang-file", "destination"));
+        assertThat(fetchTask.getPropertiesForDisplay().size()).isEqualTo(4);
     }
 
     @Test
-    public void shouldNotFailValidationIfUpstreamExists_PipelineConfigSave() {
+    void shouldNotFailValidationIfUpstreamExists_PipelineConfigSave() {
         PipelineConfig upstream = new PipelineConfig(new CaseInsensitiveString("upstream-pipeline"),
                 new MaterialConfigs(), new StageConfig(new CaseInsensitiveString("upstream-stage"),
                 new JobConfigs(new JobConfig(new CaseInsensitiveString("upstream-job")))));
@@ -627,11 +616,11 @@ public class FetchTaskTest {
                 new StageConfig(new CaseInsensitiveString("downstream-stage"), new JobConfigs(job)));
 
         fetchTask.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", new BasicCruiseConfig(new BasicPipelineConfigs(upstream, downstream)), downstream, downstream.getFirstStageConfig(), downstream.getFirstStageConfig().getJobs().first()));
-        assertThat(fetchTask.errors().isEmpty(), is(true));
+        assertThat(fetchTask.errors().isEmpty()).isTrue();
     }
 
     @Test
-    public void shouldFailValidationIfFetchArtifactPipelineIsNotAMaterial_PipelineConfigSave() {
+    void shouldFailValidationIfFetchArtifactPipelineIsNotAMaterial_PipelineConfigSave() {
         PipelineConfig upstream = new PipelineConfig(new CaseInsensitiveString("upstream-pipeline"),
                 new MaterialConfigs(), new StageConfig(new CaseInsensitiveString("upstream-stage"),
                 new JobConfigs(new JobConfig(new CaseInsensitiveString("upstream-job")))));
@@ -645,12 +634,12 @@ public class FetchTaskTest {
                 new StageConfig(new CaseInsensitiveString("downstream-stage"), new JobConfigs(job)));
 
         fetchTask.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", new BasicCruiseConfig(new BasicPipelineConfigs(upstream, downstream)), downstream, downstream.getFirstStageConfig(), downstream.getFirstStageConfig().getJobs().first()));
-        assertThat(fetchTask.errors().isEmpty(), is(false));
-        assertThat(fetchTask.errors().on(FetchTask.PIPELINE_NAME), is("Pipeline \"downstream-pipeline\" tries to fetch artifact from pipeline \"upstream-pipeline\" which is not an upstream pipeline"));
+        assertThat(fetchTask.errors().isEmpty()).isFalse();
+        assertThat(fetchTask.errors().on(FetchTask.PIPELINE_NAME)).isEqualTo("Pipeline \"downstream-pipeline\" tries to fetch artifact from pipeline \"upstream-pipeline\" which is not an upstream pipeline");
     }
 
     @Test
-    public void shouldFailValidationIfFetchArtifactPipelineAndStageExistsButJobDoesNot_PipelineConfigSave() {
+    void shouldFailValidationIfFetchArtifactPipelineAndStageExistsButJobDoesNot_PipelineConfigSave() {
         PipelineConfig upstream = new PipelineConfig(new CaseInsensitiveString("upstream-pipeline"),
                 new MaterialConfigs(), new StageConfig(new CaseInsensitiveString("upstream-stage"),
                 new JobConfigs(new JobConfig(new CaseInsensitiveString("upstream-job")))));
@@ -664,19 +653,19 @@ public class FetchTaskTest {
                 new StageConfig(new CaseInsensitiveString("downstream-stage"), new JobConfigs(job)));
 
         fetchTask.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", new BasicCruiseConfig(new BasicPipelineConfigs(upstream, downstream)), downstream, downstream.getFirstStageConfig(), downstream.getFirstStageConfig().getJobs().first()));
-        assertThat(fetchTask.errors().isEmpty(), is(false));
-        assertThat(fetchTask.errors().on(FetchTask.JOB), is("\"downstream-pipeline :: downstream-stage :: downstream-job\" tries to fetch artifact from job \"upstream-pipeline :: upstream-stage :: some-random-job\" which does not exist."));
+        assertThat(fetchTask.errors().isEmpty()).isFalse();
+        assertThat(fetchTask.errors().on(FetchTask.JOB)).isEqualTo("\"downstream-pipeline :: downstream-stage :: downstream-job\" tries to fetch artifact from job \"upstream-pipeline :: upstream-stage :: some-random-job\" which does not exist.");
     }
 
     @Test
-    public void shouldPassValidationWhenFetchingFromAnInstanceOfRunOnAllJob() {
+    void shouldPassValidationWhenFetchingFromAnInstanceOfRunOnAllJob() {
         StageConfig stage = upstream.getFirstStageConfig();
         JobConfig job = stage.getJobs().get(0);
         job.setRunOnAllAgents(true);
         FetchTask task = new FetchTask(upstream.name(), stage.name(), new CaseInsensitiveString(job.name() + "-runOnAll-1"), "src", "dest");
         task.validate(ConfigSaveValidationContext.forChain(config, new BasicPipelineConfigs(), upstream, stage, job));
 
-        assertThat(task.errors().on(FetchTask.JOB), is(Matchers.nullValue()));
+        assertThat(task.errors().on(FetchTask.JOB)).isNull();
     }
 
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/AbstractFetchTask.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/AbstractFetchTask.java
@@ -197,8 +197,8 @@ public abstract class AbstractFetchTask extends AbstractTask implements FetchArt
 
         PipelineConfig ancestor = validationContext.getPipelineConfigByName(pipelineName.getAncestorName());
         if (matchingMaterial == null) {
-            addError(PIPELINE_NAME, String.format("Pipeline \"%s\" tries to fetch artifact from pipeline "
-                    + "\"%s\" which is not an upstream pipeline", currentPipeline.name(), pipelineName));
+            addError(PIPELINE_NAME, String.format("Pipeline \"%s\" tries to fetch artifact from pipeline \"%s\" which is not an upstream pipeline", currentPipeline.name(), pipelineName));
+            currentPipeline.addError("base", String.format("The pipeline contains a fetch artifact task referring to %s:%s:%s but %s:%s is not added as a material to this pipeline.", pipelineName, stage, job, pipelineName, stage));
             return;
         }
         List<StageConfig> validStages = ancestor.validStagesForFetchArtifact(currentPipeline, validationContext.getStage().name());

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/serialization.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/serialization.ts
@@ -37,6 +37,8 @@ export interface UsernamePasswordJSON {
 
 export interface ScmAttributesJSON extends BaseAttributesJSON, UsernamePasswordJSON {
   destination?: string;
+  filter?: FilterJSON;
+  invert_filter?: boolean;
 }
 
 export interface GitMaterialAttributesJSON extends ScmAttributesJSON {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/types_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/types_spec.ts
@@ -228,4 +228,39 @@ describe("Material Types", () => {
     });
   });
 
+  it('should reset password if it is present and has been updated', () => {
+    const material = new Material("git", new GitMaterialAttributes("name", true, "some-url", "master", "username", "password"));
+    const attrs    = (material.attributes() as GitMaterialAttributes);
+    attrs.password().edit();
+
+    expect(attrs.password().value()).toBe('');
+
+    material.resetPasswordIfAny();
+
+    expect(attrs.password().value()).toBe('password');
+  });
+
+  describe('Clone', () => {
+    it('should clone only the type is attrs are not present', () => {
+      const material = new Material("git");
+      const clone    = material.clone();
+
+      expect(clone.type()).toBe(material.type());
+      expect(clone.attributes()).toBeUndefined();
+    });
+
+    it('should clone the attrs as well', () => {
+      const material = new Material("git", new GitMaterialAttributes("name", true, "some-url", "master", "username", "password"));
+      const clone    = material.clone();
+
+      expect(clone.type()).toBe(material.type());
+      expect(clone.attributes()!.name()).toEqual(material.attributes()!.name());
+      expect(clone.attributes()!.autoUpdate()).toEqual(material.attributes()!.autoUpdate());
+      expect((clone.attributes()! as GitMaterialAttributes).url()).toEqual((material.attributes()! as GitMaterialAttributes).url());
+      expect((clone.attributes()! as GitMaterialAttributes).branch()).toEqual((material.attributes()! as GitMaterialAttributes).branch());
+      expect((clone.attributes()! as GitMaterialAttributes).username()).toEqual((material.attributes()! as GitMaterialAttributes).username());
+      expect((clone.attributes()! as GitMaterialAttributes).password().valueForDisplay()).toEqual((material.attributes()! as GitMaterialAttributes).password().valueForDisplay());
+    });
+  });
+
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
@@ -260,15 +260,19 @@ export abstract class ScmMaterialAttributes extends MaterialAttributes {
   destination: Stream<string>       = Stream();
   username: Stream<string | undefined>;
   password: Stream<EncryptedValue>;
+  filter: Stream<Filter | undefined>;
+  invertFilter: Stream<boolean | undefined>;
 
-  constructor(name?: string, autoUpdate?: boolean, username?: string, password?: string, encryptedPassword?: string) {
+  constructor(name?: string, autoUpdate?: boolean, username?: string, password?: string, encryptedPassword?: string, filter?: Filter, invertFilter?: boolean) {
     super(name, autoUpdate);
     this.validateFormatOf("destination",
                           ScmMaterialAttributes.DESTINATION_REGEX,
                           {message: "Must be a relative path within the pipeline's working directory"});
 
-    this.username = Stream(username);
-    this.password = Stream(plainOrCipherValue({plainText: password, cipherText: encryptedPassword}));
+    this.username     = Stream(username);
+    this.password     = Stream(plainOrCipherValue({plainText: password, cipherText: encryptedPassword}));
+    this.filter       = Stream(filter);
+    this.invertFilter = Stream(invertFilter);
   }
 }
 
@@ -323,12 +327,20 @@ export class GitMaterialAttributes extends ScmMaterialAttributes {
       attrs.destination(json.destination);
     }
     attrs.errors(new Errors(json.errors));
+    if (json.filter !== undefined) {
+      attrs.filter(Filter.fromJSON(json.filter));
+    }
+    attrs.invertFilter(json.invert_filter);
     return attrs;
   }
 
   clone(): MaterialAttributes {
     const gitAttrs = new GitMaterialAttributes(this.name(), this.autoUpdate(), this.url(), this.branch(), this.username());
     gitAttrs.password(this.password());
+    if (this.filter() !== undefined) {
+      gitAttrs.filter(new Filter(this.filter()!.ignore()));
+    }
+    gitAttrs.invertFilter(this.invertFilter());
     return gitAttrs;
   }
 }
@@ -365,12 +377,20 @@ export class SvnMaterialAttributes extends ScmMaterialAttributes {
       attrs.destination(json.destination);
     }
     attrs.errors(new Errors(json.errors));
+    if (json.filter !== undefined) {
+      attrs.filter(Filter.fromJSON(json.filter));
+    }
+    attrs.invertFilter(json.invert_filter);
     return attrs;
   }
 
   clone(): MaterialAttributes {
     const svnAttrs = new SvnMaterialAttributes(this.name(), this.autoUpdate(), this.url(), this.checkExternals(), this.username());
     svnAttrs.password(this.password());
+    if (this.filter() !== undefined) {
+      svnAttrs.filter(new Filter(this.filter()!.ignore()));
+    }
+    svnAttrs.invertFilter(this.invertFilter());
     return svnAttrs;
   }
 }
@@ -406,6 +426,10 @@ export class HgMaterialAttributes extends ScmMaterialAttributes {
       attrs.destination(json.destination);
     }
     attrs.errors(new Errors(json.errors));
+    if (json.filter !== undefined) {
+      attrs.filter(Filter.fromJSON(json.filter));
+    }
+    attrs.invertFilter(json.invert_filter);
     return attrs;
   }
 
@@ -413,6 +437,10 @@ export class HgMaterialAttributes extends ScmMaterialAttributes {
     const hgAttrs = new HgMaterialAttributes(this.name(), this.autoUpdate(), this.url(), this.username());
     hgAttrs.password(this.password());
     hgAttrs.branch(this.branch());
+    if (this.filter() !== undefined) {
+      hgAttrs.filter(new Filter(this.filter()!.ignore()));
+    }
+    hgAttrs.invertFilter(this.invertFilter());
     return hgAttrs;
   }
 }
@@ -455,12 +483,20 @@ export class P4MaterialAttributes extends ScmMaterialAttributes {
       attrs.destination(json.destination);
     }
     attrs.errors(new Errors(json.errors));
+    if (json.filter !== undefined) {
+      attrs.filter(Filter.fromJSON(json.filter));
+    }
+    attrs.invertFilter(json.invert_filter);
     return attrs;
   }
 
   clone(): MaterialAttributes {
     const p4Attrs = new P4MaterialAttributes(this.name(), this.autoUpdate(), this.port(), this.useTickets(), this.view(), this.username());
     p4Attrs.password(this.password());
+    if (this.filter() !== undefined) {
+      p4Attrs.filter(new Filter(this.filter()!.ignore()));
+    }
+    p4Attrs.invertFilter(this.invertFilter());
     return p4Attrs;
   }
 }
@@ -504,13 +540,21 @@ export class TfsMaterialAttributes extends ScmMaterialAttributes {
       attrs.destination(json.destination);
     }
     attrs.errors(new Errors(json.errors));
+    if (json.filter !== undefined) {
+      attrs.filter(Filter.fromJSON(json.filter));
+    }
+    attrs.invertFilter(json.invert_filter);
     return attrs;
   }
 
   clone(): MaterialAttributes {
-    const gitAttrs = new TfsMaterialAttributes(this.name(), this.autoUpdate(), this.url(), this.domain(), this.projectPath(), this.username());
-    gitAttrs.password(this.password());
-    return gitAttrs;
+    const tfsAttrs = new TfsMaterialAttributes(this.name(), this.autoUpdate(), this.url(), this.domain(), this.projectPath(), this.username());
+    tfsAttrs.password(this.password());
+    if (this.filter() !== undefined) {
+      tfsAttrs.filter(new Filter(this.filter()!.ignore()));
+    }
+    tfsAttrs.invertFilter(this.invertFilter());
+    return tfsAttrs;
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_activity/pipeline_activity_crud.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_activity/pipeline_activity_crud.ts
@@ -20,7 +20,7 @@ import {PipelineActivity, Stage} from "models/pipeline_activity/pipeline_activit
 import {ResultAwarePage} from "views/pages/page_operations";
 
 export class PipelineActivityService {
-  private static API_VERSION_HEADER = ApiVersion.v1;
+  private static API_VERSION_HEADER = ApiVersion.latest;
 
   activities(pipelineName: string, start: number, filter: string, page: ResultAwarePage<PipelineActivity>): void {
     let params: { [key: string]: string | number } = {pipelineName, start};

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/switch/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/switch/index.scss
@@ -29,6 +29,10 @@ $switch-small-paddle-size: 0.75rem;
 $switch-small-space-between: 0.1255rem;
 $switch-small-translate-x: 1rem;
 
+.switch-wrapper {
+  margin-bottom: 10px;
+}
+
 .switch-btn {
   display:     flex;
   outline:     0;
@@ -42,8 +46,8 @@ $switch-small-translate-x: 1rem;
   display:      flex;
   align-self:   center;
   margin-right: 5px;
-  font-weight: normal;
-  cursor: pointer;
+  font-weight:  normal;
+  cursor:       pointer;
 }
 
 .switch-paddle {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/switch/index.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/switch/index.scss.d.ts
@@ -7,3 +7,4 @@ export const switchInput: string;
 export const switchLabel: string;
 export const switchPaddle: string;
 export const switchSmall: string;
+export const switchWrapper: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/switch/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/switch/index.tsx
@@ -37,7 +37,7 @@ export class SwitchBtn extends MithrilViewComponent<Attrs> {
     const switchId = `switch-${uuid4()}`;
 
     const dataTestId = vnode.attrs.dataTestId? vnode.attrs.dataTestId: "switch-checkbox";
-    return <div>
+    return <div class={styles.switchWrapper}>
       <div class={classnames({[styles.switchSmall]: small}, styles.switchBtn)} data-test-id="switch-wrapper">
         {this.label(vnode.attrs, switchId)}
         <input id={switchId} type="checkbox"

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/spec/edit_pipeline_group_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/spec/edit_pipeline_group_modal_spec.tsx
@@ -20,7 +20,6 @@ import m from "mithril";
 import {PipelineGroup} from "models/admin_pipelines/admin_pipelines";
 import {PipelineGroupCRUD} from "models/admin_pipelines/pipeline_groups_crud";
 import {pipelineGroupJSON} from "models/admin_pipelines/specs/admin_pipelines_spec";
-import {Authorization} from "models/authorization/authorization";
 import {ModalManager} from "views/components/modal/modal_manager";
 import {TestHelper} from "views/pages/spec/test_helper";
 import {EditPipelineGroupModal} from "../edit_pipeline_group_modal";
@@ -322,7 +321,7 @@ describe('EditPipelineGroupModal', () => {
       resolve(ApiResult.success("", 200, new Map()).map<ObjectWithEtag<PipelineGroup>>(
         () => {
           return {
-            object: new PipelineGroup("grp", new Authorization()),
+            object: PipelineGroup.fromJSON(pipelineGroupJSON()),
             etag:   "some-etag"
           } as ObjectWithEtag<PipelineGroup>;
         }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/spec/edit_pipeline_group_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/spec/edit_pipeline_group_modal_spec.tsx
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
+import {ApiResult, ObjectWithEtag} from "helpers/api_request_builder";
 import _ from "lodash";
 import m from "mithril";
-import {ApiResult, ObjectWithEtag} from "../../../../helpers/api_request_builder";
-import {PipelineGroup} from "../../../../models/admin_pipelines/admin_pipelines";
-import {PipelineGroupCRUD} from "../../../../models/admin_pipelines/pipeline_groups_crud";
-import {pipelineGroupJSON} from "../../../../models/admin_pipelines/specs/admin_pipelines_spec";
-import {ModalManager} from "../../../components/modal/modal_manager";
-import {TestHelper} from "../../spec/test_helper";
+import {PipelineGroup} from "models/admin_pipelines/admin_pipelines";
+import {PipelineGroupCRUD} from "models/admin_pipelines/pipeline_groups_crud";
+import {pipelineGroupJSON} from "models/admin_pipelines/specs/admin_pipelines_spec";
+import {Authorization} from "models/authorization/authorization";
+import {ModalManager} from "views/components/modal/modal_manager";
+import {TestHelper} from "views/pages/spec/test_helper";
 import {EditPipelineGroupModal} from "../edit_pipeline_group_modal";
 
 describe('EditPipelineGroupModal', () => {
@@ -318,7 +319,14 @@ describe('EditPipelineGroupModal', () => {
   it("should update pipeline group on click of save button", () => {
     mount();
     spyOn(PipelineGroupCRUD, "update").and.returnValue(new Promise<ApiResult<ObjectWithEtag<PipelineGroup>>>((resolve) => {
-      resolve();
+      resolve(ApiResult.success("", 200, new Map()).map<ObjectWithEtag<PipelineGroup>>(
+        () => {
+          return {
+            object: new PipelineGroup("grp", new Authorization()),
+            etag:   "some-etag"
+          } as ObjectWithEtag<PipelineGroup>;
+        }
+      ));
     }));
 
     testHelper.click(testHelper.byTestId("save-pipeline-group"));

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/modals/material_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/modals/material_modal_spec.tsx
@@ -42,7 +42,7 @@ describe("MaterialModalSpec", () => {
   afterEach(() => ModalManager.closeAll());
 
   it('should render material editor', () => {
-    const modal = new MaterialModal( "Some modal title", Stream(material), Stream(materials), Stream(scms), Stream(pkgRepos), Stream(pluginInfos), jasmine.createSpy("pipelineConfigSave"), true, false);
+    const modal = new MaterialModal("Some modal title", Stream(material), "test", Stream(materials), Stream(scms), Stream(pkgRepos), Stream(pluginInfos), jasmine.createSpy("pipelineConfigSave"), true, false);
     modal.render();
     m.redraw.sync();
     const helper = new TestHelper().forModal();
@@ -55,12 +55,12 @@ describe("MaterialModalSpec", () => {
 
   it('should render material destination blank warning message', () => {
     materials.push(new Material("git", new GitMaterialAttributes()));
-    const modal = new MaterialModal( "Some modal title", Stream(material), Stream(materials), Stream(scms), Stream(pkgRepos), Stream(pluginInfos), jasmine.createSpy("pipelineConfigSave"), true, false);
+    const modal = new MaterialModal("Some modal title", Stream(material), "test", Stream(materials), Stream(scms), Stream(pkgRepos), Stream(pluginInfos), jasmine.createSpy("pipelineConfigSave"), true, false);
     modal.render();
     m.redraw.sync();
     const helper = new TestHelper().forModal();
 
     expect(helper.byTestId('materials-destination-warning-message')).toBeInDOM();
-    expect(helper.byTestId('materials-destination-warning-message').textContent).toBe("In order to configure multiple SCM materials for this pipeline, each of its material needs have to a 'Destination Directory' specified. Please edit the existing material and specify a 'Destination Directory' in order to proceed with this operation.");
+    expect(helper.byTestId('materials-destination-warning-message').textContent).toBe("In order to configure multiple SCM materials for this pipeline, each of its material needs have to a 'Alternate Checkout Path' specified. Please edit the existing material and specify a 'Alternate Checkout Path' in order to proceed with this operation.");
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/materials_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/materials_widget_spec.tsx
@@ -19,17 +19,8 @@ import Stream from "mithril/stream";
 import {Filter} from "models/maintenance_mode/material";
 import {Scm, Scms} from "models/materials/pluggable_scm";
 import {Material, PackageMaterialAttributes, PluggableScmMaterialAttributes} from "models/materials/types";
-import {
-  Package,
-  PackageRepositories,
-  PackageRepository,
-  Packages
-} from "models/package_repositories/package_repositories";
-import {
-  getPackage,
-  getPackageRepository,
-  pluginInfoWithPackageRepositoryExtension
-} from "models/package_repositories/spec/test_data";
+import {Package, PackageRepositories, PackageRepository, Packages} from "models/package_repositories/package_repositories";
+import {getPackage, getPackageRepository, pluginInfoWithPackageRepositoryExtension} from "models/package_repositories/spec/test_data";
 import {Materials, PipelineConfig} from "models/pipeline_configs/pipeline_config";
 import {PipelineConfigTestData} from "models/pipeline_configs/spec/test_data";
 import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
@@ -59,7 +50,7 @@ describe("MaterialsWidgetSpec", () => {
     helper.mount(() => <MaterialsWidget materials={materials} readonly={readonly}
                                         pluginInfos={Stream(pluginInfos)}
                                         packageRepositories={Stream(pkgRepos)}
-                                        packages={Stream(pkgs)} scmMaterials={Stream(scms)}
+                                        packages={Stream(pkgs)} scmMaterials={Stream(scms)} parentPipelineName={pipelineConfig.name()}
                                         pipelineConfigSave={jasmine.createSpy("pipelineConfigSave")}
                                         flashMessage={new FlashMessageModelWithTimeout()}/>);
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/materials_tab_content.tsx
@@ -64,6 +64,7 @@ export class MaterialsTabContent extends TabContent<PipelineConfig> {
   protected renderer(entity: PipelineConfig, templateConfig: TemplateConfig, flashMessage: FlashMessageModelWithTimeout, pipelineConfigSave: () => Promise<any>, pipelineConfigReset: () => any) {
     const mergedPkgRepos = PackageRepositoriesPage.getMergedList(this.packageRepositories, this.packages);
     return <MaterialsWidget materials={entity.materials}
+                            parentPipelineName={entity.name()}
                             readonly={this.isEntityDefinedInConfigRepository()}
                             pluginInfos={this.pluginInfos}
                             flashMessage={flashMessage}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
@@ -31,11 +31,7 @@ import {
   TfsMaterialAttributes
 } from "models/materials/types";
 import {PackageRepositories} from "models/package_repositories/package_repositories";
-import {
-  ExtensionTypeString,
-  PackageRepoExtensionType,
-  SCMExtensionType
-} from "models/shared/plugin_infos_new/extension_type";
+import {ExtensionTypeString, PackageRepoExtensionType, SCMExtensionType} from "models/shared/plugin_infos_new/extension_type";
 import {PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {Form, FormBody} from "views/components/forms/form";
@@ -58,6 +54,7 @@ interface Attrs {
   pluggableScms?: Scms;
   disableScmMaterials?: boolean;
   readonly?: boolean;
+  parentPipelineName?: string;
 }
 
 export class MaterialEditor extends MithrilViewComponent<Attrs> {
@@ -90,7 +87,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
       </SelectField>
 
       <Form last={true} compactForm={true}>
-        {this.fieldsForType(attrs.readonly!, attrs.material, this.cache, showLocalWorkingCopyOptions, hideTestConnection, attrs.disabled, attrs.packageRepositories, attrs.pluginInfos, attrs.pluggableScms)}
+        {this.fieldsForType(attrs.readonly!, attrs.material, this.cache, showLocalWorkingCopyOptions, hideTestConnection, attrs.disabled, attrs.packageRepositories, attrs.pluginInfos, attrs.pluggableScms, attrs.parentPipelineName)}
       </Form>
     </FormBody>;
   }
@@ -111,7 +108,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
     return options;
   }
 
-  fieldsForType(readonly: boolean, material: Material, cacheable: SuggestionCache, showLocalWorkingCopyOptions: boolean, hideTestConnection: boolean, disabled?: boolean, packageRepositories?: PackageRepositories, pluginInfos?: PluginInfos, scms?: Scms): m.Children {
+  fieldsForType(readonly: boolean, material: Material, cacheable: SuggestionCache, showLocalWorkingCopyOptions: boolean, hideTestConnection: boolean, disabled?: boolean, packageRepositories?: PackageRepositories, pluginInfos?: PluginInfos, scms?: Scms, parentPipelineName?: string): m.Children {
     switch (material.type()) {
       case "git":
         if (!(material.attributes() instanceof GitMaterialAttributes)) {
@@ -147,7 +144,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
         if (!(material.attributes() instanceof DependencyMaterialAttributes)) {
           material.attributes(new DependencyMaterialAttributes());
         }
-        return <DependencyFields material={material} cache={cacheable} readonly={readonly}
+        return <DependencyFields material={material} cache={cacheable} readonly={readonly} parentPipelineName={parentPipelineName}
                                  showLocalWorkingCopyOptions={showLocalWorkingCopyOptions}/>;
       case "package":
         if (!(material.attributes() instanceof PackageMaterialAttributes)) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/messages.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/messages.ts
@@ -16,3 +16,4 @@
 
 export const IDENTIFIER_FORMAT_HELP_MESSAGE = "No spaces. Only letters, numbers, hyphens, underscores, and periods. Max 255 chars.";
 export const DESTINATION_DIR_HELP_MESSAGE = "Specify a different path to clone/checkout this repository. Must be a relative path within the pipeline’s working directory. Defaults to the root of the pipeline's working directory.";
+export const BLACKLIST_HELP_MESSAGE = "Enter the paths to be excluded. Separate multiple entries with a comma.";

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
@@ -15,7 +15,14 @@
  */
 
 import m from "mithril";
-import {GitMaterialAttributes, HgMaterialAttributes, Material, P4MaterialAttributes, SvnMaterialAttributes, TfsMaterialAttributes,} from "models/materials/types";
+import {
+  GitMaterialAttributes,
+  HgMaterialAttributes,
+  Material,
+  P4MaterialAttributes,
+  SvnMaterialAttributes,
+  TfsMaterialAttributes,
+} from "models/materials/types";
 import {TestHelper} from "views/pages/spec/test_helper";
 import {GitFields, HgFields, P4Fields, SvnFields, TfsFields} from "../scm_material_fields";
 
@@ -35,6 +42,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "password":                "Password",
       "alternate-checkout-path": "Alternate Checkout Path",
       "material-name":           "Material Name",
+      "blacklist":               "Blacklist",
     });
     assertAutoUpdateSwitchPresent();
 
@@ -52,6 +60,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "password":                "Password",
       "alternate-checkout-path": "Alternate Checkout Path",
       "material-name":           "Material Name",
+      "blacklist":               "Blacklist"
     });
     assertAutoUpdateSwitchPresent();
 
@@ -69,6 +78,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "password":                "Password",
       "alternate-checkout-path": "Alternate Checkout Path",
       "material-name":           "Material Name",
+      "blacklist":               "Blacklist"
     });
     assertAutoUpdateSwitchPresent();
 
@@ -87,6 +97,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "password":                  "Password",
       "alternate-checkout-path":   "Alternate Checkout Path",
       "material-name":             "Material Name",
+      "blacklist":                 "Blacklist"
     });
     assertAutoUpdateSwitchPresent();
 
@@ -105,6 +116,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "password":                "Password*",
       "alternate-checkout-path": "Alternate Checkout Path",
       "material-name":           "Material Name",
+      "blacklist":               "Blacklist"
     });
     assertAutoUpdateSwitchPresent();
 
@@ -122,6 +134,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "password":                "Password",
       "alternate-checkout-path": "Alternate Checkout Path",
       "material-name":           "Material Name",
+      "blacklist":               "Blacklist"
     });
     assertAutoUpdateSwitchPresent();
 
@@ -149,6 +162,7 @@ describe("AddPipeline: SCM Material Fields", () => {
     assertLabelledInputsAbsent(
       "alternate-checkout-path",
       "material-name",
+      "blacklist"
     );
     assertAutoUpdateSwitchAbsent();
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/spec/pipeline_activity_page_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/spec/pipeline_activity_page_spec.tsx
@@ -96,7 +96,7 @@ describe("PipelineActivityPage", () => {
       expect(request.url).toEqual(SparkRoutes.pipelineTriggerPath(activity.pipelineName()));
       expect(request.method).toEqual("POST");
       expect(request.data()).toEqual({});
-      expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+      expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
     });
   });
 
@@ -126,7 +126,7 @@ describe("PipelineActivityPage", () => {
         .toEqual(SparkRoutes.runStage(activity.pipelineName(), manualStage.pipelineCounter(), manualStage.stageName()));
       expect(request.method).toEqual("POST");
       expect(request.data()).toEqual({});
-      expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+      expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
     });
   });
 


### PR DESCRIPTION
Issue: #7816

Description:
 - showcasing name when material is deleted when a name is not explicitly added
 - making sure that if changes is cancelled it does not affect the main tab content
 - updated message to contain `Alternate Checkout Path` instead of `Destination Directory`
 - showcase circular dependencies error messages
 - not showcasing the current pipeline in the list of pipelines on dependency material popup
 - showcasing message when a material is deleted which is used in a fetch artifact task
 - adding support for `blacklist` for scm materials
