### PR TITLE
Pipeline config spa fixes

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
@@ -293,9 +293,13 @@ export class TasksTabContent extends TabContent<Job> {
 
     const selectedJob = this.selectedEntity(pipelineConfig, routeParams);
 
+    const onReset = () => {
+      this.entityReOrderHandler = undefined;
+      return reset();
+    };
+
     if (!this.entityReOrderHandler) {
-      this.entityReOrderHandler = new EntityReOrderHandler("Task", flashMessage, save,
-                                                           reset, this.hasOrderChanged.bind(this, selectedJob));
+      this.entityReOrderHandler = new EntityReOrderHandler("Task", flashMessage, save, onReset, this.hasOrderChanged.bind(this, selectedJob));
     }
 
     if (!this.originalTasks) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stages_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stages_tab_content.tsx
@@ -76,9 +76,14 @@ export class StagesTabContent extends TabContent<PipelineConfig | TemplateConfig
       this.originalStages = pipelineConfig.stages().names();
     }
 
+    const onReset = () => {
+      this.entityReOrderHandler = undefined;
+      return pipelineConfigReset();
+    };
+
     if (!this.entityReOrderHandler) {
       this.entityReOrderHandler = new EntityReOrderHandler("Stage", flashMessage,
-                                                           pipelineConfigSave, pipelineConfigReset,
+                                                           pipelineConfigSave, onReset,
                                                            this.hasOrderChanged.bind(this, pipelineConfig));
     }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
@@ -55,6 +55,7 @@ interface Attrs {
   disableScmMaterials?: boolean;
   readonly?: boolean;
   parentPipelineName?: string;
+  showGitMaterialShallowClone?: boolean;
 }
 
 export class MaterialEditor extends MithrilViewComponent<Attrs> {
@@ -73,6 +74,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
     const readonly                    = attrs.readonly;
     const hideTestConnection          = readonly || !!attrs.hideTestConnection;
     const disableScmMaterials         = attrs.disableScmMaterials !== undefined && attrs.disableScmMaterials === true;
+    const showGitMaterialShallowClone = attrs.showGitMaterialShallowClone === undefined ? true : attrs.showGitMaterialShallowClone;
 
     return <FormBody>
       <SelectField label="Material Type" property={vnode.attrs.material.type} required={true}
@@ -81,7 +83,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
       </SelectField>
 
       <Form last={true} compactForm={true}>
-        {this.fieldsForType(attrs.readonly!, attrs.material, this.cache, showLocalWorkingCopyOptions, hideTestConnection, disableScmMaterials, attrs.disabled, attrs.packageRepositories, attrs.pluginInfos, attrs.pluggableScms, attrs.parentPipelineName)}
+        {this.fieldsForType(attrs.readonly!, attrs.material, this.cache, showLocalWorkingCopyOptions, hideTestConnection, disableScmMaterials, attrs.disabled, attrs.packageRepositories, attrs.pluginInfos, attrs.pluggableScms, attrs.parentPipelineName, showGitMaterialShallowClone)}
       </Form>
     </FormBody>;
   }
@@ -106,7 +108,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
     return options;
   }
 
-  fieldsForType(readonly: boolean, material: Material, cacheable: SuggestionCache, showLocalWorkingCopyOptions: boolean, hideTestConnection: boolean, disableScmMaterials: boolean, disabled?: boolean, packageRepositories?: PackageRepositories, pluginInfos?: PluginInfos, scms?: Scms, parentPipelineName?: string): m.Children {
+  fieldsForType(readonly: boolean, material: Material, cacheable: SuggestionCache, showLocalWorkingCopyOptions: boolean, hideTestConnection: boolean, disableScmMaterials: boolean, disabled?: boolean, packageRepositories?: PackageRepositories, pluginInfos?: PluginInfos, scms?: Scms, parentPipelineName?: string, showGitMaterialShallowClone?: boolean): m.Children {
     const warningMsg = <FlashMessage type={MessageType.warning} dataTestId={"materials-destination-warning-message"}>
       In order to configure multiple SCM materials for this pipeline, each of its material needs have to a 'Alternate Checkout Path' specified.
       Please edit the existing material and specify a 'Alternate Checkout Path' in order to proceed with this operation.
@@ -120,7 +122,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
           material.attributes(new GitMaterialAttributes(undefined, true));
         }
         return <GitFields material={material} hideTestConnection={hideTestConnection} readonly={readonly} parentPipelineName={parentPipelineName}
-                          showLocalWorkingCopyOptions={showLocalWorkingCopyOptions} disabled={disabled}/>;
+                          showGitMaterialShallowClone={showGitMaterialShallowClone} showLocalWorkingCopyOptions={showLocalWorkingCopyOptions} disabled={disabled}/>;
       case "hg":
         if (disableScmMaterials) {
           return warningMsg;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
@@ -50,6 +50,26 @@ describe("AddPipeline: SCM Material Fields", () => {
     expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
 
+  it("GitFields structure for Config Repo", () => {
+    const material = new Material("git", new GitMaterialAttributes());
+    helper.mount(() => <GitFields showGitMaterialShallowClone={false} material={material} showLocalWorkingCopyOptions={true}/>);
+
+    assertLabelledInputsPresent({
+                                  "repository-url": "Repository URL*",
+                                  "repository-branch": "Repository Branch",
+                                  "username": "Username",
+                                  "password": "Password",
+                                  "alternate-checkout-path": "Alternate Checkout Path",
+                                  "material-name": "Material Name",
+                                  "blacklist": "Blacklist"
+                                });
+
+    assertLabelledInputsAbsent("shallow-clone-recommended-for-large-repositories");
+    assertAutoUpdateSwitchPresent();
+
+    expect(helper.byTestId("test-connection-button")).toBeInDOM();
+  });
+
   it("HgFields structure", () => {
     const material = new Material("hg", new HgMaterialAttributes());
     helper.mount(() => <HgFields material={material} showLocalWorkingCopyOptions={true}/>);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines_as_code.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines_as_code.tsx
@@ -147,7 +147,7 @@ export class PipelinesAsCodeCreatePage extends Page {
               }}
             />
 
-            <MaterialEditor readonly={false} material={this.configRepo().material()!} hideTestConnection={syncConfigRepoWithMaterial()} scmOnly={true} showLocalWorkingCopyOptions={false} disabled={syncConfigRepoWithMaterial()}/>
+            <MaterialEditor readonly={false} material={this.configRepo().material()!} hideTestConnection={syncConfigRepoWithMaterial()} scmOnly={true} showLocalWorkingCopyOptions={false} showGitMaterialShallowClone={false} disabled={syncConfigRepoWithMaterial()}/>
 
             <IdentifierInputField label="Name This Connection" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} placeholder="e.g., Pipelines-as-Code-Repository" property={this.configRepo().id} errorText={this.configRepo().errors().errorsForDisplay("id")} required={true}/>
           </UserInputPane>


### PR DESCRIPTION
Issue: #7816

Description:

* Do not show shallow clone option for config repo git material.

* Enable add button when entity reordering is cancelled.
  * Enable add stage button when stage reordering is reverted.
  * Enable tasks dropdown and add task button when task reordering is reverted.


