### PR TITLE
Validate Job run instance count for input 0

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/JobConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/JobConfig.java
@@ -360,7 +360,6 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
 
     @Override
     public void validate(ValidationContext validationContext) {
-
         if (isBlank(CaseInsensitiveString.str(jobName))) {
             errors.add(NAME, "Name is a required field");
         } else {
@@ -379,6 +378,9 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
         if (runInstanceCount != null) {
             try {
                 int runInstanceCountForValidation = Integer.parseInt(this.runInstanceCount);
+                if (runInstanceCountForValidation == 0) {
+                    errors().add(RUN_TYPE, "'Run Instance Count' cannot be 0 as it represents number of instances GoCD needs to spawn during runtime.");
+                }
                 if (runInstanceCountForValidation < 0) {
                     errors().add(RUN_TYPE, "'Run Instance Count' cannot be a negative number as it represents number of instances GoCD needs to spawn during runtime.");
                 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/JobConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/JobConfigTest.java
@@ -173,6 +173,15 @@ class JobConfigTest {
         ConfigErrors configErrors2 = jobConfig2.errors();
         assertThat(configErrors2.isEmpty()).isFalse();
         assertThat(configErrors2.on(JobConfig.RUN_TYPE)).isEqualTo("'Run Instance Count' should be a valid positive integer as it represents number of instances GoCD needs to spawn during runtime.");
+
+        JobConfig jobConfig3 = new JobConfig(new CaseInsensitiveString("test"));
+        ReflectionUtil.setField(jobConfig3, "runInstanceCount", "0");
+
+        jobConfig3.validate(ConfigSaveValidationContext.forChain(new BasicCruiseConfig()));
+
+        ConfigErrors configErrors3 = jobConfig3.errors();
+        assertThat(configErrors3.isEmpty()).isFalse();
+        assertThat(configErrors3.on(JobConfig.RUN_TYPE)).isEqualTo("'Run Instance Count' cannot be 0 as it represents number of instances GoCD needs to spawn during runtime.");
     }
 
     @Test


### PR DESCRIPTION
Issue: https://github.com/gocd/gocd/issues/7816#issuecomment-621340263 [Point 6]

Description:

* Do not fail with config xsd validation. Add an API validation
  error when job run instance count is set to 0.

<img width="585" alt="Screen Shot 2020-05-05 at 10 31 58 AM" src="https://user-images.githubusercontent.com/15275847/81036286-23922e80-8ebc-11ea-86ce-6737851ff19b.png">

