### PR TITLE
Send blank string when config value is null

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/config/ConfigurationProperty.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/config/ConfigurationProperty.java
@@ -181,7 +181,7 @@ public class ConfigurationProperty implements Serializable, Validatable {
                 throw new RuntimeException(format("Could not decrypt secure configuration property value for key %s", configurationKey.getName()), e);
             }
         }
-        return configurationValue == null ? null : configurationValue.getValue();
+        return configurationValue == null ? EMPTY : configurationValue.getValue();
     }
 
     @Override

--- a/config/config-api/src/test/java/com/thoughtworks/go/domain/config/ConfigurationPropertyTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/domain/config/ConfigurationPropertyTest.java
@@ -281,9 +281,9 @@ public class ConfigurationPropertyTest {
     }
 
     @Test
-    void shouldGetNullValueForPropertyWhenValueIsNull() {
+    void shouldGetEmptyValueForPropertyWhenValueIsNull() {
         ConfigurationProperty configurationProperty = new ConfigurationProperty(new ConfigurationKey("key"), null, null, cipher);
-        assertThat(configurationProperty.getValue()).isNull();
+        assertThat(configurationProperty.getValue()).isEmpty();
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/common/settings/PluginSettingsJsonMessageHandlerTestBase.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/common/settings/PluginSettingsJsonMessageHandlerTestBase.java
@@ -45,7 +45,7 @@ public abstract class PluginSettingsJsonMessageHandlerTestBase {
                 "}";
         PluginSettingsConfiguration configuration = messageHandler.responseMessageForPluginSettingsConfiguration(responseBody);
 
-        assertPropertyConfiguration((PluginSettingsProperty) configuration.get("key-one"), "key-one", null, true, false, "key-one", 0);
+        assertPropertyConfiguration((PluginSettingsProperty) configuration.get("key-one"), "key-one", "", true, false, "key-one", 0);
         assertPropertyConfiguration((PluginSettingsProperty) configuration.get("key-two"), "key-two", "two", true, true, "display-two", 1);
         assertPropertyConfiguration((PluginSettingsProperty) configuration.get("key-three"), "key-three", "three", false, false, "display-three", 2);
     }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/packagematerial/JsonMessageHandler1_0Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/packagematerial/JsonMessageHandler1_0Test.java
@@ -62,7 +62,7 @@ public class JsonMessageHandler1_0Test {
                 "}";
 
         RepositoryConfiguration repositoryConfiguration = messageHandler.responseMessageForRepositoryConfiguration(responseBody);
-        assertPropertyConfiguration((PackageMaterialProperty) repositoryConfiguration.get("key-one"), "key-one", null, true, true, false, "", 0);
+        assertPropertyConfiguration((PackageMaterialProperty) repositoryConfiguration.get("key-one"), "key-one", "", true, true, false, "", 0);
         assertPropertyConfiguration((PackageMaterialProperty) repositoryConfiguration.get("key-two"), "key-two", "two", true, true, true, "display-two", 1);
         assertPropertyConfiguration((PackageMaterialProperty) repositoryConfiguration.get("key-three"), "key-three", "three", false, false, false, "display-three", 2);
     }
@@ -76,7 +76,7 @@ public class JsonMessageHandler1_0Test {
                 "}";
 
         com.thoughtworks.go.plugin.api.material.packagerepository.PackageConfiguration packageConfiguration = messageHandler.responseMessageForPackageConfiguration(responseBody);
-        assertPropertyConfiguration((PackageMaterialProperty) packageConfiguration.get("key-one"), "key-one", null, true, true, false, "", 0);
+        assertPropertyConfiguration((PackageMaterialProperty) packageConfiguration.get("key-one"), "key-one", "", true, true, false, "", 0);
         assertPropertyConfiguration((PackageMaterialProperty) packageConfiguration.get("key-two"), "key-two", "two", true, true, true, "display-two", 1);
         assertPropertyConfiguration((PackageMaterialProperty) packageConfiguration.get("key-three"), "key-three", "three", false, false, false, "display-three", 2);
     }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/packagematerial/PackageRepositoryExtensionTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/packagematerial/PackageRepositoryExtensionTest.java
@@ -172,7 +172,7 @@ public class PackageRepositoryExtensionTest {
         RepositoryConfiguration repositoryConfiguration = extension.getRepositoryConfiguration(PLUGIN_ID);
 
         assertRequest(requestArgumentCaptor.getValue(), PACKAGE_MATERIAL_EXTENSION, "1.0", PackageRepositoryExtension.REQUEST_REPOSITORY_CONFIGURATION, expectedRequestBody);
-        assertPropertyConfiguration((PackageMaterialProperty) repositoryConfiguration.get("key-one"), "key-one", null, true, true, false, "", 0);
+        assertPropertyConfiguration((PackageMaterialProperty) repositoryConfiguration.get("key-one"), "key-one", "", true, true, false, "", 0);
         assertPropertyConfiguration((PackageMaterialProperty) repositoryConfiguration.get("key-two"), "key-two", "two", true, true, true, "display-two", 1);
         assertPropertyConfiguration((PackageMaterialProperty) repositoryConfiguration.get("key-three"), "key-three", "three", false, false, false, "display-three", 2);
     }
@@ -192,7 +192,7 @@ public class PackageRepositoryExtensionTest {
         com.thoughtworks.go.plugin.api.material.packagerepository.PackageConfiguration packageConfiguration = extension.getPackageConfiguration(PLUGIN_ID);
 
         assertRequest(requestArgumentCaptor.getValue(), PACKAGE_MATERIAL_EXTENSION, "1.0", PackageRepositoryExtension.REQUEST_PACKAGE_CONFIGURATION, expectedRequestBody);
-        assertPropertyConfiguration((PackageMaterialProperty) packageConfiguration.get("key-one"), "key-one", null, true, true, false, "", 0);
+        assertPropertyConfiguration((PackageMaterialProperty) packageConfiguration.get("key-one"), "key-one", "", true, true, false, "", 0);
         assertPropertyConfiguration((PackageMaterialProperty) packageConfiguration.get("key-two"), "key-two", "two", true, true, true, "display-two", 1);
         assertPropertyConfiguration((PackageMaterialProperty) packageConfiguration.get("key-three"), "key-three", "three", false, false, false, "display-three", 2);
     }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/scm/JsonMessageHandler1_0Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/scm/JsonMessageHandler1_0Test.java
@@ -63,7 +63,7 @@ public class JsonMessageHandler1_0Test {
                 "}";
         SCMPropertyConfiguration scmConfiguration = messageHandler.responseMessageForSCMConfiguration(responseBody);
 
-        assertPropertyConfiguration((SCMProperty) scmConfiguration.get("key-one"), "key-one", null, true, true, false, "", 0);
+        assertPropertyConfiguration((SCMProperty) scmConfiguration.get("key-one"), "key-one", "", true, true, false, "", 0);
         assertPropertyConfiguration((SCMProperty) scmConfiguration.get("key-two"), "key-two", "two", true, true, true, "display-two", 1);
         assertPropertyConfiguration((SCMProperty) scmConfiguration.get("key-three"), "key-three", "three", false, false, false, "display-three", 2);
     }

--- a/plugin-infra/go-plugin-api/src/main/java/com/thoughtworks/go/plugin/api/config/Property.java
+++ b/plugin-infra/go-plugin-api/src/main/java/com/thoughtworks/go/plugin/api/config/Property.java
@@ -55,7 +55,7 @@ public class Property {
 
     private String key;
     private String value;
-    private String defaultValue;
+    private String defaultValue = "";
 
     public Property(String key) {
         this.key = key;

--- a/plugin-infra/go-plugin-api/src/test/java/com/thoughtworks/go/plugin/api/config/PropertyTest.java
+++ b/plugin-infra/go-plugin-api/src/test/java/com/thoughtworks/go/plugin/api/config/PropertyTest.java
@@ -41,7 +41,7 @@ public class PropertyTest {
         property = new Property("key").withDefault(defaultValue);
         assertThat(property.getValue(), is(defaultValue));
         property = new Property("key");
-        assertThat(property.getValue() == null, is(true));
+        assertThat(property.getValue(), is(""));
         String value = "yek";
         property = new Property("key", value, defaultValue);
         assertThat(property.getValue(), is(value));

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/PluginSettingsTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/PluginSettingsTest.java
@@ -58,7 +58,7 @@ public class PluginSettingsTest {
         assertThat(settingsAsKeyValuePair.size(), is(3));
         assertThat(settingsAsKeyValuePair.get("key-1"), is("value1"));
         assertThat(settingsAsKeyValuePair.get("key-2"), is(""));
-        assertThat(settingsAsKeyValuePair.get("key-3"), is(nullValue()));
+        assertThat(settingsAsKeyValuePair.get("key-3"), is(""));
     }
 
     @Test
@@ -94,7 +94,7 @@ public class PluginSettingsTest {
         assertThat(configuration.size(), is(3));
         assertThat(configuration.get("key-1").getValue(), is("value1"));
         assertThat(configuration.get("key-2").getValue(), is(""));
-        assertThat(configuration.get("key-3").getValue(), is(nullValue()));
+        assertThat(configuration.get("key-3").getValue(), is(""));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PluginServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PluginServiceTest.java
@@ -131,7 +131,7 @@ public class PluginServiceTest {
         assertThat(pluginSettings.getSettingsAsKeyValuePair().keySet().size(), is(3));
         assertThat(pluginSettings.getSettingsAsKeyValuePair(), hasEntry("key-1", "v1"));
         assertThat(pluginSettings.getSettingsAsKeyValuePair(), hasEntry("key-2", ""));
-        assertThat(pluginSettings.getSettingsAsKeyValuePair(), hasEntry("key-3", null));
+        assertThat(pluginSettings.getSettingsAsKeyValuePair(), hasEntry("key-3", ""));
     }
 
     @Test
@@ -258,7 +258,7 @@ public class PluginServiceTest {
         assertThat(plugin.getPluginId(), is(elasticAgentPluginId));
         assertThat(plugin.getConfigurationValue("key-1"), is("v1"));
         assertThat(plugin.getConfigurationValue("key-2"), is(""));
-        assertThat(plugin.getConfigurationValue("key-3"), nullValue());
+        assertThat(plugin.getConfigurationValue("key-3"), is(""));
     }
 
     @Test
@@ -281,7 +281,7 @@ public class PluginServiceTest {
         assertThat(plugin.getPluginId(), is(elasticAgentPluginId));
         assertThat(plugin.getConfigurationValue("key-1"), is("v1"));
         assertThat(plugin.getConfigurationValue("key-2"), is(""));
-        assertThat(plugin.getConfigurationValue("key-3"), nullValue());
+        assertThat(plugin.getConfigurationValue("key-3"), is(""));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/tasks/TaskViewServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/tasks/TaskViewServiceTest.java
@@ -51,7 +51,8 @@ import static com.thoughtworks.go.util.DataStructureUtils.s;
 import static java.util.Arrays.asList;
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class TaskViewServiceTest {
@@ -119,8 +120,8 @@ public class TaskViewServiceTest {
         storeTaskPreferences(plugin2, "key_3", "key_4");
         when(registry.implementersOf(Task.class)).thenReturn(Arrays.<Class<? extends Task>>asList(ExecTask.class, PluggableTask.class));
 
-        PluggableTask expectedPluggableTaskForPlugin1 = new PluggableTask(new PluginConfiguration(plugin1, "1"), new Configuration(create("key_1"), create("key_2")));
-        PluggableTask expectedPluggableTaskForPlugin2 = new PluggableTask(new PluginConfiguration(plugin2, "1"), new Configuration(create("key_3"), create("key_4")));
+        PluggableTask expectedPluggableTaskForPlugin1 = new PluggableTask(new PluginConfiguration(plugin1, "1"), new Configuration(create("key_1", ""), create("key_2", "")));
+        PluggableTask expectedPluggableTaskForPlugin2 = new PluggableTask(new PluginConfiguration(plugin2, "1"), new Configuration(create("key_3", ""), create("key_4", "")));
 
         when(registry.getViewModelFor(new ExecTask(), "new")).thenReturn(viewModel(new ExecTask()));
         when(registry.getViewModelFor(expectedPluggableTaskForPlugin1, "new")).thenReturn(viewModel(expectedPluggableTaskForPlugin1));
@@ -153,7 +154,7 @@ public class TaskViewServiceTest {
         PluggableTask pluggableTask = (PluggableTask) taskViewService.taskInstanceFor(new PluggableTask(new PluginConfiguration(plugin, "1"), new Configuration()).getTaskType());
         assertThat(pluggableTask.getConfiguration().getProperty("key1").getValue(), is("default1"));
         assertThat(pluggableTask.getConfiguration().getProperty("key2").getValue(), is("default2"));
-        assertNull(pluggableTask.getConfiguration().getProperty("key3").getValue());
+        assertThat(pluggableTask.getConfiguration().getProperty("key3").getValue(), is(""));
     }
 
     @Test


### PR DESCRIPTION
Issue: #8119

Description:
When a config value is not specified - it is stored as null. When it is converted to json to be send to the plugin, the nulls are ignored.
This PR proposes sending blank string instead when a config value is null.

Also, the config values are set as environmental variables. When the config value is not set, the env var value is set as null. This value when send to agent leads to a `NullPointerException` [here](https://github.com/gocd/gocd/blob/master/commandline/src/main/java/com/thoughtworks/go/util/ProcessManager.java#L55). Hence, setting this value as empty string as well.
