### PR TITLE
Pipeline config spa fixes

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.tsx
@@ -93,6 +93,10 @@ export class MaterialModal extends Modal {
   }
 
   buttons(): m.ChildArray {
+    if (this.readonly) {
+      return [];
+    }
+
     return [
       <Primary data-test-id="button-save" onclick={this.addOrUpdateEntity.bind(this)}>Save</Primary>,
       <Cancel data-test-id="button-cancel" onclick={this.close.bind(this)}>Cancel</Cancel>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/modals/material_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/modals/material_modal_spec.tsx
@@ -52,4 +52,24 @@ describe("MaterialModalSpec", () => {
     expect(helper.byTestId('form-field-input-material-type')).toBeInDOM();
     expect(helper.byTestId('materials-destination-warning-message')).not.toBeInDOM();
   });
+
+  it("should show save and reset buttons", () => {
+    const modal = new MaterialModal("Some modal title", Stream(material), "test", Stream(materials), Stream(scms), Stream(pkgRepos), Stream(pluginInfos), jasmine.createSpy("pipelineConfigSave"), true, false);
+    modal.render();
+    m.redraw.sync();
+    const helper = new TestHelper().forModal();
+
+    expect(helper.byTestId('button-save', document.body)).toBeInDOM();
+    expect(helper.byTestId('button-cancel', document.body)).toBeInDOM();
+  });
+
+  it("should not show save and reset buttons for read only materials", () => {
+    const modal = new MaterialModal("Some modal title", Stream(material), "test", Stream(materials), Stream(scms), Stream(pkgRepos), Stream(pluginInfos), jasmine.createSpy("pipelineConfigSave"), true, true);
+    modal.render();
+    m.redraw.sync();
+    const helper = new TestHelper().forModal();
+
+    expect(helper.byTestId('button-save', document.body)).not.toBeInDOM();
+    expect(helper.byTestId('button-cancel', document.body)).not.toBeInDOM();
+  });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
@@ -53,7 +53,7 @@ function markAllDisabled(vnodes: m.ChildArray) {
         markAllDisabled(vnode);
       } else {
         //@ts-ignore
-        if (FormField.isPrototypeOf(vnode.tag) || vnode.tag.name === "SwitchBtn") {
+        if (FormField.isPrototypeOf(vnode.tag)) {
           (vnode.attrs as any).readonly = true;
           (vnode.attrs as any).disabled = true;
         } else {
@@ -117,6 +117,7 @@ abstract class ScmFields extends MithrilViewComponent<Attrs> {
                    dataTestId="auto-update-material"
                    small={true}
                    css={styles}
+                   disabled={vnode.attrs.readonly}
                    field={mattrs.autoUpdate}
                    errorText={this.errs(mattrs, "autoUpdate")}/>,
 


### PR DESCRIPTION
Issue: #7816

Description:

* Do not show save and reset button for config repo pipeline materials.
* Disable poll for changes switch for config repo pipeline materials
