### PR TITLE
Revert "Update lodash and kind-of to fix security warnings"

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -138,9 +138,5 @@
     "webpack": "^4.43.0",
     "webpack-build-notifier": "^2.0.0",
     "webpack-cli": "^3.3.11"
-  },
-  "resolutions": {
-    "lodash": "^4.17.15",
-    "kind-of": "^6.0.3"
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -4873,6 +4873,11 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
+is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
 is-builtin-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
@@ -5471,10 +5476,29 @@ karma@^5.0.5:
     ua-parser-js "0.7.21"
     yargs "^15.3.1"
 
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
-  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
 known-css-properties@^0.3.0:
   version "0.3.0"
@@ -5623,10 +5647,15 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~2.2.0, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@~2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.2.1.tgz#ca935fd14ab3c0c872abacf198b9cda501440867"
+  integrity sha1-ypNf0UqzwMhyq6zxmLnNpQFECGc=
 
 log4js@^4.0.0:
   version "4.5.0"


### PR DESCRIPTION
This reverts commit cbe2fc2d43222bb5065d64e8c3a16caca4e5437a.
 - the jasmine test task was getting blocked with the following message:
```
ERROR [karma-server]: UncaughtException:: _.any is not a function
ERROR [karma-server]: TypeError: _.any is not a function
    at getOverallState (/go/pipelines/build-linux-PR/server/src/main/webapp/WEB-INF/rails/node_modules/karma-html-reporter/index.js:248:9)
    at /go/pipelines/build-linux-PR/server/src/main/webapp/WEB-INF/rails/node_modules/karma-html-reporter/index.js:226:23
    at /go/pipelines/build-linux-PR/server/src/main/webapp/WEB-INF/rails/node_modules/lodash/lodash.js:3543:27
    at /go/pipelines/build-linux-PR/server/src/main/webapp/WEB-INF/rails/node_modules/lodash/lodash.js:4905:15
    at baseForOwn (/go/pipelines/build-linux-PR/server/src/main/webapp/WEB-INF/rails/node_modules/lodash/lodash.js:2990:24)
    at /go/pipelines/build-linux-PR/server/src/main/webapp/WEB-INF/rails/node_modules/lodash/lodash.js:4874:18
    at baseMap (/go/pipelines/build-linux-PR/server/src/main/webapp/WEB-INF/rails/node_modules/lodash/lodash.js:3542:7)
    at Function.map (/go/pipelines/build-linux-PR/server/src/main/webapp/WEB-INF/rails/node_modules/lodash/lodash.js:9554:14)
    at suitesToArray (/go/pipelines/build-linux-PR/server/src/main/webapp/WEB-INF/rails/node_modules/karma-html-reporter/index.js:224:12)
    at prepareResults (/go/pipelines/build-linux-PR/server/src/main/webapp/WEB-INF/rails/node_modules/karma-html-reporter/index.js:214:20)
```

