### PR TITLE
Make job resources autocomplete works when user switches tab (#7816)

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/job_settings_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/job_settings_tab_content.tsx
@@ -168,6 +168,8 @@ export class JobSettingsTabContent extends TabContent<Job> {
   private readonly resources: Stream<string[]>       = Stream([] as string[]);
   private readonly elasticAgentIds: Stream<string[]> = Stream([] as string[]);
   private readonly defaultJobTimeout: Stream<number> = Stream();
+  private resourcesSuggestionsProvider: ResourcesSuggestionsProvider | undefined;
+  private elasticAgentsSuggestionsProvider: ElasticAgentSuggestionsProvider | undefined;
 
   constructor() {
     super();
@@ -181,13 +183,17 @@ export class JobSettingsTabContent extends TabContent<Job> {
   }
 
   protected renderer(entity: Job, templateConfig: TemplateConfig): m.Children {
-    const resourcesSuggestionsProvider     = new ResourcesSuggestionsProvider(entity.resources, this.resources);
-    const elasticAgentsSuggestionsProvider = new ElasticAgentSuggestionsProvider(this.elasticAgentIds);
+    if (!this.resourcesSuggestionsProvider) {
+      this.resourcesSuggestionsProvider = new ResourcesSuggestionsProvider(entity.resources, this.resources);
+    }
+    if (!this.elasticAgentsSuggestionsProvider) {
+      this.elasticAgentsSuggestionsProvider = new ElasticAgentSuggestionsProvider(this.elasticAgentIds);
+    }
 
     return <JobSettingsTabContentWidget entity={entity}
                                         readonly={this.isEntityDefinedInConfigRepository()}
-                                        resourcesSuggestions={resourcesSuggestionsProvider}
-                                        elasticAgentsSuggestions={elasticAgentsSuggestionsProvider}
+                                        resourcesSuggestions={this.resourcesSuggestionsProvider}
+                                        elasticAgentsSuggestions={this.elasticAgentsSuggestionsProvider}
                                         defaultJobTimeout={this.defaultJobTimeout}
                                         resources={this.resources}
                                         templateConfig={templateConfig}/>;


### PR DESCRIPTION
Issue: #7816

Description:

* Initialize autocompletion provider only once. Reinitialization
  of autocompletion causes old model to be bounded with the view,
  resulting in not updating the suggestion.
