### PR TITLE
Additional fixes on materials

### DIFF
--- a/api/api-compare-v2/src/test/groovy/com/thoughtworks/go/apiv2/compare/representers/material/GitMaterialRepresenterTest.groovy
+++ b/api/api-compare-v2/src/test/groovy/com/thoughtworks/go/apiv2/compare/representers/material/GitMaterialRepresenterTest.groovy
@@ -134,7 +134,7 @@ class GitMaterialRepresenterTest implements MaterialRepresenterTrait {
       ],
       errors    : [
         name       : ["You have defined multiple materials called '!nV@l!d'. Material names are case-insensitive and must be unique. Note that for dependency materials the default materialName is the name of the upstream pipeline. You can override this by setting the materialName explicitly for the upstream pipeline.", "Invalid material name '!nV@l!d'. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."],
-        destination: ["Destination directory is required when specifying multiple scm materials"],
+        destination: ["Destination directory is required when a pipeline has multiple SCM materials."],
         url        : ["URL cannot be blank"]
       ]
     ]

--- a/api/api-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/materials/representers/materials/GitMaterialRepresenterTest.groovy
+++ b/api/api-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/materials/representers/materials/GitMaterialRepresenterTest.groovy
@@ -106,7 +106,7 @@ class GitMaterialRepresenterTest implements MaterialRepresenterTrait<GitMaterial
       ],
       errors     : [
         name       : ["You have defined multiple materials called '!nV@l!d'. Material names are case-insensitive and must be unique. Note that for dependency materials the default materialName is the name of the upstream pipeline. You can override this by setting the materialName explicitly for the upstream pipeline.", "Invalid material name '!nV@l!d'. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."],
-        destination: ["Destination directory is required when specifying multiple scm materials"],
+        destination: ["Destination directory is required when a pipeline has multiple SCM materials."],
         url        : ["URL cannot be blank"]
       ]
     ]

--- a/api/api-materials-v2/src/test/groovy/com/thoughtworks/go/apiv2/materials/representers/materials/GitMaterialRepresenterTest.groovy
+++ b/api/api-materials-v2/src/test/groovy/com/thoughtworks/go/apiv2/materials/representers/materials/GitMaterialRepresenterTest.groovy
@@ -106,7 +106,7 @@ class GitMaterialRepresenterTest implements MaterialRepresenterTrait<GitMaterial
       ],
       errors     : [
         name       : ["You have defined multiple materials called '!nV@l!d'. Material names are case-insensitive and must be unique. Note that for dependency materials the default materialName is the name of the upstream pipeline. You can override this by setting the materialName explicitly for the upstream pipeline.", "Invalid material name '!nV@l!d'. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."],
-        destination: ["Destination directory is required when specifying multiple scm materials"],
+        destination: ["Destination directory is required when a pipeline has multiple SCM materials."],
         url        : ["URL cannot be blank"]
       ]
     ]

--- a/api/api-shared-v1/src/test/groovy/com/thoughtworks/go/apiv1/shared/representers/materials/GitMaterialRepresenterTest.groovy
+++ b/api/api-shared-v1/src/test/groovy/com/thoughtworks/go/apiv1/shared/representers/materials/GitMaterialRepresenterTest.groovy
@@ -197,7 +197,7 @@ class GitMaterialRepresenterTest implements MaterialRepresenterTrait {
       ],
       errors    : [
         name       : ["You have defined multiple materials called '!nV@l!d'. Material names are case-insensitive and must be unique. Note that for dependency materials the default materialName is the name of the upstream pipeline. You can override this by setting the materialName explicitly for the upstream pipeline.", "Invalid material name '!nV@l!d'. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."],
-        destination: ["Destination directory is required when specifying multiple scm materials"],
+        destination: ["Destination directory is required when a pipeline has multiple SCM materials."],
         url        : ["URL cannot be blank"]
       ]
     ]

--- a/api/api-shared-v10/src/test/groovy/com/thoughtworks/go/apiv10/shared/representers/PipelineConfigRepresenterTest.groovy
+++ b/api/api-shared-v10/src/test/groovy/com/thoughtworks/go/apiv10/shared/representers/PipelineConfigRepresenterTest.groovy
@@ -576,7 +576,7 @@ class PipelineConfigRepresenterTest {
         ],
         [
           type  : 'git', attributes: [url: null, destination: null, filter: null, invert_filter: false, name: null, auto_update: true, branch: 'master', submodule_folder: null, shallow_clone: false],
-          errors: [destination: ['Destination directory is required when specifying multiple scm materials'], url: ['URL cannot be blank']]
+          errors: [destination: ['Destination directory is required when a pipeline has multiple SCM materials.'], url: ['URL cannot be blank']]
         ]
       ],
       stages: [[name: 'stage1', fetch_materials: true, clean_working_directory: false, never_cleanup_artifacts: false, approval: [type: 'success', allow_only_on_success: false, authorization: [roles: [], users: []]], environment_variables: [], jobs: []]],

--- a/api/api-shared-v10/src/test/groovy/com/thoughtworks/go/apiv10/shared/representers/materials/GitMaterialRepresenterTest.groovy
+++ b/api/api-shared-v10/src/test/groovy/com/thoughtworks/go/apiv10/shared/representers/materials/GitMaterialRepresenterTest.groovy
@@ -281,7 +281,7 @@ class GitMaterialRepresenterTest implements MaterialRepresenterTrait {
       ],
       errors    : [
         name       : ["You have defined multiple materials called '!nV@l!d'. Material names are case-insensitive and must be unique. Note that for dependency materials the default materialName is the name of the upstream pipeline. You can override this by setting the materialName explicitly for the upstream pipeline.", "Invalid material name '!nV@l!d'. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."],
-        destination: ["Destination directory is required when specifying multiple scm materials"],
+        destination: ["Destination directory is required when a pipeline has multiple SCM materials."],
         url        : ["URL cannot be blank"]
       ]
     ]

--- a/api/api-shared-v9/src/test/groovy/com/thoughtworks/go/apiv9/shared/representers/PipelineConfigRepresenterTest.groovy
+++ b/api/api-shared-v9/src/test/groovy/com/thoughtworks/go/apiv9/shared/representers/PipelineConfigRepresenterTest.groovy
@@ -573,7 +573,7 @@ class PipelineConfigRepresenterTest {
         ],
         [
           type  : 'git', attributes: [url: null, destination: null, filter: null, invert_filter: false, name: null, auto_update: true, branch: 'master', submodule_folder: null, shallow_clone: false],
-          errors: [destination: ['Destination directory is required when specifying multiple scm materials'], url: ['URL cannot be blank']]
+          errors: [destination: ['Destination directory is required when a pipeline has multiple SCM materials.'], url: ['URL cannot be blank']]
         ]
       ],
       stages               : [[name: 'stage1', fetch_materials: true, clean_working_directory: false, never_cleanup_artifacts: false, approval: [type: 'success', allow_only_on_success: false, authorization: [roles: [], users: []]], environment_variables: [], jobs: []]],

--- a/api/api-shared-v9/src/test/groovy/com/thoughtworks/go/apiv9/shared/representers/materials/GitMaterialRepresenterTest.groovy
+++ b/api/api-shared-v9/src/test/groovy/com/thoughtworks/go/apiv9/shared/representers/materials/GitMaterialRepresenterTest.groovy
@@ -281,7 +281,7 @@ class GitMaterialRepresenterTest implements MaterialRepresenterTrait {
       ],
       errors    : [
         name       : ["You have defined multiple materials called '!nV@l!d'. Material names are case-insensitive and must be unique. Note that for dependency materials the default materialName is the name of the upstream pipeline. You can override this by setting the materialName explicitly for the upstream pipeline.", "Invalid material name '!nV@l!d'. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."],
-        destination: ["Destination directory is required when specifying multiple scm materials"],
+        destination: ["Destination directory is required when a pipeline has multiple SCM materials."],
         url        : ["URL cannot be blank"]
       ]
     ]

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/MaterialConfigs.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/MaterialConfigs.java
@@ -167,7 +167,7 @@ public class MaterialConfigs extends BaseCollection<MaterialConfig> implements V
             for (MaterialConfig material : allSCMMaterials) {
                 if (StringUtils.isBlank(material.getFolder())) {
                     String fieldName = material instanceof ScmMaterialConfig ? ScmMaterialConfig.FOLDER : PluggableSCMMaterialConfig.FOLDER;
-                    material.addError(fieldName, "Destination directory is required when specifying multiple scm materials");
+                    material.addError(fieldName, "Destination directory is required when a pipeline has multiple SCM materials.");
                 } else {
                     validateDestinationFolder(allSCMMaterials, material);
                 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/CruiseConfigTestBase.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/CruiseConfigTestBase.java
@@ -355,7 +355,7 @@ public abstract class CruiseConfigTestBase {
         assertThat(allErrors.get(0).on("searchBase"), is("invalid search base"));
         assertThat(allErrors.get(1).on("base"), is("Some base errors"));
         assertThat(allErrors.get(2).on("role"), is("Roles must be proper"));
-        assertThat(allErrors.get(3).on(ScmMaterialConfig.FOLDER), is("Destination directory is required when specifying multiple scm materials"));
+        assertThat(allErrors.get(3).on(ScmMaterialConfig.FOLDER), is("Destination directory is required when a pipeline has multiple SCM materials."));
         assertThat(allErrors.get(4).on("materialName"), is("material name does not follow pattern"));
     }
 

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
@@ -1051,7 +1051,7 @@ public class MagicalGoConfigXmlLoaderTest {
                         + "    <svn url=\"/hgrepo1\" />\n"
                         + "    <svn url=\"/hgrepo2\" dest=\"folder1\" />\n"
                         + "  </materials>\n";
-        String message = "Destination directory is required when specifying multiple scm materials";
+        String message = "Destination directory is required when a pipeline has multiple SCM materials.";
         MagicalGoConfigXmlLoaderFixture.assertNotValid(message, materials);
     }
 

--- a/server/src/main/webapp/WEB-INF/rails/spec/presenters/api_v1/admin/pipelines/materials/material_representer_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/presenters/api_v1/admin/pipelines/materials/material_representer_spec.rb
@@ -226,7 +226,7 @@ describe ApiV1::Admin::Pipelines::Materials::MaterialRepresenter do
         },
         errors: {
           name: ["You have defined multiple materials called '!nV@l!d'. Material names are case-insensitive and must be unique. Note that for dependency materials the default materialName is the name of the upstream pipeline. You can override this by setting the materialName explicitly for the upstream pipeline.", "Invalid material name '!nV@l!d'. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."],
-          destination: ["Destination directory is required when specifying multiple scm materials"],
+          destination: ["Destination directory is required when a pipeline has multiple SCM materials."],
           url: ["URL cannot be blank"]
         }
       }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/serialization.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/serialization.ts
@@ -44,6 +44,7 @@ export interface ScmAttributesJSON extends BaseAttributesJSON, UsernamePasswordJ
 export interface GitMaterialAttributesJSON extends ScmAttributesJSON {
   url: string;
   branch: string;
+  shallow_clone: boolean;
 }
 
 export interface SvnMaterialAttributesJSON extends ScmAttributesJSON {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/types_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/types_spec.ts
@@ -28,7 +28,7 @@ import {
   SvnMaterialAttributes,
   TfsMaterialAttributes
 } from "models/materials/types";
-import {Configurations} from "../../shared/configuration";
+import {Configurations} from "models/shared/configuration";
 import {PluginMetadata, Scm} from "../pluggable_scm";
 import {DependencyMaterialAttributesJSON} from "../serialization";
 
@@ -55,6 +55,27 @@ describe("Material Types", () => {
       expect(materialAttrs.pipeline()).toBe(json.pipeline);
       expect(materialAttrs.stage()).toBe(json.stage);
       expect(materialAttrs.ignoreForScheduling()).toBeFalse();
+    });
+
+    it("should deserialize git material with shallow clone", () => {
+      const gitJson               = {
+        url:           "foo/bar",
+        destination:   "bar",
+        invert_filter: false,
+        name:          "Dummy git",
+        auto_update:   true,
+        branch:        "master",
+        shallow_clone: false
+      };
+      const gitMaterialAttributes = GitMaterialAttributes.fromJSON(gitJson);
+
+      expect(gitMaterialAttributes.url()).toBe(gitJson.url);
+      expect(gitMaterialAttributes.destination()).toBe(gitJson.destination);
+      expect(gitMaterialAttributes.invertFilter()).toBe(gitJson.invert_filter);
+      expect(gitMaterialAttributes.name()).toBe(gitJson.name);
+      expect(gitMaterialAttributes.autoUpdate()).toBe(gitJson.auto_update);
+      expect(gitMaterialAttributes.branch()).toBe(gitJson.branch);
+      expect(gitMaterialAttributes.shallowClone()).toBe(gitJson.shallow_clone);
     });
   });
 
@@ -178,6 +199,7 @@ describe("Material Types", () => {
                                                               true,
                                                               "http://user:pass@host",
                                                               "master",
+                                                              false,
                                                               "user",
                                                               "pass"));
       expect(material.isValid()).toBe(false);
@@ -261,7 +283,7 @@ describe("Material Types", () => {
   });
 
   it('should reset password if it is present and has been updated', () => {
-    const material = new Material("git", new GitMaterialAttributes("name", true, "some-url", "master", "username", "password"));
+    const material = new Material("git", new GitMaterialAttributes("name", true, "some-url", "master", false, "username", "password"));
     const attrs    = (material.attributes() as GitMaterialAttributes);
     attrs.password().edit();
 
@@ -282,7 +304,7 @@ describe("Material Types", () => {
     });
 
     it('should clone the attrs as well', () => {
-      const gitAttrs = new GitMaterialAttributes("name", true, "some-url", "master", "username", "password");
+      const gitAttrs = new GitMaterialAttributes("name", true, "some-url", "master", false, "username", "password");
       gitAttrs.destination("some-destination");
       const material = new Material("git", gitAttrs);
       const clone    = material.clone();
@@ -295,6 +317,7 @@ describe("Material Types", () => {
       expect((clone.attributes()! as GitMaterialAttributes).username()).toEqual((material.attributes()! as GitMaterialAttributes).username());
       expect((clone.attributes()! as GitMaterialAttributes).password().valueForDisplay()).toEqual((material.attributes()! as GitMaterialAttributes).password().valueForDisplay());
       expect((clone.attributes()! as GitMaterialAttributes).destination()).toEqual((material.attributes()! as GitMaterialAttributes).destination());
+      expect((clone.attributes()! as GitMaterialAttributes).shallowClone()).toEqual((material.attributes()! as GitMaterialAttributes).shallowClone());
     });
   });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
@@ -340,6 +340,7 @@ export class GitMaterialAttributes extends ScmMaterialAttributes {
   clone(): MaterialAttributes {
     const gitAttrs = new GitMaterialAttributes(this.name(), this.autoUpdate(), this.url(), this.branch(), this.username());
     gitAttrs.password(this.password());
+    gitAttrs.destination(this.destination());
     if (this.filter() !== undefined) {
       gitAttrs.filter(new Filter(this.filter()!.ignore()));
     }
@@ -390,6 +391,7 @@ export class SvnMaterialAttributes extends ScmMaterialAttributes {
   clone(): MaterialAttributes {
     const svnAttrs = new SvnMaterialAttributes(this.name(), this.autoUpdate(), this.url(), this.checkExternals(), this.username());
     svnAttrs.password(this.password());
+    svnAttrs.destination(this.destination());
     if (this.filter() !== undefined) {
       svnAttrs.filter(new Filter(this.filter()!.ignore()));
     }
@@ -439,6 +441,7 @@ export class HgMaterialAttributes extends ScmMaterialAttributes {
   clone(): MaterialAttributes {
     const hgAttrs = new HgMaterialAttributes(this.name(), this.autoUpdate(), this.url(), this.username());
     hgAttrs.password(this.password());
+    hgAttrs.destination(this.destination());
     hgAttrs.branch(this.branch());
     if (this.filter() !== undefined) {
       hgAttrs.filter(new Filter(this.filter()!.ignore()));
@@ -496,6 +499,7 @@ export class P4MaterialAttributes extends ScmMaterialAttributes {
   clone(): MaterialAttributes {
     const p4Attrs = new P4MaterialAttributes(this.name(), this.autoUpdate(), this.port(), this.useTickets(), this.view(), this.username());
     p4Attrs.password(this.password());
+    p4Attrs.destination(this.destination());
     if (this.filter() !== undefined) {
       p4Attrs.filter(new Filter(this.filter()!.ignore()));
     }
@@ -516,7 +520,8 @@ export class TfsMaterialAttributes extends ScmMaterialAttributes {
               projectPath?: string,
               username?: string,
               password?: string,
-              encryptedPassword?: string) {
+              encryptedPassword?: string,
+              shouldValidatePresenceOfPassword: boolean = true) {
     super(name, autoUpdate, username, password, encryptedPassword);
     this.url         = Stream(url);
     this.domain      = Stream(domain);
@@ -525,7 +530,7 @@ export class TfsMaterialAttributes extends ScmMaterialAttributes {
     this.validatePresenceOf("url");
     this.validatePresenceOf("projectPath");
     this.validatePresenceOf("username");
-    this.validatePresenceOfPassword("password");
+    this.validatePresenceOfPassword("password", {condition: Stream(shouldValidatePresenceOfPassword)});
   }
 
   static fromJSON(json: TfsMaterialAttributesJSON) {
@@ -553,6 +558,7 @@ export class TfsMaterialAttributes extends ScmMaterialAttributes {
   clone(): MaterialAttributes {
     const tfsAttrs = new TfsMaterialAttributes(this.name(), this.autoUpdate(), this.url(), this.domain(), this.projectPath(), this.username());
     tfsAttrs.password(this.password());
+    tfsAttrs.destination(this.destination());
     if (this.filter() !== undefined) {
       tfsAttrs.filter(new Filter(this.filter()!.ignore()));
     }
@@ -599,6 +605,8 @@ export class PackageMaterialAttributes extends MaterialAttributes {
   constructor(name?: string, autoUpdate?: boolean, ref?: string) {
     super(name, autoUpdate);
     this.ref = Stream(ref);
+
+    this.validatePresenceOf("ref", {message: "A package reference must be present"});
   }
 
   static fromJSON(data: PackageMaterialAttributesJSON): PackageMaterialAttributes {
@@ -622,6 +630,8 @@ export class PluggableScmMaterialAttributes extends MaterialAttributes {
     this.ref         = Stream(ref);
     this.filter      = Stream(filter);
     this.destination = Stream(destination);
+
+    this.validatePresenceOf("ref", {message: "An SCM reference must be present"});
   }
 
   static fromJSON(data: PluggableScmMaterialAttributesJSON): PluggableScmMaterialAttributes {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
@@ -303,14 +303,16 @@ class AuthNotSetInUrlAndUserPassFieldsValidator extends Validator {
 export class GitMaterialAttributes extends ScmMaterialAttributes {
   url: Stream<string | undefined>;
   branch: Stream<string | undefined>;
+  shallowClone: Stream<boolean | undefined>;
 
-  constructor(name?: string, autoUpdate?: boolean, url?: string, branch?: string,
+  constructor(name?: string, autoUpdate?: boolean, url?: string, branch?: string, shallowClone?: boolean,
               username?: string,
               password?: string,
               encryptedPassword?: string) {
     super(name, autoUpdate, username, password, encryptedPassword);
-    this.url    = Stream(url);
-    this.branch = Stream(branch);
+    this.url          = Stream(url);
+    this.branch       = Stream(branch);
+    this.shallowClone = Stream(shallowClone);
 
     this.validatePresenceOf("url");
     this.validateWith(new AuthNotSetInUrlAndUserPassFieldsValidator(), "url");
@@ -322,6 +324,7 @@ export class GitMaterialAttributes extends ScmMaterialAttributes {
       json.auto_update,
       json.url,
       json.branch,
+      json.shallow_clone,
       json.username,
       json.password,
       json.encrypted_password,
@@ -338,7 +341,7 @@ export class GitMaterialAttributes extends ScmMaterialAttributes {
   }
 
   clone(): MaterialAttributes {
-    const gitAttrs = new GitMaterialAttributes(this.name(), this.autoUpdate(), this.url(), this.branch(), this.username());
+    const gitAttrs = new GitMaterialAttributes(this.name(), this.autoUpdate(), this.url(), this.branch(), this.shallowClone(), this.username());
     gitAttrs.password(this.password());
     gitAttrs.destination(this.destination());
     if (this.filter() !== undefined) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.tsx
@@ -113,10 +113,18 @@ export class MaterialModal extends Modal {
           .catch((errorResponse: ErrorResponse) => {
             const parse            = JSON.parse(errorResponse.body!);
             const unconsumedErrors = this.entity().consumeErrorsResponse(parse.data);
-            this.errorMessage(<span>{parse.message}<br/> {unconsumedErrors.allErrorsForDisplay()}</span>);
+            this.errorMessage(<span>
+              {parse.message}<br/>
+              <ul>
+              {unconsumedErrors.allErrorsForDisplay().map((msg) => {
+                return <li>{msg}</li>;
+              })}
+              </ul>
+            </span>);
 
-            if (this.isNew) {
-              this.materials().delete(this.entity());
+            this.materials().delete(this.entity());
+            if (!this.isNew) {
+              this.materials().push(this.originalEntity());
             }
           });
     }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
@@ -153,7 +153,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
           return warningMsg;
         }
         if (!(material.attributes() instanceof TfsMaterialAttributes)) {
-          material.attributes(new TfsMaterialAttributes(undefined, true));
+          material.attributes(new TfsMaterialAttributes(undefined, true, undefined, undefined, undefined, undefined, undefined, undefined, false));
         }
         return <TfsFields material={material} hideTestConnection={hideTestConnection} readonly={readonly} parentPipelineName={parentPipelineName}
                           showLocalWorkingCopyOptions={showLocalWorkingCopyOptions} disabled={disabled}/>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -151,7 +151,8 @@ export class DependencyFields extends MithrilComponent<Attrs, State> {
     if (showLocalWorkingCopyOptions) {
       return <AdvancedSettings forceOpen={mat.errors().hasErrors("name")}>
         <TextField label="Material Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} readonly={attrs.readonly}
-                   placeholder="A human-friendly label for this material" property={mat.name}/>
+                   placeholder="A human-friendly label for this material" property={mat.name}
+                   errorText={this.errs(mat, "name")}/>
 
         <SwitchBtn label="Do not schedule the pipeline when this material is updated"
                    helpText="When set to true, the pipeline will not be automatically scheduled for changes to this material."

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
@@ -229,7 +229,7 @@ export class TfsFields extends ScmFields {
       <TextField label="Repository URL" property={mat.url} errorText={this.errs(attrs, "url")} required={true}/>,
       <TextField label="Project Path" property={mat.projectPath} errorText={this.errs(attrs, "projectPath")} required={true}/>,
       <TextField label="Username" property={mat.username} errorText={this.errs(attrs, "username")} required={true}/>,
-      <PasswordField label="Password" property={mat.password} errorText={this.errs(attrs, "password")} required={true}/>,
+      <PasswordField label="Password" property={mat.password} errorText={this.errs(attrs, "password")}/>,
     ];
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
@@ -113,7 +113,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "project-path":            "Project Path*",
       "domain":                  "Domain",
       "username":                "Username*",
-      "password":                "Password*",
+      "password":                "Password",
       "alternate-checkout-path": "Alternate Checkout Path",
       "material-name":           "Material Name",
       "blacklist":               "Blacklist"

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
@@ -44,6 +44,10 @@ describe("AddPipeline: SCM Material Fields", () => {
       "material-name":           "Material Name",
       "blacklist":               "Blacklist",
     });
+    assertCheckBoxPresent([
+      {dataTestId: 'invert-filter', label: 'Invert the file filter, e.g. a Blacklist becomes a Whitelist instead.'},
+      {dataTestId: 'shallow-clone-git-material', label: 'Shallow clone (recommended for large repositories)'}
+    ]);
     assertAutoUpdateSwitchPresent();
 
     expect(helper.byTestId("test-connection-button")).toBeInDOM();
@@ -164,7 +168,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "material-name",
       "blacklist"
     );
-    assertAutoUpdateSwitchAbsent();
+    assertSwitchOrCheckboxAbsent('auto-update-material', 'invert-filter', 'shallow-clone-git-material');
 
     expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
@@ -197,7 +201,18 @@ describe("AddPipeline: SCM Material Fields", () => {
     expect(helpTextElement.textContent).toEqual("By default GoCD polls the repository for changes automatically. If set to false, then GoCD will not poll the repository for changes");
   }
 
-  function assertAutoUpdateSwitchAbsent() {
-    expect(helper.byTestId('auto-update-material')).not.toBeInDOM();
+  function assertSwitchOrCheckboxAbsent(...keys: string[]) {
+    expect(keys.length > 0).toBe(true);
+
+    for (const id of keys) {
+      expect(helper.byTestId(id)).not.toBeInDOM();
+    }
+  }
+
+  function assertCheckBoxPresent(values: Array<{ dataTestId: string, label: string }>) {
+    values.forEach((row) => {
+      expect(helper.byTestId(row.dataTestId)).toBeInDOM();
+      expect(helper.q(`input[data-test-id="${row.dataTestId}"] + label`).textContent).toBe(row.label);
+    });
   }
 });

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
@@ -597,7 +597,7 @@ public class PipelineConfigServiceIntegrationTest {
         pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, md5, result);
 
         assertThat(result.toString(), result.isSuccessful(), is(false));
-        assertThat(scmMaterialConfig.errors().on(PluggableSCMMaterialConfig.FOLDER), is("Destination directory is required when specifying multiple scm materials"));
+        assertThat(scmMaterialConfig.errors().on(PluggableSCMMaterialConfig.FOLDER), is("Destination directory is required when a pipeline has multiple SCM materials."));
         assertThat(scmMaterialConfig.errors().on(PluggableSCMMaterialConfig.SCM_ID), is("Could not find plugin for scm-id: [scmid]."));
         assertThat(configRepository.getCurrentRevCommit().name(), is(headCommitBeforeUpdate));
         assertThat(goConfigDao.loadConfigHolder().configForEdit, is(goConfigHolder.configForEdit));


### PR DESCRIPTION
Issue: #7816  

Description:
 - updated the mandatory destination dir msg to 'Destination directory is required when a pipeline has multiple SCM materials.'
 - fixed the JS errors on browser when an update of a material throws 422 and then cancel is clicked.
 - made the validation of password on TFS attributes based on a variable
 - mapped the name on error in dependency material
 - added destination to clone method on material attributes
 - Added support for `shallow_clone` for git material as a part of advanced options
