### PR TITLE
use latest notification filter for the preference page

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/mrequest.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/mrequest.ts
@@ -36,7 +36,10 @@ export const mrequest = {
       }
     });
   },
-  versionHeader(version: string) {
+  versionHeader(version?: string) {
+    if (!version) {
+      return 'application/vnd.go.cd+json';
+    }
     return `application/vnd.go.cd.${version}+json`;
   },
   xhrConfig: {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/preferences/notification_filters.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/preferences/notification_filters.js
@@ -22,7 +22,7 @@ import _ from "lodash";
 import $ from "jquery";
 
 function req(method, url, data) {
-  const headers = {"Accept": mrequest.versionHeader("v1")}, timeout = mrequest.timeout, contentType = "application/json",
+  const headers = {"Accept": mrequest.versionHeader()}, timeout = mrequest.timeout, contentType = "application/json",
         dataType                                                                        = "json";
   return $.ajax(_.omitBy({method, url, timeout, headers, data, contentType, dataType}, _.isEmpty));
 }


### PR DESCRIPTION
Issue: Fix the error `The resource you requested was not found!` on the preference page

Description:
The page used the notification filter API v1 which was removed.
Updated the same to use `latest`.

