### PR TITLE
Improvement to config repo error message

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/EntityType.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/EntityType.java
@@ -51,7 +51,7 @@ public enum EntityType {
 
     private final String entityType;
     private final NameOrId nameOrId;
-    public static final String RULE_ERROR_PREFIX = "Not allowed to refer";
+    public static final String RULE_ERROR_PREFIX = "Not allowed to refer to";
 
     EntityType(String entityType, NameOrId nameOrId) {
         this.entityType = entityType;
@@ -202,6 +202,6 @@ public enum EntityType {
     }
 
     public String notAllowedToRefer(String identifier) {
-        return format("%s %s '%s' from the config repository.", RULE_ERROR_PREFIX, this.entityType, identifier);
+        return format("%s %s '%s'. Check the 'Rules' of this config repository.", RULE_ERROR_PREFIX, this.entityType, identifier);
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/GoConfigInvalidMergeException.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/GoConfigInvalidMergeException.java
@@ -64,6 +64,7 @@ public class GoConfigInvalidMergeException extends GoConfigInvalidException {
             for (int i = 1; i <= ruleValidationErrors.size(); i++) {
                 b.append('\t').append(i).append(". ").append(ruleValidationErrors.get(i - 1)).append(";; \n");
             }
+            b.append("\n");
             List<String> configValidationErrors = new ArrayList<>(allErrors);
             configValidationErrors.removeAll(ruleValidationErrors);
             b.append("II. Config Validation Errors: \n");

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/modals.tsx
@@ -52,7 +52,7 @@ class MaterialEditWidget extends MithrilViewComponent<EditableMaterial> {
 
     const errorMessage = vnode.attrs.error ? <div class={styles.errorWrapper}>{vnode.attrs.error}</div> : undefined;
     const infoMsg = <span>Configure rules to allow which environment/pipeline group/pipeline the config repository can refer to. By default, the config repository cannot refer to an entity unless explicitly allowed. <Link
-      href={docsUrl("advanced_usage/pipelines_as_code.html")} externalLinkIcon={true}>Learn More</Link></span>;
+      href={docsUrl("advanced_usage/pipelines_as_code.html")} target="_blank" externalLinkIcon={true}>Learn More</Link></span>;
 
     return [
       errorMessage,

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommandTest.java
@@ -83,7 +83,7 @@ class PartialConfigUpdateCommandTest {
         CruiseConfig updated = command.update(cruiseConfig);
         List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
         assertThat(allErrors).hasSize(1);
-        assertThat(allErrors.get(0).on("pipeline_group")).isEqualTo("Not allowed to refer pipeline group 'first' from the config repository.");
+        assertThat(allErrors.get(0).on("pipeline_group")).isEqualTo("Not allowed to refer to pipeline group 'first'. Check the 'Rules' of this config repository.");
         assertThat(updated.hasPipelineGroup("first")).isFalse();
     }
 
@@ -101,7 +101,7 @@ class PartialConfigUpdateCommandTest {
 
         List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
         assertThat(allErrors).hasSize(1);
-        assertThat(allErrors.get(0).on("pipeline_group")).isEqualTo("Not allowed to refer pipeline group 'first' from the config repository.");
+        assertThat(allErrors.get(0).on("pipeline_group")).isEqualTo("Not allowed to refer to pipeline group 'first'. Check the 'Rules' of this config repository.");
         assertThat(updated.hasPipelineGroup("first")).isFalse();
     }
 
@@ -120,7 +120,7 @@ class PartialConfigUpdateCommandTest {
 
         List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
         assertThat(allErrors).hasSize(1);
-        assertThat(allErrors.get(0).on("environment")).isEqualTo("Not allowed to refer environment 'uat' from the config repository.");
+        assertThat(allErrors.get(0).on("environment")).isEqualTo("Not allowed to refer to environment 'uat'. Check the 'Rules' of this config repository.");
         assertThat(updated.getEnvironments().hasEnvironmentNamed(uatEnv)).isFalse();
     }
 
@@ -138,7 +138,7 @@ class PartialConfigUpdateCommandTest {
 
         List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
         assertThat(allErrors).hasSize(1);
-        assertThat(allErrors.get(0).on("pipeline")).isEqualTo("Not allowed to refer pipeline 'deploy' from the config repository.");
+        assertThat(allErrors.get(0).on("pipeline")).isEqualTo("Not allowed to refer to pipeline 'deploy'. Check the 'Rules' of this config repository.");
         assertThat(updated.hasPipelineGroup("first")).isFalse();
     }
 


### PR DESCRIPTION
The error message is sometimes a little confusing:

```
INVALID MERGED CONFIGURATION
Number of errors: 1+
I. Rule Validation Errors:
       1. Not allowed to refer pipeline group 'PaymentGateway' from the config repository.;;
II. Config Validation Errors:
- For Config Repo: ...
```

It's not always clear that when it says: `Not allowed to refer`, it means that it is related to the `Rules` configured for that config repository. Adding that to the end of the message.

It should now read:

```
Not allowed to refer to pipeline group 'PaymentGateway'. Check the "Rules" of this config repository.
```

I don't see any functional tests with this message.

--------------------------------

Looks like this now:

<img width="913" alt="2020_05_13_21-16-27" src="https://user-images.githubusercontent.com/172235/81860738-1251bd80-955f-11ea-83e1-62173f38d0b0.png">
