### PR TITLE
Open view template on click of view template icon

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/widgets/navigation_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/widgets/navigation_widget.tsx
@@ -120,7 +120,8 @@ export class NavigationWidget extends MithrilViewComponent<Attrs> {
     });
   }
 
-  onTemplateViewClick(templateName: string) {
+  onTemplateViewClick(templateName: string, e: MouseEvent) {
+    e.stopPropagation();
     window.location.href = `/go/admin/templates#!${templateName}/view`;
   }
 


### PR DESCRIPTION
Issue: #7816

Description:
* As the click event was bubbled up to the parent div. The edit
  template handler was also handling the same click event,
  causing the page to go to template edit instead of view.

* Avoid propagating click event when view template is clicked.

