### PR TITLE
set auto_update to true by default for package

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/package_repositories/package_repositories.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/package_repositories/package_repositories.ts
@@ -86,7 +86,7 @@ export class Package extends ValidatableMixin {
   }
 
   static default() {
-    return new Package("", "", false, new Configurations([]), new PackageRepositorySummary());
+    return new Package("", "", true, new Configurations([]), new PackageRepositorySummary());
   }
 
   toJSON(): object {


### PR DESCRIPTION
Description: the rails based package creation used to set the value of `auto_update` as true.

On the mithrill based page, it was defaulted to `false`. Changing it to reflect the original behaviour.

