### PR TITLE
Update TextAreaField to set the value as `value` attribute

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/forms/input_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/forms/input_fields.tsx
@@ -21,7 +21,7 @@ import _ from "lodash";
 import m from "mithril";
 import {TriStateCheckbox} from "models/tri_state_checkbox";
 import s from "underscore.string";
-import { v4 as uuid } from 'uuid';
+import {v4 as uuid} from 'uuid';
 import * as Buttons from "views/components/buttons";
 import {OnClickHandler} from "views/components/buttons";
 import {EncryptedValue} from "views/components/forms/encrypted_value";
@@ -446,7 +446,8 @@ export class TextAreaField extends FormField<string, TextAreaFieldAttrs> {
           if (vnode.attrs.onchange) {
             vnode.attrs.onchange(e);
           }
-        }}>{vnode.attrs.property()}</textarea>
+        }}
+        value={vnode.attrs.property()}/>
     );
   }
 


### PR DESCRIPTION
Issue: https://github.com/gocd/gocd/issues/7816#issuecomment-625413544

Description:
I suspect the issue above is caused as the inner content of the `textarea` is not recognised by mithril. There is an open issue regarding this: https://github.com/MithrilJS/mithril.js/issues/2123.

The issue can be verified on the master:

![job-args-error](https://user-images.githubusercontent.com/41165891/81534247-5b4e1a00-9385-11ea-859c-a065c41d04a1.gif)

The issue mentions that the issue is on Edge/IE. However the same exists on other browsers as well. I tested it on
 - Chrome: Version 81.0.4044.138
 - Firefox: 75.0
 - Safari: Version 13.0.2 (13608.2.40.1.2)


On Safari, this issue is clearer to see after inspecting element:

![job-args-error-safari](https://user-images.githubusercontent.com/41165891/81534238-55f0cf80-9385-11ea-8391-e68c9869ee8d.gif)


