### PR TITLE
Use SHA-512/256 for all entity hashing

### DIFF
--- a/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2.java
+++ b/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2.java
@@ -118,7 +118,7 @@ public class AdminControllerV2 extends ApiController implements SparkSpringContr
 
     @Override
     public String etagFor(AdminsConfig entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-admins-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2Test.groovy
+++ b/api/api-admins-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2Test.groovy
@@ -95,14 +95,14 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
       @Test
       void 'should render the security admins config'() {
         AdminsConfig config = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin")))
-        when(entityHashingService.md5ForEntity(config)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(config)).thenReturn('digest')
         when(adminsConfigService.systemAdmins()).thenReturn(config)
 
         getWithApiHeader(controller.controllerPath())
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(config, AdminsConfigRepresenter)
       }
@@ -110,9 +110,9 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
       @Test
       void 'should render 304 if etag matches'() {
         def config = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin")))
-        when(entityHashingService.md5ForEntity(config)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(config)).thenReturn('digest')
         when(adminsConfigService.systemAdmins()).thenReturn(config)
-        getWithApiHeader(controller.controllerPath(), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath(), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isNotModified()
@@ -122,13 +122,13 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
       @Test
       void 'should render 200 if etag does not match'() {
         def config = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin-new")))
-        when(entityHashingService.md5ForEntity(config)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(config)).thenReturn('digest')
         when(adminsConfigService.systemAdmins()).thenReturn(config)
         getWithApiHeader(controller.controllerPath(), ['if-none-match': '"junk"'])
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(config, AdminsConfigRepresenter)
       }
@@ -145,7 +145,7 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
       void setUp() {
         config = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin")))
         when(adminsConfigService.systemAdmins()).thenReturn(config)
-        when(entityHashingService.md5ForEntity(config)).thenReturn('cached-md5')
+        when(entityHashingService.hashForEntity(config)).thenReturn('cached-digest')
       }
 
       @Override
@@ -157,7 +157,7 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
       void makeHttpCall() {
         sendRequest('put', controller.controllerPath(), [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'cached-md5',
+          'If-Match'    : 'cached-digest',
           'content-type': 'application/json'
         ], toObjectString({ AdminsConfigRepresenter.toJSON(it, this.config) }))
       }
@@ -178,13 +178,13 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
           new AdminUser(new CaseInsensitiveString("new_admin")))
 
         when(adminsConfigService.systemAdmins()).thenReturn(configInServer)
-        when(entityHashingService.md5ForEntity(configInServer)).thenReturn("cached-md5")
+        when(entityHashingService.hashForEntity(configInServer)).thenReturn("cached-digest")
 
-        putWithApiHeader(controller.controllerPath(), ['if-match': 'cached-md5'], toObjectString({
+        putWithApiHeader(controller.controllerPath(), ['if-match': 'cached-digest'], toObjectString({
           AdminsConfigRepresenter.toJSON(it, configFromRequest)
         }))
 
-        verify(adminsConfigService).update(any(), eq(configFromRequest), eq("cached-md5"), any(HttpLocalizedOperationResult.class))
+        verify(adminsConfigService).update(any(), eq(configFromRequest), eq("cached-digest"), any(HttpLocalizedOperationResult.class))
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
@@ -199,13 +199,13 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
 
 
         when(adminsConfigService.systemAdmins()).thenReturn(configInServer)
-        when(entityHashingService.md5ForEntity(configInServer)).thenReturn("cached-md5")
-        when(adminsConfigService.update(any(), eq(configFromRequest), eq("cached-md5"), any(HttpLocalizedOperationResult.class))).then({ InvocationOnMock invocation ->
+        when(entityHashingService.hashForEntity(configInServer)).thenReturn("cached-digest")
+        when(adminsConfigService.update(any(), eq(configFromRequest), eq("cached-digest"), any(HttpLocalizedOperationResult.class))).then({ InvocationOnMock invocation ->
           HttpLocalizedOperationResult result = invocation.getArguments().last()
           result.unprocessableEntity("validation failed")
         })
 
-        putWithApiHeader(controller.controllerPath(), ['if-match': 'cached-md5'], toObjectString({
+        putWithApiHeader(controller.controllerPath(), ['if-match': 'cached-digest'], toObjectString({
           AdminsConfigRepresenter.toJSON(it, configFromRequest)
         }))
 
@@ -221,7 +221,7 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
         AdminsConfig systemAdminsInServer = new AdminsConfig(new AdminRole(new CaseInsensitiveString("role1")))
 
         when(adminsConfigService.systemAdmins()).thenReturn(systemAdminsInServer)
-        when(entityHashingService.md5ForEntity(systemAdminsInServer)).thenReturn('cached-md5')
+        when(entityHashingService.hashForEntity(systemAdminsInServer)).thenReturn('cached-digest')
 
         putWithApiHeader(controller.controllerPath(), ['if-match': 'some-string'], toObjectString({
           AdminsConfigRepresenter.toJSON(it, systemAdminsRequest)
@@ -245,7 +245,7 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
       void setUp() {
         config = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin")))
         when(adminsConfigService.systemAdmins()).thenReturn(config)
-        when(entityHashingService.md5ForEntity(config)).thenReturn('cached-md5')
+        when(entityHashingService.hashForEntity(config)).thenReturn('cached-digest')
       }
 
       @Override
@@ -273,9 +273,9 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
           new AdminRole("super"), new AdminRole("duper"))
 
         when(adminsConfigService.systemAdmins()).thenReturn(expectedConfig)
-        when(adminsConfigService.bulkUpdate(any(), eq(["jez", "tez"]), eq(["admin"]), eq(["super", "duper"]), eq(["wonky", "donkey"]), eq("cached-md5")))
+        when(adminsConfigService.bulkUpdate(any(), eq(["jez", "tez"]), eq(["admin"]), eq(["super", "duper"]), eq(["wonky", "donkey"]), eq("cached-digest")))
           .thenReturn(new BulkUpdateAdminsResult())
-        when(entityHashingService.md5ForEntity(expectedConfig)).thenReturn("cached-md5")
+        when(entityHashingService.hashForEntity(expectedConfig)).thenReturn("cached-digest")
 
         patchWithApiHeader(controller.controllerPath(), [
           operations: [
@@ -290,7 +290,7 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
           ]
         ])
 
-        verify(adminsConfigService).bulkUpdate(any(), eq(["jez", "tez"]), eq(["admin"]), eq(["super", "duper"]), eq(["wonky", "donkey"]), eq("cached-md5"))
+        verify(adminsConfigService).bulkUpdate(any(), eq(["jez", "tez"]), eq(["admin"]), eq(["super", "duper"]), eq(["wonky", "donkey"]), eq("cached-digest"))
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
@@ -305,8 +305,8 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
         result.nonExistentRoles = [new CaseInsensitiveString("jez"), new CaseInsensitiveString("tez")]
         result.unprocessableEntity("validation failed")
         when(adminsConfigService.systemAdmins()).thenReturn(configInServer)
-        when(entityHashingService.md5ForEntity(configInServer)).thenReturn("cached-md5")
-        when(adminsConfigService.bulkUpdate(any(), eq(["jez", "tez"]), eq([]), eq([]), eq([]), eq("cached-md5")))
+        when(entityHashingService.hashForEntity(configInServer)).thenReturn("cached-digest")
+        when(adminsConfigService.bulkUpdate(any(), eq(["jez", "tez"]), eq([]), eq([]), eq([]), eq("cached-digest")))
           .thenReturn(result)
 
         patchWithApiHeader(controller.controllerPath(), [

--- a/api/api-artifact-config-v1/src/main/java/com/thoughtworks/go/apiv1/artifactconfig/ArtifactConfigControllerV1.java
+++ b/api/api-artifact-config-v1/src/main/java/com/thoughtworks/go/apiv1/artifactconfig/ArtifactConfigControllerV1.java
@@ -108,7 +108,7 @@ public class ArtifactConfigControllerV1 extends ApiController implements SparkSp
 
     @Override
     public String etagFor(ArtifactConfig entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-artifact-store-config-v1/src/main/java/com/thoughtworks/go/apiv1/artifactstoreconfig/ArtifactStoreConfigController.java
+++ b/api/api-artifact-store-config-v1/src/main/java/com/thoughtworks/go/apiv1/artifactstoreconfig/ArtifactStoreConfigController.java
@@ -62,7 +62,7 @@ public class ArtifactStoreConfigController extends ApiController implements Spar
 
     @Override
     public String etagFor(ArtifactStore entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-artifact-store-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/artifactstoreconfig/ArtifactStoreConfigControllerTest.groovy
+++ b/api/api-artifact-store-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/artifactstoreconfig/ArtifactStoreConfigControllerTest.groovy
@@ -142,14 +142,14 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
       @Test
       void 'should render artifact store of specified id'() {
         def artifactStore = new ArtifactStore("docker", "cd.go.artifact.docker", ConfigurationPropertyMother.create("RegistryURL", false, "http://foo"))
-        when(entityHashingService.md5ForEntity(artifactStore)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(artifactStore)).thenReturn('digest')
         when(artifactStoreService.findArtifactStore('test')).thenReturn(artifactStore)
 
         getWithApiHeader(controller.controllerPath('/test'))
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(artifactStore, ArtifactStoreRepresenter)
       }
@@ -170,10 +170,10 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
       void 'should render 304 if etag matches'() {
         def artifactStore = new ArtifactStore("docker", "cd.go.artifact.docker",
           ConfigurationPropertyMother.create("RegistryURL", false, "http://foo"))
-        when(entityHashingService.md5ForEntity(artifactStore)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(artifactStore)).thenReturn('digest')
         when(artifactStoreService.findArtifactStore('test')).thenReturn(artifactStore)
 
-        getWithApiHeader(controller.controllerPath('/test'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/test'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isNotModified()
@@ -184,14 +184,14 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
       void 'should render 200 if etag does not match'() {
         def artifactStore = new ArtifactStore("docker", "cd.go.artifact.docker",
           ConfigurationPropertyMother.create("RegistryURL", false, "http://foo"))
-        when(entityHashingService.md5ForEntity(artifactStore)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(artifactStore)).thenReturn('digest')
         when(artifactStoreService.findArtifactStore('test')).thenReturn(artifactStore)
 
         getWithApiHeader(controller.controllerPath('/test'), ['if-none-match': '"junk"'])
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(artifactStore, ArtifactStoreRepresenter)
       }
@@ -226,7 +226,7 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
       @Test
       void 'should deserialize artifact store config from given payload'() {
         def artifactStore = new ArtifactStore("test", "cd.go.artifact.docker", ConfigurationPropertyMother.create("RegistryURL", false, "http://foo"))
-        when(entityHashingService.md5ForEntity(artifactStore)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(artifactStore)).thenReturn('some-digest')
 
         postWithApiHeader(controller.controllerPath(), toObjectString({
           ArtifactStoreRepresenter.toJSON(it, artifactStore)
@@ -234,7 +234,7 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"some-md5"')
+          .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(artifactStore, ArtifactStoreRepresenter)
       }
@@ -311,7 +311,7 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
         def artifactStore = new ArtifactStore("test", "cd.go.artifact.docker", ConfigurationPropertyMother.create("RegistryURL", false, "http://foo"))
 
         when(artifactStoreService.findArtifactStore('test')).thenReturn(null)
-        when(entityHashingService.md5ForEntity(artifactStore)).thenReturn('cached-md5')
+        when(entityHashingService.hashForEntity(artifactStore)).thenReturn('cached-digest')
 
         putWithApiHeader(controller.controllerPath('/test'), ['if-match': 'some-string'], toObjectString({
           ArtifactStoreRepresenter.toJSON(it, artifactStore)
@@ -327,7 +327,7 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
         def artifactStore = new ArtifactStore("test", "cd.go.artifact.docker", ConfigurationPropertyMother.create("RegistryURL", false, "http://foo"))
 
         when(artifactStoreService.findArtifactStore('test')).thenReturn(artifactStore)
-        when(entityHashingService.md5ForEntity(artifactStore)).thenReturn('cached-md5')
+        when(entityHashingService.hashForEntity(artifactStore)).thenReturn('cached-digest')
 
         putWithApiHeader(controller.controllerPath('/test'), ['if-match': 'some-string'], toObjectString({
           ArtifactStoreRepresenter.toJSON(it, artifactStore)
@@ -344,16 +344,16 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
         def newArtifactStore = new ArtifactStore("test", "cd.go.artifact.artifactory", ConfigurationPropertyMother.create("RegistryURL", false, "http://foo"))
 
         when(artifactStoreService.findArtifactStore('test')).thenReturn(artifactStore)
-        when(entityHashingService.md5ForEntity(artifactStore)).thenReturn('cached-md5')
-        when(entityHashingService.md5ForEntity(newArtifactStore)).thenReturn('new-md5')
+        when(entityHashingService.hashForEntity(artifactStore)).thenReturn('cached-digest')
+        when(entityHashingService.hashForEntity(newArtifactStore)).thenReturn('new-digest')
 
-        putWithApiHeader(controller.controllerPath('/test'), ['if-match': 'cached-md5'], toObjectString({
+        putWithApiHeader(controller.controllerPath('/test'), ['if-match': 'cached-digest'], toObjectString({
           ArtifactStoreRepresenter.toJSON(it, newArtifactStore)
         }))
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"new-md5"')
+          .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(newArtifactStore, ArtifactStoreRepresenter)
       }
@@ -364,10 +364,10 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
         def newArtifactStore = new ArtifactStore("test1", "cd.go.artifact.artifactory", ConfigurationPropertyMother.create("RegistryURL", false, "http://foo"))
 
         when(artifactStoreService.findArtifactStore('test')).thenReturn(artifactStore)
-        when(entityHashingService.md5ForEntity(artifactStore)).thenReturn('cached-md5')
-        when(entityHashingService.md5ForEntity(newArtifactStore)).thenReturn('new-md5')
+        when(entityHashingService.hashForEntity(artifactStore)).thenReturn('cached-digest')
+        when(entityHashingService.hashForEntity(newArtifactStore)).thenReturn('new-digest')
 
-        putWithApiHeader(controller.controllerPath('/test'), ['if-match': 'cached-md5'], toObjectString({
+        putWithApiHeader(controller.controllerPath('/test'), ['if-match': 'cached-digest'], toObjectString({
           ArtifactStoreRepresenter.toJSON(it, newArtifactStore)
         }))
 

--- a/api/api-cluster-profiles-v1/src/main/java/com/thoughtworks/go/apiv1/clusterprofiles/ClusterProfilesControllerV1.java
+++ b/api/api-cluster-profiles-v1/src/main/java/com/thoughtworks/go/apiv1/clusterprofiles/ClusterProfilesControllerV1.java
@@ -163,7 +163,7 @@ public class ClusterProfilesControllerV1 extends ApiController implements SparkS
 
     @Override
     public String etagFor(ClusterProfile entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-cluster-profiles-v1/src/test/groovy/com/thoughtworks/go/apiv1/clusterprofiles/ClusterProfilesControllerV1Test.groovy
+++ b/api/api-cluster-profiles-v1/src/test/groovy/com/thoughtworks/go/apiv1/clusterprofiles/ClusterProfilesControllerV1Test.groovy
@@ -130,7 +130,7 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
         clusterProfile = new ClusterProfile("docker", "cd.go.docker")
 
         when(clusterProfilesService.findProfile("docker")).thenReturn(clusterProfile)
-        when(entityHashingService.md5ForEntity(clusterProfile)).thenReturn("md5")
+        when(entityHashingService.hashForEntity(clusterProfile)).thenReturn("digest")
       }
 
       @Test
@@ -140,13 +140,13 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasBodyWithJsonObject(clusterProfile, ClusterProfileRepresenter.class)
       }
 
       @Test
       void 'should render not modified when ETag matches'() {
-        getWithApiHeader(controller.controllerPath("/docker"), ['if-none-match': 'md5'])
+        getWithApiHeader(controller.controllerPath("/docker"), ['if-none-match': 'digest'])
 
         assertThatResponse()
           .isNotModified()
@@ -190,7 +190,7 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
         loginAsAdmin()
 
         clusterProfile = new ClusterProfile("docker", "cd.go.docker")
-        when(entityHashingService.md5ForEntity(clusterProfile)).thenReturn("md5")
+        when(entityHashingService.hashForEntity(clusterProfile)).thenReturn("digest")
       }
 
       @Test
@@ -204,7 +204,7 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(clusterProfile, ClusterProfileRepresenter)
       }
@@ -223,7 +223,7 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
             ]
           ]]
 
-        when(entityHashingService.md5ForEntity(Mockito.any() as ClusterProfile)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as ClusterProfile)).thenReturn('some-digest')
         when(clusterProfilesService.findProfile("docker")).thenReturn(existingClusterProfile)
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
@@ -353,15 +353,15 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
             ]
           ]]
 
-        when(entityHashingService.md5ForEntity(existingCluster)).thenReturn('some-md5')
-        when(entityHashingService.md5ForEntity(updatedCluster)).thenReturn('new-md5')
+        when(entityHashingService.hashForEntity(existingCluster)).thenReturn('some-digest')
+        when(entityHashingService.hashForEntity(updatedCluster)).thenReturn('new-digest')
         when(clusterProfilesService.findProfile("docker")).thenReturn(existingCluster)
 
-        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'some-digest'], jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"new-md5"')
+          .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(updatedCluster, ClusterProfileRepresenter)
       }
@@ -380,10 +380,10 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
             ]
           ]]
 
-        when(entityHashingService.md5ForEntity(existingProfile)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingProfile)).thenReturn('some-digest')
         when(clusterProfilesService.findProfile("docker")).thenReturn(existingProfile)
 
-        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'wrong-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'wrong-digest'], jsonPayload)
 
         assertThatResponse()
           .isPreconditionFailed()
@@ -394,7 +394,7 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
       @Test
       void 'should return 404 if the profile does not exists'() {
         when(clusterProfilesService.findProfile("docker")).thenReturn(null)
-        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'wrong-md5'], [:])
+        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'wrong-digest'], [:])
 
         assertThatResponse()
           .isNotFound()
@@ -415,10 +415,10 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
             ]
           ]]
 
-        when(entityHashingService.md5ForEntity(existingCluster)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingCluster)).thenReturn('some-digest')
         when(clusterProfilesService.findProfile("docker")).thenReturn(existingCluster)
 
-        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'some-digest'], jsonPayload)
 
         assertThatResponse()
           .isUnprocessableEntity()
@@ -439,7 +439,7 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
             ]
           ]]
 
-        when(entityHashingService.md5ForEntity(existingCluster)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingCluster)).thenReturn('some-digest')
         when(clusterProfilesService.findProfile("docker")).thenReturn(existingCluster)
 
         when(clusterProfilesService.update(Mockito.any() as ClusterProfile, Mockito.any() as Username, Mockito.any() as HttpLocalizedOperationResult)).then({ InvocationOnMock invocation ->
@@ -449,7 +449,7 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
           result.unprocessableEntity("validation failed")
         })
 
-        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'some-digest'], jsonPayload)
 
         def expectedResponseBody = [
           message: "validation failed",

--- a/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/ConfigReposControllerV2.java
+++ b/api/api-config-repos-v2/src/main/java/com/thoughtworks/go/apiv2/configrepos/ConfigReposControllerV2.java
@@ -168,7 +168,7 @@ public class ConfigReposControllerV2 extends ApiController implements SparkSprin
 
     @Override
     public String etagFor(ConfigRepoConfig repo) {
-        return entityHashingService.md5ForEntity(repo);
+        return entityHashingService.hashForEntity(repo);
     }
 
     @Override

--- a/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposControllerV2Test.groovy
+++ b/api/api-config-repos-v2/src/test/groovy/com/thoughtworks/go/apiv2/configrepos/ConfigReposControllerV2Test.groovy
@@ -239,13 +239,13 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
       ConfigRepoConfig repo = repo(ID_1)
       when(service.getConfigRepo(ID_1)).thenReturn(repo)
-      when(entityHashingService.md5ForEntity(repo)).thenReturn('md5')
+      when(entityHashingService.hashForEntity(repo)).thenReturn('digest')
 
       getWithApiHeader(controller.controllerPath(ID_1))
 
       assertThatResponse().
         isOk().
-        hasHeader('ETag', '"md5"'). // test etag does not change
+        hasHeader('ETag', '"digest"'). // test etag does not change
         hasJsonBody(expectedRepoJson(ID_1))
     }
 
@@ -412,10 +412,10 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
       ConfigRepoConfig existing = ConfigRepoConfig.createConfigRepoConfig(hg("https://fakeurl.com", null), TEST_PLUGIN_ID, id)
       ConfigRepoConfig repoFromRequest = ConfigRepoConfig.createConfigRepoConfig(hg("https://newfakeurl.com", null), TEST_PLUGIN_ID, id)
       when(service.getConfigRepo(id)).thenReturn(existing)
-      when(entityHashingService.md5ForEntity(existing)).thenReturn('md5')
-      when(entityHashingService.md5ForEntity(repoFromRequest)).thenReturn('new_md5')
+      when(entityHashingService.hashForEntity(existing)).thenReturn('digest')
+      when(entityHashingService.hashForEntity(repoFromRequest)).thenReturn('new_digest')
 
-      putWithApiHeader(controller.controllerPath(id), ['If-Match': 'md5'], [
+      putWithApiHeader(controller.controllerPath(id), ['If-Match': 'digest'], [
         id           : id,
         plugin_id    : TEST_PLUGIN_ID,
         material     : [
@@ -430,11 +430,11 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
       ])
 
       verify(service, times(1)).
-        updateConfigRepo(eq(id), eq(repoFromRequest), eq('md5'), any() as Username, any() as HttpLocalizedOperationResult)
+        updateConfigRepo(eq(id), eq(repoFromRequest), eq('digest'), any() as Username, any() as HttpLocalizedOperationResult)
 
       assertThatResponse().
         isOk().
-        hasHeader('ETag', '"new_md5"'). // test etag should change
+        hasHeader('ETag', '"new_digest"'). // test etag should change
         hasJsonBody(expectedRepoJson(id, "https://newfakeurl.com"))
     }
 
@@ -456,7 +456,7 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
 
       ConfigRepoConfig existing = repo(id)
       when(service.getConfigRepo(id)).thenReturn(existing)
-      when(entityHashingService.md5ForEntity(existing)).thenReturn("unknown-etag")
+      when(entityHashingService.hashForEntity(existing)).thenReturn("unknown-etag")
 
       Map payload = [
         id           : id,
@@ -487,7 +487,7 @@ class ConfigReposControllerV2Test implements SecurityServiceTrait, ControllerTra
     void 'should throw 403 if the user does not have permission to update config-repo'() {
       String id = "test-id"
 
-      putWithApiHeader(controller.controllerPath(id), ['If-Match': 'md5'], [
+      putWithApiHeader(controller.controllerPath(id), ['If-Match': 'digest'], [
         id           : id,
         plugin_id    : TEST_PLUGIN_ID,
         material     : [

--- a/api/api-config-repos-v3/src/main/java/com/thoughtworks/go/apiv3/configrepos/ConfigReposControllerV3.java
+++ b/api/api-config-repos-v3/src/main/java/com/thoughtworks/go/apiv3/configrepos/ConfigReposControllerV3.java
@@ -50,8 +50,7 @@ import java.util.function.Consumer;
 import static com.thoughtworks.go.api.util.HaltApiResponses.haltBecauseEntityAlreadyExists;
 import static com.thoughtworks.go.api.util.HaltApiResponses.haltBecauseEtagDoesNotMatch;
 import static com.thoughtworks.go.config.policy.SupportedEntity.CONFIG_REPO;
-
-import static com.thoughtworks.go.util.CachedDigestUtils.sha256Hex;
+import static com.thoughtworks.go.util.CachedDigestUtils.sha512_256Hex;
 import static java.util.stream.Collectors.toCollection;
 import static spark.Spark.*;
 
@@ -136,7 +135,7 @@ public class ConfigReposControllerV3 extends ApiController implements SparkSprin
     }
 
     String showRepo(Request req, Response res) {
-            ConfigRepoConfig repo = fetchEntityFromConfig(req.params(":id"));
+        ConfigRepoConfig repo = fetchEntityFromConfig(req.params(":id"));
         String etag = etagFor(repo);
 
         setEtagHeader(res, etag);
@@ -227,11 +226,11 @@ public class ConfigReposControllerV3 extends ApiController implements SparkSprin
 
     @Override
     public String etagFor(ConfigRepoConfig repo) {
-        return entityHashingService.md5ForEntity(repo);
+        return entityHashingService.hashForEntity(repo);
     }
 
     private String etagFor(PartialConfig entity) {
-        return sha256Hex(Integer.toString(entity.hashCode()));
+        return sha512_256Hex(Integer.toString(entity.hashCode()));
     }
 
     @Override

--- a/api/api-config-repos-v3/src/main/java/com/thoughtworks/go/apiv3/configrepos/ConfigReposInternalControllerV3.java
+++ b/api/api-config-repos-v3/src/main/java/com/thoughtworks/go/apiv3/configrepos/ConfigReposInternalControllerV3.java
@@ -42,7 +42,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.thoughtworks.go.config.policy.SupportedEntity.CONFIG_REPO;
-import static com.thoughtworks.go.util.CachedDigestUtils.sha256Hex;
+import static com.thoughtworks.go.util.CachedDigestUtils.sha512_256Hex;
 import static java.util.stream.Collectors.toList;
 import static spark.Spark.*;
 
@@ -116,7 +116,7 @@ public class ConfigReposInternalControllerV3 extends ApiController implements Sp
     }
 
     private String etagFor(Object entity) {
-        return sha256Hex(Integer.toString(entity.hashCode()));
+        return sha512_256Hex(Integer.toString(entity.hashCode()));
     }
 
     private List<ConfigRepoWithResult> allRepos() {

--- a/api/api-config-repos-v3/src/test/groovy/com/thoughtworks/go/apiv3/configrepos/ConfigReposControllerV3Test.groovy
+++ b/api/api-config-repos-v3/src/test/groovy/com/thoughtworks/go/apiv3/configrepos/ConfigReposControllerV3Test.groovy
@@ -290,13 +290,13 @@ class ConfigReposControllerV3Test implements SecurityServiceTrait, ControllerTra
 
       ConfigRepoConfig repo = repo(ID_1)
       when(service.getConfigRepo(ID_1)).thenReturn(repo)
-      when(entityHashingService.md5ForEntity(repo)).thenReturn('md5')
+      when(entityHashingService.hashForEntity(repo)).thenReturn('digest')
 
       getWithApiHeader(controller.controllerPath(ID_1))
 
       assertThatResponse().
           isOk().
-          hasHeader('ETag', '"md5"'). // test etag does not change
+          hasHeader('ETag', '"digest"'). // test etag does not change
           hasJsonBody(expectedRepoJson(ID_1))
     }
 
@@ -464,10 +464,10 @@ class ConfigReposControllerV3Test implements SecurityServiceTrait, ControllerTra
       ConfigRepoConfig existing = ConfigRepoConfig.createConfigRepoConfig(hg("https://fakeurl.com", null), TEST_PLUGIN_ID, id)
       ConfigRepoConfig repoFromRequest = ConfigRepoConfig.createConfigRepoConfig(hg("https://newfakeurl.com", null), TEST_PLUGIN_ID, id)
       when(service.getConfigRepo(id)).thenReturn(existing)
-      when(entityHashingService.md5ForEntity(existing)).thenReturn('md5')
-      when(entityHashingService.md5ForEntity(repoFromRequest)).thenReturn('new_md5')
+      when(entityHashingService.hashForEntity(existing)).thenReturn('digest')
+      when(entityHashingService.hashForEntity(repoFromRequest)).thenReturn('new_digest')
 
-      putWithApiHeader(controller.controllerPath(id), ['If-Match': 'md5'], [
+      putWithApiHeader(controller.controllerPath(id), ['If-Match': 'digest'], [
           id           : id,
           plugin_id    : TEST_PLUGIN_ID,
           material     : [
@@ -482,11 +482,11 @@ class ConfigReposControllerV3Test implements SecurityServiceTrait, ControllerTra
       ])
 
       verify(service, times(1)).
-          updateConfigRepo(eq(id), eq(repoFromRequest), eq('md5'), any() as Username, any() as HttpLocalizedOperationResult)
+          updateConfigRepo(eq(id), eq(repoFromRequest), eq('digest'), any() as Username, any() as HttpLocalizedOperationResult)
 
       assertThatResponse().
           isOk().
-          hasHeader('ETag', '"new_md5"'). // test etag should change
+          hasHeader('ETag', '"new_digest"'). // test etag should change
           hasJsonBody(expectedRepoJson(id, "https://newfakeurl.com"))
     }
 
@@ -508,7 +508,7 @@ class ConfigReposControllerV3Test implements SecurityServiceTrait, ControllerTra
 
       ConfigRepoConfig existing = repo(id)
       when(service.getConfigRepo(id)).thenReturn(existing)
-      when(entityHashingService.md5ForEntity(existing)).thenReturn("unknown-etag")
+      when(entityHashingService.hashForEntity(existing)).thenReturn("unknown-etag")
 
       Map payload = [
           id           : id,
@@ -539,7 +539,7 @@ class ConfigReposControllerV3Test implements SecurityServiceTrait, ControllerTra
     void 'should throw 403 if the user does not have permission to update config-repo'() {
       String id = "test-id"
 
-      putWithApiHeader(controller.controllerPath(id), ['If-Match': 'md5'], [
+      putWithApiHeader(controller.controllerPath(id), ['If-Match': 'digest'], [
           id           : id,
           plugin_id    : TEST_PLUGIN_ID,
           material     : [

--- a/api/api-config-repos-v4/src/main/java/com/thoughtworks/go/apiv4/configrepos/ConfigReposControllerV4.java
+++ b/api/api-config-repos-v4/src/main/java/com/thoughtworks/go/apiv4/configrepos/ConfigReposControllerV4.java
@@ -51,7 +51,7 @@ import java.util.function.Consumer;
 import static com.thoughtworks.go.api.util.HaltApiResponses.haltBecauseEntityAlreadyExists;
 import static com.thoughtworks.go.api.util.HaltApiResponses.haltBecauseEtagDoesNotMatch;
 import static com.thoughtworks.go.config.policy.SupportedEntity.CONFIG_REPO;
-import static com.thoughtworks.go.util.CachedDigestUtils.sha256Hex;
+import static com.thoughtworks.go.util.CachedDigestUtils.sha512_256Hex;
 import static java.util.stream.Collectors.toCollection;
 import static spark.Spark.*;
 
@@ -228,11 +228,11 @@ public class ConfigReposControllerV4 extends ApiController implements SparkSprin
 
     @Override
     public String etagFor(ConfigRepoConfig repo) {
-        return entityHashingService.md5ForEntity(repo);
+        return entityHashingService.hashForEntity(repo);
     }
 
     private String etagFor(PartialConfig entity) {
-        return sha256Hex(Integer.toString(entity.hashCode()));
+        return sha512_256Hex(Integer.toString(entity.hashCode()));
     }
 
     @Override

--- a/api/api-config-repos-v4/src/main/java/com/thoughtworks/go/apiv4/configrepos/ConfigReposInternalControllerV4.java
+++ b/api/api-config-repos-v4/src/main/java/com/thoughtworks/go/apiv4/configrepos/ConfigReposInternalControllerV4.java
@@ -42,7 +42,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.thoughtworks.go.config.policy.SupportedEntity.CONFIG_REPO;
-import static com.thoughtworks.go.util.CachedDigestUtils.sha256Hex;
+import static com.thoughtworks.go.util.CachedDigestUtils.sha512_256Hex;
 import static java.util.stream.Collectors.toList;
 import static spark.Spark.*;
 
@@ -116,7 +116,7 @@ public class ConfigReposInternalControllerV4 extends ApiController implements Sp
     }
 
     private String etagFor(Object entity) {
-        return sha256Hex(Integer.toString(entity.hashCode()));
+        return sha512_256Hex(Integer.toString(entity.hashCode()));
     }
 
     private List<ConfigRepoWithResult> allRepos() {

--- a/api/api-config-repos-v4/src/test/groovy/com/thoughtworks/go/apiv4/configrepos/ConfigReposControllerV4Test.groovy
+++ b/api/api-config-repos-v4/src/test/groovy/com/thoughtworks/go/apiv4/configrepos/ConfigReposControllerV4Test.groovy
@@ -290,13 +290,13 @@ class ConfigReposControllerV4Test implements SecurityServiceTrait, ControllerTra
 
       ConfigRepoConfig repo = repo(ID_1)
       when(service.getConfigRepo(ID_1)).thenReturn(repo)
-      when(entityHashingService.md5ForEntity(repo)).thenReturn('md5')
+      when(entityHashingService.hashForEntity(repo)).thenReturn('digest')
 
       getWithApiHeader(controller.controllerPath(ID_1))
 
       assertThatResponse().
         isOk().
-        hasHeader('ETag', '"md5"'). // test etag does not change
+        hasHeader('ETag', '"digest"'). // test etag does not change
         hasJsonBody(expectedRepoJson(ID_1))
     }
 
@@ -464,10 +464,10 @@ class ConfigReposControllerV4Test implements SecurityServiceTrait, ControllerTra
       ConfigRepoConfig existing = ConfigRepoConfig.createConfigRepoConfig(hg("https://fakeurl.com", null), TEST_PLUGIN_ID, id)
       ConfigRepoConfig repoFromRequest = ConfigRepoConfig.createConfigRepoConfig(hg("https://newfakeurl.com", null), TEST_PLUGIN_ID, id)
       when(service.getConfigRepo(id)).thenReturn(existing)
-      when(entityHashingService.md5ForEntity(existing)).thenReturn('md5')
-      when(entityHashingService.md5ForEntity(repoFromRequest)).thenReturn('new_md5')
+      when(entityHashingService.hashForEntity(existing)).thenReturn('digest')
+      when(entityHashingService.hashForEntity(repoFromRequest)).thenReturn('new_digest')
 
-      putWithApiHeader(controller.controllerPath(id), ['If-Match': 'md5'], [
+      putWithApiHeader(controller.controllerPath(id), ['If-Match': 'digest'], [
         id           : id,
         plugin_id    : TEST_PLUGIN_ID,
         material     : [
@@ -482,11 +482,11 @@ class ConfigReposControllerV4Test implements SecurityServiceTrait, ControllerTra
       ])
 
       verify(service, times(1)).
-        updateConfigRepo(eq(id), eq(repoFromRequest), eq('md5'), any() as Username, any() as HttpLocalizedOperationResult)
+        updateConfigRepo(eq(id), eq(repoFromRequest), eq('digest'), any() as Username, any() as HttpLocalizedOperationResult)
 
       assertThatResponse().
         isOk().
-        hasHeader('ETag', '"new_md5"'). // test etag should change
+        hasHeader('ETag', '"new_digest"'). // test etag should change
         hasJsonBody(expectedRepoJson(id, "https://newfakeurl.com"))
     }
 
@@ -508,7 +508,7 @@ class ConfigReposControllerV4Test implements SecurityServiceTrait, ControllerTra
 
       ConfigRepoConfig existing = repo(id)
       when(service.getConfigRepo(id)).thenReturn(existing)
-      when(entityHashingService.md5ForEntity(existing)).thenReturn("unknown-etag")
+      when(entityHashingService.hashForEntity(existing)).thenReturn("unknown-etag")
 
       Map payload = [
         id           : id,
@@ -539,7 +539,7 @@ class ConfigReposControllerV4Test implements SecurityServiceTrait, ControllerTra
     void 'should throw 403 if the user does not have permission to update config-repo'() {
       String id = "test-id"
 
-      putWithApiHeader(controller.controllerPath(id), ['If-Match': 'md5'], [
+      putWithApiHeader(controller.controllerPath(id), ['If-Match': 'digest'], [
         id           : id,
         plugin_id    : TEST_PLUGIN_ID,
         material     : [

--- a/api/api-data-sharing-settings-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/settings/DataSharingSettingsControllerV1.java
+++ b/api/api-data-sharing-settings-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/settings/DataSharingSettingsControllerV1.java
@@ -110,7 +110,7 @@ public class DataSharingSettingsControllerV1 extends ApiController implements Sp
 
     @Override
     public String etagFor(DataSharingSettings entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-data-sharing-settings-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/settings/DataSharingSettingsControllerV1Test.groovy
+++ b/api/api-data-sharing-settings-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/settings/DataSharingSettingsControllerV1Test.groovy
@@ -88,8 +88,8 @@ class DataSharingSettingsControllerV1Test implements SecurityServiceTrait, Contr
                 def dataSharingSettings = new DataSharingSettings(false, "Bob", new Date())
 
                 when(dataSharingSettingsService.get()).thenReturn(dataSharingSettings)
-                def etag = "md5"
-                when(entityHashingService.md5ForEntity(any() as DataSharingSettings)).thenReturn(etag)
+                def etag = "digest"
+                when(entityHashingService.hashForEntity(any() as DataSharingSettings)).thenReturn(etag)
 
                 getWithApiHeader(controller.controllerPath())
 

--- a/api/api-elastic-profile-v2/src/main/java/com/thoughtworks/go/apiv2/elasticprofile/ElasticProfileControllerV2.java
+++ b/api/api-elastic-profile-v2/src/main/java/com/thoughtworks/go/apiv2/elasticprofile/ElasticProfileControllerV2.java
@@ -174,7 +174,7 @@ public class ElasticProfileControllerV2 extends ApiController implements SparkSp
 
     @Override
     public String etagFor(ElasticProfile entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-elastic-profile-v2/src/test/groovy/com/thoughtworks/go/apiv2/elasticprofile/ElasticProfileControllerV2Test.groovy
+++ b/api/api-elastic-profile-v2/src/test/groovy/com/thoughtworks/go/apiv2/elasticprofile/ElasticProfileControllerV2Test.groovy
@@ -146,14 +146,14 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
       void 'should return elastic profile of specified id'() {
         def dockerElasticProfile = new ElasticProfile("docker", "prod-cluster", create("docker-uri", false, "unix:///var/run/docker"))
 
-        when(entityHashingService.md5ForEntity(dockerElasticProfile)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(dockerElasticProfile)).thenReturn('digest')
         when(elasticProfileService.findProfile('docker')).thenReturn(dockerElasticProfile)
 
         getWithApiHeader(controller.controllerPath('/docker'))
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(dockerElasticProfile, ElasticProfileRepresenter)
       }
@@ -174,10 +174,10 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
       void 'should return 304 if elastic profile is not modified'() {
         def dockerElasticProfile = new ElasticProfile("docker", "prod-cluster", create("docker-uri", false, "unix:///var/run/docker"))
 
-        when(entityHashingService.md5ForEntity(dockerElasticProfile)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(dockerElasticProfile)).thenReturn('digest')
         when(elasticProfileService.findProfile('docker')).thenReturn(dockerElasticProfile)
 
-        getWithApiHeader(controller.controllerPath('/docker'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/docker'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isNotModified()
@@ -188,14 +188,14 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
       void 'should return 200 with elastic profile if etag does not match'() {
         def dockerElasticProfile = new ElasticProfile("docker", "prod-cluster", create("docker-uri", false, "unix:///var/run/docker"))
 
-        when(entityHashingService.md5ForEntity(dockerElasticProfile)).thenReturn('md5-new')
+        when(entityHashingService.hashForEntity(dockerElasticProfile)).thenReturn('digest-new')
         when(elasticProfileService.findProfile('docker')).thenReturn(dockerElasticProfile)
 
-        getWithApiHeader(controller.controllerPath('/docker'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/docker'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5-new"')
+          .hasEtag('"digest-new"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(dockerElasticProfile, ElasticProfileRepresenter)
       }
@@ -240,13 +240,13 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
           ]]
 
         when(clusterProfileService.findProfile("prod-cluster")).thenReturn(new ClusterProfile("prod-cluster", "cd.go.docker"))
-        when(entityHashingService.md5ForEntity(Mockito.any() as ElasticProfile)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as ElasticProfile)).thenReturn('some-digest')
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"some-md5"')
+          .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(new ElasticProfile("docker", "prod-cluster", create("DockerURI", false, "http://foo")), ElasticProfileRepresenter)
       }
@@ -263,7 +263,7 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
             ]
           ]]
 
-        when(entityHashingService.md5ForEntity(Mockito.any() as ElasticProfile)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as ElasticProfile)).thenReturn('some-digest')
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
 
@@ -324,7 +324,7 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
             ]
           ]]
 
-        when(entityHashingService.md5ForEntity(Mockito.any() as ElasticProfile)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as ElasticProfile)).thenReturn('some-digest')
         when(elasticProfileService.findProfile("docker")).thenReturn(existingElasticProfile)
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
@@ -391,15 +391,15 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
           ]]
 
         when(clusterProfileService.findProfile("prod-cluster")).thenReturn(new ClusterProfile("prod-cluster", "cd.go.docker"))
-        when(entityHashingService.md5ForEntity(existingProfile)).thenReturn('some-md5')
-        when(entityHashingService.md5ForEntity(updatedProfile)).thenReturn('new-md5')
+        when(entityHashingService.hashForEntity(existingProfile)).thenReturn('some-digest')
+        when(entityHashingService.hashForEntity(updatedProfile)).thenReturn('new-digest')
         when(elasticProfileService.findProfile("docker")).thenReturn(existingProfile)
 
-        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'some-digest'], jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"new-md5"')
+          .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(updatedProfile, ElasticProfileRepresenter)
       }
@@ -418,11 +418,11 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
             ]
           ]]
 
-        when(entityHashingService.md5ForEntity(existingProfile)).thenReturn('some-md5')
-        when(entityHashingService.md5ForEntity(updatedProfile)).thenReturn('new-md5')
+        when(entityHashingService.hashForEntity(existingProfile)).thenReturn('some-digest')
+        when(entityHashingService.hashForEntity(updatedProfile)).thenReturn('new-digest')
         when(elasticProfileService.findProfile("docker")).thenReturn(existingProfile)
 
-        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'some-digest'], jsonPayload)
 
         assertThatResponse()
           .isUnprocessableEntity()
@@ -442,10 +442,10 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
             ]
           ]]
 
-        when(entityHashingService.md5ForEntity(existingProfile)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingProfile)).thenReturn('some-digest')
         when(elasticProfileService.findProfile("docker")).thenReturn(existingProfile)
 
-        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'wrong-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'wrong-digest'], jsonPayload)
 
         assertThatResponse()
           .isPreconditionFailed()
@@ -456,7 +456,7 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
       @Test
       void 'should return 404 if the profile does not exists'() {
         when(elasticProfileService.findProfile("docker")).thenReturn(null)
-        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'wrong-md5'], [:])
+        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'wrong-digest'], [:])
 
         assertThatResponse()
           .isNotFound()
@@ -477,10 +477,10 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
             ]
           ]]
 
-        when(entityHashingService.md5ForEntity(existingProfile)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingProfile)).thenReturn('some-digest')
         when(elasticProfileService.findProfile("docker")).thenReturn(existingProfile)
 
-        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'some-digest'], jsonPayload)
 
         assertThatResponse()
           .isUnprocessableEntity()
@@ -502,7 +502,7 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
           ]]
 
         when(clusterProfileService.findProfile("prod-cluster")).thenReturn(new ClusterProfile("prod-cluster", "cd.go.docker"))
-        when(entityHashingService.md5ForEntity(existingProfile)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingProfile)).thenReturn('some-digest')
         when(elasticProfileService.findProfile("docker")).thenReturn(existingProfile)
 
         when(elasticProfileService.update(Mockito.any() as Username, Mockito.any() as String, Mockito.any() as ElasticProfile, Mockito.any() as LocalizedOperationResult))
@@ -513,7 +513,7 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
           result.unprocessableEntity("validation failed")
         })
 
-        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/docker"), ['if-match': 'some-digest'], jsonPayload)
 
         def expectedResponseBody = [
           message: "validation failed",

--- a/api/api-environments-v3/src/main/java/com/thoughtworks/go/apiv3/environments/EnvironmentsControllerV3.java
+++ b/api/api-environments-v3/src/main/java/com/thoughtworks/go/apiv3/environments/EnvironmentsControllerV3.java
@@ -216,7 +216,7 @@ public class EnvironmentsControllerV3 extends ApiController implements SparkSpri
 
     @Override
     public String etagFor(EnvironmentConfig entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override
@@ -258,6 +258,6 @@ public class EnvironmentsControllerV3 extends ApiController implements SparkSpri
     }
 
     private String calculateEtag(EnvironmentsConfig envConfigs) {
-        return entityHashingService.md5ForEntity(envConfigs);
+        return entityHashingService.hashForEntity(envConfigs);
     }
 }

--- a/api/api-environments-v3/src/test/groovy/com/thoughtworks/go/apiv3/environments/EnvironmentsControllerV3Test.groovy
+++ b/api/api-environments-v3/src/test/groovy/com/thoughtworks/go/apiv3/environments/EnvironmentsControllerV3Test.groovy
@@ -227,14 +227,14 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         env1.addPipeline(new CaseInsensitiveString("Pipeline1"))
         env1.addPipeline(new CaseInsensitiveString("Pipeline2"))
 
-        when(entityHashingService.md5ForEntity(env1)).thenReturn("md5-hash")
+        when(entityHashingService.hashForEntity(env1)).thenReturn("digest-hash")
         when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(env1)
 
         getWithApiHeader(controller.controllerPath("env1"))
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5-hash"')
+          .hasEtag('"digest-hash"')
           .hasBodyWithJsonObject(env1, EnvironmentRepresenter)
       }
 
@@ -256,10 +256,10 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         env1.addPipeline(new CaseInsensitiveString("Pipeline1"))
         env1.addPipeline(new CaseInsensitiveString("Pipeline2"))
 
-        when(entityHashingService.md5ForEntity(env1)).thenReturn("md5-hash")
+        when(entityHashingService.hashForEntity(env1)).thenReturn("digest-hash")
         when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(env1)
 
-        getWithApiHeader(controller.controllerPath("env1"), ['if-none-match': 'md5-hash'])
+        getWithApiHeader(controller.controllerPath("env1"), ['if-none-match': 'digest-hash'])
 
         assertThatResponse()
           .isNotModified()
@@ -274,14 +274,14 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         env1.addPipeline(new CaseInsensitiveString("Pipeline1"))
         env1.addPipeline(new CaseInsensitiveString("Pipeline2"))
 
-        when(entityHashingService.md5ForEntity(env1)).thenReturn("md5-hash")
+        when(entityHashingService.hashForEntity(env1)).thenReturn("digest-hash")
         when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(env1)
 
-        getWithApiHeader(controller.controllerPath("env1"), ['if-none-match': 'md5-old-hash'])
+        getWithApiHeader(controller.controllerPath("env1"), ['if-none-match': 'digest-old-hash'])
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5-hash"')
+          .hasEtag('"digest-hash"')
           .hasBodyWithJsonObject(env1, EnvironmentRepresenter)
       }
     }
@@ -355,10 +355,10 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         env1.addPipeline(new CaseInsensitiveString("Pipeline1"))
         env1.addPipeline(new CaseInsensitiveString("Pipeline2"))
 
-        when(entityHashingService.md5ForEntity(env1)).thenReturn("md5-hash")
+        when(entityHashingService.hashForEntity(env1)).thenReturn("digest-hash")
         when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(env1)
 
-        getWithApiHeader(controller.controllerPath("env1"), ['if-none-match': 'md5-hash'])
+        getWithApiHeader(controller.controllerPath("env1"), ['if-none-match': 'digest-hash'])
 
         assertThatResponse()
           .isNotModified()
@@ -373,14 +373,14 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         env1.addPipeline(new CaseInsensitiveString("Pipeline1"))
         env1.addPipeline(new CaseInsensitiveString("Pipeline2"))
 
-        when(entityHashingService.md5ForEntity(env1)).thenReturn("md5-hash")
+        when(entityHashingService.hashForEntity(env1)).thenReturn("digest-hash")
         when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(env1)
 
-        getWithApiHeader(controller.controllerPath("env1"), ['if-none-match': 'md5-old-hash'])
+        getWithApiHeader(controller.controllerPath("env1"), ['if-none-match': 'digest-old-hash'])
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5-hash"')
+          .hasEtag('"digest-hash"')
           .hasBodyWithJsonObject(env1, EnvironmentRepresenter)
       }
     }
@@ -419,7 +419,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         newConfig.addEnvironmentVariable("JAVA_HOME", "/bin/java")
         newConfig.addPipeline(new CaseInsensitiveString("Pipeline1"))
 
-        when(entityHashingService.md5ForEntity(existingConfig)).thenReturn("ffff")
+        when(entityHashingService.hashForEntity(existingConfig)).thenReturn("ffff")
         when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(existingConfig)
 
         def json = toObjectString({ EnvironmentRepresenter.toJSON(it, newConfig) })
@@ -441,7 +441,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         newConfig.addEnvironmentVariable("JAVA_HOME", "/bin/java")
         newConfig.addPipeline(new CaseInsensitiveString("Pipeline1"))
 
-        when(entityHashingService.md5ForEntity(existingConfig)).thenReturn("ffff")
+        when(entityHashingService.hashForEntity(existingConfig)).thenReturn("ffff")
         when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(existingConfig)
 
         def json = toObjectString({ EnvironmentRepresenter.toJSON(it, newConfig) })
@@ -463,7 +463,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
 
         when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(env1)
 
-        when(entityHashingService.md5ForEntity(env1)).thenReturn("wrong-md5")
+        when(entityHashingService.hashForEntity(env1)).thenReturn("wrong-digest")
 
         def json = toObjectString({ EnvironmentRepresenter.toJSON(it, env1) })
 
@@ -482,7 +482,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         env1.addPipeline(new CaseInsensitiveString("Pipeline1"))
         env1.addPipeline(new CaseInsensitiveString("Pipeline2"))
 
-        when(entityHashingService.md5ForEntity(env1)).thenReturn("ffff")
+        when(entityHashingService.hashForEntity(env1)).thenReturn("ffff")
 
         when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(env1)
 
@@ -552,7 +552,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         env1.addPipeline(new CaseInsensitiveString("Pipeline1"))
         env1.addPipeline(new CaseInsensitiveString("Pipeline2"))
 
-        when(entityHashingService.md5ForEntity(env1)).thenReturn("ffff")
+        when(entityHashingService.hashForEntity(env1)).thenReturn("ffff")
 
         when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(env1)
 
@@ -620,7 +620,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
 
       @Test
       void 'should update attributes of environment'() {
-        when(entityHashingService.md5ForEntity(updatedConfig)).thenReturn("md5-hash")
+        when(entityHashingService.hashForEntity(updatedConfig)).thenReturn("digest-hash")
         when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(oldConfig)
         when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(updatedConfig)
         when(environmentConfigService.patchEnvironment(
@@ -657,7 +657,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5-hash"')
+          .hasEtag('"digest-hash"')
           .hasBodyWithJsonObject(updatedConfig, EnvironmentRepresenter)
       }
 
@@ -678,7 +678,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
 
       @Test
       void 'should error out if there are errors in parsing environment variable to add in patch request'() {
-        when(entityHashingService.md5ForEntity(updatedConfig)).thenReturn("md5-hash")
+        when(entityHashingService.hashForEntity(updatedConfig)).thenReturn("digest-hash")
         when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(oldConfig)
         when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(updatedConfig)
         when(environmentConfigService.patchEnvironment(
@@ -774,7 +774,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
 
         def json = toObjectString({ EnvironmentRepresenter.toJSON(it, env1) })
 
-        when(entityHashingService.md5ForEntity(env1)).thenReturn("md5-hash")
+        when(entityHashingService.hashForEntity(env1)).thenReturn("digest-hash")
         when(environmentConfigService.createEnvironment(eq(env1), eq(currentUsername()), any(HttpLocalizedOperationResult))).then({
           InvocationOnMock invocation ->
             HttpLocalizedOperationResult result = (HttpLocalizedOperationResult) invocation.arguments.last()
@@ -785,7 +785,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5-hash"')
+          .hasEtag('"digest-hash"')
           .hasJsonBody(json)
       }
 
@@ -850,7 +850,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
       @Test
       void 'should error out if the environment already exists'() {
         when(environmentConfigService.getMergedEnvironmentforDisplay(anyString(), any(HttpLocalizedOperationResult.class)))
-          .thenReturn(new ConfigElementForEdit<EnvironmentConfig>(new BasicEnvironmentConfig(), "md5string"))
+          .thenReturn(new ConfigElementForEdit<EnvironmentConfig>(new BasicEnvironmentConfig(), "digeststring"))
 
         postWithApiHeader(controller.controllerPath(), [name: "env1"])
 

--- a/api/api-internal-command-snippets-v1/src/main/java/com/thoughtworks/go/apiv1/internalcommandsnippets/InternalCommandSnippetsControllerV1.java
+++ b/api/api-internal-command-snippets-v1/src/main/java/com/thoughtworks/go/apiv1/internalcommandsnippets/InternalCommandSnippetsControllerV1.java
@@ -88,6 +88,6 @@ public class InternalCommandSnippetsControllerV1 extends ApiController implement
     }
 
     private String etagFor(List<CommandSnippet> commandSnippets) {
-        return entityHashingService.md5ForEntity(new CommandSnippets(commandSnippets));
+        return entityHashingService.hashForEntity(new CommandSnippets(commandSnippets));
     }
 }

--- a/api/api-internal-command-snippets-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalcommandsnippets/InternalCommandSnippetsControllerV1Test.groovy
+++ b/api/api-internal-command-snippets-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalcommandsnippets/InternalCommandSnippetsControllerV1Test.groovy
@@ -90,12 +90,12 @@ class InternalCommandSnippetsControllerV1Test implements SecurityServiceTrait, C
         def prefix = "curl"
         List<CommandSnippet> snippets = new ArrayList<>()
         when(commandRepositoryService.lookupCommand(prefix)).thenReturn(snippets)
-        when(entityHashingService.md5ForEntity(new CommandSnippets(snippets))).thenReturn("md5")
+        when(entityHashingService.hashForEntity(new CommandSnippets(snippets))).thenReturn("digest")
         getWithApiHeader(controller.controllerPath([prefix: prefix]))
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasBodyWithJson(toObjectString({ CommandSnippetsRepresenter.toJSON(it, snippets, prefix) }))
       }
 
@@ -104,8 +104,8 @@ class InternalCommandSnippetsControllerV1Test implements SecurityServiceTrait, C
         def prefix = "curl"
         List<CommandSnippet> snippets = new ArrayList<>()
         when(commandRepositoryService.lookupCommand(prefix)).thenReturn(snippets)
-        when(entityHashingService.md5ForEntity(new CommandSnippets(snippets))).thenReturn("md5")
-        getWithApiHeader(controller.controllerPath([prefix: prefix]), ['if-none-match': 'md5'])
+        when(entityHashingService.hashForEntity(new CommandSnippets(snippets))).thenReturn("digest")
+        getWithApiHeader(controller.controllerPath([prefix: prefix]), ['if-none-match': 'digest'])
 
         assertThatResponse()
           .isNotModified()

--- a/api/api-notification-filter-v2/src/main/java/com/thoughtworks/go/apiv2/notificationfilter/NotificationFilterControllerV2.java
+++ b/api/api-notification-filter-v2/src/main/java/com/thoughtworks/go/apiv2/notificationfilter/NotificationFilterControllerV2.java
@@ -146,7 +146,7 @@ public class NotificationFilterControllerV2 extends ApiController implements Spa
 
     @Override
     public String etagFor(NotificationFilter entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-notification-filter-v2/src/test/groovy/com/thoughtworks/go/apiv2/notificationfilter/NotificationFilterControllerV2Test.groovy
+++ b/api/api-notification-filter-v2/src/test/groovy/com/thoughtworks/go/apiv2/notificationfilter/NotificationFilterControllerV2Test.groovy
@@ -213,7 +213,7 @@ class NotificationFilterControllerV2Test implements SecurityServiceTrait, Contro
       def fromPayload = new NotificationFilter("up42", "unit-test", StageEvent.Breaks, true)
       def withId = new NotificationFilter(fromPayload)
       withId.setId(100L)
-      when(entityHashingService.md5ForEntity(withId)).thenReturn("Md5")
+      when(entityHashingService.hashForEntity(withId)).thenReturn("digest")
       doAnswer({ invocation ->
         invocation.getArgument(1).setId(100)
       }).when(userService).addNotificationFilter(currentUserLoginId(), fromPayload)
@@ -223,7 +223,7 @@ class NotificationFilterControllerV2Test implements SecurityServiceTrait, Contro
       verify(userService).addNotificationFilter(currentUserLoginId(), fromPayload)
       assertThatResponse()
         .isOk()
-        .hasEtag('"Md5"')
+        .hasEtag('"digest"')
         .hasBodyWithJsonObject(NotificationFilterRepresenter, withId)
     }
 
@@ -380,7 +380,7 @@ class NotificationFilterControllerV2Test implements SecurityServiceTrait, Contro
       user.addNotificationFilter(notificationFilter(100, "up42", "up42_stage", StageEvent.All))
       user.addNotificationFilter(notificationFilter(101, "up43", "up43_stage", StageEvent.Breaks))
       def updatedFilterValue = notificationFilter(100, "up42", "unit-test", StageEvent.Breaks)
-      when(entityHashingService.md5ForEntity(updatedFilterValue)).thenReturn("Updated etag")
+      when(entityHashingService.hashForEntity(updatedFilterValue)).thenReturn("Updated etag")
 
       patchWithApiHeader(controller.controllerPath(100L), payload)
 

--- a/api/api-package-repository-v1/src/main/java/com/thoughtworks/go/apiv1/packagerepository/PackageRepositoryControllerV1.java
+++ b/api/api-package-repository-v1/src/main/java/com/thoughtworks/go/apiv1/packagerepository/PackageRepositoryControllerV1.java
@@ -136,7 +136,7 @@ public class PackageRepositoryControllerV1 extends ApiController implements Spar
 
     @Override
     public String etagFor(PackageRepository entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-package-repository-v1/src/main/java/com/thoughtworks/go/apiv1/packagerepository/PackageRepositoryInternalControllerV1.java
+++ b/api/api-package-repository-v1/src/main/java/com/thoughtworks/go/apiv1/packagerepository/PackageRepositoryInternalControllerV1.java
@@ -81,7 +81,7 @@ public class PackageRepositoryInternalControllerV1 extends ApiController impleme
 
     @Override
     public String etagFor(PackageRepository entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-package-repository-v1/src/test/groovy/com/thoughtworks/go/apiv1/packagerepository/PackageRepositoryControllerV1Test.groovy
+++ b/api/api-package-repository-v1/src/test/groovy/com/thoughtworks/go/apiv1/packagerepository/PackageRepositoryControllerV1Test.groovy
@@ -26,7 +26,6 @@ import com.thoughtworks.go.domain.packagerepository.PackageRepositoryMother
 import com.thoughtworks.go.server.service.EntityHashingService
 import com.thoughtworks.go.server.service.materials.PackageRepositoryService
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult
-import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.GroupAdminUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
@@ -117,7 +116,7 @@ class PackageRepositoryControllerV1Test implements SecurityServiceTrait, Control
         def configuration = new Configuration(ConfigurationPropertyMother.create('key', 'value'))
         def packageRepository = PackageRepositoryMother.create('repo-id', 'repo-name', 'plugin-id', '1.0.0', configuration)
 
-        when(entityHashingService.md5ForEntity(packageRepository)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(packageRepository)).thenReturn('etag')
         when(packageRepositoryService.getPackageRepository('repo-id')).thenReturn(packageRepository)
 
         getWithApiHeader(controller.controllerPath('repo-id'))
@@ -135,7 +134,7 @@ class PackageRepositoryControllerV1Test implements SecurityServiceTrait, Control
         def configuration = new Configuration(ConfigurationPropertyMother.create('key', 'value'))
         def packageRepository = PackageRepositoryMother.create('repo-id', 'repo-name', 'plugin-id', '1.0.0', configuration)
 
-        when(entityHashingService.md5ForEntity(packageRepository)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(packageRepository)).thenReturn('etag')
         when(packageRepositoryService.getPackageRepository('repo-id')).thenReturn(packageRepository)
 
         getWithApiHeader(controller.controllerPath('repo-id'), ['if-none-match': 'etag'])
@@ -158,7 +157,7 @@ class PackageRepositoryControllerV1Test implements SecurityServiceTrait, Control
         def configuration = new Configuration(ConfigurationPropertyMother.create('key', 'value'))
         def packageRepository = PackageRepositoryMother.create('repo-id', 'repo-name', 'plugin-id', '1.0.0', configuration)
 
-        when(entityHashingService.md5ForEntity(packageRepository)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(packageRepository)).thenReturn('etag')
         when(packageRepositoryService.getPackageRepository('repo-id')).thenReturn(packageRepository)
 
         getWithApiHeader(controller.controllerPath('repo-id'), ['if-none-match': 'another-etag'])
@@ -203,7 +202,7 @@ class PackageRepositoryControllerV1Test implements SecurityServiceTrait, Control
 
         def json = toObjectString({ PackageRepositoryRepresenter.toJSON(it, packageRepository) })
 
-        when(entityHashingService.md5ForEntity(packageRepository)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(packageRepository)).thenReturn('etag')
         when(packageRepositoryService.createPackageRepository(eq(packageRepository), eq(currentUsername()), any(HttpLocalizedOperationResult.class))).then({
           InvocationOnMock invocation ->
             HttpLocalizedOperationResult result = (HttpLocalizedOperationResult) invocation.arguments.last()
@@ -307,8 +306,8 @@ class PackageRepositoryControllerV1Test implements SecurityServiceTrait, Control
         def json = toObjectString({ PackageRepositoryRepresenter.toJSON(it, updatedPackageRepository) })
 
         when(packageRepositoryService.getPackageRepository('repo-id')).thenReturn(packageRepository)
-        when(entityHashingService.md5ForEntity(packageRepository)).thenReturn('etag')
-        when(entityHashingService.md5ForEntity(updatedPackageRepository)).thenReturn('updated-etag')
+        when(entityHashingService.hashForEntity(packageRepository)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(updatedPackageRepository)).thenReturn('updated-etag')
         when(packageRepositoryService.updatePackageRepository(eq(updatedPackageRepository), eq(currentUsername()), anyString(), any(), anyString())).then({
           InvocationOnMock invocation ->
             HttpLocalizedOperationResult result = (HttpLocalizedOperationResult) invocation.arguments[3]
@@ -334,8 +333,8 @@ class PackageRepositoryControllerV1Test implements SecurityServiceTrait, Control
         def json = toObjectString({ PackageRepositoryRepresenter.toJSON(it, updatedPackageRepository) })
 
         when(packageRepositoryService.getPackageRepository('repo-id')).thenReturn(packageRepository)
-        when(entityHashingService.md5ForEntity(packageRepository)).thenReturn('etag')
-        when(entityHashingService.md5ForEntity(updatedPackageRepository)).thenReturn('updated-etag')
+        when(entityHashingService.hashForEntity(packageRepository)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(updatedPackageRepository)).thenReturn('updated-etag')
 
         putWithApiHeader(controller.controllerPath('repo-id'), ['if-match': 'invalid-etag'], json)
 
@@ -374,8 +373,8 @@ class PackageRepositoryControllerV1Test implements SecurityServiceTrait, Control
         ]
 
         when(packageRepositoryService.getPackageRepository('repo-id')).thenReturn(packageRepository)
-        when(entityHashingService.md5ForEntity(packageRepository)).thenReturn('etag')
-        when(entityHashingService.md5ForEntity(updatedPackageRepository)).thenReturn('updated-etag')
+        when(entityHashingService.hashForEntity(packageRepository)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(updatedPackageRepository)).thenReturn('updated-etag')
         when(packageRepositoryService.updatePackageRepository(any(), any(), any(), any(), any())).then({
           InvocationOnMock invocation ->
             HttpLocalizedOperationResult result = (HttpLocalizedOperationResult) invocation.arguments[3]

--- a/api/api-packages-v1/src/main/java/com/thoughtworks/go/apiv1/packages/PackagesControllerV1.java
+++ b/api/api-packages-v1/src/main/java/com/thoughtworks/go/apiv1/packages/PackagesControllerV1.java
@@ -113,14 +113,14 @@ public class PackagesControllerV1 extends ApiController implements SparkSpringCo
         String oldPackageId = request.params("package_id");
         PackageDefinition newPackageDefinition = buildEntityFromRequestBody(request);
         PackageDefinition oldPackageDefinition = fetchEntityFromConfig(oldPackageId);
-        String md5 = entityHashingService.md5ForEntity(oldPackageDefinition);
+        String digest = entityHashingService.hashForEntity(oldPackageDefinition);
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
 
         if (isPutRequestStale(request, oldPackageDefinition)) {
             throw haltBecauseEtagDoesNotMatch("packageDefinition", oldPackageId);
         }
 
-        packageDefinitionService.updatePackage(oldPackageId, newPackageDefinition, md5, currentUsername(), result);
+        packageDefinitionService.updatePackage(oldPackageId, newPackageDefinition, digest, currentUsername(), result);
 
         setEtagHeader(newPackageDefinition, response);
         return handleCreateOrUpdateResponse(request, response, newPackageDefinition, result);
@@ -138,7 +138,7 @@ public class PackagesControllerV1 extends ApiController implements SparkSpringCo
 
     @Override
     public String etagFor(PackageDefinition entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-packages-v1/src/test/groovy/com/thoughtworks/go/apiv1/packages/PackagesControllerV1Test.groovy
+++ b/api/api-packages-v1/src/test/groovy/com/thoughtworks/go/apiv1/packages/PackagesControllerV1Test.groovy
@@ -131,7 +131,7 @@ class PackagesControllerV1Test implements SecurityServiceTrait, ControllerTrait<
         def packageDefinition = PackageDefinitionMother.create('id', 'name', configuration, PackageRepositoryMother.create('repo-id'))
 
         when(packageDefinitionService.find('id')).thenReturn(packageDefinition)
-        when(entityHashingService.md5ForEntity(packageDefinition)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(packageDefinition)).thenReturn('etag')
 
         getWithApiHeader(controller.controllerPath('id'))
 
@@ -149,7 +149,7 @@ class PackagesControllerV1Test implements SecurityServiceTrait, ControllerTrait<
         def packageDefinition = PackageDefinitionMother.create('id', 'name', configuration, PackageRepositoryMother.create('repo-id'))
 
         when(packageDefinitionService.find('id')).thenReturn(packageDefinition)
-        when(entityHashingService.md5ForEntity(packageDefinition)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(packageDefinition)).thenReturn('etag')
 
         getWithApiHeader(controller.controllerPath('id'), ['if-none-match': 'etag'])
 
@@ -172,7 +172,7 @@ class PackagesControllerV1Test implements SecurityServiceTrait, ControllerTrait<
         def packageDefinition = PackageDefinitionMother.create('id', 'name', configuration, PackageRepositoryMother.create('repo-id'))
 
         when(packageDefinitionService.find('id')).thenReturn(packageDefinition)
-        when(entityHashingService.md5ForEntity(packageDefinition)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(packageDefinition)).thenReturn('etag')
 
         getWithApiHeader(controller.controllerPath('id'), ['if-none-match': 'another-etag'])
 
@@ -216,7 +216,7 @@ class PackagesControllerV1Test implements SecurityServiceTrait, ControllerTrait<
 
         def json = toObjectString({ PackageDefinitionRepresenter.toJSON(it, packageDefinition) })
 
-        when(entityHashingService.md5ForEntity(packageDefinition)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(packageDefinition)).thenReturn('etag')
         when(packageDefinitionService.createPackage(eq(packageDefinition), eq('repo-id'), eq(currentUsername()), any(HttpLocalizedOperationResult.class))).then({
           InvocationOnMock invocation ->
             HttpLocalizedOperationResult result = (HttpLocalizedOperationResult) invocation.arguments.last()
@@ -317,8 +317,8 @@ class PackagesControllerV1Test implements SecurityServiceTrait, ControllerTrait<
 
         def json = toObjectString({ PackageDefinitionRepresenter.toJSON(it, updatedPackageDefinition) })
 
-        when(entityHashingService.md5ForEntity(packageDefinition)).thenReturn('etag')
-        when(entityHashingService.md5ForEntity(updatedPackageDefinition)).thenReturn('updated-etag')
+        when(entityHashingService.hashForEntity(packageDefinition)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(updatedPackageDefinition)).thenReturn('updated-etag')
         when(packageDefinitionService.find('id')).thenReturn(packageDefinition)
         when(packageDefinitionService.updatePackage(eq('id'), eq(updatedPackageDefinition), eq('etag'), eq(currentUsername()), any(HttpLocalizedOperationResult.class))).then({
           InvocationOnMock invocation ->
@@ -344,8 +344,8 @@ class PackagesControllerV1Test implements SecurityServiceTrait, ControllerTrait<
 
         def json = toObjectString({ PackageDefinitionRepresenter.toJSON(it, updatedPackageDefinition) })
 
-        when(entityHashingService.md5ForEntity(packageDefinition)).thenReturn('etag')
-        when(entityHashingService.md5ForEntity(updatedPackageDefinition)).thenReturn('updated-etag')
+        when(entityHashingService.hashForEntity(packageDefinition)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(updatedPackageDefinition)).thenReturn('updated-etag')
         when(packageDefinitionService.find('id')).thenReturn(packageDefinition)
 
         putWithApiHeader(controller.controllerPath('id'), ['if-match': 'unknown-etag'], json)
@@ -386,8 +386,8 @@ class PackagesControllerV1Test implements SecurityServiceTrait, ControllerTrait<
         def json = toObjectString({ PackageDefinitionRepresenter.toJSON(it, updatedPackageDefinition) })
 
         when(packageDefinitionService.find('id')).thenReturn(packageDefinition)
-        when(entityHashingService.md5ForEntity(packageDefinition)).thenReturn('etag')
-        when(entityHashingService.md5ForEntity(updatedPackageDefinition)).thenReturn('updated-etag')
+        when(entityHashingService.hashForEntity(packageDefinition)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(updatedPackageDefinition)).thenReturn('updated-etag')
         when(packageDefinitionService.updatePackage(anyString(), any(), any(), any(), any())).then({
           InvocationOnMock invocation ->
             HttpLocalizedOperationResult result = (HttpLocalizedOperationResult) invocation.arguments.last()

--- a/api/api-packages-v2/src/main/java/com/thoughtworks/go/apiv2/packages/PackagesControllerV2.java
+++ b/api/api-packages-v2/src/main/java/com/thoughtworks/go/apiv2/packages/PackagesControllerV2.java
@@ -121,14 +121,14 @@ public class PackagesControllerV2 extends ApiController implements SparkSpringCo
         String oldPackageId = request.params("package_id");
         PackageDefinition newPackageDefinition = buildEntityFromRequestBody(request);
         PackageDefinition oldPackageDefinition = fetchEntityFromConfig(oldPackageId);
-        String md5 = entityHashingService.md5ForEntity(oldPackageDefinition);
+        String digest = entityHashingService.hashForEntity(oldPackageDefinition);
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
 
         if (isPutRequestStale(request, oldPackageDefinition)) {
             throw haltBecauseEtagDoesNotMatch("packageDefinition", oldPackageId);
         }
 
-        packageDefinitionService.updatePackage(oldPackageId, newPackageDefinition, md5, currentUsername(), result);
+        packageDefinitionService.updatePackage(oldPackageId, newPackageDefinition, digest, currentUsername(), result);
 
         setEtagHeader(newPackageDefinition, response);
         return handleCreateOrUpdateResponse(request, response, newPackageDefinition, result);
@@ -155,7 +155,7 @@ public class PackagesControllerV2 extends ApiController implements SparkSpringCo
 
     @Override
     public String etagFor(PackageDefinition entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-packages-v2/src/main/java/com/thoughtworks/go/apiv2/packages/PackagesInternalControllerV2.java
+++ b/api/api-packages-v2/src/main/java/com/thoughtworks/go/apiv2/packages/PackagesInternalControllerV2.java
@@ -88,7 +88,7 @@ public class PackagesInternalControllerV2 extends ApiController implements Spark
 
     @Override
     public String etagFor(PackageDefinition entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-packages-v2/src/test/groovy/com/thoughtworks/go/apiv2/packages/PackagesControllerV2Test.groovy
+++ b/api/api-packages-v2/src/test/groovy/com/thoughtworks/go/apiv2/packages/PackagesControllerV2Test.groovy
@@ -139,7 +139,7 @@ class PackagesControllerV2Test implements SecurityServiceTrait, ControllerTrait<
         def packageDefinition = PackageDefinitionMother.create('id', 'name', configuration, PackageRepositoryMother.create('repo-id'))
 
         when(packageDefinitionService.find('id')).thenReturn(packageDefinition)
-        when(entityHashingService.md5ForEntity(packageDefinition)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(packageDefinition)).thenReturn('etag')
 
         getWithApiHeader(controller.controllerPath('id'))
 
@@ -157,7 +157,7 @@ class PackagesControllerV2Test implements SecurityServiceTrait, ControllerTrait<
         def packageDefinition = PackageDefinitionMother.create('id', 'name', configuration, PackageRepositoryMother.create('repo-id'))
 
         when(packageDefinitionService.find('id')).thenReturn(packageDefinition)
-        when(entityHashingService.md5ForEntity(packageDefinition)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(packageDefinition)).thenReturn('etag')
 
         getWithApiHeader(controller.controllerPath('id'), ['if-none-match': 'etag'])
 
@@ -180,7 +180,7 @@ class PackagesControllerV2Test implements SecurityServiceTrait, ControllerTrait<
         def packageDefinition = PackageDefinitionMother.create('id', 'name', configuration, PackageRepositoryMother.create('repo-id'))
 
         when(packageDefinitionService.find('id')).thenReturn(packageDefinition)
-        when(entityHashingService.md5ForEntity(packageDefinition)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(packageDefinition)).thenReturn('etag')
 
         getWithApiHeader(controller.controllerPath('id'), ['if-none-match': 'another-etag'])
 
@@ -224,7 +224,7 @@ class PackagesControllerV2Test implements SecurityServiceTrait, ControllerTrait<
 
         def json = toObjectString({ PackageDefinitionRepresenter.toJSON(it, packageDefinition) })
 
-        when(entityHashingService.md5ForEntity(packageDefinition)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(packageDefinition)).thenReturn('etag')
         when(packageDefinitionService.createPackage(eq(packageDefinition), eq('repo-id'), eq(currentUsername()), any(HttpLocalizedOperationResult.class))).then({
           InvocationOnMock invocation ->
             HttpLocalizedOperationResult result = (HttpLocalizedOperationResult) invocation.arguments.last()
@@ -325,8 +325,8 @@ class PackagesControllerV2Test implements SecurityServiceTrait, ControllerTrait<
 
         def json = toObjectString({ PackageDefinitionRepresenter.toJSON(it, updatedPackageDefinition) })
 
-        when(entityHashingService.md5ForEntity(packageDefinition)).thenReturn('etag')
-        when(entityHashingService.md5ForEntity(updatedPackageDefinition)).thenReturn('updated-etag')
+        when(entityHashingService.hashForEntity(packageDefinition)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(updatedPackageDefinition)).thenReturn('updated-etag')
         when(packageDefinitionService.find('id')).thenReturn(packageDefinition)
         when(packageDefinitionService.updatePackage(eq('id'), eq(updatedPackageDefinition), eq('etag'), eq(currentUsername()), any(HttpLocalizedOperationResult.class))).then({
           InvocationOnMock invocation ->
@@ -352,8 +352,8 @@ class PackagesControllerV2Test implements SecurityServiceTrait, ControllerTrait<
 
         def json = toObjectString({ PackageDefinitionRepresenter.toJSON(it, updatedPackageDefinition) })
 
-        when(entityHashingService.md5ForEntity(packageDefinition)).thenReturn('etag')
-        when(entityHashingService.md5ForEntity(updatedPackageDefinition)).thenReturn('updated-etag')
+        when(entityHashingService.hashForEntity(packageDefinition)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(updatedPackageDefinition)).thenReturn('updated-etag')
         when(packageDefinitionService.find('id')).thenReturn(packageDefinition)
 
         putWithApiHeader(controller.controllerPath('id'), ['if-match': 'unknown-etag'], json)
@@ -394,8 +394,8 @@ class PackagesControllerV2Test implements SecurityServiceTrait, ControllerTrait<
         def json = toObjectString({ PackageDefinitionRepresenter.toJSON(it, updatedPackageDefinition) })
 
         when(packageDefinitionService.find('id')).thenReturn(packageDefinition)
-        when(entityHashingService.md5ForEntity(packageDefinition)).thenReturn('etag')
-        when(entityHashingService.md5ForEntity(updatedPackageDefinition)).thenReturn('updated-etag')
+        when(entityHashingService.hashForEntity(packageDefinition)).thenReturn('etag')
+        when(entityHashingService.hashForEntity(updatedPackageDefinition)).thenReturn('updated-etag')
         when(packageDefinitionService.updatePackage(anyString(), any(), any(), any(), any())).then({
           InvocationOnMock invocation ->
             HttpLocalizedOperationResult result = (HttpLocalizedOperationResult) invocation.arguments.last()

--- a/api/api-pipeline-config-v10/src/main/java/com/thoughtworks/go/apiv10/admin/pipelineconfig/PipelineConfigControllerV10.java
+++ b/api/api-pipeline-config-v10/src/main/java/com/thoughtworks/go/apiv10/admin/pipelineconfig/PipelineConfigControllerV10.java
@@ -217,7 +217,7 @@ public class PipelineConfigControllerV10 extends ApiController implements SparkS
     @Override
     public String etagFor(PipelineConfig pipelineConfig) {
         String groupName = goConfigService.findGroupNameByPipeline(pipelineConfig.name());
-        return entityHashingService.md5ForEntity(pipelineConfig, groupName);
+        return entityHashingService.hashForEntity(pipelineConfig, groupName);
     }
 
     @Override

--- a/api/api-pipeline-groups-v1/src/main/java/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1.java
+++ b/api/api-pipeline-groups-v1/src/main/java/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1.java
@@ -23,10 +23,8 @@ import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.api.util.GsonTransformer;
-import com.thoughtworks.go.api.util.MessageJson;
 import com.thoughtworks.go.apiv1.admin.pipelinegroups.representers.PipelineGroupRepresenter;
 import com.thoughtworks.go.apiv1.admin.pipelinegroups.representers.PipelineGroupsRepresenter;
-import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.PipelineConfigs;
 import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
@@ -39,7 +37,6 @@ import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import spark.Request;
 import spark.Response;
@@ -48,7 +45,6 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static com.thoughtworks.go.api.util.HaltApiResponses.haltBecauseEntityAlreadyExists;
 import static com.thoughtworks.go.api.util.HaltApiResponses.haltBecauseEtagDoesNotMatch;
@@ -98,7 +94,7 @@ public class PipelineGroupsControllerV1 extends ApiController implements SparkSp
 
     public String index(Request req, Response res) throws IOException {
         PipelineGroups pipelineGroups = new PipelineGroups(streamAllPipelineGroups().toArray(PipelineConfigs[]::new));
-        String etag = entityHashingService.md5ForEntity(pipelineGroups);
+        String etag = entityHashingService.hashForEntity(pipelineGroups);
 
         if (fresh(req, etag)) {
             return notModified(res);
@@ -158,7 +154,7 @@ public class PipelineGroupsControllerV1 extends ApiController implements SparkSp
 
     @Override
     public String etagFor(PipelineConfigs pipelineConfigs) {
-        return entityHashingService.md5ForEntity(pipelineConfigs);
+        return entityHashingService.hashForEntity(pipelineConfigs);
     }
 
     @Override

--- a/api/api-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1Test.groovy
+++ b/api/api-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1Test.groovy
@@ -93,7 +93,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
         def configs = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig('pipeline1'))
         configs.setGroup("group")
         def expectedPipelineGroups = new PipelineGroups([configs])
-        when(entityHashingService.md5ForEntity(expectedPipelineGroups)).thenReturn("some-etag")
+        when(entityHashingService.hashForEntity(expectedPipelineGroups)).thenReturn("some-etag")
         when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(expectedPipelineGroups)
 
         getWithApiHeader(controller.controllerPath())
@@ -111,7 +111,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
         configs.setGroup("group")
         def expectedPipelineGroups = new PipelineGroups([configs])
 
-        when(entityHashingService.md5ForEntity(expectedPipelineGroups)).thenReturn("some-etag")
+        when(entityHashingService.hashForEntity(expectedPipelineGroups)).thenReturn("some-etag")
         when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(expectedPipelineGroups)
 
         getWithApiHeader(controller.controllerPath(), ['if-none-match': '"some-etag"'])
@@ -244,17 +244,17 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
         def group = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig('pipeline1'))
         group.setGroup("group")
         def pipelineGroups = new PipelineGroups([group])
-        def group_md5 = 'md5_for_group'
+        def group_digest = 'digest_for_group'
 
         when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(pipelineGroups)
-        when(entityHashingService.md5ForEntity(group)).thenReturn(group_md5)
+        when(entityHashingService.hashForEntity(group)).thenReturn(group_digest)
 
         getWithApiHeader(controller.controllerPath("/group"))
 
         assertThatResponse()
           .isOk()
           .hasBodyWithJsonObject(group, PipelineGroupRepresenter)
-          .hasEtag('"md5_for_group"')
+          .hasEtag('"digest_for_group"')
       }
 
       @Test
@@ -262,12 +262,12 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
         def group = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig('pipeline1'))
         group.setGroup("group")
         def pipelineGroups = new PipelineGroups([group])
-        def group_md5 = 'md5_for_group'
+        def group_digest = 'digest_for_group'
 
         when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(pipelineGroups)
-        when(entityHashingService.md5ForEntity(group)).thenReturn(group_md5)
+        when(entityHashingService.hashForEntity(group)).thenReturn(group_digest)
 
-        getWithApiHeader(controller.controllerPath('/group'), ['if-none-match': '"md5_for_group"'])
+        getWithApiHeader(controller.controllerPath('/group'), ['if-none-match': '"digest_for_group"'])
 
         assertThatResponse()
           .isNotModified()
@@ -291,16 +291,16 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
         def group = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig('pipeline1'))
         group.setGroup("group")
         def pipelineGroups = new PipelineGroups([group])
-        def group_md5 = 'md5_for_group'
+        def group_digest = 'digest_for_group'
 
         when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(pipelineGroups)
-        when(entityHashingService.md5ForEntity(group)).thenReturn(group_md5)
+        when(entityHashingService.hashForEntity(group)).thenReturn(group_digest)
 
         getWithApiHeader(controller.controllerPath('/group'), ['if-none-match': '"junk"'])
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5_for_group"')
+          .hasEtag('"digest_for_group"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(group, PipelineGroupRepresenter)
       }
@@ -322,7 +322,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
         def group = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig('pipeline1'))
         group.setGroup("group")
         def headers = [
-          'If-Match': 'cached-md5',
+          'If-Match': 'cached-digest',
         ]
         putWithApiHeader(controller.controllerPath('/group'), headers, toObjectString({
           PipelineGroupRepresenter.toJSON(it, group)
@@ -343,12 +343,12 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
       void "should update group for an admin"() {
         def group = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig("pipeline1"))
         group.setGroup("group1")
-        when(entityHashingService.md5ForEntity(group)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(group)).thenReturn('digest')
         when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups([group]))
         when(pipelineConfigsService.updateGroup(any(), any(), any(), any())).thenReturn(group)
 
         def headers = [
-          'If-Match': 'md5',
+          'If-Match': 'digest',
         ]
 
         putWithApiHeader(controller.controllerPath("/group1"), headers, toObjectString({
@@ -399,7 +399,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
         HttpLocalizedOperationResult result
         def group = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig("pipeline1"))
         group.setGroup("group1")
-        when(entityHashingService.md5ForEntity(group)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(group)).thenReturn('digest')
         when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups([group]))
 
         group.addError("authorization", "Invalid authorization")
@@ -410,7 +410,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
         })
 
         def headers = [
-          'If-Match': 'md5',
+          'If-Match': 'digest',
         ]
 
         putWithApiHeader(controller.controllerPath("/group1"), headers, toObjectString({

--- a/api/api-plugin-infos-v6/src/main/java/com/thoughtworks/go/apiv6/plugininfos/PluginInfosControllerV6.java
+++ b/api/api-plugin-infos-v6/src/main/java/com/thoughtworks/go/apiv6/plugininfos/PluginInfosControllerV6.java
@@ -149,10 +149,10 @@ public class PluginInfosControllerV6 extends ApiController implements SparkSprin
     }
 
     private String etagFor(CombinedPluginInfo pluginInfo) {
-        return entityHashingService.md5ForEntity(pluginInfo);
+        return entityHashingService.hashForEntity(pluginInfo);
     }
 
     private String etagFor(Collection<CombinedPluginInfo> pluginInfos) {
-        return entityHashingService.md5ForEntity(pluginInfos);
+        return entityHashingService.hashForEntity(pluginInfos);
     }
 }

--- a/api/api-plugin-infos-v6/src/test/groovy/com/thoughtworks/go/apiv6/plugininfos/PluginInfosControllerV6Test.groovy
+++ b/api/api-plugin-infos-v6/src/test/groovy/com/thoughtworks/go/apiv6/plugininfos/PluginInfosControllerV6Test.groovy
@@ -96,13 +96,13 @@ class PluginInfosControllerV6Test implements SecurityServiceTrait, ControllerTra
         def pluginInfo = new CombinedPluginInfo(createAuthorizationPluginInfo())
 
         when(pluginInfoFinder.pluginInfoFor('plugin_id')).thenReturn(pluginInfo)
-        when(entityHashingService.md5ForEntity(pluginInfo)).thenReturn("md5")
+        when(entityHashingService.hashForEntity(pluginInfo)).thenReturn("digest")
 
         getWithApiHeader(controller.controllerPath('/plugin_id'))
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(pluginInfo, PluginInfoRepresenter)
       }
@@ -177,9 +177,9 @@ class PluginInfosControllerV6Test implements SecurityServiceTrait, ControllerTra
         def pluginInfo = new CombinedPluginInfo(new PluginInfo(descriptor, "authorization", null, null))
 
         when(pluginInfoFinder.pluginInfoFor('plugin_id')).thenReturn(pluginInfo)
-        when(entityHashingService.md5ForEntity(pluginInfo)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(pluginInfo)).thenReturn('digest')
 
-        getWithApiHeader(controller.controllerPath('/plugin_id'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/plugin_id'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isNotModified()
@@ -222,13 +222,13 @@ class PluginInfosControllerV6Test implements SecurityServiceTrait, ControllerTra
       @Test
       void 'should return all plugin infos'() {
         when(pluginInfoFinder.allPluginInfos()).thenReturn(pluginInfos)
-        when(entityHashingService.md5ForEntity(pluginInfos)).thenReturn("md5")
+        when(entityHashingService.hashForEntity(pluginInfos)).thenReturn("digest")
 
         getWithApiHeader(controller.controllerPath())
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(pluginInfos, PluginInfosRepresenter)
       }
@@ -341,9 +341,9 @@ class PluginInfosControllerV6Test implements SecurityServiceTrait, ControllerTra
       @Test
       void 'should return 304 if plugin info is not modified'() {
         when(pluginInfoFinder.allPluginInfos()).thenReturn(pluginInfos)
-        when(entityHashingService.md5ForEntity(pluginInfos)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(pluginInfos)).thenReturn('digest')
 
-        getWithApiHeader(controller.controllerPath(), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath(), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isNotModified()

--- a/api/api-plugin-infos-v7/src/main/java/com/thoughtworks/go/apiv7/plugininfos/PluginInfosControllerV7.java
+++ b/api/api-plugin-infos-v7/src/main/java/com/thoughtworks/go/apiv7/plugininfos/PluginInfosControllerV7.java
@@ -151,10 +151,10 @@ public class PluginInfosControllerV7 extends ApiController implements SparkSprin
     }
 
     private String etagFor(CombinedPluginInfo pluginInfo) {
-        return entityHashingService.md5ForEntity(pluginInfo);
+        return entityHashingService.hashForEntity(pluginInfo);
     }
 
     private String etagFor(Collection<CombinedPluginInfo> pluginInfos) {
-        return entityHashingService.md5ForEntity(pluginInfos);
+        return entityHashingService.hashForEntity(pluginInfos);
     }
 }

--- a/api/api-plugin-infos-v7/src/test/groovy/com/thoughtworks/go/apiv7/plugininfos/PluginInfosControllerV7Test.groovy
+++ b/api/api-plugin-infos-v7/src/test/groovy/com/thoughtworks/go/apiv7/plugininfos/PluginInfosControllerV7Test.groovy
@@ -96,13 +96,13 @@ class PluginInfosControllerV7Test implements SecurityServiceTrait, ControllerTra
         def pluginInfo = new CombinedPluginInfo(createAuthorizationPluginInfo())
 
         when(pluginInfoFinder.pluginInfoFor('plugin_id')).thenReturn(pluginInfo)
-        when(entityHashingService.md5ForEntity(pluginInfo)).thenReturn("md5")
+        when(entityHashingService.hashForEntity(pluginInfo)).thenReturn("digest")
 
         getWithApiHeader(controller.controllerPath('/plugin_id'))
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(pluginInfo, PluginInfoRepresenter)
       }
@@ -177,9 +177,9 @@ class PluginInfosControllerV7Test implements SecurityServiceTrait, ControllerTra
         def pluginInfo = new CombinedPluginInfo(new PluginInfo(descriptor, "authorization", null, null))
 
         when(pluginInfoFinder.pluginInfoFor('plugin_id')).thenReturn(pluginInfo)
-        when(entityHashingService.md5ForEntity(pluginInfo)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(pluginInfo)).thenReturn('digest')
 
-        getWithApiHeader(controller.controllerPath('/plugin_id'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/plugin_id'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isNotModified()
@@ -222,13 +222,13 @@ class PluginInfosControllerV7Test implements SecurityServiceTrait, ControllerTra
       @Test
       void 'should return all plugin infos'() {
         when(pluginInfoFinder.allPluginInfos()).thenReturn(pluginInfos)
-        when(entityHashingService.md5ForEntity(pluginInfos)).thenReturn("md5")
+        when(entityHashingService.hashForEntity(pluginInfos)).thenReturn("digest")
 
         getWithApiHeader(controller.controllerPath())
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(pluginInfos, PluginInfosRepresenter)
       }
@@ -341,9 +341,9 @@ class PluginInfosControllerV7Test implements SecurityServiceTrait, ControllerTra
       @Test
       void 'should return 304 if plugin info is not modified'() {
         when(pluginInfoFinder.allPluginInfos()).thenReturn(pluginInfos)
-        when(entityHashingService.md5ForEntity(pluginInfos)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(pluginInfos)).thenReturn('digest')
 
-        getWithApiHeader(controller.controllerPath(), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath(), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isNotModified()

--- a/api/api-plugin-settings-v1/src/main/java/com/thoughtworks/go/apiv1/pluginsettings/PluginSettingsControllerV1.java
+++ b/api/api-plugin-settings-v1/src/main/java/com/thoughtworks/go/apiv1/pluginsettings/PluginSettingsControllerV1.java
@@ -118,7 +118,7 @@ public class PluginSettingsControllerV1 extends ApiController implements SparkSp
 
     @Override
     public String etagFor(PluginSettings entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-plugin-settings-v1/src/test/groovy/com/thoughtworks/go/apiv1/pluginsettings/PluginSettingsControllerV1Test.groovy
+++ b/api/api-plugin-settings-v1/src/test/groovy/com/thoughtworks/go/apiv1/pluginsettings/PluginSettingsControllerV1Test.groovy
@@ -92,13 +92,13 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
         def pluginSettings = pluginSettings()
 
         when(pluginService.getPluginSettings("plugin_id")).thenReturn(pluginSettings)
-        when(entityHashingService.md5ForEntity(pluginSettings)).thenReturn("md5")
+        when(entityHashingService.hashForEntity(pluginSettings)).thenReturn("digest")
 
         getWithApiHeader(controller.controllerPath('/plugin_id'))
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(pluginSettings, PluginSettingsRepresenter)
       }
@@ -119,9 +119,9 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
         def pluginSettings = pluginSettings()
 
         when(pluginService.getPluginSettings("plugin_id")).thenReturn(pluginSettings)
-        when(entityHashingService.md5ForEntity(pluginSettings)).thenReturn("md5")
+        when(entityHashingService.hashForEntity(pluginSettings)).thenReturn("digest")
 
-        getWithApiHeader(controller.controllerPath('/plugin_id'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/plugin_id'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isNotModified()
@@ -162,12 +162,12 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
 
         when(pluginService.isPluginLoaded(pluginSettings.pluginId)).thenReturn(true)
         when(pluginService.pluginInfoForExtensionThatHandlesPluginSettings(pluginSettings.pluginId)).thenReturn(pluginInfo())
-        when(entityHashingService.md5ForEntity(pluginSettings)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(pluginSettings)).thenReturn('some-digest')
         postWithApiHeader(controller.controllerPath(), jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"some-md5"')
+          .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(pluginSettings, PluginSettingsRepresenter)
       }
@@ -206,7 +206,7 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
 
         when(pluginService.isPluginLoaded(pluginSettings.pluginId)).thenReturn(true)
         when(pluginService.pluginInfoForExtensionThatHandlesPluginSettings(pluginSettings.pluginId)).thenReturn(pluginInfo())
-        when(entityHashingService.md5ForEntity(pluginSettings)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(pluginSettings)).thenReturn('some-digest')
         doAnswer({ InvocationOnMock invocation ->
           def result = (HttpLocalizedOperationResult) invocation.arguments.last()
           result.unprocessableEntity("Boom!")
@@ -255,11 +255,11 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
         when(pluginService.getPluginSettings(pluginSettings.pluginId)).thenReturn(pluginSettings)
         when(pluginService.isPluginLoaded(pluginSettings.pluginId)).thenReturn(true)
         when(pluginService.pluginInfoForExtensionThatHandlesPluginSettings(pluginSettings.pluginId)).thenReturn(pluginInfo())
-        when(entityHashingService.md5ForEntity(pluginSettings)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(pluginSettings)).thenReturn('some-digest')
 
         def headers = [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'some-md5',
+          'If-Match'    : 'some-digest',
           'content-type': 'application/json'
         ]
 
@@ -267,7 +267,7 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"some-md5"')
+          .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(pluginSettings, PluginSettingsRepresenter)
       }
@@ -281,7 +281,7 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
 
         def headers = [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'some-md5',
+          'If-Match'    : 'some-digest',
           'content-type': 'application/json'
         ]
 
@@ -300,11 +300,11 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
         when(pluginService.getPluginSettings(pluginSettings.pluginId)).thenReturn(pluginSettings)
         when(pluginService.isPluginLoaded(pluginSettings.pluginId)).thenReturn(false)
         when(pluginService.pluginInfoForExtensionThatHandlesPluginSettings(pluginSettings.pluginId)).thenReturn(pluginInfo())
-        when(entityHashingService.md5ForEntity(pluginSettings)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(pluginSettings)).thenReturn('some-digest')
 
         def headers = [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'some-md5',
+          'If-Match'    : 'some-digest',
           'content-type': 'application/json'
         ]
 
@@ -323,11 +323,11 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
         when(pluginService.getPluginSettings(pluginSettings.pluginId)).thenReturn(pluginSettings)
         when(pluginService.isPluginLoaded(pluginSettings.pluginId)).thenReturn(true)
         when(pluginService.pluginInfoForExtensionThatHandlesPluginSettings(pluginSettings.pluginId)).thenReturn(null)
-        when(entityHashingService.md5ForEntity(pluginSettings)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(pluginSettings)).thenReturn('some-digest')
 
         def headers = [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'some-md5',
+          'If-Match'    : 'some-digest',
           'content-type': 'application/json'
         ]
 
@@ -346,7 +346,7 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
         when(pluginService.getPluginSettings(pluginSettings.pluginId)).thenReturn(pluginSettings)
         when(pluginService.isPluginLoaded(pluginSettings.pluginId)).thenReturn(true)
         when(pluginService.pluginInfoForExtensionThatHandlesPluginSettings(pluginSettings.pluginId)).thenReturn(pluginInfo())
-        when(entityHashingService.md5ForEntity(pluginSettings)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(pluginSettings)).thenReturn('some-digest')
 
         def headers = [
           'accept'      : controller.mimeType,
@@ -368,11 +368,11 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
         when(pluginService.getPluginSettings(pluginSettings.pluginId)).thenReturn(pluginSettings)
         when(pluginService.isPluginLoaded(pluginSettings.pluginId)).thenReturn(true)
         when(pluginService.pluginInfoForExtensionThatHandlesPluginSettings(pluginSettings.pluginId)).thenReturn(pluginInfo())
-        when(entityHashingService.md5ForEntity(pluginSettings)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(pluginSettings)).thenReturn('some-digest')
 
         def headers = [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'some-fancy-md5',
+          'If-Match'    : 'some-fancy-digest',
           'content-type': 'application/json'
         ]
 
@@ -391,7 +391,7 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
         when(pluginService.getPluginSettings(pluginSettings.pluginId)).thenReturn(pluginSettings)
         when(pluginService.isPluginLoaded(pluginSettings.pluginId)).thenReturn(true)
         when(pluginService.pluginInfoForExtensionThatHandlesPluginSettings(pluginSettings.pluginId)).thenReturn(pluginInfo())
-        when(entityHashingService.md5ForEntity(pluginSettings)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(pluginSettings)).thenReturn('some-digest')
         doAnswer({ InvocationOnMock invocation ->
           def result = (HttpLocalizedOperationResult) invocation.arguments[2]
           result.unprocessableEntity("Boom!")
@@ -400,7 +400,7 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
 
         def headers = [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'some-md5',
+          'If-Match'    : 'some-digest',
           'content-type': 'application/json'
         ]
 

--- a/api/api-roles-config-v3/src/main/java/com/thoughtworks/go/apiv3/rolesconfig/RolesControllerV3.java
+++ b/api/api-roles-config-v3/src/main/java/com/thoughtworks/go/apiv3/rolesconfig/RolesControllerV3.java
@@ -89,7 +89,7 @@ public class RolesControllerV3 extends ApiController implements SparkSpringContr
     public String index(Request req, Response res) throws IOException {
         String pluginType = req.queryParams("type");
         RolesConfig roles = roleConfigService.getRoles().ofType(pluginType);
-        String etag = entityHashingService.md5ForEntity(roles);
+        String etag = entityHashingService.hashForEntity(roles);
 
         if (fresh(req, etag)) {
             return notModified(res);
@@ -163,7 +163,7 @@ public class RolesControllerV3 extends ApiController implements SparkSpringContr
 
     @Override
     public String etagFor(Role entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-scms-v1/src/main/java/com/thoughtworks/go/apiv1/scms/SCMControllerV1.java
+++ b/api/api-scms-v1/src/main/java/com/thoughtworks/go/apiv1/scms/SCMControllerV1.java
@@ -89,7 +89,7 @@ public class SCMControllerV1 extends ApiController implements SparkSpringControl
     public String index(Request request, Response response) throws IOException {
         SCMs scms = pluggableScmService.listAllScms();
 
-        String etag = entityHashingService.md5ForEntity(scms);
+        String etag = entityHashingService.hashForEntity(scms);
         if (fresh(request, etag)) {
             return notModified(response);
         }
@@ -102,7 +102,7 @@ public class SCMControllerV1 extends ApiController implements SparkSpringControl
 
         SCM scm = fetchEntityFromConfig(materialName);
 
-        String etag = entityHashingService.md5ForEntity(scm);
+        String etag = entityHashingService.hashForEntity(scm);
         if (fresh(request, etag)) {
             return notModified(response);
         }
@@ -146,7 +146,7 @@ public class SCMControllerV1 extends ApiController implements SparkSpringControl
 
     @Override
     public String etagFor(SCM entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-scms-v1/src/test/groovy/com/thoughtworks/go/apiv1/scms/SCMControllerV1Test.groovy
+++ b/api/api-scms-v1/src/test/groovy/com/thoughtworks/go/apiv1/scms/SCMControllerV1Test.groovy
@@ -31,7 +31,6 @@ import com.thoughtworks.go.server.service.materials.PluggableScmService
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult
 import com.thoughtworks.go.spark.ControllerTrait
-import com.thoughtworks.go.spark.DeprecatedAPI
 import com.thoughtworks.go.spark.DeprecatedApiTrait
 import com.thoughtworks.go.spark.GroupAdminUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
@@ -99,7 +98,7 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
 
         SCMs scms = new SCMs(scm)
 
-        when(entityHashingService.md5ForEntity(scms)).thenReturn("some-etag")
+        when(entityHashingService.hashForEntity(scms)).thenReturn("some-etag")
         when(scmService.listAllScms()).thenReturn(scms)
 
         getWithApiHeader(controller.controllerPath())
@@ -120,7 +119,7 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
 
         SCMs scms = new SCMs(scm)
 
-        when(entityHashingService.md5ForEntity(scms)).thenReturn("some-etag")
+        when(entityHashingService.hashForEntity(scms)).thenReturn("some-etag")
         when(scmService.listAllScms()).thenReturn(scms)
 
         getWithApiHeader(controller.controllerPath(), ['if-none-match': '"some-etag"'])
@@ -163,14 +162,14 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ConfigurationPropertyMother.create("key2", true, "secret"),
         ))
 
-        when(entityHashingService.md5ForEntity(scm)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(scm)).thenReturn('digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(scm);
 
         getWithApiHeader(controller.controllerPath('/foobar'))
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(scm, SCMRepresenter)
       }
@@ -192,10 +191,10 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ConfigurationPropertyMother.create("key2", true, "secret"),
         ))
 
-        when(entityHashingService.md5ForEntity(scm)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(scm)).thenReturn('digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(scm);
 
-        getWithApiHeader(controller.controllerPath('/foobar'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/foobar'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isNotModified()
@@ -209,14 +208,14 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ConfigurationPropertyMother.create("key2", true, "secret"),
         ))
 
-        when(entityHashingService.md5ForEntity(scm)).thenReturn('md5-new')
+        when(entityHashingService.hashForEntity(scm)).thenReturn('digest-new')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(scm)
 
-        getWithApiHeader(controller.controllerPath('/foobar'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/foobar'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5-new"')
+          .hasEtag('"digest-new"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(scm, SCMRepresenter)
       }
@@ -275,13 +274,13 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
         ))
 
         when(scmService.listAllScms()).thenReturn(new SCMs())
-        when(entityHashingService.md5ForEntity(Mockito.any() as SCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as SCM)).thenReturn('some-digest')
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"some-md5"')
+          .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(scm, SCMRepresenter)
       }
@@ -308,13 +307,13 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
         ]
 
         when(scmService.listAllScms()).thenReturn(new SCMs())
-        when(entityHashingService.md5ForEntity(Mockito.any() as SCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as SCM)).thenReturn('some-digest')
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"some-md5"')
+          .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
 
         assertThatJson(response.getContentAsString()).hasProperty("id")
@@ -346,7 +345,7 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ConfigurationPropertyMother.create("key2", true, "secret"),
         ))
 
-        when(entityHashingService.md5ForEntity(Mockito.any() as SCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as SCM)).thenReturn('some-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
@@ -502,15 +501,15 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ]
         ]
 
-        when(entityHashingService.md5ForEntity(existingSCM)).thenReturn('some-md5')
-        when(entityHashingService.md5ForEntity(updatedSCM)).thenReturn('new-md5')
+        when(entityHashingService.hashForEntity(existingSCM)).thenReturn('some-digest')
+        when(entityHashingService.hashForEntity(updatedSCM)).thenReturn('new-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-digest'], jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"new-md5"')
+          .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(updatedSCM, SCMRepresenter)
       }
@@ -541,10 +540,10 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ]
         ]
 
-        when(entityHashingService.md5ForEntity(existingSCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingSCM)).thenReturn('some-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'wrong-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'wrong-digest'], jsonPayload)
 
         assertThatResponse()
           .isPreconditionFailed()
@@ -555,7 +554,7 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
       @Test
       void 'should return 404 if the scm does not exist'() {
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(null)
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'wrong-md5'], [:])
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'wrong-digest'], [:])
 
         assertThatResponse()
           .isNotFound()
@@ -589,10 +588,10 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ]
         ]
 
-        when(entityHashingService.md5ForEntity(existingSCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingSCM)).thenReturn('some-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-digest'], jsonPayload)
 
         assertThatResponse()
           .isUnprocessableEntity()
@@ -626,7 +625,7 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ]
         ]
 
-        when(entityHashingService.md5ForEntity(existingSCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingSCM)).thenReturn('some-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
         when(scmService.updatePluggableScmMaterial(
@@ -643,7 +642,7 @@ class SCMControllerV1Test implements SecurityServiceTrait, ControllerTrait<SCMCo
               result.unprocessableEntity("validation failed")
           })
 
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-digest'], jsonPayload)
 
         def expectedResponseBody = [
           message: "validation failed",

--- a/api/api-scms-v2/src/main/java/com/thoughtworks/go/apiv2/scms/SCMControllerV2.java
+++ b/api/api-scms-v2/src/main/java/com/thoughtworks/go/apiv2/scms/SCMControllerV2.java
@@ -91,7 +91,7 @@ public class SCMControllerV2 extends ApiController implements SparkSpringControl
     public String index(Request request, Response response) throws IOException {
         SCMs scms = pluggableScmService.listAllScms();
 
-        String etag = entityHashingService.md5ForEntity(scms);
+        String etag = entityHashingService.hashForEntity(scms);
         if (fresh(request, etag)) {
             return notModified(response);
         }
@@ -104,7 +104,7 @@ public class SCMControllerV2 extends ApiController implements SparkSpringControl
 
         SCM scm = fetchEntityFromConfig(materialName);
 
-        String etag = entityHashingService.md5ForEntity(scm);
+        String etag = entityHashingService.hashForEntity(scm);
         if (fresh(request, etag)) {
             return notModified(response);
         }
@@ -157,7 +157,7 @@ public class SCMControllerV2 extends ApiController implements SparkSpringControl
 
     @Override
     public String etagFor(SCM entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-scms-v2/src/test/groovy/com/thoughtworks/go/apiv2/scms/SCMControllerV2Test.groovy
+++ b/api/api-scms-v2/src/test/groovy/com/thoughtworks/go/apiv2/scms/SCMControllerV2Test.groovy
@@ -98,7 +98,7 @@ class SCMControllerV2Test implements SecurityServiceTrait, ControllerTrait<SCMCo
 
         SCMs scms = new SCMs(scm)
 
-        when(entityHashingService.md5ForEntity(scms)).thenReturn("some-etag")
+        when(entityHashingService.hashForEntity(scms)).thenReturn("some-etag")
         when(scmService.listAllScms()).thenReturn(scms)
 
         getWithApiHeader(controller.controllerPath())
@@ -119,7 +119,7 @@ class SCMControllerV2Test implements SecurityServiceTrait, ControllerTrait<SCMCo
 
         SCMs scms = new SCMs(scm)
 
-        when(entityHashingService.md5ForEntity(scms)).thenReturn("some-etag")
+        when(entityHashingService.hashForEntity(scms)).thenReturn("some-etag")
         when(scmService.listAllScms()).thenReturn(scms)
 
         getWithApiHeader(controller.controllerPath(), ['if-none-match': '"some-etag"'])
@@ -162,14 +162,14 @@ class SCMControllerV2Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ConfigurationPropertyMother.create("key2", true, "secret"),
         ))
 
-        when(entityHashingService.md5ForEntity(scm)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(scm)).thenReturn('digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(scm);
 
         getWithApiHeader(controller.controllerPath('/foobar'))
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(scm, SCMRepresenter)
       }
@@ -191,10 +191,10 @@ class SCMControllerV2Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ConfigurationPropertyMother.create("key2", true, "secret"),
         ))
 
-        when(entityHashingService.md5ForEntity(scm)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(scm)).thenReturn('digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(scm);
 
-        getWithApiHeader(controller.controllerPath('/foobar'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/foobar'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isNotModified()
@@ -208,14 +208,14 @@ class SCMControllerV2Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ConfigurationPropertyMother.create("key2", true, "secret"),
         ))
 
-        when(entityHashingService.md5ForEntity(scm)).thenReturn('md5-new')
+        when(entityHashingService.hashForEntity(scm)).thenReturn('digest-new')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(scm)
 
-        getWithApiHeader(controller.controllerPath('/foobar'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/foobar'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5-new"')
+          .hasEtag('"digest-new"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(scm, SCMRepresenter)
       }
@@ -274,13 +274,13 @@ class SCMControllerV2Test implements SecurityServiceTrait, ControllerTrait<SCMCo
         ))
 
         when(scmService.listAllScms()).thenReturn(new SCMs())
-        when(entityHashingService.md5ForEntity(Mockito.any() as SCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as SCM)).thenReturn('some-digest')
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"some-md5"')
+          .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(scm, SCMRepresenter)
       }
@@ -307,13 +307,13 @@ class SCMControllerV2Test implements SecurityServiceTrait, ControllerTrait<SCMCo
         ]
 
         when(scmService.listAllScms()).thenReturn(new SCMs())
-        when(entityHashingService.md5ForEntity(Mockito.any() as SCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as SCM)).thenReturn('some-digest')
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"some-md5"')
+          .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
 
         assertThatJson(response.getContentAsString()).hasProperty("id")
@@ -345,7 +345,7 @@ class SCMControllerV2Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ConfigurationPropertyMother.create("key2", true, "secret"),
         ))
 
-        when(entityHashingService.md5ForEntity(Mockito.any() as SCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as SCM)).thenReturn('some-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
@@ -501,15 +501,15 @@ class SCMControllerV2Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ]
         ]
 
-        when(entityHashingService.md5ForEntity(existingSCM)).thenReturn('some-md5')
-        when(entityHashingService.md5ForEntity(updatedSCM)).thenReturn('new-md5')
+        when(entityHashingService.hashForEntity(existingSCM)).thenReturn('some-digest')
+        when(entityHashingService.hashForEntity(updatedSCM)).thenReturn('new-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-digest'], jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"new-md5"')
+          .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(updatedSCM, SCMRepresenter)
       }
@@ -540,10 +540,10 @@ class SCMControllerV2Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ]
         ]
 
-        when(entityHashingService.md5ForEntity(existingSCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingSCM)).thenReturn('some-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'wrong-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'wrong-digest'], jsonPayload)
 
         assertThatResponse()
           .isPreconditionFailed()
@@ -554,7 +554,7 @@ class SCMControllerV2Test implements SecurityServiceTrait, ControllerTrait<SCMCo
       @Test
       void 'should return 404 if the scm does not exist'() {
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(null)
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'wrong-md5'], [:])
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'wrong-digest'], [:])
 
         assertThatResponse()
           .isNotFound()
@@ -588,10 +588,10 @@ class SCMControllerV2Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ]
         ]
 
-        when(entityHashingService.md5ForEntity(existingSCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingSCM)).thenReturn('some-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-digest'], jsonPayload)
 
         assertThatResponse()
           .isUnprocessableEntity()
@@ -625,7 +625,7 @@ class SCMControllerV2Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ]
         ]
 
-        when(entityHashingService.md5ForEntity(existingSCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingSCM)).thenReturn('some-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
         when(scmService.updatePluggableScmMaterial(
@@ -642,7 +642,7 @@ class SCMControllerV2Test implements SecurityServiceTrait, ControllerTrait<SCMCo
               result.unprocessableEntity("validation failed")
           })
 
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-digest'], jsonPayload)
 
         def expectedResponseBody = [
           message: "validation failed",

--- a/api/api-scms-v3/src/main/java/com/thoughtworks/go/apiv3/scms/SCMControllerV3.java
+++ b/api/api-scms-v3/src/main/java/com/thoughtworks/go/apiv3/scms/SCMControllerV3.java
@@ -99,7 +99,7 @@ public class SCMControllerV3 extends ApiController implements SparkSpringControl
     public String index(Request request, Response response) throws IOException {
         SCMs scms = pluggableScmService.listAllScms();
 
-        String etag = entityHashingService.md5ForEntity(scms);
+        String etag = entityHashingService.hashForEntity(scms);
         if (fresh(request, etag)) {
             return notModified(response);
         }
@@ -112,7 +112,7 @@ public class SCMControllerV3 extends ApiController implements SparkSpringControl
 
         SCM scm = fetchEntityFromConfig(materialName);
 
-        String etag = entityHashingService.md5ForEntity(scm);
+        String etag = entityHashingService.hashForEntity(scm);
         if (fresh(request, etag)) {
             return notModified(response);
         }
@@ -174,7 +174,7 @@ public class SCMControllerV3 extends ApiController implements SparkSpringControl
 
     @Override
     public String etagFor(SCM entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-scms-v3/src/test/groovy/com/thoughtworks/go/apiv3/scms/SCMControllerV3Test.groovy
+++ b/api/api-scms-v3/src/test/groovy/com/thoughtworks/go/apiv3/scms/SCMControllerV3Test.groovy
@@ -105,7 +105,7 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
 
         SCMs scms = new SCMs(scm)
 
-        when(entityHashingService.md5ForEntity(scms)).thenReturn("some-etag")
+        when(entityHashingService.hashForEntity(scms)).thenReturn("some-etag")
         when(scmService.listAllScms()).thenReturn(scms)
 
         getWithApiHeader(controller.controllerPath())
@@ -126,7 +126,7 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
 
         SCMs scms = new SCMs(scm)
 
-        when(entityHashingService.md5ForEntity(scms)).thenReturn("some-etag")
+        when(entityHashingService.hashForEntity(scms)).thenReturn("some-etag")
         when(scmService.listAllScms()).thenReturn(scms)
 
         getWithApiHeader(controller.controllerPath(), ['if-none-match': '"some-etag"'])
@@ -169,14 +169,14 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ConfigurationPropertyMother.create("key2", true, "secret"),
         ))
 
-        when(entityHashingService.md5ForEntity(scm)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(scm)).thenReturn('digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(scm);
 
         getWithApiHeader(controller.controllerPath('/foobar'))
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(scm, SCMRepresenter)
       }
@@ -198,10 +198,10 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ConfigurationPropertyMother.create("key2", true, "secret"),
         ))
 
-        when(entityHashingService.md5ForEntity(scm)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(scm)).thenReturn('digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(scm);
 
-        getWithApiHeader(controller.controllerPath('/foobar'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/foobar'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isNotModified()
@@ -215,14 +215,14 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ConfigurationPropertyMother.create("key2", true, "secret"),
         ))
 
-        when(entityHashingService.md5ForEntity(scm)).thenReturn('md5-new')
+        when(entityHashingService.hashForEntity(scm)).thenReturn('digest-new')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(scm)
 
-        getWithApiHeader(controller.controllerPath('/foobar'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/foobar'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5-new"')
+          .hasEtag('"digest-new"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(scm, SCMRepresenter)
       }
@@ -281,13 +281,13 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
         ))
 
         when(scmService.listAllScms()).thenReturn(new SCMs())
-        when(entityHashingService.md5ForEntity(Mockito.any() as SCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as SCM)).thenReturn('some-digest')
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"some-md5"')
+          .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(scm, SCMRepresenter)
       }
@@ -314,13 +314,13 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
         ]
 
         when(scmService.listAllScms()).thenReturn(new SCMs())
-        when(entityHashingService.md5ForEntity(Mockito.any() as SCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as SCM)).thenReturn('some-digest')
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"some-md5"')
+          .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
 
         assertThatJson(response.getContentAsString()).hasProperty("id")
@@ -352,7 +352,7 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ConfigurationPropertyMother.create("key2", true, "secret"),
         ))
 
-        when(entityHashingService.md5ForEntity(Mockito.any() as SCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as SCM)).thenReturn('some-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
@@ -508,15 +508,15 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ]
         ]
 
-        when(entityHashingService.md5ForEntity(existingSCM)).thenReturn('some-md5')
-        when(entityHashingService.md5ForEntity(updatedSCM)).thenReturn('new-md5')
+        when(entityHashingService.hashForEntity(existingSCM)).thenReturn('some-digest')
+        when(entityHashingService.hashForEntity(updatedSCM)).thenReturn('new-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-digest'], jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"new-md5"')
+          .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(updatedSCM, SCMRepresenter)
       }
@@ -547,10 +547,10 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ]
         ]
 
-        when(entityHashingService.md5ForEntity(existingSCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingSCM)).thenReturn('some-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'wrong-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'wrong-digest'], jsonPayload)
 
         assertThatResponse()
           .isPreconditionFailed()
@@ -561,7 +561,7 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
       @Test
       void 'should return 404 if the scm does not exist'() {
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(null)
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'wrong-md5'], [:])
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'wrong-digest'], [:])
 
         assertThatResponse()
           .isNotFound()
@@ -595,10 +595,10 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ]
         ]
 
-        when(entityHashingService.md5ForEntity(existingSCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingSCM)).thenReturn('some-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-digest'], jsonPayload)
 
         assertThatResponse()
           .isUnprocessableEntity()
@@ -632,7 +632,7 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           ]
         ]
 
-        when(entityHashingService.md5ForEntity(existingSCM)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingSCM)).thenReturn('some-digest')
         when(scmService.findPluggableScmMaterial("foobar")).thenReturn(existingSCM)
 
         when(scmService.updatePluggableScmMaterial(
@@ -649,7 +649,7 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
               result.unprocessableEntity("validation failed")
           })
 
-        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/foobar"), ['if-match': 'some-digest'], jsonPayload)
 
         def expectedResponseBody = [
           message: "validation failed",
@@ -784,7 +784,7 @@ class SCMControllerV3Test implements SecurityServiceTrait, ControllerTrait<SCMCo
 
       SCM scm = SCMMother.create("scm-id", "scm-name", "plugin1", "v1.0", new Configuration())
 
-      when(entityHashingService.md5ForEntity(scm)).thenReturn('md5')
+      when(entityHashingService.hashForEntity(scm)).thenReturn('digest')
       when(scmService.findPluggableScmMaterial("scm-name")).thenReturn(scm)
     }
 

--- a/api/api-secret-configs-v1/src/main/java/com/thoughtworks/go/apiv1/secretconfigs/SecretConfigsControllerV1.java
+++ b/api/api-secret-configs-v1/src/main/java/com/thoughtworks/go/apiv1/secretconfigs/SecretConfigsControllerV1.java
@@ -145,7 +145,7 @@ public class SecretConfigsControllerV1 extends ApiController implements SparkSpr
 
     @Override
     public String etagFor(SecretConfig entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override
@@ -181,6 +181,6 @@ public class SecretConfigsControllerV1 extends ApiController implements SparkSpr
     }
 
     private String etagFor(SecretConfigs allSecretConfigs) {
-        return entityHashingService.md5ForEntity(allSecretConfigs);
+        return entityHashingService.hashForEntity(allSecretConfigs);
     }
 }

--- a/api/api-secret-configs-v1/src/test/groovy/com/thoughtworks/go/apiv1/secretconfigs/SecretConfigsControllerV1Test.groovy
+++ b/api/api-secret-configs-v1/src/test/groovy/com/thoughtworks/go/apiv1/secretconfigs/SecretConfigsControllerV1Test.groovy
@@ -101,7 +101,7 @@ class SecretConfigsControllerV1Test implements SecurityServiceTrait, ControllerT
         ))
 
         when(secretConfigService.getAllSecretConfigs()).thenReturn(expectedConfigs)
-        when(entityHashingService.md5ForEntity(expectedConfigs)).thenReturn("ffff")
+        when(entityHashingService.hashForEntity(expectedConfigs)).thenReturn("ffff")
 
         getWithApiHeader(controller.controllerPath())
 
@@ -120,7 +120,7 @@ class SecretConfigsControllerV1Test implements SecurityServiceTrait, ControllerT
         ))
 
         when(secretConfigService.getAllSecretConfigs()).thenReturn(expectedConfigs)
-        when(entityHashingService.md5ForEntity(expectedConfigs)).thenReturn("ffff")
+        when(entityHashingService.hashForEntity(expectedConfigs)).thenReturn("ffff")
 
         getWithApiHeader(controller.controllerPath(), ['if-none-match': '"ffff"'])
 
@@ -176,14 +176,14 @@ class SecretConfigsControllerV1Test implements SecurityServiceTrait, ControllerT
           ConfigurationPropertyMother.create("password", true, "Doe")
         )
 
-        when(entityHashingService.md5ForEntity(expectedConfig)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(expectedConfig)).thenReturn('digest')
         when(secretConfigService.getAllSecretConfigs()).thenReturn(new SecretConfigs(expectedConfig))
 
         getWithApiHeader(controller.controllerPath("/ForDeploy"))
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(expectedConfig, SecretConfigRepresenter)
       }
@@ -207,10 +207,10 @@ class SecretConfigsControllerV1Test implements SecurityServiceTrait, ControllerT
           ConfigurationPropertyMother.create("password", true, "Doe")
         )
 
-        when(entityHashingService.md5ForEntity(expectedConfig)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(expectedConfig)).thenReturn('digest')
         when(secretConfigService.getAllSecretConfigs()).thenReturn(new SecretConfigs(expectedConfig))
 
-        getWithApiHeader(controller.controllerPath('/ForDeploy'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/ForDeploy'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isNotModified()
@@ -224,14 +224,14 @@ class SecretConfigsControllerV1Test implements SecurityServiceTrait, ControllerT
           ConfigurationPropertyMother.create("password", true, "Doe")
         )
 
-        when(entityHashingService.md5ForEntity(expectedConfig)).thenReturn('md5-new')
+        when(entityHashingService.hashForEntity(expectedConfig)).thenReturn('digest-new')
         when(secretConfigService.getAllSecretConfigs()).thenReturn(new SecretConfigs(expectedConfig))
 
-        getWithApiHeader(controller.controllerPath('/ForDeploy'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/ForDeploy'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5-new"')
+          .hasEtag('"digest-new"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(expectedConfig, SecretConfigRepresenter)
       }
@@ -301,14 +301,14 @@ class SecretConfigsControllerV1Test implements SecurityServiceTrait, ControllerT
 
         def secretConfig = fromJSON(GsonTransformer.instance.jsonReaderFrom(jsonPayload))
 
-        when(entityHashingService.md5ForEntity(Mockito.any() as SecretConfig)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as SecretConfig)).thenReturn('some-digest')
         when(secretConfigService.getAllSecretConfigs()).thenReturn(new SecretConfigs())
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"some-md5"')
+          .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(secretConfig, SecretConfigRepresenter)
       }
@@ -320,7 +320,7 @@ class SecretConfigsControllerV1Test implements SecurityServiceTrait, ControllerT
           ConfigurationPropertyMother.create("username", false, "Jane"),
         )
 
-        when(entityHashingService.md5ForEntity(expectedConfig)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(expectedConfig)).thenReturn('digest')
         when(secretConfigService.getAllSecretConfigs()).thenReturn(new SecretConfigs(expectedConfig))
 
         def jsonPayload = toObjectString({ toJSON(it, expectedConfig) })
@@ -349,7 +349,7 @@ class SecretConfigsControllerV1Test implements SecurityServiceTrait, ControllerT
           ConfigurationPropertyMother.create("username", false, "Jane"),
         )
 
-        when(entityHashingService.md5ForEntity(expectedConfig)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(expectedConfig)).thenReturn('digest')
         when(secretConfigService.getAllSecretConfigs()).thenReturn(new SecretConfigs())
 
         def jsonPayload = toObjectString({ toJSON(it, expectedConfig) })
@@ -456,19 +456,19 @@ class SecretConfigsControllerV1Test implements SecurityServiceTrait, ControllerT
 
         def newSecretConfig = fromJSON(GsonTransformer.instance.jsonReaderFrom(requestJson))
 
-        when(entityHashingService.md5ForEntity(secretConfig)).thenReturn('old-md5')
-        when(entityHashingService.md5ForEntity(newSecretConfig)).thenReturn('new-md5')
+        when(entityHashingService.hashForEntity(secretConfig)).thenReturn('old-digest')
+        when(entityHashingService.hashForEntity(newSecretConfig)).thenReturn('new-digest')
         when(secretConfigService.getAllSecretConfigs()).thenReturn(new SecretConfigs(secretConfig)).thenReturn(new SecretConfigs(newSecretConfig))
-        when(secretConfigService.update(eq(currentUsername()), eq('some-md5'), eq(newSecretConfig), any(LocalizedOperationResult))).thenAnswer({
+        when(secretConfigService.update(eq(currentUsername()), eq('some-digest'), eq(newSecretConfig), any(LocalizedOperationResult))).thenAnswer({
           HttpLocalizedOperationResult result = (HttpLocalizedOperationResult) it.getArguments().last()
           result.setMessage("SecretConfig 'secrets_id' was updated successfully.")
         })
 
-        putWithApiHeader(controller.controllerPath("/secrets_id"), ['if-match': 'old-md5'], requestJson)
+        putWithApiHeader(controller.controllerPath("/secrets_id"), ['if-match': 'old-digest'], requestJson)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"new-md5"')
+          .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(newSecretConfig, SecretConfigRepresenter)
       }
@@ -486,12 +486,12 @@ class SecretConfigsControllerV1Test implements SecurityServiceTrait, ControllerT
 
         def newSecretConfig = fromJSON(GsonTransformer.instance.jsonReaderFrom(requestJson))
 
-        when(entityHashingService.md5ForEntity(secretConfig)).thenReturn('changed-md5')
-        when(entityHashingService.md5ForEntity(newSecretConfig)).thenReturn('new-md5')
+        when(entityHashingService.hashForEntity(secretConfig)).thenReturn('changed-digest')
+        when(entityHashingService.hashForEntity(newSecretConfig)).thenReturn('new-digest')
         when(secretConfigService.getAllSecretConfigs()).thenReturn(new SecretConfigs(secretConfig)).thenReturn(new SecretConfigs(newSecretConfig))
-        verify(secretConfigService, times(0)).update(eq(currentUsername()), eq('new-md5'), eq(newSecretConfig), any(LocalizedOperationResult))
+        verify(secretConfigService, times(0)).update(eq(currentUsername()), eq('new-digest'), eq(newSecretConfig), any(LocalizedOperationResult))
 
-        putWithApiHeader(controller.controllerPath("/secrets_id"), ['if-match': 'old-md5'], requestJson)
+        putWithApiHeader(controller.controllerPath("/secrets_id"), ['if-match': 'old-digest'], requestJson)
 
         assertThatResponse()
           .isPreconditionFailed()
@@ -511,12 +511,12 @@ class SecretConfigsControllerV1Test implements SecurityServiceTrait, ControllerT
 
         def newSecretConfig = fromJSON(GsonTransformer.instance.jsonReaderFrom(requestJson))
 
-        when(entityHashingService.md5ForEntity(secretConfig)).thenReturn('old-md5')
-        when(entityHashingService.md5ForEntity(newSecretConfig)).thenReturn('new-md5')
+        when(entityHashingService.hashForEntity(secretConfig)).thenReturn('old-digest')
+        when(entityHashingService.hashForEntity(newSecretConfig)).thenReturn('new-digest')
         when(secretConfigService.getAllSecretConfigs()).thenReturn(new SecretConfigs(secretConfig)).thenReturn(new SecretConfigs(newSecretConfig))
-        verify(secretConfigService, times(0)).update(eq(currentUsername()), eq('new-md5'), eq(newSecretConfig), any(LocalizedOperationResult))
+        verify(secretConfigService, times(0)).update(eq(currentUsername()), eq('new-digest'), eq(newSecretConfig), any(LocalizedOperationResult))
 
-        putWithApiHeader(controller.controllerPath("/secrets_id"), ['if-match': 'old-md5'], requestJson)
+        putWithApiHeader(controller.controllerPath("/secrets_id"), ['if-match': 'old-digest'], requestJson)
 
         assertThatResponse()
           .isUnprocessableEntity()
@@ -534,9 +534,9 @@ class SecretConfigsControllerV1Test implements SecurityServiceTrait, ControllerT
         def newSecretConfig = fromJSON(GsonTransformer.instance.jsonReaderFrom(requestJson))
 
         when(secretConfigService.getAllSecretConfigs()).thenReturn(new SecretConfigs()).thenReturn(new SecretConfigs(newSecretConfig))
-        verify(secretConfigService, times(0)).update(eq(currentUsername()), eq('new-md5'), eq(newSecretConfig), any(LocalizedOperationResult))
+        verify(secretConfigService, times(0)).update(eq(currentUsername()), eq('new-digest'), eq(newSecretConfig), any(LocalizedOperationResult))
 
-        putWithApiHeader(controller.controllerPath("/secrets_id"), ['if-match': 'old-md5'], requestJson)
+        putWithApiHeader(controller.controllerPath("/secrets_id"), ['if-match': 'old-digest'], requestJson)
 
         assertThatResponse()
           .isNotFound()
@@ -549,7 +549,7 @@ class SecretConfigsControllerV1Test implements SecurityServiceTrait, ControllerT
             new SecretConfigs(new SecretConfig("foo", "bar-plugin"))
         )
 
-        putWithApiHeader(controller.controllerPath("/foo"), ['if-match': 'md5-does-not-matter'], [:])
+        putWithApiHeader(controller.controllerPath("/foo"), ['if-match': 'digest-does-not-matter'], [:])
 
         assertThatResponse()
           .isUnprocessableEntity()

--- a/api/api-security-auth-config-v2/src/main/java/com/thoughtworks/go/apiv2/securityauthconfig/SecurityAuthConfigInternalControllerV2.java
+++ b/api/api-security-auth-config-v2/src/main/java/com/thoughtworks/go/apiv2/securityauthconfig/SecurityAuthConfigInternalControllerV2.java
@@ -84,7 +84,7 @@ public class SecurityAuthConfigInternalControllerV2 extends ApiController implem
 
     @Override
     public String etagFor(SecurityAuthConfig entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-security-auth-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/securityauthconfig/SecurityAuthConfigControllerV2Test.groovy
+++ b/api/api-security-auth-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/securityauthconfig/SecurityAuthConfigControllerV2Test.groovy
@@ -104,7 +104,7 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasEtag('"55c59fefca1806d3c81364d569634e56"')
+          .hasEtag('"2ed2348f198e14381f2dd0e5a0e317f8a2287feb8807891a90ca9cd60248d45b"')
           .hasBodyWithJsonObject(securityAuthConfigs, SecurityAuthConfigsRepresenter)
       }
     }
@@ -138,14 +138,14 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
       void 'should return security auth config of specified id'() {
         def securityAuthConfig = new SecurityAuthConfig("file", "cd.go.authorization.file", create("Path", false, "/var/lib/pass.prop"))
 
-        when(entityHashingService.md5ForEntity(securityAuthConfig)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(securityAuthConfig)).thenReturn('digest')
         when(securityAuthConfigService.findProfile('file')).thenReturn(securityAuthConfig)
 
         getWithApiHeader(controller.controllerPath('/file'))
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(securityAuthConfig, SecurityAuthConfigRepresenter)
       }
@@ -164,10 +164,10 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
       void 'should return 304 if security auth config is not modified'() {
         def securityAuthConfig = new SecurityAuthConfig("file", "cd.go.authorization.file", create("Path", false, "/var/lib/pass.prop"))
 
-        when(entityHashingService.md5ForEntity(securityAuthConfig)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(securityAuthConfig)).thenReturn('digest')
         when(securityAuthConfigService.findProfile('file')).thenReturn(securityAuthConfig)
 
-        getWithApiHeader(controller.controllerPath('/file'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/file'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isNotModified()
@@ -178,14 +178,14 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
       void 'should return 200 with security auth config if etag does not match'() {
         def securityAuthConfig = new SecurityAuthConfig("file", "cd.go.authorization.file", create("Path", false, "/var/lib/pass.prop"))
 
-        when(entityHashingService.md5ForEntity(securityAuthConfig)).thenReturn('md5-new')
+        when(entityHashingService.hashForEntity(securityAuthConfig)).thenReturn('digest-new')
         when(securityAuthConfigService.findProfile('file')).thenReturn(securityAuthConfig)
 
-        getWithApiHeader(controller.controllerPath('/file'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/file'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5-new"')
+          .hasEtag('"digest-new"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(securityAuthConfig, SecurityAuthConfigRepresenter)
       }
@@ -229,13 +229,13 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
             ]
           ]]
 
-        when(entityHashingService.md5ForEntity(Mockito.any() as SecurityAuthConfig)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as SecurityAuthConfig)).thenReturn('some-digest')
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"some-md5"')
+          .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(new SecurityAuthConfig("file", "cd.go.authorization.file", create("Path", false, "/var/lib/pass.prop")), SecurityAuthConfigRepresenter)
       }
@@ -289,7 +289,7 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
           properties                       : []
         ]
 
-        when(entityHashingService.md5ForEntity(Mockito.any() as SecurityAuthConfig)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(Mockito.any() as SecurityAuthConfig)).thenReturn('some-digest')
         when(securityAuthConfigService.findProfile("file")).thenReturn(existingElasticProfile)
 
         postWithApiHeader(controller.controllerPath(), jsonPayload)
@@ -353,15 +353,15 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
             ]
           ]]
 
-        when(entityHashingService.md5ForEntity(existingAuthConfig)).thenReturn('some-md5')
-        when(entityHashingService.md5ForEntity(updatedProfile)).thenReturn('new-md5')
+        when(entityHashingService.hashForEntity(existingAuthConfig)).thenReturn('some-digest')
+        when(entityHashingService.hashForEntity(updatedProfile)).thenReturn('new-digest')
         when(securityAuthConfigService.findProfile("file")).thenReturn(existingAuthConfig)
 
-        putWithApiHeader(controller.controllerPath("/file"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/file"), ['if-match': 'some-digest'], jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"new-md5"')
+          .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(updatedProfile, SecurityAuthConfigRepresenter)
       }
@@ -379,15 +379,15 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
             ]
           ]]
 
-        when(entityHashingService.md5ForEntity(existingAuthConfig)).thenReturn('some-md5')
-        when(entityHashingService.md5ForEntity(updatedProfile)).thenReturn('new-md5')
+        when(entityHashingService.hashForEntity(existingAuthConfig)).thenReturn('some-digest')
+        when(entityHashingService.hashForEntity(updatedProfile)).thenReturn('new-digest')
         when(securityAuthConfigService.findProfile("file")).thenReturn(existingAuthConfig)
 
-        putWithApiHeader(controller.controllerPath("/file"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/file"), ['if-match': 'some-digest'], jsonPayload)
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"new-md5"')
+          .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
           .hasBodyWithJsonObject(SecurityAuthConfigRepresenter, updatedProfile)
       }
@@ -405,10 +405,10 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
             ]
           ]]
 
-        when(entityHashingService.md5ForEntity(existingAuthConfig)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingAuthConfig)).thenReturn('some-digest')
         when(securityAuthConfigService.findProfile("file")).thenReturn(existingAuthConfig)
 
-        putWithApiHeader(controller.controllerPath("/file"), ['if-match': 'wrong-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/file"), ['if-match': 'wrong-digest'], jsonPayload)
 
         assertThatResponse()
           .isPreconditionFailed()
@@ -419,7 +419,7 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
       @Test
       void 'should return 404 if the profile does not exists'() {
         when(securityAuthConfigService.findProfile("non-existent-auth-config")).thenReturn(null)
-        putWithApiHeader(controller.controllerPath("/non-existent-auth-config"), ['if-match': 'wrong-md5'], [:])
+        putWithApiHeader(controller.controllerPath("/non-existent-auth-config"), ['if-match': 'wrong-digest'], [:])
 
         assertThatResponse()
           .isNotFound()
@@ -436,10 +436,10 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
           properties: []
         ]
 
-        when(entityHashingService.md5ForEntity(existingAuthConfig)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingAuthConfig)).thenReturn('some-digest')
         when(securityAuthConfigService.findProfile("file")).thenReturn(existingAuthConfig)
 
-        putWithApiHeader(controller.controllerPath("/file"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/file"), ['if-match': 'some-digest'], jsonPayload)
 
         assertThatResponse()
           .isUnprocessableEntity()
@@ -457,7 +457,7 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
           properties                       : []
         ]
 
-        when(entityHashingService.md5ForEntity(existingAuthConfig)).thenReturn('some-md5')
+        when(entityHashingService.hashForEntity(existingAuthConfig)).thenReturn('some-digest')
         when(securityAuthConfigService.findProfile("file")).thenReturn(existingAuthConfig)
 
         when(securityAuthConfigService.update(Mockito.any() as Username, Mockito.any() as String, Mockito.any() as SecurityAuthConfig, Mockito.any() as LocalizedOperationResult))
@@ -468,7 +468,7 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
           result.unprocessableEntity("validation failed")
         })
 
-        putWithApiHeader(controller.controllerPath("/file"), ['if-match': 'some-md5'], jsonPayload)
+        putWithApiHeader(controller.controllerPath("/file"), ['if-match': 'some-digest'], jsonPayload)
 
         def expectedResponseBody = [
           message: "validation failed",

--- a/api/api-template-authorization-v1/src/main/java/com/thoughtworks/go/apiv1/templateauthorization/TemplateAuthorizationControllerV1.java
+++ b/api/api-template-authorization-v1/src/main/java/com/thoughtworks/go/apiv1/templateauthorization/TemplateAuthorizationControllerV1.java
@@ -26,7 +26,6 @@ import com.thoughtworks.go.api.util.GsonTransformer;
 import com.thoughtworks.go.api.util.MessageJson;
 import com.thoughtworks.go.apiv1.templateauthorization.representers.AuthorizationRepresenter;
 import com.thoughtworks.go.config.Authorization;
-import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.PipelineTemplateConfig;
 import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.exceptions.NotImplementedException;
@@ -109,7 +108,7 @@ public class TemplateAuthorizationControllerV1 extends ApiController implements 
 
     @Override
     public String etagFor(PipelineTemplateConfig entityFromServer) {
-        return entityHashingService.md5ForEntity(entityFromServer);
+        return entityHashingService.hashForEntity(entityFromServer);
     }
 
     @Override

--- a/api/api-template-authorization-v1/src/test/groovy/com/thoughtworks/go/apiv1/templateauthorization/TemplateAuthorizationControllerV1Test.groovy
+++ b/api/api-template-authorization-v1/src/test/groovy/com/thoughtworks/go/apiv1/templateauthorization/TemplateAuthorizationControllerV1Test.groovy
@@ -96,23 +96,23 @@ class TemplateAuthorizationControllerV1Test implements SecurityServiceTrait, Con
         def authorization = new Authorization(viewConfig, null, adminsConfig)
 
         templateConfig.setAuthorization(authorization)
-        when(entityHashingService.md5ForEntity(any(PipelineTemplateConfig) as PipelineTemplateConfig)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(any(PipelineTemplateConfig) as PipelineTemplateConfig)).thenReturn('digest')
         when(templateConfigService.loadForView(templateName, result)).thenReturn(templateConfig)
 
         getWithApiHeader(controller.controllerPath("/${templateName}/authorization"))
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5"')
+          .hasEtag('"digest"')
           .hasBodyWithJsonObject(AuthorizationRepresenter, templateConfig.getAuthorization())
       }
 
       @Test
       void "should return 304 if etag sent in request is fresh"() {
-        when(entityHashingService.md5ForEntity(any(PipelineTemplateConfig) as PipelineTemplateConfig)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(any(PipelineTemplateConfig) as PipelineTemplateConfig)).thenReturn('digest')
         when(templateConfigService.loadForView("t1", result)).thenReturn(createTemplate("t1"))
 
-        getWithApiHeader(controller.controllerPath('/t1/authorization'), ['if-none-match': '"md5"'])
+        getWithApiHeader(controller.controllerPath('/t1/authorization'), ['if-none-match': '"digest"'])
 
         assertThatResponse()
           .isNotModified()
@@ -155,7 +155,7 @@ class TemplateAuthorizationControllerV1Test implements SecurityServiceTrait, Con
       void makeHttpCall() {
         putWithApiHeader(controller.controllerPath('/t1/authorization'), [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'cached-md5',
+          'If-Match'    : 'cached-digest',
           'content-type': 'application/json'
         ], toObjectString({ AuthorizationRepresenter.toJSON(it, authorization) }))
       }
@@ -183,14 +183,14 @@ class TemplateAuthorizationControllerV1Test implements SecurityServiceTrait, Con
         def authorizationRequest = new Authorization(viewConfig, new OperationConfig(), adminsConfig)
         templateConfigAfterUpdate.setAuthorization(authorizationRequest)
 
-        when(entityHashingService.md5ForEntity(any(PipelineTemplateConfig) as PipelineTemplateConfig)).thenReturn('md5').thenReturn('md5_after_update')
+        when(entityHashingService.hashForEntity(any(PipelineTemplateConfig) as PipelineTemplateConfig)).thenReturn('digest').thenReturn('digest_after_update')
         when(templateConfigService.loadForView(templateName, result)).thenReturn(templateConfig).thenReturn(templateConfigAfterUpdate)
         doNothing().when(templateConfigService).updateTemplateAuthConfig(any(Username.class) as Username, eq(templateConfig),
-          any(), eq(result), eq("md5"))
+          any(), eq(result), eq("digest"))
 
         def headers = [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'md5',
+          'If-Match'    : 'digest',
           'content-type': 'application/json'
         ]
 
@@ -200,7 +200,7 @@ class TemplateAuthorizationControllerV1Test implements SecurityServiceTrait, Con
 
         assertThatResponse()
           .isOk()
-          .hasEtag('"md5_after_update"')
+          .hasEtag('"digest_after_update"')
           .hasBodyWithJsonObject(AuthorizationRepresenter, authorizationRequest)
       }
 
@@ -210,11 +210,11 @@ class TemplateAuthorizationControllerV1Test implements SecurityServiceTrait, Con
         def templateConfig = createTemplate(templateName)
 
         when(templateConfigService.loadForView(templateName, result)).thenReturn(templateConfig)
-        when(entityHashingService.md5ForEntity(any(PipelineTemplateConfig.class) as PipelineTemplateConfig)).thenReturn("another-etag")
+        when(entityHashingService.hashForEntity(any(PipelineTemplateConfig.class) as PipelineTemplateConfig)).thenReturn("another-etag")
 
         def headers = [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'md5',
+          'If-Match'    : 'digest',
           'content-type': 'application/json'
         ]
 
@@ -233,7 +233,7 @@ class TemplateAuthorizationControllerV1Test implements SecurityServiceTrait, Con
 
         def headers = [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'md5',
+          'If-Match'    : 'digest',
           'content-type': 'application/json'
         ]
 
@@ -254,7 +254,7 @@ class TemplateAuthorizationControllerV1Test implements SecurityServiceTrait, Con
         def adminsConfig = new AdminsConfig(new AdminRole(new CaseInsensitiveString("role_admin")), new AdminUser("admin"))
         def authorizationRequest = new Authorization(viewConfig, null, adminsConfig)
 
-        when(entityHashingService.md5ForEntity(any(PipelineTemplateConfig) as PipelineTemplateConfig)).thenReturn('md5').thenReturn('md5')
+        when(entityHashingService.hashForEntity(any(PipelineTemplateConfig) as PipelineTemplateConfig)).thenReturn('digest').thenReturn('digest')
         when(templateConfigService.loadForView(templateName, result)).thenReturn(templateConfig)
         doAnswer({ InvocationOnMock invocation ->
           authorizationRequest.addError("name", "Role \"role_admin\" does not exist.")
@@ -262,12 +262,12 @@ class TemplateAuthorizationControllerV1Test implements SecurityServiceTrait, Con
           HttpLocalizedOperationResult result = invocation.arguments[3]
           result.unprocessableEntity("Validation Errors.")
         }).when(templateConfigService).updateTemplateAuthConfig(any(Username.class) as Username, eq(templateConfig),
-          any(), eq(result), eq("md5"))
+          any(), eq(result), eq("digest"))
 
 
         def headers = [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'md5',
+          'If-Match'    : 'digest',
           'content-type': 'application/json'
         ]
 

--- a/api/api-template-config-v6/src/main/java/com/thoughtworks/go/apiv6/admin/templateconfig/TemplateConfigControllerV6.java
+++ b/api/api-template-config-v6/src/main/java/com/thoughtworks/go/apiv6/admin/templateconfig/TemplateConfigControllerV6.java
@@ -66,7 +66,7 @@ public class TemplateConfigControllerV6 extends ApiController implements SparkSp
 
     @Override
     public String etagFor(PipelineTemplateConfig pipelineTemplateConfig) {
-        return entityHashingService.md5ForEntity(pipelineTemplateConfig);
+        return entityHashingService.hashForEntity(pipelineTemplateConfig);
     }
 
     @Override

--- a/api/api-template-config-v6/src/test/groovy/com/thoughtworks/go/apiv6/admin/templateconfig/TemplateConfigControllerV6Test.groovy
+++ b/api/api-template-config-v6/src/test/groovy/com/thoughtworks/go/apiv6/admin/templateconfig/TemplateConfigControllerV6Test.groovy
@@ -129,7 +129,7 @@ class TemplateConfigControllerV6Test implements SecurityServiceTrait, Controller
 
       @Test
       void 'should render the template of specified name'() {
-        when(entityHashingService.md5ForEntity(any(PipelineTemplateConfig) as PipelineTemplateConfig)).thenReturn('md5')
+        when(entityHashingService.hashForEntity(any(PipelineTemplateConfig) as PipelineTemplateConfig)).thenReturn('digest')
         when(templateConfigService.loadForView('template', result)).thenReturn(template)
 
         getWithApiHeader(controller.controllerPath("/template"))
@@ -143,10 +143,10 @@ class TemplateConfigControllerV6Test implements SecurityServiceTrait, Controller
       @Test
       void "should return 304 for show pipeline config if etag sent in request is fresh"() {
 
-        when(entityHashingService.md5ForEntity(any(PipelineTemplateConfig) as PipelineTemplateConfig)).thenReturn('md5_for_template_config')
+        when(entityHashingService.hashForEntity(any(PipelineTemplateConfig) as PipelineTemplateConfig)).thenReturn('digest_for_template_config')
         when(templateConfigService.loadForView("template", result)).thenReturn(template)
 
-        getWithApiHeader(controller.controllerPath('/template'), ['if-none-match': '"md5_for_template_config"'])
+        getWithApiHeader(controller.controllerPath('/template'), ['if-none-match': '"digest_for_template_config"'])
 
         assertThatResponse()
           .isNotModified()
@@ -312,7 +312,7 @@ class TemplateConfigControllerV6Test implements SecurityServiceTrait, Controller
       void makeHttpCall() {
         putWithApiHeader(controller.controllerPath('/foo'), [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'cached-md5',
+          'If-Match'    : 'cached-digest',
           'content-type': 'application/json'
         ], toObjectString({ TemplateConfigRepresenter.toJSON(it, template) }))
       }
@@ -333,13 +333,13 @@ class TemplateConfigControllerV6Test implements SecurityServiceTrait, Controller
       @Test
       void 'should deserialize template from given parameters'() {
         when(templateConfigService.loadForView("some-template", result)).thenReturn(template)
-        when(entityHashingService.md5ForEntity(template)).thenReturn("md5")
+        when(entityHashingService.hashForEntity(template)).thenReturn("digest")
 
-        doNothing().when(templateConfigService).updateTemplateConfig(any(Username.class) as Username, any(PipelineTemplateConfig.class) as PipelineTemplateConfig, eq(result), eq("md5"))
+        doNothing().when(templateConfigService).updateTemplateConfig(any(Username.class) as Username, any(PipelineTemplateConfig.class) as PipelineTemplateConfig, eq(result), eq("digest"))
 
         def headers = [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'md5',
+          'If-Match'    : 'digest',
           'content-type': 'application/json'
         ]
 
@@ -356,7 +356,7 @@ class TemplateConfigControllerV6Test implements SecurityServiceTrait, Controller
 
         def headers = [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'md5',
+          'If-Match'    : 'digest',
           'content-type': 'application/json'
         ]
 
@@ -385,11 +385,11 @@ class TemplateConfigControllerV6Test implements SecurityServiceTrait, Controller
       void 'should fail update if etag does not match' () {
         when(templateConfigService.loadForView("some-template", result)).thenReturn(template)
 
-        when(entityHashingService.md5ForEntity(any(PipelineTemplateConfig.class) as PipelineTemplateConfig)).thenReturn("another-etag")
+        when(entityHashingService.hashForEntity(any(PipelineTemplateConfig.class) as PipelineTemplateConfig)).thenReturn("another-etag")
 
         def headers = [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'md5',
+          'If-Match'    : 'digest',
           'content-type': 'application/json'
         ]
 
@@ -404,16 +404,16 @@ class TemplateConfigControllerV6Test implements SecurityServiceTrait, Controller
       void 'should not update existing material if validations fail' () {
         when(templateConfigService.loadForView("some-template", result)).thenReturn(template)
 
-        when(entityHashingService.md5ForEntity(any(PipelineTemplateConfig.class) as PipelineTemplateConfig)).thenReturn("md5")
+        when(entityHashingService.hashForEntity(any(PipelineTemplateConfig.class) as PipelineTemplateConfig)).thenReturn("digest")
 
         doAnswer({ InvocationOnMock invocation ->
           result = invocation.arguments[2]
           result.unprocessableEntity("some error")
-        }).when(templateConfigService).updateTemplateConfig(any(Username.class) as Username, eq(template), eq(result), eq("md5"))
+        }).when(templateConfigService).updateTemplateConfig(any(Username.class) as Username, eq(template), eq(result), eq("digest"))
 
         def headers = [
           'accept'      : controller.mimeType,
-          'If-Match'    : 'md5',
+          'If-Match'    : 'digest',
           'content-type': 'application/json'
         ]
 

--- a/api/api-template-config-v7/src/main/java/com/thoughtworks/go/apiv7/admin/templateconfig/TemplateConfigControllerV7.java
+++ b/api/api-template-config-v7/src/main/java/com/thoughtworks/go/apiv7/admin/templateconfig/TemplateConfigControllerV7.java
@@ -66,7 +66,7 @@ public class TemplateConfigControllerV7 extends ApiController implements SparkSp
 
     @Override
     public String etagFor(PipelineTemplateConfig pipelineTemplateConfig) {
-        return entityHashingService.md5ForEntity(pipelineTemplateConfig);
+        return entityHashingService.hashForEntity(pipelineTemplateConfig);
     }
 
     @Override
@@ -177,7 +177,7 @@ public class TemplateConfigControllerV7 extends ApiController implements SparkSp
     public String showParameters(Request req, Response res) throws IOException {
         PipelineTemplateConfig templateConfig = fetchEntityFromConfig(req.params("template_name"));
         ParamsConfig paramConfigs = templateConfig.referredParams();
-        String etagFromServer = entityHashingService.md5ForEntity(paramConfigs);
+        String etagFromServer = entityHashingService.hashForEntity(paramConfigs);
         if (fresh(req, etagFromServer)) {
             return notModified(res);
         } else {

--- a/build.gradle
+++ b/build.gradle
@@ -1210,7 +1210,7 @@ task newApi {
 
               @Override
               public String etagFor(${entityClassName} entityFromServer) {
-                  return entityHashingService.md5ForEntity(entityFromServer);
+                  return entityHashingService.hashForEntity(entityFromServer);
               }
 
               @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Cacheable.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Cacheable.java
@@ -15,10 +15,10 @@
  */
 package com.thoughtworks.go.config;
 
-import static com.thoughtworks.go.util.CachedDigestUtils.sha256Hex;
+import static com.thoughtworks.go.util.CachedDigestUtils.sha512_256Hex;
 
 public interface Cacheable {
     default String etag() {
-        return sha256Hex(Integer.toString(hashCode()));
+        return sha512_256Hex(Integer.toString(hashCode()));
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/util/CachedDigestUtils.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/util/CachedDigestUtils.java
@@ -34,23 +34,32 @@ import java.io.InputStream;
 public class CachedDigestUtils {
 
     private static final int STREAM_BUFFER_LENGTH = 1024;
-    private static DigestObjectPools objectPools = new DigestObjectPools();
-    private static Cache<String, String> shaDigestCache = CacheBuilder.
+    private static final DigestObjectPools objectPools = new DigestObjectPools();
+    private static final Cache<String, String> sha256DigestCache = CacheBuilder.
+            newBuilder().
+            maximumSize(1024).
+            build();
+    private static final Cache<String, String> sha512DigestCache = CacheBuilder.
             newBuilder().
             maximumSize(1024).
             build();
 
     @SneakyThrows // compute() doesn't throw checked exceptions
+    public static String sha512_256Hex(String data) {
+        return sha512DigestCache.get(data, () -> compute(data, DigestObjectPools.SHA_512_256));
+    }
+
+    @SneakyThrows // compute() doesn't throw checked exceptions
     public static String sha256Hex(String string) {
-        return shaDigestCache.get(string, () -> compute(string, DigestObjectPools.SHA_256));
+        return sha256DigestCache.get(string, () -> compute(string, DigestObjectPools.SHA_256));
     }
 
     public static String md5Hex(String string) {
-        return compute(string, DigestObjectPools.MD_5);
+        return compute(string, DigestObjectPools.MD5);
     }
 
     public static String md5Hex(final InputStream data) {
-        return objectPools.computeDigest(DigestObjectPools.MD_5, digest -> {
+        return objectPools.computeDigest(DigestObjectPools.MD5, digest -> {
             byte[] buffer = new byte[STREAM_BUFFER_LENGTH];
             int read = data.read(buffer, 0, STREAM_BUFFER_LENGTH);
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/util/CachedDigestUtilsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/util/CachedDigestUtilsTest.java
@@ -15,53 +15,62 @@
  */
 package com.thoughtworks.go.util;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Random;
-
 import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import java.io.ByteArrayInputStream;
+import java.util.Random;
 
+import static com.thoughtworks.go.util.CachedDigestUtils.*;
+import static org.junit.Assert.assertEquals;
 
 public class CachedDigestUtilsTest {
-
     @Test
-    public void shouldComputeForAGiveStringUsing256SHA() {
+    public void shouldComputeForAGivenStringUsingSHA_512_256() {
         String fingerprint = "Some String";
-        String computeMD5 = CachedDigestUtils.sha256Hex(fingerprint);
-        assertThat(computeMD5, is(DigestUtils.sha256Hex(fingerprint)));
+        String digest = sha512_256Hex(fingerprint);
+        assertEquals(DigestUtils.sha512_256Hex(fingerprint), digest);
     }
 
     @Test
-    public void shouldComputeForAnEmptyStringUsing256SHA() {
+    public void shouldComputeForAnEmptyStringUsingSHA_512_256() {
         String fingerprint = "";
-        String computeMD5 = CachedDigestUtils.sha256Hex(fingerprint);
-        assertThat(computeMD5, is(DigestUtils.sha256Hex(fingerprint)));
+        String digest = sha512_256Hex(fingerprint);
+        assertEquals(DigestUtils.sha512_256Hex(fingerprint), digest);
     }
 
     @Test
-    public void shouldComputeForAGiveStringUsingMD5() {
+    public void shouldComputeForAGivenStringUsingSHA_256() {
         String fingerprint = "Some String";
-        String computeMD5 = CachedDigestUtils.md5Hex(fingerprint);
-        assertThat(computeMD5, is(DigestUtils.md5Hex(fingerprint)));
+        String digest = sha256Hex(fingerprint);
+        assertEquals(DigestUtils.sha256Hex(fingerprint), digest);
+    }
+
+    @Test
+    public void shouldComputeForAnEmptyStringUsingSHA_256() {
+        String fingerprint = "";
+        String digest = sha256Hex(fingerprint);
+        assertEquals(DigestUtils.sha256Hex(fingerprint), digest);
+    }
+
+    @Test
+    public void shouldComputeForAGivenStringUsingMD5() {
+        String fingerprint = "Some String";
+        String digest = md5Hex(fingerprint);
+        assertEquals(DigestUtils.md5Hex(fingerprint), digest);
     }
 
     @Test
     public void shouldComputeForAnEmptyStringUsingMD5() {
         String fingerprint = "";
-        String computeMD5 = CachedDigestUtils.md5Hex(fingerprint);
-        assertThat(computeMD5, is(DigestUtils.md5Hex(fingerprint)));
+        String digest = md5Hex(fingerprint);
+        assertEquals(DigestUtils.md5Hex(fingerprint), digest);
     }
 
     @Test
-    public void shouldComputeMD5ForAGiveString() throws IOException {
+    public void shouldComputeForAGivenStreamUsingMD5() {
         byte[] testData = new byte[1024 * 1024];
         new Random().nextBytes(testData);
-        assertThat(DigestUtils.md5Hex(testData),
-                is(CachedDigestUtils.md5Hex(new ByteArrayInputStream(testData))));
-
+        assertEquals(DigestUtils.md5Hex(testData), md5Hex(new ByteArrayInputStream(testData)));
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigRepoPlugin.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigRepoPlugin.java
@@ -29,12 +29,12 @@ import com.thoughtworks.go.plugin.configrepo.contract.CRPipeline;
 import java.io.File;
 import java.util.*;
 
-import static com.thoughtworks.go.util.CachedDigestUtils.sha256Hex;
+import static com.thoughtworks.go.util.CachedDigestUtils.sha512_256Hex;
 
 public class ConfigRepoPlugin implements PartialConfigProvider {
-    private ConfigConverter configConverter;
-    private ConfigRepoExtension crExtension;
-    private String pluginId;
+    private final ConfigConverter configConverter;
+    private final ConfigRepoExtension crExtension;
+    private final String pluginId;
 
     public ConfigRepoPlugin(ConfigConverter configConverter, ConfigRepoExtension crExtension, String pluginId) {
         this.configConverter = configConverter;
@@ -97,6 +97,6 @@ public class ConfigRepoPlugin implements PartialConfigProvider {
     }
 
     public String etagForExport(PipelineConfig pipelineConfig, String groupName) {
-        return sha256Hex(Integer.toString(Objects.hash(pipelineConfig, groupName, crExtension.pluginDescriptorFor(pluginId))));
+        return sha512_256Hex(Integer.toString(Objects.hash(pipelineConfig, groupName, crExtension.pluginDescriptorFor(pluginId))));
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/AdminsConfigUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/AdminsConfigUpdateCommand.java
@@ -37,12 +37,12 @@ public class AdminsConfigUpdateCommand implements EntityConfigUpdateCommand<Admi
     protected final AdminsConfig admin;
     protected final Username currentUser;
     protected final LocalizedOperationResult result;
-    private final String md5;
+    private final String digest;
 
     public AdminsConfigUpdateCommand(GoConfigService goConfigService, AdminsConfig adminsConfig, Username currentUser,
-                                     LocalizedOperationResult result, EntityHashingService hashingService, String md5) {
+                                     LocalizedOperationResult result, EntityHashingService hashingService, String digest) {
         this.hashingService = hashingService;
-        this.md5 = md5;
+        this.digest = digest;
         this.goConfigService = goConfigService;
         this.admin = adminsConfig;
         this.currentUser = currentUser;
@@ -93,7 +93,7 @@ public class AdminsConfigUpdateCommand implements EntityConfigUpdateCommand<Admi
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
         AdminsConfig existingAdminsConfig = findExistingAdmin(cruiseConfig);
 
-        boolean freshRequest = hashingService.md5ForEntity(existingAdminsConfig).equals(md5);
+        boolean freshRequest = hashingService.hashForEntity(existingAdminsConfig).equals(digest);
 
         if (!freshRequest) {
             result.stale(staleResourceConfig("System admins", existingAdminsConfig.getClass().getName()));

--- a/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileUpdateCommand.java
@@ -26,12 +26,12 @@ import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 
 public class ElasticAgentProfileUpdateCommand extends ElasticAgentProfileCommand {
     private final EntityHashingService hashingService;
-    private final String md5;
+    private final String digest;
 
-    public ElasticAgentProfileUpdateCommand(GoConfigService goConfigService, ElasticProfile newProfile, ElasticAgentExtension extension, Username currentUser, LocalizedOperationResult result, EntityHashingService hashingService, String md5) {
+    public ElasticAgentProfileUpdateCommand(GoConfigService goConfigService, ElasticProfile newProfile, ElasticAgentExtension extension, Username currentUser, LocalizedOperationResult result, EntityHashingService hashingService, String digest) {
         super(goConfigService, newProfile, extension, currentUser, result);
         this.hashingService = hashingService;
-        this.md5 = md5;
+        this.digest = digest;
     }
 
     @Override
@@ -58,7 +58,7 @@ public class ElasticAgentProfileUpdateCommand extends ElasticAgentProfileCommand
 
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
         ElasticProfile existingProfile = findExistingProfile(cruiseConfig);
-        boolean freshRequest = hashingService.md5ForEntity(existingProfile).equals(md5);
+        boolean freshRequest = hashingService.hashForEntity(existingProfile).equals(digest);
         if (!freshRequest) {
             result.stale(getObjectDescriptor().staleConfig(existingProfile.getId()));
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/RoleConfigUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/RoleConfigUpdateCommand.java
@@ -27,12 +27,12 @@ import static com.thoughtworks.go.serverhealth.HealthStateType.notFound;
 
 public class RoleConfigUpdateCommand extends RoleConfigCommand {
     private final EntityHashingService hashingService;
-    private final String md5;
+    private final String digest;
 
-    public RoleConfigUpdateCommand(GoConfigService goConfigService, Role newRole, Username currentUser, LocalizedOperationResult result, EntityHashingService hashingService, String md5) {
+    public RoleConfigUpdateCommand(GoConfigService goConfigService, Role newRole, Username currentUser, LocalizedOperationResult result, EntityHashingService hashingService, String digest) {
         super(goConfigService, newRole, currentUser, result);
         this.hashingService = hashingService;
-        this.md5 = md5;
+        this.digest = digest;
     }
 
     @Override
@@ -53,7 +53,7 @@ public class RoleConfigUpdateCommand extends RoleConfigCommand {
             return false;
         }
 
-        boolean freshRequest = hashingService.md5ForEntity(existingRole).equals(md5);
+        boolean freshRequest = hashingService.hashForEntity(existingRole).equals(digest);
 
         if (!freshRequest) {
             result.stale(EntityType.Role.staleConfig(existingRole.getName()));

--- a/server/src/main/java/com/thoughtworks/go/config/update/SecretConfigUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/SecretConfigUpdateCommand.java
@@ -53,7 +53,7 @@ public class SecretConfigUpdateCommand extends SecretConfigCommand {
 
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
         SecretConfig existingSecretConfig = findExistingProfile(cruiseConfig);
-        boolean freshRequest = hashingService.md5ForEntity(existingSecretConfig).equals(md5);
+        boolean freshRequest = hashingService.hashForEntity(existingSecretConfig).equals(md5);
         if (!freshRequest) {
             result.stale(getObjectDescriptor().staleConfig(existingSecretConfig.getId()));
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/SecurityAuthConfigUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/SecurityAuthConfigUpdateCommand.java
@@ -27,12 +27,12 @@ import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 public class SecurityAuthConfigUpdateCommand extends SecurityAuthConfigCommand {
 
     private final EntityHashingService hashingService;
-    private final String md5;
+    private final String digest;
 
-    public SecurityAuthConfigUpdateCommand(GoConfigService goConfigService, SecurityAuthConfig newSecurityAuthConfig, AuthorizationExtension extension, Username currentUser, LocalizedOperationResult result, EntityHashingService hashingService, String md5) {
+    public SecurityAuthConfigUpdateCommand(GoConfigService goConfigService, SecurityAuthConfig newSecurityAuthConfig, AuthorizationExtension extension, Username currentUser, LocalizedOperationResult result, EntityHashingService hashingService, String digest) {
         super(goConfigService, newSecurityAuthConfig, extension, currentUser, result);
         this.hashingService = hashingService;
-        this.md5 = md5;
+        this.digest = digest;
     }
 
     @Override
@@ -54,7 +54,7 @@ public class SecurityAuthConfigUpdateCommand extends SecurityAuthConfigCommand {
 
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
         SecurityAuthConfig existingProfile = findExistingProfile(cruiseConfig);
-        boolean freshRequest = hashingService.md5ForEntity(existingProfile).equals(md5);
+        boolean freshRequest = hashingService.hashForEntity(existingProfile).equals(digest);
         if (!freshRequest) {
             result.stale(getObjectDescriptor().staleConfig(existingProfile.getId()));
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdateArtifactStoreConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdateArtifactStoreConfigCommand.java
@@ -26,12 +26,12 @@ import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 
 public class UpdateArtifactStoreConfigCommand extends ArtifactStoreConfigCommand {
     private final EntityHashingService hashingService;
-    private final String md5;
+    private final String digest;
 
-    public UpdateArtifactStoreConfigCommand(GoConfigService goConfigService, ArtifactStore newArtifactStore, ArtifactExtension extension, Username currentUser, LocalizedOperationResult result, EntityHashingService hashingService, String md5) {
+    public UpdateArtifactStoreConfigCommand(GoConfigService goConfigService, ArtifactStore newArtifactStore, ArtifactExtension extension, Username currentUser, LocalizedOperationResult result, EntityHashingService hashingService, String digest) {
         super(goConfigService, newArtifactStore, extension, currentUser, result);
         this.hashingService = hashingService;
-        this.md5 = md5;
+        this.digest = digest;
     }
 
     @Override
@@ -53,7 +53,7 @@ public class UpdateArtifactStoreConfigCommand extends ArtifactStoreConfigCommand
 
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
         ArtifactStore existingProfile = findExistingProfile(cruiseConfig);
-        boolean freshRequest = hashingService.md5ForEntity(existingProfile).equals(md5);
+        boolean freshRequest = hashingService.hashForEntity(existingProfile).equals(digest);
         if (!freshRequest) {
             result.stale(getObjectDescriptor().staleConfig(existingProfile.getId()));
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdateConfigRepoCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdateConfigRepoCommand.java
@@ -29,17 +29,17 @@ public class UpdateConfigRepoCommand extends ConfigRepoCommand {
     private final EntityHashingService entityHashingService;
     private final String repoIdToUpdate;
     private final ConfigRepoConfig newConfigRepo;
-    private final String md5;
+    private final String digest;
     private final HttpLocalizedOperationResult result;
 
     public UpdateConfigRepoCommand(SecurityService securityService, EntityHashingService entityHashingService,
-                                   String repoIdToUpdate, ConfigRepoConfig newConfigRepo, String md5, Username username,
+                                   String repoIdToUpdate, ConfigRepoConfig newConfigRepo, String digest, Username username,
                                    HttpLocalizedOperationResult result, ConfigRepoExtension configRepoExtension) {
         super(securityService, newConfigRepo, username, result, configRepoExtension);
         this.entityHashingService = entityHashingService;
         this.repoIdToUpdate = repoIdToUpdate;
         this.newConfigRepo = newConfigRepo;
-        this.md5 = md5;
+        this.digest = digest;
         this.result = result;
     }
 
@@ -57,7 +57,7 @@ public class UpdateConfigRepoCommand extends ConfigRepoCommand {
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
         ConfigRepoConfig configRepo = cruiseConfig.getConfigRepos().getConfigRepo(repoIdToUpdate);
 
-        boolean freshRequest = entityHashingService.md5ForEntity(configRepo).equals(md5);
+        boolean freshRequest = entityHashingService.hashForEntity(configRepo).equals(digest);
         if (!freshRequest) {
             result.stale(EntityType.ConfigRepo.staleConfig(repoIdToUpdate));
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdateEnvironmentCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdateEnvironmentCommand.java
@@ -29,13 +29,13 @@ import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 public class UpdateEnvironmentCommand extends EnvironmentCommand {
 
     private final String oldEnvironmentConfigName;
-    private String md5;
+    private String digest;
     private EntityHashingService hashingService;
 
-    public UpdateEnvironmentCommand(GoConfigService goConfigService, String oldEnvironmentConfigName, EnvironmentConfig newEnvironmentConfig, Username username, String actionFailed, String md5, EntityHashingService hashingService, HttpLocalizedOperationResult result) {
+    public UpdateEnvironmentCommand(GoConfigService goConfigService, String oldEnvironmentConfigName, EnvironmentConfig newEnvironmentConfig, Username username, String actionFailed, String digest, EntityHashingService hashingService, HttpLocalizedOperationResult result) {
         super(actionFailed, newEnvironmentConfig, result, goConfigService, username);
         this.oldEnvironmentConfigName = oldEnvironmentConfigName;
-        this.md5 = md5;
+        this.digest = digest;
         this.hashingService = hashingService;
     }
 
@@ -59,7 +59,7 @@ public class UpdateEnvironmentCommand extends EnvironmentCommand {
             config = ((MergeEnvironmentConfig) config).getFirstEditablePart();
         }
 
-        boolean freshRequest =  hashingService.md5ForEntity(config).equals(md5);
+        boolean freshRequest =  hashingService.hashForEntity(config).equals(digest);
         if (!freshRequest) {
             result.stale(EntityType.Environment.staleConfig(oldEnvironmentConfigName));
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdatePackageConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdatePackageConfigCommand.java
@@ -30,16 +30,16 @@ public class UpdatePackageConfigCommand extends PackageConfigCommand {
     private final GoConfigService goConfigService;
     private final String oldPackageId;
     private final PackageDefinition newPackage;
-    private String md5;
+    private String digest;
     private EntityHashingService entityHashingService;
     private final HttpLocalizedOperationResult result;
 
-    public UpdatePackageConfigCommand(GoConfigService goConfigService, String oldPackageId, PackageDefinition newPackage, Username username, String md5, EntityHashingService entityHashingService, HttpLocalizedOperationResult result, PackageDefinitionService packageDefinitionService) {
+    public UpdatePackageConfigCommand(GoConfigService goConfigService, String oldPackageId, PackageDefinition newPackage, Username username, String digest, EntityHashingService entityHashingService, HttpLocalizedOperationResult result, PackageDefinitionService packageDefinitionService) {
         super(newPackage, result, packageDefinitionService, goConfigService, username);
         this.goConfigService = goConfigService;
         this.oldPackageId = oldPackageId;
         this.newPackage = newPackage;
-        this.md5 = md5;
+        this.digest = digest;
         this.entityHashingService = entityHashingService;
         this.result = result;
     }
@@ -87,7 +87,7 @@ public class UpdatePackageConfigCommand extends PackageConfigCommand {
 
     private boolean isRequestFresh() {
         PackageDefinition oldPackage = goConfigService.getConfigForEditing().getPackageRepositories().findPackageDefinitionWith(oldPackageId);
-        boolean freshRequest = entityHashingService.md5ForEntity(oldPackage).equals(md5);
+        boolean freshRequest = entityHashingService.hashForEntity(oldPackage).equals(digest);
         if (!freshRequest) {
             result.stale(EntityType.PackageDefinition.staleConfig(oldPackage.getId()));
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdatePackageRepositoryCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdatePackageRepositoryCommand.java
@@ -28,16 +28,16 @@ import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 public class UpdatePackageRepositoryCommand extends PackageRepositoryCommand {
     private final GoConfigService goConfigService;
     private final PackageRepository newRepo;
-    private final String md5;
+    private final String digest;
     private final EntityHashingService entityHashingService;
     private final HttpLocalizedOperationResult result;
     private String oldRepoId;
 
-    public UpdatePackageRepositoryCommand(GoConfigService goConfigService, PackageRepositoryService packageRepositoryService, PackageRepository newRepo, Username username, String md5, EntityHashingService entityHashingService, HttpLocalizedOperationResult result, String oldRepoId) {
+    public UpdatePackageRepositoryCommand(GoConfigService goConfigService, PackageRepositoryService packageRepositoryService, PackageRepository newRepo, Username username, String digest, EntityHashingService entityHashingService, HttpLocalizedOperationResult result, String oldRepoId) {
         super(packageRepositoryService, newRepo, result, goConfigService, username);
         this.goConfigService = goConfigService;
         this.newRepo = newRepo;
-        this.md5 = md5;
+        this.digest = digest;
         this.entityHashingService = entityHashingService;
         this.result = result;
         this.oldRepoId = oldRepoId;
@@ -67,7 +67,7 @@ public class UpdatePackageRepositoryCommand extends PackageRepositoryCommand {
 
     private boolean isRequestFresh() {
         PackageRepository oldRepo = goConfigService.getPackageRepository(newRepo.getRepoId());
-        boolean freshRequest = entityHashingService.md5ForEntity(oldRepo).equals(md5);
+        boolean freshRequest = entityHashingService.hashForEntity(oldRepo).equals(digest);
         if (!freshRequest) {
             result.stale(EntityType.PackageRepository.staleConfig(newRepo.getRepoId()));
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommand.java
@@ -33,17 +33,17 @@ public class UpdatePipelineConfigCommand extends PipelineConfigCommand {
     private final EntityHashingService entityHashingService;
     private final String newGroupName;
     private final Username currentUser;
-    private final String md5;
+    private final String digest;
     private final LocalizedOperationResult result;
     public String existingGroupName;
 
     public UpdatePipelineConfigCommand(GoConfigService goConfigService, EntityHashingService entityHashingService, PipelineConfig pipelineConfig, String newGroupName,
-                                       Username currentUser, String md5, LocalizedOperationResult result, ExternalArtifactsService externalArtifactsService) {
+                                       Username currentUser, String digest, LocalizedOperationResult result, ExternalArtifactsService externalArtifactsService) {
         super(pipelineConfig, goConfigService, externalArtifactsService);
         this.entityHashingService = entityHashingService;
         this.newGroupName = newGroupName;
         this.currentUser = currentUser;
-        this.md5 = md5;
+        this.digest = digest;
         this.result = result;
     }
 
@@ -103,7 +103,7 @@ public class UpdatePipelineConfigCommand extends PipelineConfigCommand {
     }
 
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
-        boolean freshRequest = entityHashingService.md5ForEntity(cruiseConfig.getPipelineConfigByName(pipelineConfig.name()), getExistingPipelineGroupName()).equals(md5);
+        boolean freshRequest = entityHashingService.hashForEntity(cruiseConfig.getPipelineConfigByName(pipelineConfig.name()), getExistingPipelineGroupName()).equals(digest);
 
         if (!freshRequest) {
             result.stale(EntityType.Pipeline.staleConfig(pipelineConfig.name()));

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdatePipelineConfigsCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdatePipelineConfigsCommand.java
@@ -28,15 +28,15 @@ import java.util.stream.StreamSupport;
 public class UpdatePipelineConfigsCommand extends PipelineConfigsCommand {
     private final PipelineConfigs oldPipelineGroup;
     private final PipelineConfigs newPipelineGroup;
-    private final String md5;
+    private final String digest;
     private final EntityHashingService entityHashingService;
 
-    public UpdatePipelineConfigsCommand(PipelineConfigs oldPipelineGroup, PipelineConfigs newPipelineGroup, LocalizedOperationResult result, Username currentUser, String md5,
+    public UpdatePipelineConfigsCommand(PipelineConfigs oldPipelineGroup, PipelineConfigs newPipelineGroup, LocalizedOperationResult result, Username currentUser, String digest,
                                         EntityHashingService entityHashingService, SecurityService securityService) {
         super(result, currentUser, securityService);
         this.oldPipelineGroup = oldPipelineGroup;
         this.newPipelineGroup = newPipelineGroup;
-        this.md5 = md5;
+        this.digest = digest;
         this.entityHashingService = entityHashingService;
     }
 
@@ -80,7 +80,7 @@ public class UpdatePipelineConfigsCommand extends PipelineConfigsCommand {
 
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
         PipelineConfigs existingPipelineConfigs = findPipelineConfigs(cruiseConfig, oldPipelineGroup.getGroup());
-        boolean freshRequest = entityHashingService.md5ForEntity(existingPipelineConfigs).equals(md5);
+        boolean freshRequest = entityHashingService.hashForEntity(existingPipelineConfigs).equals(digest);
         if (!freshRequest) {
             result.stale(EntityType.PipelineGroup.staleConfig(oldPipelineGroup.getGroup()));
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdateSCMConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdateSCMConfigCommand.java
@@ -27,12 +27,12 @@ import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 
 public class UpdateSCMConfigCommand extends SCMConfigCommand {
 
-    private String md5;
+    private String digest;
     private EntityHashingService entityHashingService;
 
-    public UpdateSCMConfigCommand(SCM globalScmConfig, PluggableScmService pluggableScmService, GoConfigService goConfigService, Username currentUser, LocalizedOperationResult result, String md5, EntityHashingService entityHashingService) {
+    public UpdateSCMConfigCommand(SCM globalScmConfig, PluggableScmService pluggableScmService, GoConfigService goConfigService, Username currentUser, LocalizedOperationResult result, String digest, EntityHashingService entityHashingService) {
         super(globalScmConfig, pluggableScmService, goConfigService, currentUser, result);
-        this.md5 = md5;
+        this.digest = digest;
         this.entityHashingService = entityHashingService;
     }
 
@@ -51,7 +51,7 @@ public class UpdateSCMConfigCommand extends SCMConfigCommand {
 
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
         SCM existingSCM = findSCM(cruiseConfig);
-        boolean freshRequest =  entityHashingService.md5ForEntity(existingSCM).equals(md5);
+        boolean freshRequest =  entityHashingService.hashForEntity(existingSCM).equals(digest);
         if (!freshRequest) {
             result.stale(EntityType.SCM.staleConfig(globalScmConfig.getName()));
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdateTemplateConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdateTemplateConfigCommand.java
@@ -30,19 +30,19 @@ import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 public class UpdateTemplateConfigCommand extends TemplateConfigCommand {
     private SecurityService securityService;
-    private String md5;
+    private String digest;
     private EntityHashingService entityHashingService;
 
     public UpdateTemplateConfigCommand(PipelineTemplateConfig templateConfig,
                                        Username currentUser,
                                        SecurityService securityService,
                                        LocalizedOperationResult result,
-                                       String md5,
+                                       String digest,
                                        EntityHashingService entityHashingService,
                                        ExternalArtifactsService externalArtifactsService) {
         super(templateConfig, result, currentUser, externalArtifactsService);
         this.securityService = securityService;
-        this.md5 = md5;
+        this.digest = digest;
         this.entityHashingService = entityHashingService;
     }
 
@@ -84,7 +84,7 @@ public class UpdateTemplateConfigCommand extends TemplateConfigCommand {
 
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
         PipelineTemplateConfig pipelineTemplateConfig = findAddedTemplate(cruiseConfig);
-        boolean freshRequest = entityHashingService.md5ForEntity(pipelineTemplateConfig).equals(md5);
+        boolean freshRequest = entityHashingService.hashForEntity(pipelineTemplateConfig).equals(digest);
         if (!freshRequest) {
             result.stale(EntityType.Template.staleConfig(templateConfig.name()));
         }

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineConfigsService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineConfigsService.java
@@ -127,7 +127,7 @@ public class PipelineConfigsService {
     }
 
     public PipelineConfigs updateGroup(Username currentUsername, PipelineConfigs pipelineConfigsFromReq, PipelineConfigs pipelineConfigsFromServer, HttpLocalizedOperationResult result) {
-        UpdatePipelineConfigsCommand updatePipelineConfigsCommand = new UpdatePipelineConfigsCommand(pipelineConfigsFromServer, pipelineConfigsFromReq, result, currentUsername, entityHashingService.md5ForEntity(pipelineConfigsFromServer), entityHashingService, securityService);
+        UpdatePipelineConfigsCommand updatePipelineConfigsCommand = new UpdatePipelineConfigsCommand(pipelineConfigsFromServer, pipelineConfigsFromReq, result, currentUsername, entityHashingService.hashForEntity(pipelineConfigsFromServer), entityHashingService, securityService);
         update(currentUsername, pipelineConfigsFromReq, result, updatePipelineConfigsCommand);
         return updatePipelineConfigsCommand.getPreprocessedEntityConfig();
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/PluginService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PluginService.java
@@ -98,7 +98,7 @@ public class PluginService {
 
     }
 
-    public void updatePluginSettings(PluginSettings newPluginSettings, Username currentUser, LocalizedOperationResult result, String md5) {
+    public void updatePluginSettings(PluginSettings newPluginSettings, Username currentUser, LocalizedOperationResult result, String digest) {
         final String pluginId = newPluginSettings.getPluginId();
 
         final String keyToLockOn = keyToLockOn(pluginId);
@@ -109,7 +109,7 @@ public class PluginService {
                     result.notFound(EntityType.PluginSettings.notFoundMessage(pluginId), HealthStateType.notFound());
                     return;
                 }
-                if (!entityHashingService.md5ForEntity(pluginSettingsFromDB).equals(md5)) {
+                if (!entityHashingService.hashForEntity(pluginSettingsFromDB).equals(digest)) {
                     result.stale(EntityType.PluginSettings.staleConfig(pluginId));
                     return;
                 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/materials/PackageDefinitionService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/materials/PackageDefinitionService.java
@@ -169,8 +169,8 @@ public class PackageDefinitionService {
         update(username, packageDefinition, result, command);
     }
 
-    public void updatePackage(String oldPackageId, PackageDefinition newPackage, String md5, Username username, HttpLocalizedOperationResult result) {
-        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, oldPackageId, newPackage, username, md5, this.entityHashingService, result, this);
+    public void updatePackage(String oldPackageId, PackageDefinition newPackage, String digest, Username username, HttpLocalizedOperationResult result) {
+        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, oldPackageId, newPackage, username, digest, this.entityHashingService, result, this);
         update(username, this.find(oldPackageId), result, command);
     }
 

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/jobs_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/jobs_controller.rb
@@ -69,7 +69,7 @@ module Admin
         load_artifact_related_data
         load_resources_and_elastic_profile_ids_for_autocomplete
         assert_load :task_view_models, task_view_service.getTaskViewModelsWith(@job.tasks().first()) unless @update_result.isSuccessful
-        assert_load :pipeline_md5, params[:pipeline_md5]
+        assert_load :pipeline_digest, params[:pipeline_digest]
         assert_load :pipeline_group_name, params[:pipeline_group_name]
         assert_load :pipeline_name, params[:pipeline_name]
       end
@@ -125,7 +125,7 @@ module Admin
         load_pipeline_and_stage
         assert_load :job, @job
         load_artifact_related_data
-        assert_load :pipeline_md5, params[:pipeline_md5]
+        assert_load :pipeline_digest, params[:pipeline_digest]
         assert_load :pipeline_group_name, params[:pipeline_group_name]
         assert_load :pipeline_name, params[:pipeline_name]
       end

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/pipelines_controller.rb
@@ -193,7 +193,7 @@ module Admin
       fast_save_page(redirect_url, error_rendering_options_or_proc) do
         assert_load(:pipeline, @pipeline)
         assert_load(:pipeline_group_name, params[:pipeline_group_name])
-        assert_load(:pipeline_md5, params[:pipeline_md5])
+        assert_load(:pipeline_digest, params[:pipeline_digest])
         load_pause_info
       end
     end

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/stages_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/stages_controller.rb
@@ -56,7 +56,7 @@ module Admin
       fast_save_popup({:action => :new, :layout => false}, {:current_tab => params[:current_tab]}) do
         assert_load(:pipeline, @pipeline)
         assert_load(:stage, @stage)
-        assert_load(:pipeline_md5, params[:pipeline_md5])
+        assert_load(:pipeline_digest, params[:pipeline_digest])
         assert_load(:pipeline_group_name, params[:pipeline_group_name])
         assert_load(:pipeline_name, params[:pipeline_name])
         assert_load(:task_view_models, task_view_service.getTaskViewModelsWith(@stage.allBuildPlans().first().tasks().first())) unless @update_result.isSuccessful()
@@ -109,7 +109,7 @@ module Admin
         @should_not_render_layout = true
         assert_load(:pipeline, ConfigUpdate::LoadConfig.for(params).load_pipeline_or_template(@cruise_config))
         assert_load(:stage, @stage_to_be_updated)
-        assert_load(:pipeline_md5, params[:pipeline_md5])
+        assert_load(:pipeline_digest, params[:pipeline_digest])
         assert_load(:pipeline_group_name, params[:pipeline_group_name])
         assert_load(:pipeline_name, params[:pipeline_name])
 

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/tasks_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin/tasks_controller.rb
@@ -68,7 +68,7 @@ module Admin
 
       failure_handler = action_failure_handler(@task, 'new')
       fast_save_popup(failure_handler, {:controller => '/admin/tasks', :current_tab => params[:current_tab]}) do
-        assert_load :pipeline_md5, params[:pipeline_md5]
+        assert_load :pipeline_digest, params[:pipeline_digest]
         assert_load :pipeline_group_name, params[:pipeline_group_name]
         assert_load :pipeline_name, params[:pipeline_name]
         assert_load :artifact_plugin_to_fetch_view, default_plugin_info_finder.pluginIdToFetchViewTemplate()
@@ -201,7 +201,7 @@ module Admin
 
       failure_handler = action_failure_handler(@task, 'edit')
       fast_save_popup(failure_handler, {:controller => '/admin/tasks', :current_tab => params[:current_tab]}) do
-        assert_load :pipeline_md5, params[:pipeline_md5]
+        assert_load :pipeline_digest, params[:pipeline_digest]
         assert_load :pipeline_group_name, params[:pipeline_group_name]
         assert_load :pipeline_name, params[:pipeline_name]
         assert_load :artifact_plugin_to_fetch_view, default_plugin_info_finder.pluginIdToFetchViewTemplate()

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/fast_admin_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/fast_admin_controller.rb
@@ -51,7 +51,7 @@ class FastAdminController < AdminController
 
   def fast_save(render_error_options_or_proc, success_message, load_data)
     @cruise_config = go_config_service.getCurrentConfig
-    @update_result = pipeline_config_service.updatePipelineConfig(current_user, @pipeline, params[:pipeline_group_name], params[:pipeline_md5])
+    @update_result = pipeline_config_service.updatePipelineConfig(current_user, @pipeline, params[:pipeline_group_name], params[:pipeline_digest])
 
     unless @update_result.isSuccessful
       @config_file_conflict = (@update_result.httpCode() == 409)

--- a/server/src/main/webapp/WEB-INF/rails/app/helpers/api_etag_helper.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/helpers/api_etag_helper.rb
@@ -45,6 +45,6 @@ module ApiEtagHelper
   end
 
   def etag_for(entity)
-    entity_hashing_service.md5ForEntity(entity)
+    entity_hashing_service.hashForEntity(entity)
   end
 end

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/artifacts.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/artifacts.html.erb
@@ -10,7 +10,7 @@
                           :onsubmit => "return AjaxForm.jquery_ajax_submit(this, AjaxForm.ConfigFormEditHandler);",
                           :class => "popup_form"} do |f| %>
     <%= md5_field %>
-    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_digest, @pipeline_digest %>
     <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
     <%= hidden_field_tag :pipeline_name, @pipeline.name %>
     <%= register_defaultable_list("job>artifactTypeConfigs") %>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/environment_variables.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/environment_variables.html.erb
@@ -10,7 +10,7 @@
                        :onsubmit => "return AjaxForm.jquery_ajax_submit(this, AjaxForm.ConfigFormEditHandler);",
                        :class => "popup_form"} do |f| %>
 
-    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_digest, @pipeline_digest %>
     <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
     <%= hidden_field_tag :pipeline_name, @pipeline.name %>
 

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/new.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/new.html.erb
@@ -9,7 +9,7 @@
                           :onsubmit => "return AjaxForm.jquery_ajax_submit(this);",
                           :class => "popup_form"}) do |f| %>
         <%= md5_field %>
-        <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+        <%= hidden_field_tag :pipeline_digest, @pipeline_digest %>
         <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
         <%= hidden_field_tag :pipeline_name, @pipeline.name %>
         <input type="hidden" name="current_tab" value="jobs" />

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/settings.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/settings.html.erb
@@ -9,7 +9,7 @@
                           :onsubmit => "return AjaxForm.jquery_ajax_submit(this, AjaxForm.ConfigFormEditHandler);",
                           :class => "popup_form"} do |f| %>
     <%= md5_field %>
-    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_digest, @pipeline_digest %>
     <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
     <%= hidden_field_tag :pipeline_name, @pipeline.name %>
     <%= render :partial => "job_basic_settings.html", :locals => {:scope => {:job => @job, :form => f, :cruise_config => @cruise_config}} -%>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/tabs.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/jobs/tabs.html.erb
@@ -12,7 +12,7 @@
                           :class => "popup_form"} do |f| %>
     <div class="fieldset">
         <%= md5_field %>
-        <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+        <%= hidden_field_tag :pipeline_digest, @pipeline_digest %>
         <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
         <%= hidden_field_tag :pipeline_name, @pipeline.name %>
         <%= current_tab_field("tabs") -%>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/environment_variables.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/environment_variables.html.erb
@@ -4,7 +4,7 @@
 <span title="Environment variables defined here are set on the agents and can be used within your tasks. <a class='' href='<%= docs_url '/faq/dev_use_current_revision_in_build.html' %>' target='_blank'>More...</a>" class="contextual_help has_go_tip_right">&nbsp;</span>
 
 <%= form_for @pipeline, :as => :pipeline, :url => pipeline_update_path(:pipeline_name => @pipeline.name(), :current_tab => 'environment_variables'), :html => {:method => :put, :id => "pipeline_edit_form"} do |f| %>
-    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_digest, @pipeline_digest %>
     <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
     <%= render partial: 'admin/shared/environment_variable_fieldset', locals: {
                                                                             form: f,

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/general.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/general.html.erb
@@ -3,7 +3,7 @@
 
 <%= form_for @pipeline, :as => :pipeline, :url => pipeline_update_path(:pipeline_name => @pipeline.name(), :current_tab => 'general'), :html => {:method => :put, :id => "pipeline_edit_form"} do |f| %>
     <%= md5_field %>
-    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_digest, @pipeline_digest %>
     <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
     <div class="fieldset">
         <div class="form_item">

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/parameters.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/parameters.html.erb
@@ -4,7 +4,7 @@
 <%= form_for @pipeline, :as => :pipeline, :url => pipeline_update_path(:pipeline_name => @pipeline.name(), :current_tab => 'parameters'), :html => {:method => :put, :id => "pipeline_edit_form"} do |f| %>
     <div class="fieldset">
         <%= md5_field %>
-        <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+        <%= hidden_field_tag :pipeline_digest, @pipeline_digest %>
         <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
         <%= register_defaultable_list("pipeline>params") %>
         <%= render :partial => "admin/shared/name_value", :locals => {:scope => {:form => f, :collection => @pipeline.getParams(), :collection_name => :params, :read_only_page => @is_config_repo_pipeline}} %>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/project_management.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines/project_management.html.erb
@@ -6,7 +6,7 @@
 <%= form_for @pipeline, :as => :pipeline, :url => pipeline_update_path(:pipeline_name => @pipeline.name(), :current_tab => 'project_management'), :html => {:method => :put, :id => 'pipeline_edit_form'} do |f| %>
     <div class="fieldset">
         <%= md5_field %>
-        <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+        <%= hidden_field_tag :pipeline_digest, @pipeline_digest %>
         <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
         <div id="tracking_tool_container">
             <%= f.fields_for com.thoughtworks.go.config.PipelineConfig::TRACKING_TOOL, @pipeline.trackingTool do |t| %>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/environment_variables.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/environment_variables.html.erb
@@ -10,7 +10,7 @@
                        :onsubmit => "return AjaxForm.jquery_ajax_submit(this, AjaxForm.ConfigFormEditHandler);",
                        :class => "popup_form"}) do |f| %>
 
-    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_digest, @pipeline_digest %>
     <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
     <%= hidden_field_tag :pipeline_name, @pipeline.name %>
 

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/new.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/new.html.erb
@@ -9,7 +9,7 @@
                          :onsubmit => "return AjaxForm.jquery_ajax_submit(this);",
                          :class => "popup_form"}) do |f| %>
     <%= md5_field %>
-    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_digest, @pipeline_digest %>
     <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
     <%= hidden_field_tag :pipeline_name, @pipeline.name %>
     <input type="hidden" name="current_tab" value="stages"/>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/permissions.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/permissions.html.erb
@@ -10,7 +10,7 @@
                           :onsubmit => "return AjaxForm.jquery_ajax_submit(this, AjaxForm.ConfigFormEditHandler);",
                           :class => "popup_form"}) do |f| %>
         <%= md5_field %>
-        <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+        <%= hidden_field_tag :pipeline_digest, @pipeline_digest %>
         <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
         <%= hidden_field_tag :pipeline_name, @pipeline.name %>
         <div class="fieldset">

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/settings.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/settings.html.erb
@@ -9,7 +9,7 @@
                          :onsubmit => "return AjaxForm.jquery_ajax_submit(this, AjaxForm.ConfigFormEditHandler);",
                          :class => "popup_form"}) do |f| %>
     <%= md5_field %>
-    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_digest, @pipeline_digest %>
     <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
     <%= hidden_field_tag :pipeline_name, @pipeline.name %>
     <%= render :partial => "admin/shared/global_errors.html", :locals => {:scope => {}} -%>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/tasks/plugin/_form.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/tasks/plugin/_form.html.erb
@@ -2,7 +2,7 @@
 <%= render :partial => "shared/config_save_actions" -%>
 <%= form_for(scope[:task], :as => :task, :url => scope[:url], :html => {"novalidate"=> "novalidate", :id=> "task_form", :name=> "task_form", :method => scope[:method], :onsubmit => "return AjaxForm.jquery_ajax_submit(this);", :class => "popup_form"}) do |f| %>
     <%= md5_field %>
-    <%= hidden_field_tag :pipeline_md5, @pipeline_md5 %>
+    <%= hidden_field_tag :pipeline_digest, @pipeline_digest %>
     <%= hidden_field_tag :pipeline_group_name, @pipeline_group_name %>
     <%= hidden_field_tag :pipeline_name, @pipeline.name %>
     <div class="form_content exec_task_editor">

--- a/server/src/main/webapp/WEB-INF/rails/lib/pipeline_config_loader.rb
+++ b/server/src/main/webapp/WEB-INF/rails/lib/pipeline_config_loader.rb
@@ -54,7 +54,7 @@ module PipelineConfigLoader
       end
 
       @pipeline_group_name = pipeline_for_edit.getProcessedConfig.findGroupOfPipeline(pipeline_for_edit.config).group
-      @pipeline_md5 = entity_hashing_service.md5ForEntity(pipeline_for_edit.config, @pipeline_group_name)
+      @pipeline_digest = entity_hashing_service.hashForEntity(pipeline_for_edit.config, @pipeline_group_name)
     end
     unless result.isSuccessful()
       render_localized_operation_result result

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/jobs_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/jobs_controller_spec.rb
@@ -219,12 +219,12 @@ describe Admin::JobsController do
         expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
         put :update, params:{:pipeline_name => "pipeline-name", :stage_name => "stage-name", :job_name => "job-1",
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                              :current_tab => "settings",:config_md5 => "1234abcd", "job"=>{"name" => "renamed_job"},
                              :stage_parent => "pipelines"}
 
         expect(response.location).to match(/admin\/pipelines\/pipeline-name\/stages\/stage-name\/job\/renamed_job\/settings?.*?fm=(.+)/)
-        expect(assigns[:pipeline_md5]).to eq("pipeline-md5")
+        expect(assigns[:pipeline_digest]).to eq("pipeline-digest")
         expect(assigns[:pipeline_group_name]).to eq("defaultGroup")
       end
 
@@ -235,7 +235,7 @@ describe Admin::JobsController do
         expect(@pipeline_pause_service).to receive(:pipelinePauseInfo).with("pipeline-name").and_return(@pause_info)
 
         put :update, params:{:pipeline_name => "pipeline-name", :stage_name => "stage-name", :job_name => "job-1",
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                              :current_tab => "settings", :config_md5 => "1234abcd", "job"=>{"name" => "doesnt_matter"},
                              :stage_parent => "pipelines"}
 
@@ -253,7 +253,7 @@ describe Admin::JobsController do
         add_resource("job-2","anything")
 
         put :update, params:{:pipeline_name => "pipeline-name", :stage_name => "stage-name", :job_name => "job-1",
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                              :current_tab => "settings",:config_md5 => "1234abcd", "job"=>{"name" => "doesnt_matter"},
                              :stage_parent => "pipelines"}
 
@@ -269,13 +269,13 @@ describe Admin::JobsController do
         add_resource("job-2","anything")
 
         put :update, params:{:pipeline_name => "pipeline-name", :stage_name => "stage-name", :job_name => "job-1",
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                              :current_tab => "settings",:config_md5 => "1234abcd", "job"=>{"name" => "doesnt_matter"},
                              :stage_parent => "pipelines"}
 
         expect(controller.instance_variable_get("@cruise_config").getMd5()).to eq("1234abcd")
         expect(@go_config_service).not_to receive(:loadForEdit)
-        expect(assigns[:pipeline_md5]).to eq("pipeline-md5")
+        expect(assigns[:pipeline_digest]).to eq("pipeline-digest")
         expect(assigns[:pipeline_group_name]).to eq("defaultGroup")
       end
 
@@ -284,7 +284,7 @@ describe Admin::JobsController do
         expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
         put :update, params:{:pipeline_name => "pipeline-name", :stage_name => "stage-name", :job_name => "job-1",
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                              :current_tab => "settings",:config_md5 => "1234abcd", "job"=>{"variables"=>[{:name=>"key", :valueForDisplay=>"value"}]}, :stage_parent => "pipelines"}
 
         variable = assigns[:job].variables().get(0)
@@ -292,7 +292,7 @@ describe Admin::JobsController do
         expect(variable.value).to eq("value")
         expect(variable.valueForDisplay).to eq("value")
         expect(response.location).to match(/admin\/pipelines\/pipeline-name\/stages\/stage-name\/job\/job-1\/settings?.*?fm=(.+)/)
-        expect(assigns[:pipeline_md5]).to eq("pipeline-md5")
+        expect(assigns[:pipeline_digest]).to eq("pipeline-digest")
         expect(assigns[:pipeline_group_name]).to eq("defaultGroup")
       end
 
@@ -301,13 +301,13 @@ describe Admin::JobsController do
        expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
         put :update, params:{:pipeline_name => "pipeline-name", :stage_name => "stage-name", :job_name => "job-1",
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                              :current_tab => "tabs",:config_md5 => "1234abcd", "job"=>{"tabs"=>[{"name"=>"tab1", "path"=>"path1"}]}, :stage_parent => "pipelines"}
 
         expect(assigns[:job].getTabs().get(0).name).to eq("tab1")
         expect(assigns[:job].getTabs().get(0).path).to eq("path1")
         expect(response.location).to match(/admin\/pipelines\/pipeline-name\/stages\/stage-name\/job\/job-1\/tabs?.*?fm=(.+)/)
-       expect(assigns[:pipeline_md5]).to eq("pipeline-md5")
+       expect(assigns[:pipeline_digest]).to eq("pipeline-digest")
        expect(assigns[:pipeline_group_name]).to eq("defaultGroup")
      end
 
@@ -316,11 +316,11 @@ describe Admin::JobsController do
         expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
         put :update, params:{:pipeline_name => "pipeline-name", :stage_name => "stage-name", :job_name => "job-1",
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                              :current_tab => "settings",:config_md5 => "1234abcd", "default_as_empty_list" => ["job>variables"], :stage_parent => "pipelines"}
 
         expect(assigns[:job].variables().isEmpty).to eq(true)
-        expect(assigns[:pipeline_md5]).to eq("pipeline-md5")
+        expect(assigns[:pipeline_digest]).to eq("pipeline-digest")
         expect(assigns[:pipeline_group_name]).to eq("defaultGroup")
       end
 
@@ -329,11 +329,11 @@ describe Admin::JobsController do
         expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
         put :update, params:{:pipeline_name => "pipeline-name", :stage_name => "stage-name", :job_name => "job-1",
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                              :current_tab => "resources",:config_md5 => "1234abcd", "job"=> {"resources" => "a,  b  ,c,d"}, :stage_parent => "pipelines"}
 
         expect(assigns[:job].resourceConfigs().exportToCsv()).to eq("a, b, c, d, ")
-        expect(assigns[:pipeline_md5]).to eq("pipeline-md5")
+        expect(assigns[:pipeline_digest]).to eq("pipeline-digest")
         expect(assigns[:pipeline_group_name]).to eq("defaultGroup")
       end
 
@@ -342,11 +342,11 @@ describe Admin::JobsController do
         expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
         put :update, params:{:pipeline_name => "pipeline-name", :stage_name => "stage-name", :job_name => "job-1",
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                              :current_tab => "artifacts",:config_md5 => "1234abcd", "default_as_empty_list" => ["job>artifactTypeConfigs"], :stage_parent => "pipelines"}
 
         expect(assigns[:job].artifactTypeConfigs().size()).to eq(0)
-        expect(assigns[:pipeline_md5]).to eq("pipeline-md5")
+        expect(assigns[:pipeline_digest]).to eq("pipeline-digest")
         expect(assigns[:pipeline_group_name]).to eq("defaultGroup")
       end
     end
@@ -398,7 +398,7 @@ describe Admin::JobsController do
                               :job => {:name => "new_job", :tasks => {:taskOptions => "exec",
                                                                       "exec" => {:command => "ls", :workingDirectory => 'work'}}},
                               :config_md5 => "1234abcd", :stage_parent => "pipelines",
-                              :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup'}
+                              :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup'}
 
         assert_template "new"
         assert_template layout: false
@@ -420,7 +420,7 @@ describe Admin::JobsController do
                               :job => {:name => "new_job", :tasks => {:taskOptions => "exec",
                                                                       "exec" => {:command => "ls", :workingDirectory => 'work'}}},
                               :config_md5 => "1234abcd", :stage_parent => "pipelines",
-                              :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup'}
+                              :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup'}
 
         expect(assigns[:autocomplete_resources]).to eq(["anything"].to_json)
         assert_template "new"

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/materials_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/materials_controller_spec.rb
@@ -43,7 +43,7 @@ describe Admin::MaterialsController do
       @pipeline_name = "pipeline-name"
       pipeline_group = BasicPipelineConfigs.new
       pipeline_group.group = "defaultGroup"
-      allow(@entity_hashing_service).to receive(:md5ForEntity).and_return('pipeline-md5')
+      allow(@entity_hashing_service).to receive(:hashForEntity).and_return('pipeline-digest')
       expect(@pipeline_pause_service).to receive(:pipelinePauseInfo).with(@pipeline_name).and_return(@pause_info)
       allow(@go_config_service).to receive(:registry).and_return(MockRegistryModule::MockRegistry.new)
       @cruise_config = double("Cruise Config")

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/pipelines_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/pipelines_controller_spec.rb
@@ -40,7 +40,7 @@ describe Admin::PipelinesController do
     allow(controller).to receive(:package_definition_service).with(no_args).and_return(@package_definition_service = StubPackageDefinitionService.new)
     allow(controller).to receive(:pipeline_selections_service).and_return(@pipeline_selections_service = double('pipeline selections service'))
     allow(controller).to receive(:entity_hashing_service).and_return(@entity_hashing_service = double('entity hashing service'))
-    allow(@entity_hashing_service).to receive(:md5ForEntity).and_return('pipeline-md5')
+    allow(@entity_hashing_service).to receive(:hashForEntity).and_return('pipeline-digest')
   end
 
   describe "routes" do
@@ -126,7 +126,7 @@ describe Admin::PipelinesController do
           expect(assigns[:pipeline].getLabelTemplate()).to eq("some_label_template")
           expect(assigns[:pause_info]).to eq(@pause_info)
           expect(assigns[:pipeline_group_name]).to eq('defaultGroup')
-          expect(assigns[:pipeline_md5]).to eq('pipeline-md5')
+          expect(assigns[:pipeline_digest]).to eq('pipeline-digest')
           assert_template layout: "pipelines/details"
         end
       end
@@ -186,7 +186,7 @@ describe Admin::PipelinesController do
         result.setMessage("saved successfully")
         expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
         request_params = {:pipeline_name => "pipeline-name", :current_tab => 'general',
-                          :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'my-group',
+                          :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'my-group',
                           :pipeline => {"labelTemplate" => "${COUNT}-something"}, :config_md5 => "md5", :stage_parent => "pipelines"}
 
         put :update, params: request_params
@@ -194,7 +194,7 @@ describe Admin::PipelinesController do
         expect(assigns[:pipeline].labelTemplate).to eq("${COUNT}-something")
         expect(assigns[:pause_info]).to eq(@pause_info)
         expect(assigns[:pipeline_group_name]).to eq('my-group')
-        expect(assigns[:pipeline_md5]).to eq('pipeline-md5')
+        expect(assigns[:pipeline_digest]).to eq('pipeline-digest')
       end
 
       it "should set variables and parameters to empty if not sent in params" do
@@ -204,7 +204,7 @@ describe Admin::PipelinesController do
         @pipeline.variables().add("key1", "value1")
 
         put :update, params:{:pipeline_name => "pipeline-name", :current_tab => 'general', :config_md5 => "md5",
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'my-group',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'my-group',
                              :default_as_empty_list => ["pipeline>variables"], :stage_parent=>"pipelines"}
 
         expect(assigns[:pipeline].variables().isEmpty()).to eq(true)
@@ -213,13 +213,13 @@ describe Admin::PipelinesController do
         @pipeline.addParam(ParamConfig.new("param1", "value1"))
 
         put :update, params:{:pipeline_name => "pipeline-name", :current_tab => 'general',
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'my-group',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'my-group',
                              :config_md5 => "md5", :default_as_empty_list => ["pipeline>params"], :stage_parent=>"pipelines"}
 
         expect(assigns[:pipeline].getParams().isEmpty()).to eq(true)
         expect(assigns[:pause_info]).to eq(@pause_info)
         expect(assigns[:pipeline_group_name]).to eq('my-group')
-        expect(assigns[:pipeline_md5]).to eq('pipeline-md5')
+        expect(assigns[:pipeline_digest]).to eq('pipeline-digest')
       end
 
       it "should update only if configuration is valid" do
@@ -228,13 +228,13 @@ describe Admin::PipelinesController do
         expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
         put :update, params:{:pipeline_name => "pipeline-name", :current_tab => 'general', :pipeline_group_name => 'my-group',
-                             :pipeline_md5 => "pipeline-md5",
+                             :pipeline_digest => "pipeline-digest",
                              :pipeline => {"labelTemplate" => "${COUNT}-#junk"}, :config_md5 => "md5", :stage_parent=>"pipelines"}
 
         expect(assigns[:errors].size).to eq(0)
         expect(assigns[:pause_info]).to eq(@pause_info)
         expect(assigns[:pipeline_group_name]).to eq('my-group')
-        expect(assigns[:pipeline_md5]).to eq('pipeline-md5')
+        expect(assigns[:pipeline_digest]).to eq('pipeline-digest')
         assert_template layout: "pipelines/details"
       end
 
@@ -250,7 +250,7 @@ describe Admin::PipelinesController do
 
           put :update, params:{:pipeline_name => "pipeline-name", :current_tab => 'parameters', :config_md5 => "md5",
                                :stage_parent=>"pipelines", :default_as_empty_list => ["pipeline>params"],
-                               :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'my-group',
+                               :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'my-group',
               :pipeline => {:params => [{:name => "to-be-modified", :valueForDisplay => "modified-value"},
                                         {:name => "added", :valueForDisplay => "added-value"}]}}
           expect(assigns[:pause_info]).to eq(@pause_info)
@@ -284,7 +284,7 @@ describe Admin::PipelinesController do
 
           put :update, params:{:pipeline_name => "pipeline-name", :current_tab => 'parameters', :config_md5 => "md5",
                                :stage_parent=>"pipelines", :default_as_empty_list => ["pipeline>params"],
-                               :pipeline_group_name => 'my-group', :pipeline_md5 => "pipeline-md5",
+                               :pipeline_group_name => 'my-group', :pipeline_digest => "pipeline-digest",
                                :pipeline => {:params => [{:name => "renamed", :valueForDisplay => "renamed-value", :original_name => "to-be-deleted"},
                                                                                                                                                                                                                    {:name => "to-be-modified", :valueForDisplay => "modified-value"}]}}
           params = assigns[:pipeline].getParams()

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/stages_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/stages_controller_spec.rb
@@ -232,7 +232,7 @@ describe Admin::StagesController do
         stage = {:name => "stage", :jobs => [{:name => "job", :tasks => {:taskOptions => "pluggableTask", "pluggableTask" => {:foo => "bar"}}}]}
         pipeline_name = "pipeline-name"
         post :create, params:{:stage_parent => "pipelines", :pipeline_name => pipeline_name, :config_md5 => "1234abcd",
-                              :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                              :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                               :stage => stage}
 
         # expect(@pipeline.last().name()).to eq(CaseInsensitiveString.new("stage"))
@@ -250,7 +250,7 @@ describe Admin::StagesController do
 
         job = {:name => "job", :tasks => {:taskOptions => "ant", "ant" => {}}}
         post :create, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :config_md5 => "1234abcd",
-                              :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                              :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                               :stage => {:name =>  "stage", :type => "cruise", :jobs => [job]}}
 
         expect(assigns[:config_file_conflict]).to eq(true)
@@ -264,7 +264,7 @@ describe Admin::StagesController do
         job = {:name => "job", :tasks => {:taskOptions => "ant", "ant" => {}}}
 
         post :create, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :config_md5 => "1234abcd",
-                              :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                              :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                               :stage => {:name =>  "stage", :type => "cruise", :jobs => [job]}}
 
         # expect(@cruise_config.getAllErrors().size).to eq(0)
@@ -284,7 +284,7 @@ describe Admin::StagesController do
         allow(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
         post :create, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :config_md5 => "1234abcd",
-                              :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                              :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                               :stage => {:name =>  "stage", :type => "cruise", :jobs => [{:name => "123", :tasks => {:taskOptions => "exec", "exec" => {:command => "ls", :workingDirectory => 'work'}}}]}}
 
         expect(assigns[:task_view_models]).to eq(tvms)
@@ -305,7 +305,7 @@ describe Admin::StagesController do
 
 
         post :create, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :config_md5 => "1234abcd",
-                              :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                              :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                               :stage => {:name =>  "stage", :type => "cruise", :jobs => [{:name => "123", :tasks => {:taskOptions => "exec", "exec" => {:command => "ls", :workingDirectory => 'work'}}}]}}
 
         #expect(assigns[:errors].size).to eq(1) Don't know how to test this
@@ -421,11 +421,11 @@ describe Admin::StagesController do
 
         put :update, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :stage_name => "stage-name",
                              :config_md5 => "1234abcd", :current_tab => "permissions",
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                              :stage => {:approval => {:type => "manual"},:variables =>[{:name=>"key", :valueForDisplay=>"value"}]}}
 
         expect(assigns[:stage].getApproval().getType()).to eq("manual")
-        expect(assigns[:pipeline_md5]).to eq('pipeline-md5')
+        expect(assigns[:pipeline_digest]).to eq('pipeline-digest')
         expect(assigns[:pipeline_group_name]).to eq('defaultGroup')
         expect(assigns[:pipeline_name]).to eq('pipeline-name')
         environment_variable = assigns[:stage].variables().get(0)
@@ -442,7 +442,7 @@ describe Admin::StagesController do
         expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
         put :update, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :stage_name => "stage-name",
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                              :config_md5 => "1234abcd", :current_tab => "permissions", :stage => {:name => "new-stage-name"}}
 
         expect(response.location).to match(/\/admin\/pipelines\/pipeline-name\/stages\/new-stage-name\/permissions\?fm=#{uuid_pattern}$/)
@@ -468,7 +468,7 @@ describe Admin::StagesController do
         expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
         put :update, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :stage_name => "stage-name",
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                              :config_md5 => "1234abcd", :current_tab => "settings",
 
                              :stage => { :securityMode => "define", :operateUsers => [{ :name => "user1"}, {:name => "user2"}],
@@ -478,7 +478,7 @@ describe Admin::StagesController do
         expect(assigns[:stage].getOperateUsers().get(1)).to eq(AdminUser.new(CaseInsensitiveString.new("user2")))
         expect(assigns[:stage].getOperateRoles().get(0)).to eq(AdminRole.new(CaseInsensitiveString.new("role1")))
         expect(assigns[:stage].getOperateRoles().get(1)).to eq(AdminRole.new(CaseInsensitiveString.new("role2")))
-        expect(assigns[:pipeline_md5]).to eq('pipeline-md5')
+        expect(assigns[:pipeline_digest]).to eq('pipeline-digest')
         expect(assigns[:pipeline_group_name]).to eq('defaultGroup')
         expect(assigns[:pipeline_name]).to eq('pipeline-name')
       end
@@ -489,7 +489,7 @@ describe Admin::StagesController do
         expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
         put :update, params:{:stage_parent => "pipelines", :pipeline_name => "pipeline-name", :stage_name => "stage-name",
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
                              :config_md5 => "1234abcd", :current_tab => "permissions", :stage => {:name => "new-stage-name"}}
 
         expect(response.location).to be_nil

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/stages_controller_view_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/stages_controller_view_spec.rb
@@ -153,8 +153,8 @@ describe Admin::StagesController, "view" do
           expect(@pipeline_config_service).to receive(:updatePipelineConfig).and_return(result)
 
           post :create, params:{:stage_parent=> "pipelines", :pipeline_name => "pipeline-name",
-                                :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup',
-                                :stage => {:name => "stage-foo", :jobs => [{:name => "another-job"}]}, :config_md5 => "some-md5"}
+                                :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup',
+                                :stage => {:name => "stage-foo", :jobs => [{:name => "another-job"}]}, :config_md5 => "some-digest"}
 
           expect(response.status).to eq(200)
           expect(response.body).to have_content("Saved successfully")

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks/fetch_external_task_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks/fetch_external_task_controller_spec.rb
@@ -52,7 +52,7 @@ describe Admin::TasksController, "fetch task" do
     @created_task = @new_task
 
     @entity_hashing_service = stub_service(:entity_hashing_service)
-    allow(@entity_hashing_service).to receive(:md5ForEntity).and_return('pipeline-md5')
+    allow(@entity_hashing_service).to receive(:hashForEntity).and_return('pipeline-digest')
   end
 
   it_should_behave_like :task_controller

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks/fetch_task_controller_example.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks/fetch_task_controller_example.rb
@@ -55,7 +55,7 @@ shared_examples_for :fetch_task_controller do
 
         put :update, params:{:current_tab=>"tasks", :pipeline_name => @pipeline_name, :stage_name => @stage_name,
                              :job_name => @job_name, :config_md5 => "abcd1234", :type => fetch_task_with_exec_on_cancel_task.getTaskType(),
-                             :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'my-groups',
+                             :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'my-groups',
                              :stage_parent => @parent_type, :task_index => '0', :task => @modify_payload}
 
         expect(assigns[:pipeline_json]).to eq(pipelines_json)

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks/fetch_task_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks/fetch_task_controller_spec.rb
@@ -25,7 +25,7 @@ describe Admin::TasksController, "fetch task" do
 
   before do
     @entity_hashing_service = stub_service(:entity_hashing_service)
-    allow(@entity_hashing_service).to receive(:md5ForEntity).and_return('pipeline-md5')
+    allow(@entity_hashing_service).to receive(:hashForEntity).and_return('pipeline-digest')
     @example_task = fetch_task_with_exec_on_cancel_task
     @task_type = @example_task.getTaskType()
     @updated_payload = {:pipelineName => 'other-pipeline', :stage => 'other-stage', :job => 'other-job', :src => 'new-src', :dest => 'new-dest', :isSourceAFile => '1', :hasCancelTask => "1", :onCancelConfig=> { :onCancelOption => 'exec', :execOnCancel => {:command => "echo", :args => "'failing'", :workingDirectory => "oncancel_working_dir"}}}

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks/task_controller_examples.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks/task_controller_examples.rb
@@ -239,7 +239,7 @@ shared_examples_for :task_controller do
         put :update, params: {:pipeline_name => "pipeline.name", :stage_name => "stage.name", :job_name => "job.1",
                               :task_index => "0", :config_md5 => "1234abcd", :type => @task_type, :task => @updated_payload,
                               :stage_parent => "pipelines", :current_tab => "tasks",
-                              :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup'}
+                              :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup'}
 
         expect(assigns[:on_cancel_task_vms]).to eq(on_cancel_task_vms)
 
@@ -293,7 +293,7 @@ shared_examples_for :task_controller do
         post :create, params: {:pipeline_name => "pipeline.name", :stage_name => "stage.name", :job_name => "job.1",
                                :type => @task_type, :config_md5 => "abcd1234", :task => @create_payload,
                                :stage_parent => "pipelines", :current_tab => "tasks",
-                               :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup'}
+                               :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup'}
 
         expect(response.status).to eq(200)
       end
@@ -310,7 +310,7 @@ shared_examples_for :task_controller do
         post :create, params: {:pipeline_name => "pipeline.name", :stage_name => "stage.name", :job_name => "job.1",
                                :type => @task_type, :config_md5 => "abcd1234", :task => @create_payload,
                                :stage_parent => "pipelines", :current_tab => "tasks",
-                               :pipeline_md5 => "pipeline-md5", :pipeline_group_name => 'defaultGroup'}
+                               :pipeline_digest => "pipeline-digest", :pipeline_group_name => 'defaultGroup'}
         expect(assigns[:on_cancel_task_vms]).to eq(@on_cancel_task_vms)
         expect(assigns[:config_store]).not_to eq(nil)
         expect(assigns[:config_store]).to eq(@config_store)

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/admin/tasks_controller_spec.rb
@@ -108,7 +108,7 @@ describe Admin::TasksController do
       expect(@go_config_service).to receive(:isPipelineDefinedInConfigRepository).and_return(false)
       expect(@pipeline_pause_service).to receive(:pipelinePauseInfo).with("pipeline.name").and_return(@pause_info)
       allow(@go_config_service).to receive(:registry).and_return(MockRegistryModule::MockRegistry.new)
-      allow(@entity_hashing_service).to receive(:md5ForEntity).and_return('pipeline-md5')
+      allow(@entity_hashing_service).to receive(:hashForEntity).and_return('pipeline-digest')
     end
 
     it "should load tasks" do

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/templates/authorization_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/templates/authorization_controller_spec.rb
@@ -77,7 +77,7 @@ describe ApiV1::Admin::Templates::AuthorizationController do
       end
 
       it 'should render the template templates for a given template' do
-        expect(@entity_hashing_service).to receive(:md5ForEntity).with(an_instance_of(PipelineTemplateConfig)).and_return('md5')
+        expect(@entity_hashing_service).to receive(:hashForEntity).with(an_instance_of(PipelineTemplateConfig)).and_return('digest')
         expect(@template_config_service).to receive(:loadForView).with('template', @result).and_return(@template)
 
         get_with_api_header :show, params:{template_name: 'template'}
@@ -144,7 +144,7 @@ describe ApiV1::Admin::Templates::AuthorizationController do
 
       it 'should deserialize template from given parameters' do
         allow(controller).to receive(:check_for_stale_request).and_return(nil)
-        allow(controller).to receive(:etag_for).and_return('md5')
+        allow(controller).to receive(:etag_for).and_return('digest')
         allow(@template_config_service).to receive(:loadForView).with(anything, anything).and_return(@template)
 
         expect(@template_config_service).to receive(:updateTemplateAuthConfig).with(anything, an_instance_of(PipelineTemplateConfig), an_instance_of(com.thoughtworks.go.config.Authorization), anything, anything)
@@ -167,11 +167,11 @@ describe ApiV1::Admin::Templates::AuthorizationController do
       end
 
       it 'should proceed with update if etag matches.' do
-        controller.request.env['HTTP_IF_MATCH'] = controller.send(:generate_strong_etag, 'md5')
+        controller.request.env['HTTP_IF_MATCH'] = controller.send(:generate_strong_etag, 'digest')
 
         allow(@template_config_service).to receive(:loadForView).with('some-template', anything).and_return(@template)
-        expect(@entity_hashing_service).to receive(:md5ForEntity).with(an_instance_of(PipelineTemplateConfig)).exactly(3).times.and_return('md5')
-        expect(@template_config_service).to receive(:updateTemplateAuthConfig).with(anything, an_instance_of(PipelineTemplateConfig), an_instance_of(com.thoughtworks.go.config.Authorization), anything, "md5")
+        expect(@entity_hashing_service).to receive(:hashForEntity).with(an_instance_of(PipelineTemplateConfig)).exactly(3).times.and_return('digest')
+        expect(@template_config_service).to receive(:updateTemplateAuthConfig).with(anything, an_instance_of(PipelineTemplateConfig), an_instance_of(com.thoughtworks.go.config.Authorization), anything, "digest")
 
         put_with_api_header :update, params:{template_name: 'some-template', authorization: template_hash}
 
@@ -184,7 +184,7 @@ describe ApiV1::Admin::Templates::AuthorizationController do
 
         result = HttpLocalizedOperationResult.new
 
-        expect(@entity_hashing_service).to receive(:md5ForEntity).with(an_instance_of(PipelineTemplateConfig)).and_return('md5')
+        expect(@entity_hashing_service).to receive(:hashForEntity).with(an_instance_of(PipelineTemplateConfig)).and_return('digest')
         allow(@template_config_service).to receive(:loadForView).and_return(@template)
         allow(@template_config_service).to receive(:updateTemplateAuthConfig).with(anything, an_instance_of(PipelineTemplateConfig), an_instance_of(com.thoughtworks.go.config.Authorization), result, anything)  do |user, template, auth, result|
           result.unprocessableEntity('some error')

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/admin/pipelines/general_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/admin/pipelines/general_html_spec.rb
@@ -29,7 +29,7 @@ describe "admin/pipelines/general.html.erb" do
     @cruise_config.addPipeline(@pipeline_group_name, @pipeline)
 
     set(@cruise_config, "md5", "abc")
-    @pipeline_md5 = entity_hashing_service.md5ForEntity(@pipeline, @pipeline_group_name)
+    @pipeline_digest = entity_hashing_service.hashForEntity(@pipeline, @pipeline_group_name)
     in_params(:pipeline_name => "foo_bar", :action => "new", :controller => "admin/stages")
   end
 
@@ -38,7 +38,7 @@ describe "admin/pipelines/general.html.erb" do
 
     Capybara.string(response.body).find('#pipeline_edit_form').tap do |form|
       expect(form).to have_selector("input[type='hidden'][name='config_md5'][value='abc']", visible: :hidden)
-      expect(form).to have_selector("input[type='hidden'][name='pipeline_md5'][value='#{@pipeline_md5}']", visible: :hidden)
+      expect(form).to have_selector("input[type='hidden'][name='pipeline_digest'][value='#{@pipeline_digest}']", visible: :hidden)
       expect(form).to have_selector("input[type='hidden'][name='pipeline_group_name'][value='group-1']", visible: :hidden)
 
       expect(form).to have_selector("div[class='contextual_help has_go_tip_right']")

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/admin/stages/new_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/admin/stages/new_html_spec.rb
@@ -33,7 +33,7 @@ describe "admin/stages/new.html.erb" do
     @pipeline_group_name = 'group-1'
     @cruise_config.addPipeline(@pipeline_group_name, @pipeline_config)
 
-    @pipeline_md5 = entity_hashing_service.md5ForEntity(@pipeline_config, @pipeline_group_name)
+    @pipeline_digest = entity_hashing_service.hashForEntity(@pipeline_config, @pipeline_group_name)
 
     set(@cruise_config, "md5", "abc")
     in_params(:stage_parent => "pipelines", :pipeline_name => "foo_bar", :action => "new", :controller => "admin/stages")

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/AdminsConfigUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/AdminsConfigUpdateCommandTest.java
@@ -82,13 +82,13 @@ public class AdminsConfigUpdateCommandTest {
     @Test
     public void shouldNotContinueIfRequestIsStale() {
         AdminsConfig adminsConfig = new AdminsConfig(new AdminUser(new CaseInsensitiveString("user")));
-        String md5 = "md5";
+        String digest = "digest";
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(true);
-        when(entityHashingService.md5ForEntity(cruiseConfig.server().security().adminsConfig())).thenReturn(md5);
+        when(entityHashingService.hashForEntity(cruiseConfig.server().security().adminsConfig())).thenReturn(digest);
 
-        AdminsConfigUpdateCommand command = new AdminsConfigUpdateCommand(goConfigService, adminsConfig, currentUser, result, entityHashingService, "stale_md5");
+        AdminsConfigUpdateCommand command = new AdminsConfigUpdateCommand(goConfigService, adminsConfig, currentUser, result, entityHashingService, "stale_digest");
 
         assertFalse(command.canContinue(cruiseConfig));
         assertThat(result.httpCode(), is(412));
@@ -97,13 +97,13 @@ public class AdminsConfigUpdateCommandTest {
     @Test
     public void canContinue_adminUserShouldBeAbleToUpdateAFreshRequest() {
         AdminsConfig adminsConfig = new AdminsConfig(new AdminUser(new CaseInsensitiveString("user")));
-        String md5 = "md5";
+        String digest = "digest";
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(true);
-        when(entityHashingService.md5ForEntity(cruiseConfig.server().security().adminsConfig())).thenReturn(md5);
+        when(entityHashingService.hashForEntity(cruiseConfig.server().security().adminsConfig())).thenReturn(digest);
 
-        AdminsConfigUpdateCommand command = new AdminsConfigUpdateCommand(goConfigService, adminsConfig, currentUser, result, entityHashingService, "md5");
+        AdminsConfigUpdateCommand command = new AdminsConfigUpdateCommand(goConfigService, adminsConfig, currentUser, result, entityHashingService, "digest");
 
         assertTrue(command.canContinue(cruiseConfig));
     }
@@ -113,7 +113,7 @@ public class AdminsConfigUpdateCommandTest {
         cruiseConfig.server().security().setAdminsConfig(adminsConfig);
         ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(cruiseConfig);
 
-        AdminsConfigUpdateCommand command = new AdminsConfigUpdateCommand(goConfigService, null, currentUser, result, entityHashingService, "md5");
+        AdminsConfigUpdateCommand command = new AdminsConfigUpdateCommand(goConfigService, null, currentUser, result, entityHashingService, "digest");
         command.isValid(cruiseConfig);
 
         verify(adminsConfig).validateTree(validationContext);
@@ -125,7 +125,7 @@ public class AdminsConfigUpdateCommandTest {
         AdminsConfig adminsConfigRequest = new AdminsConfig(new AdminUser(new CaseInsensitiveString("")));
         cruiseConfig.server().security().setAdminsConfig(adminsInPreprocessedConfig);
 
-        AdminsConfigUpdateCommand command = new AdminsConfigUpdateCommand(goConfigService, adminsConfigRequest, currentUser, result, entityHashingService, "md5");
+        AdminsConfigUpdateCommand command = new AdminsConfigUpdateCommand(goConfigService, adminsConfigRequest, currentUser, result, entityHashingService, "digest");
 
         assertFalse(command.isValid(cruiseConfig));
         TestCase.assertTrue(adminsConfigRequest.hasErrors());

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/ElasticAgentProfileUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/ElasticAgentProfileUpdateCommandTest.java
@@ -77,10 +77,10 @@ public class ElasticAgentProfileUpdateCommandTest {
 
         EntityHashingService entityHashingService = mock(EntityHashingService.class);
 
-        when(entityHashingService.md5ForEntity(oldProfile)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(oldProfile)).thenReturn("digest");
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        ElasticAgentProfileUpdateCommand command = new ElasticAgentProfileUpdateCommand(goConfigService, newProfile, null, currentUser, result, entityHashingService, "bad-md5");
+        ElasticAgentProfileUpdateCommand command = new ElasticAgentProfileUpdateCommand(goConfigService, newProfile, null, currentUser, result, entityHashingService, "bad-digest");
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result.toString(), containsString("Someone has modified the configuration for"));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/RoleConfigUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/RoleConfigUpdateCommandTest.java
@@ -70,7 +70,7 @@ public class RoleConfigUpdateCommandTest {
 
         when(goConfigService.isUserAdmin(viewUser)).thenReturn(false);
 
-        RoleConfigUpdateCommand command = new RoleConfigUpdateCommand(goConfigService, new RoleConfig("some-role"), viewUser, result, mock(EntityHashingService.class), "md5");
+        RoleConfigUpdateCommand command = new RoleConfigUpdateCommand(goConfigService, new RoleConfig("some-role"), viewUser, result, mock(EntityHashingService.class), "digest");
 
         assertFalse(command.canContinue(null));
         assertFalse(result.isSuccessful());
@@ -84,10 +84,10 @@ public class RoleConfigUpdateCommandTest {
 
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(true);
         cruiseConfig.server().security().getRoles().add(oldRole);
-        when(entityHashingService.md5ForEntity(oldRole)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(oldRole)).thenReturn("digest");
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        RoleConfigCommand command = new RoleConfigUpdateCommand(goConfigService, updatedRole, currentUser, result, entityHashingService, "bad-md5");
+        RoleConfigCommand command = new RoleConfigUpdateCommand(goConfigService, updatedRole, currentUser, result, entityHashingService, "bad-digest");
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result.message(), is(EntityType.Role.staleConfig(updatedRole.getName())));
@@ -100,7 +100,7 @@ public class RoleConfigUpdateCommandTest {
 
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(true);
 
-        RoleConfigCommand command = new RoleConfigUpdateCommand(goConfigService, updatedRole, currentUser, result, entityHashingService, "bad-md5");
+        RoleConfigCommand command = new RoleConfigUpdateCommand(goConfigService, updatedRole, currentUser, result, entityHashingService, "bad-digest");
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertFalse(result.isSuccessful());

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/SecretConfigUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/SecretConfigUpdateCommandTest.java
@@ -76,10 +76,10 @@ public class SecretConfigUpdateCommandTest {
 
         EntityHashingService entityHashingService = mock(EntityHashingService.class);
 
-        when(entityHashingService.md5ForEntity(oldConfig)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(oldConfig)).thenReturn("digest");
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        SecretConfigUpdateCommand command = new SecretConfigUpdateCommand(goConfigService, newConfig, null, currentUser, result, entityHashingService, "bad-md5");
+        SecretConfigUpdateCommand command = new SecretConfigUpdateCommand(goConfigService, newConfig, null, currentUser, result, entityHashingService, "bad-digest");
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result.toString(), containsString("Someone has modified the configuration for"));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/SecurityAuthConfigUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/SecurityAuthConfigUpdateCommandTest.java
@@ -78,10 +78,10 @@ public class SecurityAuthConfigUpdateCommandTest {
 
         EntityHashingService entityHashingService = mock(EntityHashingService.class);
 
-        when(entityHashingService.md5ForEntity(oldAuthConfig)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(oldAuthConfig)).thenReturn("digest");
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        SecurityAuthConfigUpdateCommand command = new SecurityAuthConfigUpdateCommand(goConfigService, newAuthConfig, null, currentUser, result, entityHashingService, "bad-md5");
+        SecurityAuthConfigUpdateCommand command = new SecurityAuthConfigUpdateCommand(goConfigService, newAuthConfig, null, currentUser, result, entityHashingService, "bad-digest");
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result.toString(), containsString("Someone has modified the configuration for"));;

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateArtifactStoreConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateArtifactStoreConfigCommandTest.java
@@ -87,10 +87,10 @@ public class UpdateArtifactStoreConfigCommandTest {
 
         EntityHashingService entityHashingService = mock(EntityHashingService.class);
 
-        when(entityHashingService.md5ForEntity(oldArtifactStore)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(oldArtifactStore)).thenReturn("digest");
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        UpdateArtifactStoreConfigCommand command = new UpdateArtifactStoreConfigCommand(goConfigService, newArtifactStore, null, currentUser, result, entityHashingService, "bad-md5");
+        UpdateArtifactStoreConfigCommand command = new UpdateArtifactStoreConfigCommand(goConfigService, newArtifactStore, null, currentUser, result, entityHashingService, "bad-digest");
 
         assertThat(command.canContinue(cruiseConfig)).isFalse();
         assertThat(result.message()).isEqualTo(EntityType.ArtifactStore.staleConfig(newArtifactStore.getId()));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateConfigRepoCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateConfigRepoCommandTest.java
@@ -43,7 +43,7 @@ public class UpdateConfigRepoCommandTest {
     private String oldConfigRepoId;
     private String newConfigRepoId;
     private HttpLocalizedOperationResult result;
-    private String md5;
+    private String digest;
 
     @Mock
     private SecurityService securityService;
@@ -64,13 +64,13 @@ public class UpdateConfigRepoCommandTest {
         oldConfigRepo = ConfigRepoConfig.createConfigRepoConfig(git("foo.git", "master"), "json-plugin", oldConfigRepoId);
         newConfigRepo = ConfigRepoConfig.createConfigRepoConfig(git("bar.git", "master"), "yaml-plugin", newConfigRepoId);
         result = new HttpLocalizedOperationResult();
-        md5 = "md5";
+        digest = "digest";
         cruiseConfig.getConfigRepos().add(oldConfigRepo);
     }
 
     @Test
     public void shouldUpdateTheSpecifiedConfigRepo() throws Exception {
-        UpdateConfigRepoCommand command = new UpdateConfigRepoCommand(securityService, entityHashingService, oldConfigRepoId, newConfigRepo, md5, currentUser, result, configRepoExtension);
+        UpdateConfigRepoCommand command = new UpdateConfigRepoCommand(securityService, entityHashingService, oldConfigRepoId, newConfigRepo, digest, currentUser, result, configRepoExtension);
 
         assertNull(cruiseConfig.getConfigRepos().getConfigRepo(newConfigRepoId));
         command.update(cruiseConfig);
@@ -78,10 +78,10 @@ public class UpdateConfigRepoCommandTest {
     }
 
     @Test
-    public void shouldNotContinueIfMD5IsStale() throws Exception {
-        UpdateConfigRepoCommand command = new UpdateConfigRepoCommand(securityService, entityHashingService, oldConfigRepoId, newConfigRepo, md5, currentUser, result, configRepoExtension);
+    public void shouldNotContinueIfDigestIsStale() throws Exception {
+        UpdateConfigRepoCommand command = new UpdateConfigRepoCommand(securityService, entityHashingService, oldConfigRepoId, newConfigRepo, digest, currentUser, result, configRepoExtension);
         when(securityService.isUserAdmin(currentUser)).thenReturn(true);
-        when(entityHashingService.md5ForEntity(oldConfigRepo)).thenReturn("some-hash");
+        when(entityHashingService.hashForEntity(oldConfigRepo)).thenReturn("some-hash");
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
         expectedResult.stale(EntityType.ConfigRepo.staleConfig(oldConfigRepoId));
 
@@ -93,7 +93,7 @@ public class UpdateConfigRepoCommandTest {
     public void isValid_shouldValidateConfigRepo() {
         newConfigRepo.setRepo(git("foobar.git", "master"));
         cruiseConfig.getConfigRepos().add(newConfigRepo);
-        UpdateConfigRepoCommand command = new UpdateConfigRepoCommand(securityService, entityHashingService, oldConfigRepoId, newConfigRepo, md5, currentUser, result, configRepoExtension);
+        UpdateConfigRepoCommand command = new UpdateConfigRepoCommand(securityService, entityHashingService, oldConfigRepoId, newConfigRepo, digest, currentUser, result, configRepoExtension);
         when(configRepoExtension.canHandlePlugin(newConfigRepo.getPluginId())).thenReturn(true);
 
         command.update(cruiseConfig);
@@ -109,7 +109,7 @@ public class UpdateConfigRepoCommandTest {
         ConfigRepoConfig configRepo = new ConfigRepoConfig();
         configRepo.setId("");
 
-        UpdateConfigRepoCommand command = new UpdateConfigRepoCommand(securityService, entityHashingService, oldConfigRepoId, configRepo, md5, currentUser, result, configRepoExtension);
+        UpdateConfigRepoCommand command = new UpdateConfigRepoCommand(securityService, entityHashingService, oldConfigRepoId, configRepo, digest, currentUser, result, configRepoExtension);
 
         assertFalse(command.isValid(cruiseConfig));
         assertThat(configRepo.errors().on("id"), is("Configuration repository id not specified"));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePackageConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePackageConfigCommandTest.java
@@ -85,7 +85,7 @@ public class UpdatePackageConfigCommandTest {
 
     @Test
     public void shouldUpdateTheSpecifiedPackage() throws Exception {
-        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, newPackageDefinition, currentUser, "md5", this.entityHashingService, result, packageDefinitionService);
+        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, newPackageDefinition, currentUser, "digest", this.entityHashingService, result, packageDefinitionService);
         assertThat(cruiseConfig.getPackageRepositories().findPackageDefinitionWith(packageUuid), is(oldPackageDefinition));
         command.update(cruiseConfig);
         assertThat(cruiseConfig.getPackageRepositories().findPackageDefinitionWith(packageUuid), is(newPackageDefinition));
@@ -93,9 +93,9 @@ public class UpdatePackageConfigCommandTest {
 
     @Test
     public void shouldNotContinueIfTheUserDontHavePermissionsToOperateOnPackages() throws Exception {
-        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, newPackageDefinition, currentUser, "md5", this.entityHashingService, result, packageDefinitionService);
+        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, newPackageDefinition, currentUser, "digest", this.entityHashingService, result, packageDefinitionService);
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
-        when(entityHashingService.md5ForEntity(oldPackageDefinition)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(oldPackageDefinition)).thenReturn("digest");
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
         expectedResult.forbidden(EntityType.PackageDefinition.forbiddenToEdit(newPackageDefinition.getId(), currentUser.getUsername()), forbidden());
 
@@ -109,7 +109,7 @@ public class UpdatePackageConfigCommandTest {
         UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, newPackageDefinition, currentUser, "stale-etag", this.entityHashingService, result, packageDefinitionService);
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(true);
         when(goConfigService.getConfigForEditing()).thenReturn(cruiseConfig);
-        when(entityHashingService.md5ForEntity(oldPackageDefinition)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(oldPackageDefinition)).thenReturn("digest");
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
         expectedResult.stale(EntityType.PackageDefinition.staleConfig(oldPackageDefinition.getId()));
 
@@ -124,7 +124,7 @@ public class UpdatePackageConfigCommandTest {
         pkg.setRepository(repository);
         repository.addPackage(pkg);
         cruiseConfig.setPackageRepositories(new PackageRepositories(repository));
-        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, pkg, currentUser, "md5", this.entityHashingService, result, packageDefinitionService);
+        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, pkg, currentUser, "digest", this.entityHashingService, result, packageDefinitionService);
         command.update(cruiseConfig);
         assertFalse(command.isValid(cruiseConfig));
         assertThat(pkg.errors().size(), is(1));
@@ -138,7 +138,7 @@ public class UpdatePackageConfigCommandTest {
         pkg.setRepository(repository);
         repository.addPackage(pkg);
         cruiseConfig.setPackageRepositories(new PackageRepositories(repository));
-        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, pkg, currentUser, "md5", this.entityHashingService, result, packageDefinitionService);
+        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, pkg, currentUser, "digest", this.entityHashingService, result, packageDefinitionService);
         command.update(cruiseConfig);
         assertFalse(command.isValid(cruiseConfig));
         assertThat(pkg.errors().size(), is(1));
@@ -156,7 +156,7 @@ public class UpdatePackageConfigCommandTest {
         pkg.setRepository(repository);
         repository.addPackage(pkg);
         cruiseConfig.setPackageRepositories(new PackageRepositories(repository));
-        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, pkg, currentUser, "md5", this.entityHashingService, result, packageDefinitionService);
+        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, pkg, currentUser, "digest", this.entityHashingService, result, packageDefinitionService);
         command.update(cruiseConfig);
         assertFalse(command.isValid(cruiseConfig));
         assertThat(pkg.getAllErrors().toString(), containsString("Duplicate key 'key' found for Package 'prettyjson'"));
@@ -169,7 +169,7 @@ public class UpdatePackageConfigCommandTest {
         pkg.setRepository(repository);
         repository.addPackage(pkg);
         cruiseConfig.setPackageRepositories(new PackageRepositories(repository));
-        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, newPackageDefinition, currentUser, "md5", this.entityHashingService, result, packageDefinitionService);
+        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, newPackageDefinition, currentUser, "digest", this.entityHashingService, result, packageDefinitionService);
         command.update(cruiseConfig);
         assertFalse(command.isValid(cruiseConfig));
         assertThat(newPackageDefinition.errors().size(), is(1));
@@ -183,7 +183,7 @@ public class UpdatePackageConfigCommandTest {
         pkg.setRepository(repository);
         repository.addPackage(pkg);
         cruiseConfig.setPackageRepositories(new PackageRepositories(repository));
-        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, newPackageDefinition, currentUser, "md5", this.entityHashingService, result, packageDefinitionService);
+        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, newPackageDefinition, currentUser, "digest", this.entityHashingService, result, packageDefinitionService);
         command.update(cruiseConfig);
         assertFalse(command.isValid(cruiseConfig));
         assertThat(newPackageDefinition.errors().size(), is(1));
@@ -195,10 +195,10 @@ public class UpdatePackageConfigCommandTest {
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(true);
         when(goConfigService.isGroupAdministrator(currentUser.getUsername())).thenReturn(false);
         when(goConfigService.getConfigForEditing()).thenReturn(cruiseConfig);
-        when(this.entityHashingService.md5ForEntity(any(PackageDefinition.class))).thenReturn("md5");
+        when(this.entityHashingService.hashForEntity(any(PackageDefinition.class))).thenReturn("digest");
 
         newPackageDefinition.setRepository(new PackageRepository(oldPackageDefinition.getRepository().getId(), "name", null, null));
-        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, newPackageDefinition, currentUser, "md5", this.entityHashingService, result, packageDefinitionService);
+        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, newPackageDefinition, currentUser, "digest", this.entityHashingService, result, packageDefinitionService);
 
         assertThat(command.canContinue(cruiseConfig), is(true));
     }
@@ -208,10 +208,10 @@ public class UpdatePackageConfigCommandTest {
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
         when(goConfigService.isGroupAdministrator(currentUser.getUsername())).thenReturn(true);
         when(goConfigService.getConfigForEditing()).thenReturn(cruiseConfig);
-        when(this.entityHashingService.md5ForEntity(any(PackageDefinition.class))).thenReturn("md5");
+        when(this.entityHashingService.hashForEntity(any(PackageDefinition.class))).thenReturn("digest");
 
         newPackageDefinition.setRepository(new PackageRepository(oldPackageDefinition.getRepository().getId(), "name", null, null));
-        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, newPackageDefinition, currentUser, "md5", this.entityHashingService, result, packageDefinitionService);
+        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, packageUuid, newPackageDefinition, currentUser, "digest", this.entityHashingService, result, packageDefinitionService);
 
         assertThat(command.canContinue(cruiseConfig), is(true));
     }
@@ -219,12 +219,12 @@ public class UpdatePackageConfigCommandTest {
     @Test
     public void shouldNotContinueIfPackageIdIsChanged() {
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(true);
-        when(entityHashingService.md5ForEntity(oldPackageDefinition)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(oldPackageDefinition)).thenReturn("digest");
         HttpLocalizedOperationResult expectResult = new HttpLocalizedOperationResult();
         expectResult.unprocessableEntity("Changing the package id is not supported by this API.");
 
         newPackageDefinition.setRepository(new PackageRepository(oldPackageDefinition.getRepository().getId(), "name", null, null));
-        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, "old-package-id", newPackageDefinition, currentUser, "md5", this.entityHashingService, result, packageDefinitionService);
+        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, "old-package-id", newPackageDefinition, currentUser, "digest", this.entityHashingService, result, packageDefinitionService);
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result, is(expectResult));
@@ -236,7 +236,7 @@ public class UpdatePackageConfigCommandTest {
         cruiseConfig.setPackageRepositories(new PackageRepositories());
         when(goConfigService.getCurrentConfig()).thenReturn(cruiseConfig);
         newPackageDefinition.setRepository(new PackageRepository("id", "name", null, null));
-        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, "old-package-id", newPackageDefinition, currentUser, "md5", this.entityHashingService, result, packageDefinitionService);
+        UpdatePackageConfigCommand command = new UpdatePackageConfigCommand(goConfigService, "old-package-id", newPackageDefinition, currentUser, "digest", this.entityHashingService, result, packageDefinitionService);
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
         expectedResult.unprocessableEntity(EntityType.PackageRepository.notFoundMessage("id"));
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommandTest.java
@@ -59,11 +59,11 @@ class UpdatePipelineConfigCommandTest {
     @Test
     void shouldDisallowStaleRequest() {
         UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, entityHashingService,
-                pipelineConfig, "group1", username, "stale_md5", localizedOperationResult, externalArtifactsService);
+                pipelineConfig, "group1", username, "stale_digest", localizedOperationResult, externalArtifactsService);
 
         when(goConfigService.findGroupNameByPipeline(pipelineConfig.name())).thenReturn("group1");
         when(goConfigService.canEditPipeline(pipelineConfig.name().toString(), username, localizedOperationResult, "group1")).thenReturn(true);
-        when(entityHashingService.md5ForEntity(pipelineConfig, "group1")).thenReturn("latest_md5");
+        when(entityHashingService.hashForEntity(pipelineConfig, "group1")).thenReturn("latest_digest");
 
         BasicCruiseConfig basicCruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(pipelineConfig));
         assertThat(command.canContinue(basicCruiseConfig)).isFalse();
@@ -72,7 +72,7 @@ class UpdatePipelineConfigCommandTest {
     @Test
     void shouldDisallowUpdateIfPipelineEditIsDisAllowed() throws Exception {
         UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, null,
-                pipelineConfig, "", username, "stale_md5", localizedOperationResult, externalArtifactsService);
+                pipelineConfig, "", username, "stale_digest", localizedOperationResult, externalArtifactsService);
 
         when(goConfigService.findGroupNameByPipeline(pipelineConfig.name())).thenReturn("group1");
         when(goConfigService.canEditPipeline(pipelineConfig.name().toString(), username, localizedOperationResult, "group1")).thenReturn(false);
@@ -87,7 +87,7 @@ class UpdatePipelineConfigCommandTest {
     @Test
     void shouldInvokeUpdateMethodOfCruiseConfig() throws Exception {
         UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, null,
-                pipelineConfig, "group1", username, "stale_md5", localizedOperationResult, externalArtifactsService);
+                pipelineConfig, "group1", username, "stale_digest", localizedOperationResult, externalArtifactsService);
 
         CruiseConfig cruiseConfig = mock(CruiseConfig.class);
         when(goConfigService.findGroupNameByPipeline(pipelineConfig.name())).thenReturn("group1");
@@ -100,7 +100,7 @@ class UpdatePipelineConfigCommandTest {
     void shouldEncryptSecurePropertiesOfPipelineConfig() {
         PipelineConfig pipelineConfig = mock(PipelineConfig.class);
         UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, null,
-                pipelineConfig, "group1", username, "stale_md5", localizedOperationResult, externalArtifactsService);
+                pipelineConfig, "group1", username, "stale_digest", localizedOperationResult, externalArtifactsService);
 
         when(pipelineConfig.name()).thenReturn(new CaseInsensitiveString("p1"));
         CruiseConfig preprocessedConfig = mock(CruiseConfig.class);
@@ -130,7 +130,7 @@ class UpdatePipelineConfigCommandTest {
                 new StageConfig(new CaseInsensitiveString("S2"), new JobConfigs(job2)));
 
         UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, null,
-                pipeline, "group", username, "stale_md5", localizedOperationResult, externalArtifactsService);
+                pipeline, "group", username, "stale_digest", localizedOperationResult, externalArtifactsService);
 
         BasicCruiseConfig preprocessedConfig = GoConfigMother.defaultCruiseConfig();
         preprocessedConfig.addPipelineWithoutValidation("group", pipeline);
@@ -157,7 +157,7 @@ class UpdatePipelineConfigCommandTest {
                 new StageConfig(new CaseInsensitiveString("S2"), new JobConfigs(job2)));
 
         UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, null,
-                pipeline, "group", username, "stale_md5", localizedOperationResult, externalArtifactsService);
+                pipeline, "group", username, "stale_digest", localizedOperationResult, externalArtifactsService);
 
         BasicCruiseConfig preprocessedConfig = GoConfigMother.defaultCruiseConfig();
         preprocessedConfig.addPipelineWithoutValidation("group", pipeline);
@@ -181,7 +181,7 @@ class UpdatePipelineConfigCommandTest {
         assertThat(pipelineGroups.hasGroup("updated_group")).isFalse();
 
         UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, null,
-                pipelineConfig, "updated_group", username, "stale_md5", localizedOperationResult, externalArtifactsService);
+                pipelineConfig, "updated_group", username, "stale_digest", localizedOperationResult, externalArtifactsService);
 
         command.update(cruiseConfig);
         verify(cruiseConfig).update("group1", pipelineConfig.name().toString(), pipelineConfig);
@@ -204,7 +204,7 @@ class UpdatePipelineConfigCommandTest {
         when(goConfigService.isUserAdminOfGroup(username.getUsername(), "group2")).thenReturn(false);
 
         UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, entityHashingService,
-                pipelineConfig, "group2", username, "md5", localizedOperationResult, externalArtifactsService);
+                pipelineConfig, "group2", username, "digest", localizedOperationResult, externalArtifactsService);
 
         boolean canContinue = command.canContinue(cruiseConfig);
 
@@ -229,10 +229,10 @@ class UpdatePipelineConfigCommandTest {
         when(username.getUsername()).thenReturn(new CaseInsensitiveString("user"));
         when(goConfigService.isUserAdminOfGroup(any(CaseInsensitiveString.class), eq("group2"))).thenReturn(true);
         when(cruiseConfig.getPipelineConfigByName(pipelineConfig.name())).thenReturn(pipelineConfig);
-        when(entityHashingService.md5ForEntity(pipelineConfig, "group1")).thenReturn("md5");
+        when(entityHashingService.hashForEntity(pipelineConfig, "group1")).thenReturn("digest");
 
         UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, entityHashingService,
-                pipelineConfig, "group2", username, "md5", localizedOperationResult, externalArtifactsService);
+                pipelineConfig, "group2", username, "digest", localizedOperationResult, externalArtifactsService);
 
         boolean canContinue = command.canContinue(cruiseConfig);
 
@@ -247,7 +247,7 @@ class UpdatePipelineConfigCommandTest {
         job.addTask(task);
         PipelineConfig pipeline = PipelineConfigMother.pipelineConfig("P1", new StageConfig(new CaseInsensitiveString("S1"), new JobConfigs(job)));
 
-        UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, null, pipeline, "group", username, "stale_md5", localizedOperationResult, externalArtifactsService);
+        UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, null, pipeline, "group", username, "stale_digest", localizedOperationResult, externalArtifactsService);
         BasicCruiseConfig preprocessedConfig = GoConfigMother.defaultCruiseConfig();
         preprocessedConfig.addPipelineWithoutValidation("group", pipeline);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePipelineConfigsCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePipelineConfigsCommandTest.java
@@ -71,7 +71,7 @@ public class UpdatePipelineConfigsCommandTest {
         Authorization newAuthorization = new Authorization(new AdminsConfig(new AdminRole(new CaseInsensitiveString("foo"))));
         PipelineConfigs newPipelineConfig = new BasicPipelineConfigs("group", newAuthorization);
 
-        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, new HttpLocalizedOperationResult(), user, "md5", entityHashingService, securityService);
+        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, new HttpLocalizedOperationResult(), user, "digest", entityHashingService, securityService);
         command.update(cruiseConfig);
 
         assertThat(cruiseConfig.hasPipelineGroup(this.pipelineConfigs.getGroup()), is(true));
@@ -85,7 +85,7 @@ public class UpdatePipelineConfigsCommandTest {
         Authorization newAuthorization = new Authorization(new AdminsConfig(new AdminRole(new CaseInsensitiveString("validRole"))));
         PipelineConfigs newPipelineConfig = new BasicPipelineConfigs("group", newAuthorization);
 
-        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, new HttpLocalizedOperationResult(), user, "md5", entityHashingService, securityService);
+        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, new HttpLocalizedOperationResult(), user, "digest", entityHashingService, securityService);
         command.isValid(cruiseConfig);
         assertThat(authorization.getAllErrors(), is(Collections.emptyList()));
     }
@@ -95,7 +95,7 @@ public class UpdatePipelineConfigsCommandTest {
         Authorization newAuthorization = new Authorization(new AdminsConfig(new AdminRole(new CaseInsensitiveString("invalidRole"))));
         PipelineConfigs newPipelineConfig = new BasicPipelineConfigs("group", newAuthorization);
 
-        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, new HttpLocalizedOperationResult(), user, "md5", entityHashingService, securityService);
+        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, new HttpLocalizedOperationResult(), user, "digest", entityHashingService, securityService);
         command.update(cruiseConfig);
         assertFalse(command.isValid(cruiseConfig));
 
@@ -108,7 +108,7 @@ public class UpdatePipelineConfigsCommandTest {
         PipelineConfigs newPipelineConfig = new BasicPipelineConfigs(null, newAuthorization);
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "md5", entityHashingService, securityService);
+        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "digest", entityHashingService, securityService);
 
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Group name cannot be null.");
@@ -124,7 +124,7 @@ public class UpdatePipelineConfigsCommandTest {
         PipelineConfigs newPipelineConfig = new BasicPipelineConfigs("  ", newAuthorization);
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "md5", entityHashingService, securityService);
+        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "digest", entityHashingService, securityService);
 
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Group name cannot be null.");
@@ -138,7 +138,7 @@ public class UpdatePipelineConfigsCommandTest {
         this.pipelineConfigs.setGroup(null);
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "md5", entityHashingService, securityService);
+        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "digest", entityHashingService, securityService);
 
         thrown.expect(RecordNotFoundException.class);
         command.isValid(cruiseConfig);
@@ -147,13 +147,13 @@ public class UpdatePipelineConfigsCommandTest {
     @Test
     public void commandShouldContinue_whenRequestIsFreshAndUserIsAuthorized() {
         when(securityService.isUserAdminOfGroup(user, "group")).thenReturn(true);
-        when(entityHashingService.md5ForEntity(pipelineConfigs)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(pipelineConfigs)).thenReturn("digest");
 
         Authorization newAuthorization = new Authorization(new AdminsConfig(new AdminRole(new CaseInsensitiveString("validRole"))));
         PipelineConfigs newPipelineConfig = new BasicPipelineConfigs("group", newAuthorization);
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "md5", entityHashingService, securityService);
+        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "digest", entityHashingService, securityService);
 
         assertTrue(command.canContinue(cruiseConfig));
     }
@@ -161,12 +161,12 @@ public class UpdatePipelineConfigsCommandTest {
     @Test
     public void commandShouldNotContinue_whenRequestIsNotFresh() {
         when(securityService.isUserAdminOfGroup(user, "group")).thenReturn(true);
-        when(entityHashingService.md5ForEntity(pipelineConfigs)).thenReturn("md5-old");
+        when(entityHashingService.hashForEntity(pipelineConfigs)).thenReturn("digest-old");
 
         Authorization newAuthorization = new Authorization(new AdminsConfig(new AdminRole(new CaseInsensitiveString("validRole"))));
         PipelineConfigs newPipelineConfig = new BasicPipelineConfigs("group", newAuthorization);
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "md5", entityHashingService, securityService);
+        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "digest", entityHashingService, securityService);
 
         assertFalse(command.canContinue(cruiseConfig));
         assertThat(result.httpCode(), is(HttpStatus.SC_PRECONDITION_FAILED));
@@ -175,12 +175,12 @@ public class UpdatePipelineConfigsCommandTest {
     @Test
     public void commandShouldNotContinue_whenUserUnauthorized() {
         when(securityService.isUserAdminOfGroup(user, "group")).thenReturn(false);
-        when(entityHashingService.md5ForEntity(pipelineConfigs)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(pipelineConfigs)).thenReturn("digest");
 
         Authorization newAuthorization = new Authorization(new AdminsConfig(new AdminRole(new CaseInsensitiveString("validRole"))));
         PipelineConfigs newPipelineConfig = new BasicPipelineConfigs("group", newAuthorization);
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "md5", entityHashingService, securityService);
+        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "digest", entityHashingService, securityService);
 
         assertFalse(command.canContinue(cruiseConfig));
         assertThat(result.httpCode(), is(HttpStatus.SC_FORBIDDEN));
@@ -189,13 +189,13 @@ public class UpdatePipelineConfigsCommandTest {
     @Test
     public void commandShouldContinue_whenPipelineGroupNameIsModified() {
         when(securityService.isUserAdminOfGroup(user, "group")).thenReturn(true);
-        when(entityHashingService.md5ForEntity(pipelineConfigs)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(pipelineConfigs)).thenReturn("digest");
 
         Authorization newAuthorization = new Authorization(new AdminsConfig(new AdminRole(new CaseInsensitiveString("validRole"))));
         PipelineConfigs newPipelineConfig = new BasicPipelineConfigs("group-2", newAuthorization);
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "md5", entityHashingService, securityService);
+        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "digest", entityHashingService, securityService);
 
         assertTrue(command.canContinue(cruiseConfig));
     }
@@ -203,7 +203,7 @@ public class UpdatePipelineConfigsCommandTest {
     @Test
     public void commandShouldNotContinue_whenPipelineGroupNameIsModifiedWhileItContainsRemotePipelines() {
         when(securityService.isUserAdminOfGroup(user, "group")).thenReturn(true);
-        when(entityHashingService.md5ForEntity(pipelineConfigs)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(pipelineConfigs)).thenReturn("digest");
         PipelineConfig remotePipeline = PipelineConfigMother.pipelineConfig("remote-pipeline");
         remotePipeline.setOrigin(new RepoConfigOrigin());
         this.pipelineConfigs.add(remotePipeline);
@@ -212,7 +212,7 @@ public class UpdatePipelineConfigsCommandTest {
         PipelineConfigs newPipelineConfig = new BasicPipelineConfigs("group-2", newAuthorization);
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "md5", entityHashingService, securityService);
+        UpdatePipelineConfigsCommand command = new UpdatePipelineConfigsCommand(this.pipelineConfigs, newPipelineConfig, result, user, "digest", entityHashingService, securityService);
 
         assertFalse(command.canContinue(cruiseConfig));
         assertFalse(result.isSuccessful());

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateSCMConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateSCMConfigCommandTest.java
@@ -79,7 +79,7 @@ public class UpdateSCMConfigCommandTest {
     public void shouldUpdateAnExistingSCMWithNewValues() throws Exception {
         SCM updatedScm = new SCM("id", new PluginConfiguration("plugin-id", "1"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key1"),new ConfigurationValue("value1"))));
         updatedScm.setName("material");
-        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "md5", entityHashingService);
+        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "digest", entityHashingService);
         assertThat(cruiseConfig.getSCMs().contains(scm), is(true));
         command.update(cruiseConfig);
         assertThat(cruiseConfig.getSCMs().contains(updatedScm), is(true));
@@ -88,7 +88,7 @@ public class UpdateSCMConfigCommandTest {
     @Test
     public void shouldThrowAnExceptionIfSCMIsNotFound() throws Exception {
         SCM updatedScm = new SCM("non-existent-id", new PluginConfiguration("non-existent-plugin-id", "1"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key1"),new ConfigurationValue("value1"))));
-        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "md5", entityHashingService);
+        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "digest", entityHashingService);
         thrown.expect(NullPointerException.class);
         thrown.expectMessage("The pluggable scm material with id 'non-existent-id' is not found.");
         command.update(cruiseConfig);
@@ -100,7 +100,7 @@ public class UpdateSCMConfigCommandTest {
         when(goConfigService.isGroupAdministrator(currentUser.getUsername())).thenReturn(false);
 
         SCM updatedScm = new SCM("id", new PluginConfiguration("plugin-id", "1"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key1"),new ConfigurationValue("value1"))));
-        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "md5", entityHashingService);
+        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "digest", entityHashingService);
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result.message(), is(EntityType.SCM.forbiddenToEdit(scm.getId(), currentUser.getUsername())));
@@ -110,10 +110,10 @@ public class UpdateSCMConfigCommandTest {
     public void shouldContinueWithConfigSaveIfUserIsAdmin() {
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(true);
         when(goConfigService.isGroupAdministrator(currentUser.getUsername())).thenReturn(false);
-        when(entityHashingService.md5ForEntity(any(SCM.class))).thenReturn("md5");
+        when(entityHashingService.hashForEntity(any(SCM.class))).thenReturn("digest");
 
         SCM updatedScm = new SCM("id", new PluginConfiguration("plugin-id", "1"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key1"),new ConfigurationValue("value1"))));
-        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "md5", entityHashingService);
+        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "digest", entityHashingService);
 
         assertThat(command.canContinue(cruiseConfig), is(true));
     }
@@ -122,10 +122,10 @@ public class UpdateSCMConfigCommandTest {
     public void shouldContinueWithConfigSaveIfUserIsGroupAdmin() {
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
         when(goConfigService.isGroupAdministrator(currentUser.getUsername())).thenReturn(true);
-        when(entityHashingService.md5ForEntity(any(SCM.class))).thenReturn("md5");
+        when(entityHashingService.hashForEntity(any(SCM.class))).thenReturn("digest");
 
         SCM updatedScm = new SCM("id", new PluginConfiguration("plugin-id", "1"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key1"),new ConfigurationValue("value1"))));
-        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "md5", entityHashingService);
+        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "digest", entityHashingService);
 
         assertThat(command.canContinue(cruiseConfig), is(true));
     }
@@ -137,8 +137,8 @@ public class UpdateSCMConfigCommandTest {
 
         SCM updatedScm = new SCM("id", new PluginConfiguration("plugin-id", "1"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key1"),new ConfigurationValue("value1"))));
         updatedScm.setName("material");
-        when(entityHashingService.md5ForEntity(cruiseConfig.getSCMs().find("id"))).thenReturn("another-md5");
-        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "md5", entityHashingService);
+        when(entityHashingService.hashForEntity(cruiseConfig.getSCMs().find("id"))).thenReturn("another-digest");
+        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "digest", entityHashingService);
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result.toString(), containsString("Someone has modified the configuration for"));;
@@ -151,7 +151,7 @@ public class UpdateSCMConfigCommandTest {
         when(goConfigService.isGroupAdministrator(currentUser.getUsername())).thenReturn(false);
 
         SCM updatedScm = new SCM("non-existent-id", new PluginConfiguration("plugin-id", "1"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key1"),new ConfigurationValue("value1"))));
-        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "md5", entityHashingService);
+        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "digest", entityHashingService);
 
         thrown.expect(NullPointerException.class);
         thrown.expectMessage("The pluggable scm material with id 'non-existent-id' is not found.");

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateTemplateConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateTemplateConfigCommandTest.java
@@ -73,7 +73,7 @@ class UpdateTemplateConfigCommandTest {
         PipelineTemplateConfig updatedTemplateConfig = new PipelineTemplateConfig(new CaseInsensitiveString("template"), StageConfigMother.oneBuildPlanWithResourcesAndMaterials("stage", "job"), StageConfigMother.oneBuildPlanWithResourcesAndMaterials("stage2"));
         cruiseConfig.addTemplate(pipelineTemplateConfig);
 
-        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(updatedTemplateConfig, currentUser, securityService, result, "md5", entityHashingService, externalArtifactsService);
+        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(updatedTemplateConfig, currentUser, securityService, result, "digest", entityHashingService, externalArtifactsService);
         assertThat(cruiseConfig.getTemplates().contains(pipelineTemplateConfig)).isTrue();
         command.update(cruiseConfig);
         assertThat(cruiseConfig.getTemplates().contains(pipelineTemplateConfig)).isFalse();
@@ -88,7 +88,7 @@ class UpdateTemplateConfigCommandTest {
 
         cruiseConfig.addTemplate(pipelineTemplateConfig);
 
-        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(updatedTemplateConfig, currentUser, securityService, result, "md5", entityHashingService, externalArtifactsService);
+        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(updatedTemplateConfig, currentUser, securityService, result, "digest", entityHashingService, externalArtifactsService);
         assertThat(cruiseConfig.getTemplates().contains(pipelineTemplateConfig)).isTrue();
         command.update(cruiseConfig);
         assertThat(command.isValid(cruiseConfig)).isTrue();
@@ -106,7 +106,7 @@ class UpdateTemplateConfigCommandTest {
         JobConfig jobConfig = updatedTemplateConfig.findBy(new CaseInsensitiveString("stage")).jobConfigByConfigName(new CaseInsensitiveString("job"));
         jobConfig.setElasticProfileId("invalidElasticProfileId");
 
-        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(updatedTemplateConfig, currentUser, securityService, result, "md5", entityHashingService, externalArtifactsService);
+        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(updatedTemplateConfig, currentUser, securityService, result, "digest", entityHashingService, externalArtifactsService);
         assertThat(cruiseConfig.getTemplates().contains(pipelineTemplateConfig)).isTrue();
         command.update(cruiseConfig);
         MagicalGoConfigXmlLoader.preprocess(cruiseConfig);
@@ -118,7 +118,7 @@ class UpdateTemplateConfigCommandTest {
 
     @Test
     void shouldThrowAnExceptionIfTemplateConfigNotFound() {
-        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(pipelineTemplateConfig, currentUser, securityService, result, "md5", entityHashingService, externalArtifactsService);
+        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(pipelineTemplateConfig, currentUser, securityService, result, "digest", entityHashingService, externalArtifactsService);
 
         thrown.expect(RecordNotFoundException.class);
         thrown.expectMessage(EntityType.Template.notFoundMessage(pipelineTemplateConfig.name()));
@@ -130,7 +130,7 @@ class UpdateTemplateConfigCommandTest {
         PipelineTemplateConfig updatedTemplateConfig = new PipelineTemplateConfig(new CaseInsensitiveString("template"), StageConfigMother.oneBuildPlanWithResourcesAndMaterials("stage", "job"), StageConfigMother.oneBuildPlanWithResourcesAndMaterials("stage2"));;
         cruiseConfig.addTemplate(pipelineTemplateConfig);
 
-        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(updatedTemplateConfig, currentUser, securityService, result, "md5", entityHashingService, externalArtifactsService);
+        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(updatedTemplateConfig, currentUser, securityService, result, "digest", entityHashingService, externalArtifactsService);
         command.update(cruiseConfig);
         assertThat(cruiseConfig.getTemplates().contains(pipelineTemplateConfig)).isFalse();
         assertThat(cruiseConfig.getTemplates().contains(updatedTemplateConfig)).isTrue();
@@ -142,10 +142,10 @@ class UpdateTemplateConfigCommandTest {
         CaseInsensitiveString templateName = new CaseInsensitiveString("template");
         PipelineTemplateConfig oldTemplate = new PipelineTemplateConfig(templateName, StageConfigMother.manualStage("foo"));
         cruiseConfig.addTemplate(oldTemplate);
-        when(entityHashingService.md5ForEntity(oldTemplate)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(oldTemplate)).thenReturn("digest");
         when(securityService.isAuthorizedToEditTemplate(templateName, currentUser)).thenReturn(false);
 
-        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(pipelineTemplateConfig, currentUser, securityService, result, "md5", entityHashingService, externalArtifactsService);
+        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(pipelineTemplateConfig, currentUser, securityService, result, "digest", entityHashingService, externalArtifactsService);
 
         assertThat(command.canContinue(cruiseConfig)).isFalse();
         assertThat(result.message()).isEqualTo(EntityType.Template.forbiddenToEdit(pipelineTemplateConfig.name(), currentUser.getUsername()));
@@ -155,9 +155,9 @@ class UpdateTemplateConfigCommandTest {
     void shouldContinueWithConfigSaveifUserIsAuthorized() {
         cruiseConfig.addTemplate(pipelineTemplateConfig);
         when(securityService.isAuthorizedToEditTemplate(new CaseInsensitiveString("template"), currentUser)).thenReturn(true);
-        when(entityHashingService.md5ForEntity(pipelineTemplateConfig)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(pipelineTemplateConfig)).thenReturn("digest");
 
-        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(pipelineTemplateConfig, currentUser, securityService, result, "md5", entityHashingService, externalArtifactsService);
+        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(pipelineTemplateConfig, currentUser, securityService, result, "digest", entityHashingService, externalArtifactsService);
 
         assertThat(command.canContinue(cruiseConfig)).isTrue();
     }
@@ -165,9 +165,9 @@ class UpdateTemplateConfigCommandTest {
     @Test
     void shouldNotContinueWithConfigSaveIfRequestIsNotFresh() {
         cruiseConfig.addTemplate(pipelineTemplateConfig);
-        when(entityHashingService.md5ForEntity(pipelineTemplateConfig)).thenReturn("another-md5");
+        when(entityHashingService.hashForEntity(pipelineTemplateConfig)).thenReturn("another-digest");
 
-        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(pipelineTemplateConfig, currentUser, securityService, result, "md5", entityHashingService, externalArtifactsService);
+        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(pipelineTemplateConfig, currentUser, securityService, result, "digest", entityHashingService, externalArtifactsService);
 
         assertThat(command.canContinue(cruiseConfig)).isFalse();
         assertThat(result.toString()).contains("Someone has modified the configuration for");
@@ -175,7 +175,7 @@ class UpdateTemplateConfigCommandTest {
 
     @Test
     void shouldNotContinueWithConfigSaveIfObjectIsNotFound() {
-        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(pipelineTemplateConfig, currentUser, securityService, result, "md5", entityHashingService, externalArtifactsService);
+        UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(pipelineTemplateConfig, currentUser, securityService, result, "digest", entityHashingService, externalArtifactsService);
 
         thrown.expectMessage(EntityType.Template.notFoundMessage(pipelineTemplateConfig.name()));
         command.canContinue(cruiseConfig);
@@ -185,7 +185,7 @@ class UpdateTemplateConfigCommandTest {
     void shouldEncryptSecurePropertiesOfPipelineConfig() {
         PipelineTemplateConfig pipelineTemplateConfig = mock(PipelineTemplateConfig.class);
         UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(pipelineTemplateConfig, null,
-                securityService, result, "stale_md5", entityHashingService, externalArtifactsService);
+                securityService, result, "stale_digest", entityHashingService, externalArtifactsService);
 
         when(pipelineTemplateConfig.name()).thenReturn(new CaseInsensitiveString("p1"));
         CruiseConfig preprocessedConfig = mock(CruiseConfig.class);
@@ -213,7 +213,7 @@ class UpdateTemplateConfigCommandTest {
                     new StageConfig(new CaseInsensitiveString("S2"), new JobConfigs(job2)));
 
             UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(template, null,
-                    securityService, result, "stale_md5", entityHashingService, externalArtifactsService);
+                    securityService, result, "stale_digest", entityHashingService, externalArtifactsService);
 
             BasicCruiseConfig preprocessedConfig = GoConfigMother.defaultCruiseConfig();
             preprocessedConfig.addTemplate(template);
@@ -244,7 +244,7 @@ class UpdateTemplateConfigCommandTest {
                     new StageConfig(new CaseInsensitiveString("S2"), new JobConfigs(job2)));
 
             UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(template, null,
-                    securityService, result, "stale_md5", entityHashingService, externalArtifactsService);
+                    securityService, result, "stale_digest", entityHashingService, externalArtifactsService);
 
             BasicCruiseConfig preprocessedConfig = GoConfigMother.defaultCruiseConfig();
             preprocessedConfig.addTemplate(template);
@@ -272,7 +272,7 @@ class UpdateTemplateConfigCommandTest {
                     " # must be followed by a parameter pattern or escaped by another #");
 
             UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(template, null,
-                    securityService, result, "stale_md5", entityHashingService, externalArtifactsService);
+                    securityService, result, "stale_digest", entityHashingService, externalArtifactsService);
 
             assertThat(command.isValid(preprocessedConfig)).isFalse();
             assertThat(template.errors().isEmpty()).isFalse();

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigsServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigsServiceTest.java
@@ -304,7 +304,7 @@ public class PipelineConfigsServiceTest {
         Authorization authorization = new Authorization(new OperationConfig(new AdminUser(validUser.getUsername())));
         PipelineConfigs pipelineConfigs = new BasicPipelineConfigs("group", authorization);
 
-        when(entityHashingService.md5ForEntity(pipelineConfigs)).thenReturn("md5");
+        when(entityHashingService.hashForEntity(pipelineConfigs)).thenReturn("digest");
         service.updateGroup(validUser, pipelineConfigs, pipelineConfigs, result);
 
         ArgumentCaptor<EntityConfigUpdateCommand> commandCaptor = ArgumentCaptor.forClass(EntityConfigUpdateCommand.class);
@@ -313,7 +313,7 @@ public class PipelineConfigsServiceTest {
 
         assertThat(ReflectionUtil.getField(command, "oldPipelineGroup"), is(pipelineConfigs));
         assertThat(ReflectionUtil.getField(command, "newPipelineGroup"), is(pipelineConfigs));
-        assertThat(ReflectionUtil.getField(command, "md5"), is("md5"));
+        assertThat(ReflectionUtil.getField(command, "digest"), is("digest"));
         assertThat(ReflectionUtil.getField(command, "result"), is(result));
         assertThat(ReflectionUtil.getField(command, "currentUser"), is(validUser));
         assertThat(ReflectionUtil.getField(command, "entityHashingService"), is(entityHashingService));
@@ -321,7 +321,7 @@ public class PipelineConfigsServiceTest {
     }
 
     @Test
-    public void shouldReturnUpdatedPipelineConfigs_whenSuccessfull_updateGroupAuthorization() {
+    public void shouldReturnUpdatedPipelineConfigs_whenSuccessful_updateGroupAuthorization() {
         Authorization authorization = new Authorization(new OperationConfig(new AdminUser(validUser.getUsername())));
         PipelineConfigs pipelineConfigs = new BasicPipelineConfigs("group", authorization);
         doAnswer(invocation -> {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PluginServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PluginServiceTest.java
@@ -412,7 +412,7 @@ public class PluginServiceTest {
     public void updatePluginSettings_shouldCheckForStaleRequest() {
         setUpElasticPluginForTheTest(true);
         when(pluginDao.findPlugin(elasticAgentPluginId)).thenReturn(getPlugin(elasticAgentPluginId));
-        when(entityHashingService.md5ForEntity(any(PluginSettings.class))).thenReturn("bar");
+        when(entityHashingService.hashForEntity(any(PluginSettings.class))).thenReturn("bar");
 
         pluginService.updatePluginSettings(pluginSettings, currentUser, result, "foo");
 
@@ -431,7 +431,7 @@ public class PluginServiceTest {
         validationResult.addError(new ValidationError("key-1", "error-message"));
         when(elasticAgentExtension.validatePluginSettings(eq(elasticAgentPluginId), any(PluginSettingsConfiguration.class))).thenReturn(validationResult);
         when(pluginSettings.hasErrors()).thenReturn(true);
-        when(entityHashingService.md5ForEntity(any(PluginSettings.class))).thenReturn("foo");
+        when(entityHashingService.hashForEntity(any(PluginSettings.class))).thenReturn("foo");
         when(result.isSuccessful()).thenReturn(false);
 
         pluginService.updatePluginSettings(pluginSettings, currentUser, result, "foo");
@@ -446,7 +446,7 @@ public class PluginServiceTest {
         final Plugin plugin = getPlugin(elasticAgentPluginId);
         setUpElasticPluginForTheTest(true);
         when(pluginDao.findPlugin(elasticAgentPluginId)).thenReturn(plugin);
-        when(entityHashingService.md5ForEntity(any(PluginSettings.class))).thenReturn("foo");
+        when(entityHashingService.hashForEntity(any(PluginSettings.class))).thenReturn("foo");
         when(pluginSettings.toPluginSettingsConfiguration()).thenReturn(mock(PluginSettingsConfiguration.class));
 
         when(elasticAgentExtension.validatePluginSettings(eq(elasticAgentPluginId), any(PluginSettingsConfiguration.class)))

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/AdminsConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/AdminsConfigServiceIntegrationTest.java
@@ -71,9 +71,9 @@ public class AdminsConfigServiceIntegrationTest {
 
         AdminUser newAdminUser = new AdminUser(new CaseInsensitiveString("new_admin_user"));
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        String md5ForEntity = entityHashingService.md5ForEntity(adminsConfigService.systemAdmins());
+        String hashForEntity = entityHashingService.hashForEntity(adminsConfigService.systemAdmins());
 
-        adminsConfigService.update(USERNAME, new AdminsConfig(newAdminUser), md5ForEntity, result);
+        adminsConfigService.update(USERNAME, new AdminsConfig(newAdminUser), hashForEntity, result);
 
         assertThat(result.httpCode(), is(200));
         assertThat(adminsConfigService.systemAdmins().size(), is(1));
@@ -91,9 +91,9 @@ public class AdminsConfigServiceIntegrationTest {
         assertTrue(adminsConfigService.systemAdmins().has(null, Collections.singletonList(devs)));
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        String md5ForEntity = entityHashingService.md5ForEntity(adminsConfigService.systemAdmins());
+        String hashForEntity = entityHashingService.hashForEntity(adminsConfigService.systemAdmins());
 
-        adminsConfigService.update(USERNAME, new AdminsConfig(new AdminRole(new CaseInsensitiveString("qas"))), md5ForEntity, result);
+        adminsConfigService.update(USERNAME, new AdminsConfig(new AdminRole(new CaseInsensitiveString("qas"))), hashForEntity, result);
 
         assertThat(result.httpCode(), is(200));
         assertThat(adminsConfigService.systemAdmins().size(), is(1));
@@ -103,10 +103,10 @@ public class AdminsConfigServiceIntegrationTest {
     @Test
     public void update_shouldEnsureOnlyValidRolesCanBeSystemAdmins() {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        String md5ForEntity = entityHashingService.md5ForEntity(adminsConfigService.systemAdmins());
+        String hashForEntity = entityHashingService.hashForEntity(adminsConfigService.systemAdmins());
         AdminsConfig newSystemAdmins = new AdminsConfig(new AdminRole(new CaseInsensitiveString("qas")));
 
-        adminsConfigService.update(USERNAME, newSystemAdmins, md5ForEntity, result);
+        adminsConfigService.update(USERNAME, newSystemAdmins, hashForEntity, result);
 
         assertThat(result.httpCode(), is(422));
         assertThat(result.message(), is("Validations failed for admins. Error(s): [Role \"qas\" does not exist.]. Please correct and resubmit."));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
@@ -302,7 +302,7 @@ public class BuildAssignmentServiceIntegrationTest {
 
         PipelineConfig originalPipelineConfig = configHelper.getCachedGoConfig().currentConfig().getPipelineConfigByName(new CaseInsensitiveString(fixture.pipelineName));
         PipelineConfig pipelineConfig = new Cloner().deepClone(originalPipelineConfig);
-        String md5 = entityHashingService.md5ForEntity(originalPipelineConfig, fixture.groupName);
+        String md5 = entityHashingService.hashForEntity(originalPipelineConfig, fixture.groupName);
         StageConfig devStage = pipelineConfig.findBy(new CaseInsensitiveString(fixture.devStage));
         pipelineConfig.remove(devStage);
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
@@ -330,7 +330,7 @@ public class BuildAssignmentServiceIntegrationTest {
         PipelineConfig originalPipelineConfig = configHelper.getCachedGoConfig().currentConfig().getPipelineConfigByName(new CaseInsensitiveString(fixture.pipelineName));
         PipelineConfig pipelineConfig = new Cloner().deepClone(originalPipelineConfig);
         String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(pipelineConfig);
-        String md5 = entityHashingService.md5ForEntity(originalPipelineConfig, fixture.groupName);
+        String md5 = entityHashingService.hashForEntity(originalPipelineConfig, fixture.groupName);
         StageConfig devStage = pipelineConfig.findBy(new CaseInsensitiveString(fixture.devStage));
         devStage.getJobs().remove(devStage.jobConfigByConfigName(new CaseInsensitiveString(fixture.JOB_FOR_DEV_STAGE)));
         pipelineConfigService.updatePipelineConfig(loserUser, pipelineConfig, fixture.groupName, md5, new HttpLocalizedOperationResult());

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigRepoServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigRepoServiceIntegrationTest.java
@@ -178,7 +178,7 @@ public class ConfigRepoServiceIntegrationTest {
         assertThat(configRepoService.getConfigRepos().size(), is(1));
         assertThat(configRepoService.getConfigRepo(repoId), is(configRepo));
 
-        configRepoService.updateConfigRepo(repoId, toUpdateWith, entityHashingService.md5ForEntity(configRepo), user, result);
+        configRepoService.updateConfigRepo(repoId, toUpdateWith, entityHashingService.hashForEntity(configRepo), user, result);
 
         assertThat(result.toString(), result.isSuccessful(), is(true));
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ElasticProfileServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ElasticProfileServiceIntegrationTest.java
@@ -165,7 +165,7 @@ public class ElasticProfileServiceIntegrationTest {
         ElasticProfile existing = elasticProfileService.getPluginProfiles().get(0);
 
         assertThat(existing.getConfigWithErrorsAsMap()).isEmpty();
-        elasticProfileService.update(username, entityHashingService.md5ForEntity(this.elasticProfile), newElasticProfile, result);
+        elasticProfileService.update(username, entityHashingService.hashForEntity(this.elasticProfile), newElasticProfile, result);
         ElasticProfile updated = elasticProfileService.getPluginProfiles().get(0);
         assertThat(updated.getId()).isEqualTo(elasticProfileId);
         assertThat(updated.get(0)).isEqualTo(new ConfigurationProperty(new ConfigurationKey("key1"), new ConfigurationValue("value1")));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
@@ -114,7 +114,7 @@ public class PipelineConfigServicePerformanceTest {
                 PipelineConfig pipelineConfig = goConfigService.getConfigForEditing().pipelineConfigByName(new CaseInsensitiveString(Thread.currentThread().getName()));
                 pipelineConfig.add(new StageConfig(new CaseInsensitiveString("additional_stage"), new JobConfigs(new JobConfig(new CaseInsensitiveString("addtn_job")))));
                 PerfTimer updateTimer = PerfTimer.start("Saving pipelineConfig : " + pipelineConfig.name());
-                pipelineConfigService.updatePipelineConfig(user, pipelineConfig, "group", entityHashingService.md5ForEntity(pipelineConfig, "group"), result);
+                pipelineConfigService.updatePipelineConfig(user, pipelineConfig, "group", entityHashingService.hashForEntity(pipelineConfig, "group"), result);
                 updateTimer.stop();
                 results.put(Thread.currentThread().getName(), result.isSuccessful());
                 if (!result.isSuccessful()) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineTriggerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineTriggerServiceIntegrationTest.java
@@ -228,8 +228,8 @@ public class PipelineTriggerServiceIntegrationTest {
         pipelineConfig.addEnvironmentVariable("ENV_VAR2", "VAL2");
         pipelineConfig.addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), "SECURE_VAR1", "SECURE_VAL", true));
         pipelineConfig.addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), "SECURE_VAR2", "SECURE_VAL2", true));
-        String md5 = entityHashingService.md5ForEntity(pipelineConfigService.getPipelineConfig(pipelineConfig.name().toString()), group);
-        pipelineConfigService.updatePipelineConfig(admin, pipelineConfig, group, md5, new HttpLocalizedOperationResult());
+        String digest = entityHashingService.hashForEntity(pipelineConfigService.getPipelineConfig(pipelineConfig.name().toString()), group);
+        pipelineConfigService.updatePipelineConfig(admin, pipelineConfig, group, digest, new HttpLocalizedOperationResult());
         Integer pipelineCounterBefore = pipelineSqlMapDao.getCounterForPipeline(pipelineName);
 
         CaseInsensitiveString pipelineNameCaseInsensitive = new CaseInsensitiveString(this.pipelineName);
@@ -270,8 +270,8 @@ public class PipelineTriggerServiceIntegrationTest {
     @Test
     public void shouldScheduleAPipelineWithTheProvidedEncryptedEnvironmentVariable() throws CryptoException {
         pipelineConfig.addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), "SECURE_VAR1", "SECURE_VAL", true));
-        String md5 = entityHashingService.md5ForEntity(pipelineConfigService.getPipelineConfig(pipelineConfig.name().toString()), group);
-        pipelineConfigService.updatePipelineConfig(admin, pipelineConfig, group, md5, new HttpLocalizedOperationResult());
+        String digest = entityHashingService.hashForEntity(pipelineConfigService.getPipelineConfig(pipelineConfig.name().toString()), group);
+        pipelineConfigService.updatePipelineConfig(admin, pipelineConfig, group, digest, new HttpLocalizedOperationResult());
         CaseInsensitiveString pipelineNameCaseInsensitive = new CaseInsensitiveString(this.pipelineName);
         assertThat(triggerMonitor.isAlreadyTriggered(pipelineNameCaseInsensitive), is(false));
         PipelineScheduleOptions pipelineScheduleOptions = new PipelineScheduleOptions();
@@ -293,8 +293,8 @@ public class PipelineTriggerServiceIntegrationTest {
     @Test
     public void shouldNotScheduleAPipelineWithTheJunkEncryptedEnvironmentVariable() {
         pipelineConfig.addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), "SECURE_VAR1", "SECURE_VAL", true));
-        String md5 = entityHashingService.md5ForEntity(pipelineConfigService.getPipelineConfig(pipelineConfig.name().toString()), group);
-        pipelineConfigService.updatePipelineConfig(admin, pipelineConfig, group, md5, new HttpLocalizedOperationResult());
+        String digest = entityHashingService.hashForEntity(pipelineConfigService.getPipelineConfig(pipelineConfig.name().toString()), group);
+        pipelineConfigService.updatePipelineConfig(admin, pipelineConfig, group, digest, new HttpLocalizedOperationResult());
         CaseInsensitiveString pipelineNameCaseInsensitive = new CaseInsensitiveString(this.pipelineName);
         assertThat(triggerMonitor.isAlreadyTriggered(pipelineNameCaseInsensitive), is(false));
         PipelineScheduleOptions pipelineScheduleOptions = new PipelineScheduleOptions();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/datasharing/DataSharingSettingsServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/datasharing/DataSharingSettingsServiceIntegrationTest.java
@@ -145,7 +145,7 @@ public class DataSharingSettingsServiceIntegrationTest {
     public void shouldUpdateMd5SumOfDataSharingSettingsUponSave() {
         DataSharingSettings loaded = dataSharingSettingsService.get();
 
-        String originalMd5 = entityHashingService.md5ForEntity(loaded);
+        String originalMd5 = entityHashingService.hashForEntity(loaded);
         assertThat(originalMd5, is(not(nullValue())));
 
         loaded.setAllowSharing(true);
@@ -153,7 +153,7 @@ public class DataSharingSettingsServiceIntegrationTest {
         loaded.setUpdatedOn(Timestamp.from(new Date().toInstant()));
         dataSharingSettingsService.createOrUpdate(loaded);
 
-        String md5AfterUpdate = entityHashingService.md5ForEntity(dataSharingSettingsService.get());
+        String md5AfterUpdate = entityHashingService.hashForEntity(dataSharingSettingsService.get());
         assertThat(originalMd5, is(not(md5AfterUpdate)));
     }
 


### PR DESCRIPTION
Trying to move away from `md5`, which is broken WRT cryptographic standards, to SHA-512/256. This isn't all of the usages (e.g., various parts of `CruiseConfig` and artifact checksums still use `md5`, but this is the majority of cases.