### PR TITLE
Pipeline config spa fixes

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/presentation/FetchArtifactViewHelper.java
+++ b/server/src/main/java/com/thoughtworks/go/server/presentation/FetchArtifactViewHelper.java
@@ -107,7 +107,9 @@ public class FetchArtifactViewHelper {
         List<PipelineConfig> pipelineConfigs = cruiseConfig.allPipelines();
         PipelineConfig dummyPipeline = new PipelineConfig();
         for (PipelineConfig pipelineConfig : pipelineConfigs) {
-            dummyPipeline.addMaterialConfig(new DependencyMaterialConfig(pipelineConfig.name(), pipelineConfig.last().name()));
+            if (pipelineConfig.last() != null) {
+                dummyPipeline.addMaterialConfig(new DependencyMaterialConfig(pipelineConfig.name(), pipelineConfig.last().name()));
+            }
         }
         PipelineTemplateConfig pipelineTemplateConfig = cruiseConfig.getTemplates().templateByName(pipelineName);
         for (StageConfig stageConfig : pipelineTemplateConfig) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/general_options_tab_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/general_options_tab_spec.tsx
@@ -56,6 +56,9 @@ describe("GeneralOptionsTag", () => {
 
       expect(helper.byTestId("automatic-pipeline-scheduling")).toBeChecked();
       expect(pipelineConfig.firstStage().approval().typeAsString()).toEqual("success");
+
+      const helpText = "If unchecked, this pipeline will only schedule in response to a Manual/API/Timer trigger. Unchecking this box is the same as making the first stage manual.";
+      expect(helper.qa('span')).toContainText(helpText);
     });
 
     it("should render approval from template when template is configured", () => {
@@ -70,6 +73,9 @@ describe("GeneralOptionsTag", () => {
 
       expect(stageInTemplate.approval().typeAsString()).toEqual("manual");
       expect(helper.byTestId("automatic-pipeline-scheduling")).not.toBeChecked();
+
+      const helpText = "If unchecked, this pipeline will only schedule in response to a Manual/API/Timer trigger. Unchecking this box is the same as making the first stage manual. Since this pipeline is based on 'template' template, automatic/manual behaviour of the pipeline is determined by the template's first stage.";
+      expect(helper.qa('span')).toContainText(helpText);
     });
   });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/job_settings_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/job_settings_tab_content.tsx
@@ -90,6 +90,7 @@ export class JobSettingsTabContentWidget extends MithrilViewComponent<Attrs> {
                          dataTestId={"elastic-agent-id-input"}
                          autoEvaluate={this.isElasticAgentIdInputOnFocus()}
                          errorText={entity.errors().errorsForDisplay("elasticProfileId")}
+                         onchange={vnode.attrs.elasticAgentsSuggestions.update.bind(vnode.attrs.elasticAgentsSuggestions)}
                          provider={vnode.attrs.elasticAgentsSuggestions}
                          readonly={vnode.attrs.readonly || !!entity.resources()}
                          helpText={<div>The Elastic Agent Profile that the current job requires to run. Visit <a href="/go/admin/elastic_agent_configurations" title="Elastic Agents Configurations">Elastic Agent Configurations</a> page to manage elastic agent profiles.</div>}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
@@ -372,8 +372,12 @@ export class TasksTabContent extends TabContent<Job> {
   private fetchUpstreamPipelines(pipelineName: string, stageName: string, isTemplate: boolean): any {
     return ApiRequestBuilder.GET(SparkRoutes.getUpstreamPipelines(pipelineName, stageName, isTemplate), ApiVersion.v1)
                             .then((result: ApiResult<string>) => {
-                              return result.map((str) => {
-                                return this.autoSuggestions(JSON.parse(str));
+                              result.do(() => {
+                                return result.map((str) => {
+                                  return this.autoSuggestions(JSON.parse(str));
+                                });
+                              }, () => {
+                                return this.autoSuggestions({});
                               });
                             });
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/general_options_tab.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/general_options_tab.tsx
@@ -29,13 +29,18 @@ export class GeneralOptionsTabContent extends TabContent<PipelineConfig> {
   }
 
   getPipelineSchedulingCheckBox(entity: PipelineConfig, templateConfig: TemplateConfig) {
+    let additionalHelpText: string = ";";
+    if (entity.isUsingTemplate()) {
+      additionalHelpText = ` Since this pipeline is based on '${entity.template()}' template, automatic/manual behaviour of the pipeline is determined by the template's first stage.`;
+    }
+
     const stage: Stage = entity.template() ? templateConfig.firstStage() : entity.firstStage();
     if (stage) {
       return <CheckboxField label="Automatic pipeline scheduling"
                             errorText={entity.errors().errorsForDisplay("")}
                             dataTestId={"automatic-pipeline-scheduling"}
                             readonly={entity.isDefinedInConfigRepo() || entity.isUsingTemplate()}
-                            helpText="If unchecked, this pipeline will only schedule in response to a Manual/API/Timer trigger. Unchecking this box is the same as making the first stage manual."
+                            helpText={`If unchecked, this pipeline will only schedule in response to a Manual/API/Timer trigger. Unchecking this box is the same as making the first stage manual.${additionalHelpText}`}
                             property={stage.approval().typeAsStream()}/>;
     }
   }


### PR DESCRIPTION
Description:

- [x] Pipeline Config SPA Fixes
    - [x] Fix client side fetch upstream autosuggestion pipelines API call
            - Do not make continuous API calls when api call fails.
            - Set autosuggestions to empty when API call fails.
    - [x] Provide auto suggestions for elastic profile id when user switches tab.
    - [x] Provide additional help text for disabled automatic pipeline scheduling
           when pipeline is extracted from a template.

- [x] Fix upstream pipelines autosuggestion API
    - Do not fail to provide autosuggestions for template when
      template is in use by pipeline.
    - Do not consider pipelines which are currently extracted from the
      template for providing autosuggestions.