### PR TITLE
Stop building alpine 3.8 based images as it has reached EOL

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -23,11 +23,9 @@ enum Distro implements DistroBehavior {
   alpine{
     @Override
     List<DistroVersion> getSupportedVersions() {
-      def installSasl_Pre_3_9 = ['apk add --no-cache cyrus-sasl']
       def installSasl_Post_3_9 = ['apk add --no-cache cyrus-sasl cyrus-sasl-plain']
 
       return [
-        new DistroVersion(version: '3.8', releaseName: '3.8', eolDate: parseDate('2020-05-01'), installPrerequisitesCommands: installSasl_Pre_3_9, continueToBuild: true),
         new DistroVersion(version: '3.9', releaseName: '3.9', eolDate: parseDate('2020-11-01'), installPrerequisitesCommands: installSasl_Post_3_9),
         new DistroVersion(version: '3.10', releaseName: '3.10', eolDate: parseDate('2021-05-01'), installPrerequisitesCommands: installSasl_Post_3_9),
         new DistroVersion(version: '3.11', releaseName: '3.11', eolDate: parseDate('2021-11-01'), installPrerequisitesCommands: installSasl_Post_3_9)


### PR DESCRIPTION
Issue: Agent docker image build failure

Description:
Alpine 3.8 has reached end of support (https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases). Hence, no longer building the same
