### PR TITLE
Pipeline config spa fixes

### DIFF
--- a/api/api-internal-dependency-pipelines-v1/src/main/java/com/thoughtworks/go/apiv1/internaldependencypipelines/InternalDependencyPipelinesControllerV1.java
+++ b/api/api-internal-dependency-pipelines-v1/src/main/java/com/thoughtworks/go/apiv1/internaldependencypipelines/InternalDependencyPipelinesControllerV1.java
@@ -28,6 +28,7 @@ import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
 import com.thoughtworks.go.util.SystemEnvironment;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import spark.Request;
@@ -78,7 +79,7 @@ public class InternalDependencyPipelinesControllerV1 extends ApiController imple
         String stageName = request.params("stage_name");
 
         CruiseConfig config = goConfigService.getMergedConfigForEditing();
-        FetchArtifactViewHelper helper = new FetchArtifactViewHelper(systemEnvironment, config, new CaseInsensitiveString(pipelineName), new CaseInsensitiveString(stageName), false);
+        FetchArtifactViewHelper helper = new FetchArtifactViewHelper(systemEnvironment, config, new CaseInsensitiveString(pipelineName), new CaseInsensitiveString(stageName), StringUtils.isNotBlank(request.queryParams("template")));
 
         response.type("application/json");
         return gson.toJson(helper.autosuggestMap());

--- a/api/api-internal-dependency-pipelines-v1/src/test/groovy/com/thoughtworks/go/apiv1/internaldependencypipelines/InternalDependencyPipelinesControllerV1Test.groovy
+++ b/api/api-internal-dependency-pipelines-v1/src/test/groovy/com/thoughtworks/go/apiv1/internaldependencypipelines/InternalDependencyPipelinesControllerV1Test.groovy
@@ -19,6 +19,10 @@ package com.thoughtworks.go.apiv1.internaldependencypipelines
 import com.thoughtworks.go.api.SecurityTestTrait
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.config.BasicCruiseConfig
+import com.thoughtworks.go.config.CaseInsensitiveString
+import com.thoughtworks.go.config.JobConfigs
+import com.thoughtworks.go.config.PipelineTemplateConfig
+import com.thoughtworks.go.config.StageConfig
 import com.thoughtworks.go.helper.PipelineConfigMother
 import com.thoughtworks.go.server.service.GoConfigService
 import com.thoughtworks.go.spark.ControllerTrait
@@ -79,6 +83,24 @@ class InternalDependencyPipelinesControllerV1Test implements SecurityServiceTrai
       '    "mingle": {}' +
       '  },' +
       '  "": {' +
+      '    "mingle": {}' +
+      '  }' +
+      '}')
+  }
+
+  @Test
+  void 'should return template auto suggestions'() {
+    def config = new BasicCruiseConfig()
+    config.addTemplate(new PipelineTemplateConfig(new CaseInsensitiveString("template1"), new StageConfig(new CaseInsensitiveString("stage1"), new JobConfigs())))
+    config.addPipeline("first", PipelineConfigMother.pipelineConfig("pipeline1"))
+    when(goConfigService.getMergedConfigForEditing()).thenReturn(config)
+
+    getWithApiHeader(path('template1', 'stage1') + '?template=true')
+
+    assertThatResponse()
+      .isOk()
+      .hasJsonBody('{' +
+      '  "pipeline1": {' +
       '    "mingle": {}' +
       '  }' +
       '}')

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -528,8 +528,12 @@ export class SparkRoutes {
     }
   }
 
-  static getUpstreamPipelines(pipelineName: string, stageName: string) {
-    return `/go/api/internal/pipelines/${pipelineName}/${stageName}/upstream`;
+  static getUpstreamPipelines(pipelineName: string, stageName: string, isTemplate: boolean) {
+    let params: string = "";
+    if (isTemplate) {
+      params = `?${m.buildQueryString({template: true})}`;
+    }
+    return `/go/api/internal/pipelines/${pipelineName}/${stageName}/upstream${params}`;
   }
 
   static packageRepositoryPath(id?: string) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/task.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/task.ts
@@ -108,6 +108,8 @@ abstract class AbstractTaskAttributes extends ValidatableMixin implements TaskAt
     super();
     this.runIf(runIf || []);
     this.onCancel(onCancel);
+
+    this.validateAssociated("onCancel");
   }
 
   abstract properties(): Map<string, string>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.tsx
@@ -111,8 +111,8 @@ export class MaterialModal extends Modal {
       this.pipelineConfigSave()
           .then(() => this.close())
           .catch((errorResponse?: ErrorResponse) => {
-            if(errorResponse) {
-              const parse            = JSON.parse(errorResponse.body!);
+            if(errorResponse && errorResponse.body) {
+              const parse            = JSON.parse(errorResponse.body);
               const unconsumedErrors = this.entity().consumeErrorsResponse(parse.data);
               this.errorMessage(<span>{parse.message}<br/> {unconsumedErrors.allErrorsForDisplay()}</span>);
             }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/pipeline_config.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/pipeline_config.tsx
@@ -75,6 +75,7 @@ export class PipelineConfigPage<T> extends TabHandler<T> {
 
   save(): Promise<any> {
     this.flashMessage.clear();
+    this.clearConfigErrors();
     const isValid = this.getEntity().isValid();
 
     if (!isValid) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tab_handler.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tab_handler.tsx
@@ -214,7 +214,7 @@ export abstract class TabHandler<T> extends Page<null, T> {
       this.pageState = PageState.FAILED;
     }
 
-    return Promise.reject(errorResponse);
+    return Promise.reject(JSON.stringify(errorResponse));
   }
 
   protected getSaveAndResetButtons(): m.Children {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/common/re_order_entity_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/common/re_order_entity_widget.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {ErrorResponse} from "helpers/api_request_builder";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {ButtonGroup, Cancel, Secondary} from "views/components/buttons";
@@ -68,8 +67,6 @@ export class EntityReOrderHandler {
   private onSave() {
     return this.pipelineConfigSave().then(() => {
       this.flashMessage.setMessage(MessageType.success, `${this.entityName}s reordered successfully.`);
-    }).catch((errorResponse: ErrorResponse) => {
-      this.flashMessage.consumeErrorResponse(errorResponse);
     }).finally(() => {
       this.pipelineConfigReset();
       this.shouldShowReorderMessage(false);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/common/re_order_entity_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/common/re_order_entity_widget.tsx
@@ -18,6 +18,7 @@ import m from "mithril";
 import Stream from "mithril/stream";
 import {ButtonGroup, Cancel, Secondary} from "views/components/buttons";
 import {FlashMessageModelWithTimeout, MessageType} from "views/components/flash_message";
+import {OperationState} from "views/pages/page_operations";
 import styles from "./re_order_entity.scss";
 
 export class EntityReOrderHandler {
@@ -27,6 +28,8 @@ export class EntityReOrderHandler {
   private readonly flashMessage: FlashMessageModelWithTimeout;
   private readonly pipelineConfigSave: () => any;
   private readonly pipelineConfigReset: () => any;
+
+  protected ajaxOperationMonitor = Stream<OperationState>(OperationState.UNKNOWN);
 
   constructor(entityName: string, flashMessage: FlashMessageModelWithTimeout,
               pipelineConfigSave: () => any, pipelineConfigReset: () => any, hasOrderChanged: () => boolean) {
@@ -46,7 +49,9 @@ export class EntityReOrderHandler {
     return (<div class={styles.container} data-test-id="reorder-confirmation">
       <span>Do you want to save the new {this.entityName} order?</span>
       <ButtonGroup>
-        <Secondary dataTestId={'save-btn'} onclick={this.onSave.bind(this)}>Save</Secondary>
+        <Secondary dataTestId={'save-btn'}
+                   ajaxOperationMonitor={this.ajaxOperationMonitor}
+                   ajaxOperation={this.onSave.bind(this)}>Save</Secondary>
         <Cancel dataTestId={'revert-btn'} onclick={this.onRevert.bind(this)}>Revert</Cancel>
       </ButtonGroup>
     </div>);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
@@ -202,12 +202,13 @@ export class TasksWidget extends MithrilComponent<Attrs, State> {
   private onTaskSaveFailure(vnode: m.Vnode<Attrs, State>,
                             onFailureCallback: () => any,
                             errorResponse?: ErrorResponse) {
-    if (errorResponse) {
-      const parsed = JSON.parse(errorResponse.body!);
+    if (errorResponse && errorResponse.body) {
+      const parsed = JSON.parse(errorResponse.body);
       vnode.state.modal.getTask()!.consumeErrorsResponse(parsed.data);
       vnode.state.modal.flashMessage.setMessage(MessageType.alert, parsed.message);
-      onFailureCallback();
     }
+
+    onFailureCallback();
 
     m.redraw.sync();
   }
@@ -277,7 +278,6 @@ export class TasksWidget extends MithrilComponent<Attrs, State> {
       vnode.attrs.flashMessage.setMessage(MessageType.success, `Task deleted successfully.`);
     }).catch((errorResponse: ErrorResponse) => {
       vnode.attrs.tasks().splice(taskIndex, 0, taskToDelete);
-      vnode.attrs.flashMessage.consumeErrorResponse(errorResponse);
     }).finally(m.redraw.sync);
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
@@ -321,11 +321,7 @@ export class TasksTabContent extends TabContent<Job> {
     }
 
     if (!this.autoSuggestions()) {
-      if (this.isPipelineConfigView()) {
-        this.fetchUpstreamPipelines(pipelineConfig.name(), routeParams.stage_name!);
-      } else {
-        this.autoSuggestions({});
-      }
+      this.fetchUpstreamPipelines(pipelineConfig.name(), routeParams.stage_name!, !this.isPipelineConfigView());
     }
 
     return super.content(pipelineConfig, templateConfig, routeParams, ajaxOperationMonitor, flashMessage, save, reset);
@@ -373,8 +369,8 @@ export class TasksTabContent extends TabContent<Job> {
                          });
   }
 
-  private fetchUpstreamPipelines(pipelineName: string, stageName: string): any {
-    return ApiRequestBuilder.GET(SparkRoutes.getUpstreamPipelines(pipelineName, stageName), ApiVersion.v1)
+  private fetchUpstreamPipelines(pipelineName: string, stageName: string, isTemplate: boolean): any {
+    return ApiRequestBuilder.GET(SparkRoutes.getUpstreamPipelines(pipelineName, stageName, isTemplate), ApiVersion.v1)
                             .then((result: ApiResult<string>) => {
                               return result.map((str) => {
                                 return this.autoSuggestions(JSON.parse(str));

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stage/add_stage_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stage/add_stage_modal.tsx
@@ -148,8 +148,8 @@ export class AddStageModal extends Modal {
   }
 
   private onTaskSaveFailure(errorResponse?: ErrorResponse) {
-    if (errorResponse) {
-      const parsed = JSON.parse(errorResponse.body!);
+    if (errorResponse && errorResponse.body) {
+      const parsed = JSON.parse(errorResponse.body);
       this.stageToCreate.consumeErrorsResponse(parsed.data);
     }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stages_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stages_tab_content.tsx
@@ -186,7 +186,6 @@ export class StagesOrTemplatesWidget extends MithrilComponent<StagesOrTemplatesA
 
     vnode.state.stageOrTemplatePropertyStream = (value?: string) => {
       if (value) {
-        vnode.attrs.reset();
         vnode.attrs.stageOrTemplateProperty((value === "template") ? "template" : "stage");
       }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/jobs/add_job_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/jobs/add_job_modal.tsx
@@ -173,8 +173,8 @@ export class AddJobModal extends Modal {
   }
 
   private onTaskSaveFailure(errorResponse?: ErrorResponse) {
-    if (errorResponse) {
-      const parsed = JSON.parse(errorResponse.body!);
+    if (errorResponse && errorResponse.body) {
+      const parsed = JSON.parse(errorResponse.body);
       this.jobToCreate.consumeErrorsResponse(parsed.data);
     }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/template_config.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/template_config.tsx
@@ -109,6 +109,7 @@ export class TemplateConfigPage<T> extends TabHandler<T> {
 
   save(): Promise<any> {
     this.flashMessage.clear();
+    this.clearConfigErrors();
     const isValid = this.getEntity().isValid();
 
     if (!isValid) {


### PR DESCRIPTION
### Issue: #7816

### Description:

- [x] Preserve stage order when deleting stage fails.
- [x] Show fetch artifact autosuggestions for template tasks.
- [x] Show button spinner on stage/task reorder.
- [x] Show ubounded error messages globally.
- [x] Perform client side validation for on cancel exec task.
- [x] Allow reordering stages after toggling use template or define stages field.
- [x] Print pipeline config json on firefox when update fails

##### Error message on firefox:
<img width="1440" alt="Screen Shot 2020-05-13 at 1 33 02 PM" src="https://user-images.githubusercontent.com/15275847/81794827-ff23fb00-9528-11ea-9718-3430f97d775d.png">


##### On Cancel exec task client side validation:
<img width="720" alt="Screen Shot 2020-05-13 at 1 33 51 PM" src="https://user-images.githubusercontent.com/15275847/81794900-195dd900-9529-11ea-90c2-e048f706cf8a.png">

##### Spinner for reorder button:
<img width="1132" alt="Screen Shot 2020-05-13 at 12 29 19 PM" src="https://user-images.githubusercontent.com/15275847/81794974-309cc680-9529-11ea-8d89-2fb39de64855.png">


##### Global ubounded error messages:
#### Case1: When there are field bounded and unbounded errors:
<img width="1427" alt="Screen Shot 2020-05-13 at 2 53 09 PM" src="https://user-images.githubusercontent.com/15275847/81795814-2d560a80-952a-11ea-9225-a8fd68318834.png">


#### Case2: When there are multiple unbounded errors:
<img width="1404" alt="Screen Shot 2020-05-13 at 2 57 19 PM" src="https://user-images.githubusercontent.com/15275847/81795825-32b35500-952a-11ea-9975-7319a56a6c56.png">

