### PR TITLE
Fix jobs resources autocomplete

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/job/job_settings_tab_content_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/job/job_settings_tab_content_spec.tsx
@@ -23,7 +23,7 @@ import {JobTestData, PipelineConfigTestData} from "models/pipeline_configs/spec/
 import {Stage} from "models/pipeline_configs/stage";
 import {TemplateConfig} from "models/pipeline_configs/template_config";
 import {
-  ElasticAgenrSuggestionsProvider,
+  ElasticAgentSuggestionsProvider,
   JobSettingsTabContentWidget,
   ResourcesSuggestionsProvider
 } from "views/pages/clicky_pipeline_config/tabs/job/job_settings_tab_content";
@@ -306,7 +306,7 @@ describe("Job Settings Tab Content", () => {
                                             resources={Stream()}
                                             resourcesSuggestions={new ResourcesSuggestionsProvider(Stream(),
                                                                                                    Stream([] as string[]))}
-                                            elasticAgentsSuggestions={new ElasticAgenrSuggestionsProvider(Stream([] as string[]))}
+                                            elasticAgentsSuggestions={new ElasticAgentSuggestionsProvider(Stream([] as string[]))}
                                             templateConfig={templateConfig}
                                             defaultJobTimeout={Stream(5)}/>;
       });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/job/job_settings_tab_content_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/job/job_settings_tab_content_spec.tsx
@@ -334,15 +334,15 @@ describe("Job Settings Tab Content", () => {
     it("should replace the select suggestion", () => {
       expect(property()).toEqual("");
       provider.replace({value: "firefox"});
-      expect(property()).toEqual("firefox");
+      expect(property()).toEqual("firefox,");
     });
 
     it("should append the select suggestion with newly selected one", () => {
       expect(property()).toEqual("");
       provider.replace({value: "firefox"});
-      expect(property()).toEqual("firefox");
+      expect(property()).toEqual("firefox,");
       provider.replace({value: "ie11"});
-      expect(property()).toEqual("firefox,ie11");
+      expect(property()).toEqual("firefox,ie11,");
     });
 
     it("should show the suggestion when it is not specified on the property", () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/job_settings_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/job_settings_tab_content.tsx
@@ -228,12 +228,13 @@ export class ResourcesSuggestionsProvider extends SuggestionProvider {
   }
 
   replace(suggestion: any) {
-    let optionalComma = "";
+    let updatedValues: string[] = [];
     if (this.property().trim().length > 0) {
-      optionalComma = this.property().trim()[this.property().trim().length - 1] === "," ? "" : ",";
+      updatedValues = this.property().split(',');
+      updatedValues.pop();
     }
-
-    this.property(this.property() + optionalComma + suggestion.value);
+    updatedValues.push(suggestion.value);
+    this.property(updatedValues.join() + ",");
     m.redraw.sync();
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/job_settings_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/job_settings_tab_content.tsx
@@ -37,7 +37,7 @@ export interface Attrs {
   defaultJobTimeout: Stream<number>;
   templateConfig: TemplateConfig;
   resourcesSuggestions: ResourcesSuggestionsProvider;
-  elasticAgentsSuggestions: ElasticAgenrSuggestionsProvider;
+  elasticAgentsSuggestions: ElasticAgentSuggestionsProvider;
 }
 
 export class JobSettingsTabContentWidget extends MithrilViewComponent<Attrs> {
@@ -172,7 +172,7 @@ export class JobSettingsTabContent extends TabContent<Job> {
 
   protected renderer(entity: Job, templateConfig: TemplateConfig): m.Children {
     const resourcesSuggestionsProvider     = new ResourcesSuggestionsProvider(entity.resources, this.resources);
-    const elasticAgentsSuggestionsProvider = new ElasticAgenrSuggestionsProvider(this.elasticAgentIds);
+    const elasticAgentsSuggestionsProvider = new ElasticAgentSuggestionsProvider(this.elasticAgentIds);
 
     return <JobSettingsTabContentWidget entity={entity}
                                         readonly={this.isEntityDefinedInConfigRepository()}
@@ -244,7 +244,7 @@ export class ResourcesSuggestionsProvider extends SuggestionProvider {
   }
 }
 
-export class ElasticAgenrSuggestionsProvider extends SuggestionProvider {
+export class ElasticAgentSuggestionsProvider extends SuggestionProvider {
   private allElasticAgentIds: Stream<string[]>;
 
   constructor(allElasticAgentIds: Stream<string[]>) {


### PR DESCRIPTION
Issue: https://github.com/gocd/gocd/issues/7816#issuecomment-620445999 (last point)

Description:
The autocomplete on job resources would append the selected value with the entered value when it should be replacing that. Fixed it in this PR.
