### PR TITLE
Do not prematurely evict config repo validation errors from `ServerHealthState`

### DIFF
--- a/api/api-config-repos-v3/src/main/java/com/thoughtworks/go/apiv3/configrepos/ConfigReposInternalControllerV3.java
+++ b/api/api-config-repos-v3/src/main/java/com/thoughtworks/go/apiv3/configrepos/ConfigReposInternalControllerV3.java
@@ -19,7 +19,7 @@ import com.thoughtworks.go.api.ApiController;
 import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv3.configrepos.representers.ConfigRepoWithResultListRepresenter;
-import com.thoughtworks.go.config.GoRepoConfigDataSource;
+import com.thoughtworks.go.config.GoConfigRepoConfigDataSource;
 import com.thoughtworks.go.config.PartialConfigParseResult;
 import com.thoughtworks.go.config.PipelineConfigs;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
@@ -50,7 +50,7 @@ import static spark.Spark.*;
 public class ConfigReposInternalControllerV3 extends ApiController implements SparkSpringController {
 
     private final ConfigRepoService service;
-    private final GoRepoConfigDataSource dataSource;
+    private final GoConfigRepoConfigDataSource dataSource;
     private final ApiAuthenticationHelper authHelper;
     private final MaterialUpdateService mus;
     private final MaterialConfigConverter converter;
@@ -58,7 +58,7 @@ public class ConfigReposInternalControllerV3 extends ApiController implements Sp
     private final PipelineConfigsService pipelineConfigsService;
 
     @Autowired
-    public ConfigReposInternalControllerV3(ApiAuthenticationHelper authHelper, ConfigRepoService service, GoRepoConfigDataSource dataSource, MaterialUpdateService mus, MaterialConfigConverter converter, EnvironmentConfigService environmentConfigService, PipelineConfigsService pipelineConfigsService) {
+    public ConfigReposInternalControllerV3(ApiAuthenticationHelper authHelper, ConfigRepoService service, GoConfigRepoConfigDataSource dataSource, MaterialUpdateService mus, MaterialConfigConverter converter, EnvironmentConfigService environmentConfigService, PipelineConfigsService pipelineConfigsService) {
         super(ApiVersion.v3);
         this.service = service;
         this.dataSource = dataSource;

--- a/api/api-config-repos-v4/src/main/java/com/thoughtworks/go/apiv4/configrepos/ConfigReposInternalControllerV4.java
+++ b/api/api-config-repos-v4/src/main/java/com/thoughtworks/go/apiv4/configrepos/ConfigReposInternalControllerV4.java
@@ -19,7 +19,7 @@ import com.thoughtworks.go.api.ApiController;
 import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv4.configrepos.representers.ConfigRepoWithResultListRepresenter;
-import com.thoughtworks.go.config.GoRepoConfigDataSource;
+import com.thoughtworks.go.config.GoConfigRepoConfigDataSource;
 import com.thoughtworks.go.config.PartialConfigParseResult;
 import com.thoughtworks.go.config.PipelineConfigs;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
@@ -50,7 +50,7 @@ import static spark.Spark.*;
 public class ConfigReposInternalControllerV4 extends ApiController implements SparkSpringController {
 
     private final ConfigRepoService service;
-    private final GoRepoConfigDataSource dataSource;
+    private final GoConfigRepoConfigDataSource dataSource;
     private final ApiAuthenticationHelper authHelper;
     private final MaterialUpdateService mus;
     private final MaterialConfigConverter converter;
@@ -58,7 +58,7 @@ public class ConfigReposInternalControllerV4 extends ApiController implements Sp
     private final PipelineConfigsService pipelineConfigsService;
 
     @Autowired
-    public ConfigReposInternalControllerV4(ApiAuthenticationHelper authHelper, ConfigRepoService service, GoRepoConfigDataSource dataSource, MaterialUpdateService mus, MaterialConfigConverter converter, EnvironmentConfigService environmentConfigService, PipelineConfigsService pipelineConfigsService) {
+    public ConfigReposInternalControllerV4(ApiAuthenticationHelper authHelper, ConfigRepoService service, GoConfigRepoConfigDataSource dataSource, MaterialUpdateService mus, MaterialConfigConverter converter, EnvironmentConfigService environmentConfigService, PipelineConfigsService pipelineConfigsService) {
         super(ApiVersion.v4);
         this.service = service;
         this.dataSource = dataSource;

--- a/api/api-config-repos-v4/src/test/groovy/com/thoughtworks/go/apiv4/configrepos/ConfigReposInternalControllerV4Test.groovy
+++ b/api/api-config-repos-v4/src/test/groovy/com/thoughtworks/go/apiv4/configrepos/ConfigReposInternalControllerV4Test.groovy
@@ -49,218 +49,218 @@ import static org.mockito.Mockito.when
 import static org.mockito.MockitoAnnotations.initMocks
 
 class ConfigReposInternalControllerV4Test implements SecurityServiceTrait, ControllerTrait<ConfigReposInternalControllerV4> {
-  private static final String TEST_PLUGIN_ID = "test.configrepo.plugin"
-  private static final String TEST_REPO_URL = "https://fakeurl.com"
-  private static final String ID_1 = "repo-01"
-  private static final String ID_2 = "repo-02"
+    private static final String TEST_PLUGIN_ID = "test.configrepo.plugin"
+    private static final String TEST_REPO_URL = "https://fakeurl.com"
+    private static final String ID_1 = "repo-01"
+    private static final String ID_2 = "repo-02"
 
-  @Mock
-  ConfigRepoService service
+    @Mock
+    ConfigRepoService service
 
-  @Mock
-  GoRepoConfigDataSource dataSource
+    @Mock
+    GoConfigRepoConfigDataSource dataSource
 
-  @Mock
-  MaterialUpdateService materialUpdateService
+    @Mock
+    MaterialUpdateService materialUpdateService
 
-  @Mock
-  MaterialConfigConverter converter
+    @Mock
+    MaterialConfigConverter converter
 
-  @Mock
-  private EnvironmentConfigService environmentConfigService
-  @Mock
-  private PipelineConfigsService pipelineConfigsService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-    Policy directives = new Policy()
-    directives.add(new Allow("administer", "config_repo", "repo-*"))
-    RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)
-
-    when(goConfigService.rolesForUser(any())).then({ InvocationOnMock invocation ->
-      CaseInsensitiveString username = invocation.getArguments()[0]
-      if (username == Username.ANONYMOUS.username) {
-        return []
-      }
-      return [roleConfig]
-    })
-    when(environmentConfigService.getEnvironmentNames()).thenReturn([])
-    when(pipelineConfigsService.getGroupsForUser(anyString())).thenReturn([])
-  }
-
-  @Override
-  ConfigReposInternalControllerV4 createControllerInstance() {
-    new ConfigReposInternalControllerV4(new ApiAuthenticationHelper(securityService, goConfigService), service, dataSource, materialUpdateService, converter, environmentConfigService, pipelineConfigsService)
-  }
-
-  @Nested
-  class IndexSecurity implements SecurityTestTrait, NormalUserSecurity {
-    @Override
-    String getControllerMethodUnderTest() {
-      return "listRepos"
-    }
-
-    @Override
-    void makeHttpCall() {
-      getWithApiHeader(controller.controllerBasePath(), [:])
-    }
-  }
-
-  @Nested
-  class Index {
+    @Mock
+    private EnvironmentConfigService environmentConfigService
+    @Mock
+    private PipelineConfigsService pipelineConfigsService
 
     @BeforeEach
-    void setup() {
-      loginAsUser()
+    void setUp() {
+        initMocks(this)
+        Policy directives = new Policy()
+        directives.add(new Allow("administer", "config_repo", "repo-*"))
+        RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)
+
+        when(goConfigService.rolesForUser(any())).then({ InvocationOnMock invocation ->
+            CaseInsensitiveString username = invocation.getArguments()[0]
+            if (username == Username.ANONYMOUS.username) {
+                return []
+            }
+            return [roleConfig]
+        })
+        when(environmentConfigService.getEnvironmentNames()).thenReturn([])
+        when(pipelineConfigsService.getGroupsForUser(anyString())).thenReturn([])
     }
 
-    @Test
-    void 'should list only those existing config repos, with associated parse results, for which the user has permission'() {
-      Modification modification = new Modification()
-      modification.setRevision("abc")
+    @Override
+    ConfigReposInternalControllerV4 createControllerInstance() {
+        new ConfigReposInternalControllerV4(new ApiAuthenticationHelper(securityService, goConfigService), service, dataSource, materialUpdateService, converter, environmentConfigService, pipelineConfigsService)
+    }
 
-      PartialConfig partialConfig = new PartialConfig()
-      PartialConfigParseResult result = PartialConfigParseResult.parseSuccess(modification, partialConfig)
+    @Nested
+    class IndexSecurity implements SecurityTestTrait, NormalUserSecurity {
+        @Override
+        String getControllerMethodUnderTest() {
+            return "listRepos"
+        }
 
-      ConfigReposConfig repos = new ConfigReposConfig(repo(ID_1), repo(ID_2), repo("test-id"))
-      when(service.getConfigRepos()).thenReturn(repos)
-      when(dataSource.getLastParseResult(repos.get(0).getRepo())).thenReturn(null)
-      when(dataSource.getLastParseResult(repos.get(1).getRepo())).thenReturn(result)
+        @Override
+        void makeHttpCall() {
+            getWithApiHeader(controller.controllerBasePath(), [:])
+        }
+    }
 
-      getWithApiHeader(controller.controllerBasePath())
+    @Nested
+    class Index {
 
-      assertThatResponse()
-        .isOk()
-        .hasJsonBody([
-          _links         : [
-            self: [href: "http://test.host/go$Routes.ConfigRepos.BASE".toString()]
-          ],
-          _embedded      : [
-            config_repos: [
-              expectedRepoJson(ID_1, null, null, false),
-              expectedRepoJson(ID_2, "abc", null, false)
+        @BeforeEach
+        void setup() {
+            loginAsUser()
+        }
+
+        @Test
+        void 'should list only those existing config repos, with associated parse results, for which the user has permission'() {
+            Modification modification = new Modification()
+            modification.setRevision("abc")
+
+            PartialConfig partialConfig = new PartialConfig()
+            PartialConfigParseResult result = PartialConfigParseResult.parseSuccess(modification, partialConfig)
+
+            ConfigReposConfig repos = new ConfigReposConfig(repo(ID_1), repo(ID_2), repo("test-id"))
+            when(service.getConfigRepos()).thenReturn(repos)
+            when(dataSource.getLastParseResult(repos.get(0).getRepo())).thenReturn(null)
+            when(dataSource.getLastParseResult(repos.get(1).getRepo())).thenReturn(result)
+
+            getWithApiHeader(controller.controllerBasePath())
+
+            assertThatResponse()
+                    .isOk()
+                    .hasJsonBody([
+                            _links         : [
+                                    self: [href: "http://test.host/go$Routes.ConfigRepos.BASE".toString()]
+                            ],
+                            _embedded      : [
+                                    config_repos: [
+                                            expectedRepoJson(ID_1, null, null, false),
+                                            expectedRepoJson(ID_2, "abc", null, false)
+                                    ]
+                            ],
+                            auto_completion: [
+                                    [key: "pipeline", value: []],
+                                    [key: "environment", value: []],
+                                    [key: "pipeline_group", value: []]
+                            ]
+                    ])
+        }
+
+        @Test
+        void 'should return empty list if the user does not have permission to view any config repos'() {
+            ConfigReposConfig repos = new ConfigReposConfig(repo("test-id"), repo("another-id"))
+            when(service.getConfigRepos()).thenReturn(repos)
+
+            getWithApiHeader(controller.controllerBasePath())
+
+            def expectedJson = [
+                    _links         : [
+                            self: [href: "http://test.host/go$Routes.ConfigRepos.BASE".toString()]
+                    ],
+                    _embedded      : [
+                            config_repos: []
+                    ],
+                    auto_completion: [
+                            [key: "pipeline", value: []],
+                            [key: "environment", value: []],
+                            [key: "pipeline_group", value: []]
+                    ]
             ]
-          ],
-          auto_completion: [
-            [key: "pipeline", value: []],
-            [key: "environment", value: []],
-            [key: "pipeline_group", value: []]
-          ]
-        ])
+            assertThatResponse()
+                    .isOk()
+                    .hasEtag("\"${new ConfigReposConfig().etag()}\"")
+                    .hasJsonBody(expectedJson)
+        }
+
+        @Test
+        void 'should set autocompletion values'() {
+            ConfigReposConfig repos = new ConfigReposConfig(repo("test-id"), repo("another-id"))
+
+            when(service.getConfigRepos()).thenReturn(repos)
+            when(environmentConfigService.getEnvironmentNames()).thenReturn(Arrays.asList("env1", "env2"))
+            when(pipelineConfigsService.getGroupsForUser(anyString())).thenReturn(Arrays.asList(new BasicPipelineConfigs("grp1", new Authorization(), PipelineConfigMother.pipelineConfig("pipeline"))))
+
+            getWithApiHeader(controller.controllerBasePath())
+
+            def expectedJson = [
+                    _links         : [
+                            self: [href: "http://test.host/go$Routes.ConfigRepos.BASE".toString()]
+                    ],
+                    _embedded      : [
+                            config_repos: []
+                    ],
+                    auto_completion: [
+                            [
+                                    key  : "pipeline",
+                                    value: ["pipeline"]
+                            ],
+                            [
+                                    key  : "environment",
+                                    value: ["env1", "env2"]
+                            ],
+                            [
+                                    key  : "pipeline_group",
+                                    value: ["grp1"]
+                            ]
+                    ]
+            ]
+
+            assertThatResponse()
+                    .isOk()
+                    .hasJsonBody(expectedJson)
+        }
     }
 
-    @Test
-    void 'should return empty list if the user does not have permission to view any config repos'() {
-      ConfigReposConfig repos = new ConfigReposConfig(repo("test-id"), repo("another-id"))
-      when(service.getConfigRepos()).thenReturn(repos)
+    static Map expectedRepoJson(String id, String revision, String error, boolean isInProgress) {
+        return [
+                _links                     : [
+                        self: [href: "http://test.host/go${Routes.ConfigRepos.id(id)}".toString()],
+                        doc : [href: Routes.ConfigRepos.DOC],
+                        find: [href: "http://test.host/go${Routes.ConfigRepos.find()}".toString()],
+                ],
 
-      getWithApiHeader(controller.controllerBasePath())
-
-      def expectedJson = [
-        _links         : [
-          self: [href: "http://test.host/go$Routes.ConfigRepos.BASE".toString()]
-        ],
-        _embedded      : [
-          config_repos: []
-        ],
-        auto_completion: [
-          [key: "pipeline", value: []],
-          [key: "environment", value: []],
-          [key: "pipeline_group", value: []]
+                id                         : id,
+                plugin_id                  : TEST_PLUGIN_ID,
+                material                   : [
+                        type      : "hg",
+                        attributes: [
+                                name       : null,
+                                url        : "${TEST_REPO_URL}/$id".toString(),
+                                auto_update: true
+                        ]
+                ],
+                configuration              : [],
+                rules                      : [],
+                material_update_in_progress: isInProgress,
+                parse_info                 : null == revision ? [:] : [
+                        error                     : error,
+                        good_modification         : [
+                                "username"     : null,
+                                "email_address": null,
+                                "revision"     : revision,
+                                "comment"      : null,
+                                "modified_time": null
+                        ],
+                        latest_parsed_modification: [
+                                "username"     : null,
+                                "email_address": null,
+                                "revision"     : revision,
+                                "comment"      : null,
+                                "modified_time": null
+                        ]
+                ]
         ]
-      ]
-      assertThatResponse()
-        .isOk()
-        .hasEtag("\"${new ConfigReposConfig().etag()}\"")
-        .hasJsonBody(expectedJson)
     }
 
-    @Test
-    void 'should set autocompletion values'() {
-      ConfigReposConfig repos = new ConfigReposConfig(repo("test-id"), repo("another-id"))
+    static ConfigRepoConfig repo(String id) {
+        HgMaterialConfig materialConfig = hg("${TEST_REPO_URL}/$id", "")
+        ConfigRepoConfig repo = ConfigRepoConfig.createConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id)
 
-      when(service.getConfigRepos()).thenReturn(repos)
-      when(environmentConfigService.getEnvironmentNames()).thenReturn(Arrays.asList("env1", "env2"))
-      when(pipelineConfigsService.getGroupsForUser(anyString())).thenReturn(Arrays.asList(new BasicPipelineConfigs("grp1", new Authorization(), PipelineConfigMother.pipelineConfig("pipeline"))))
-
-      getWithApiHeader(controller.controllerBasePath())
-
-      def expectedJson = [
-        _links         : [
-          self: [href: "http://test.host/go$Routes.ConfigRepos.BASE".toString()]
-        ],
-        _embedded      : [
-          config_repos: []
-        ],
-        auto_completion: [
-          [
-            key  : "pipeline",
-            value: ["pipeline"]
-          ],
-          [
-            key  : "environment",
-            value: ["env1", "env2"]
-          ],
-          [
-            key  : "pipeline_group",
-            value: ["grp1"]
-          ]
-        ]
-      ]
-
-      assertThatResponse()
-        .isOk()
-        .hasJsonBody(expectedJson)
+        return repo
     }
-  }
-
-  static Map expectedRepoJson(String id, String revision, String error, boolean isInProgress) {
-    return [
-      _links                     : [
-        self: [href: "http://test.host/go${Routes.ConfigRepos.id(id)}".toString()],
-        doc : [href: Routes.ConfigRepos.DOC],
-        find: [href: "http://test.host/go${Routes.ConfigRepos.find()}".toString()],
-      ],
-
-      id                         : id,
-      plugin_id                  : TEST_PLUGIN_ID,
-      material                   : [
-        type      : "hg",
-        attributes: [
-          name       : null,
-          url        : "${TEST_REPO_URL}/$id".toString(),
-          auto_update: true
-        ]
-      ],
-      configuration              : [],
-      rules                      : [],
-      material_update_in_progress: isInProgress,
-      parse_info                 : null == revision ? [:] : [
-        error                     : error,
-        good_modification         : [
-          "username"     : null,
-          "email_address": null,
-          "revision"     : revision,
-          "comment"      : null,
-          "modified_time": null
-        ],
-        latest_parsed_modification: [
-          "username"     : null,
-          "email_address": null,
-          "revision"     : revision,
-          "comment"      : null,
-          "modified_time": null
-        ]
-      ]
-    ]
-  }
-
-  static ConfigRepoConfig repo(String id) {
-    HgMaterialConfig materialConfig = hg("${TEST_REPO_URL}/$id", "")
-    ConfigRepoConfig repo = ConfigRepoConfig.createConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id)
-
-    return repo
-  }
 
 }

--- a/server/src/main/java/com/thoughtworks/go/config/CachedGoPartials.java
+++ b/server/src/main/java/com/thoughtworks/go/config/CachedGoPartials.java
@@ -30,8 +30,8 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class CachedGoPartials implements PartialConfigResolver {
     private final ServerHealthService serverHealthService;
-    private Map<String, PartialConfig> fingerprintToLatestValidConfigMap = new ConcurrentHashMap<>();
-    private Map<String, PartialConfig> fingerprintToLatestKnownConfigMap = new ConcurrentHashMap<>();
+    private final Map<String, PartialConfig> fingerprintToLatestValidConfigMap = new ConcurrentHashMap<>();
+    private final Map<String, PartialConfig> fingerprintToLatestKnownConfigMap = new ConcurrentHashMap<>();
 
     @Autowired
     public CachedGoPartials(ServerHealthService serverHealthService) {
@@ -76,7 +76,7 @@ public class CachedGoPartials implements PartialConfigResolver {
         }
     }
 
-    public void addOrUpdate(String fingerprint, PartialConfig newPart) {
+    public void cacheAsLastKnown(String fingerprint, PartialConfig newPart) {
         fingerprintToLatestKnownConfigMap.put(fingerprint, newPart);
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListener.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListener.java
@@ -15,7 +15,7 @@
  */
 package com.thoughtworks.go.server.materials;
 
-import com.thoughtworks.go.config.GoRepoConfigDataSource;
+import com.thoughtworks.go.config.GoConfigRepoConfigDataSource;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
 import com.thoughtworks.go.domain.MaterialRevisions;
 import com.thoughtworks.go.domain.materials.Material;
@@ -36,13 +36,13 @@ import java.io.File;
 public class ConfigMaterialUpdateListener implements GoMessageListener<MaterialUpdateCompletedMessage> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigMaterialUpdateListener.class);
 
-    private GoRepoConfigDataSource repoConfigDataSource;
-    private MaterialRepository materialRepository;
-    private MaterialUpdateCompletedTopic topic;
-    private MaterialService materialService;
-    private SubprocessExecutionContext subprocessExecutionContext;
+    private final GoConfigRepoConfigDataSource repoConfigDataSource;
+    private final MaterialRepository materialRepository;
+    private final MaterialUpdateCompletedTopic topic;
+    private final MaterialService materialService;
+    private final SubprocessExecutionContext subprocessExecutionContext;
 
-    public ConfigMaterialUpdateListener(GoRepoConfigDataSource repoConfigDataSource,
+    public ConfigMaterialUpdateListener(GoConfigRepoConfigDataSource repoConfigDataSource,
                                         MaterialRepository materialRepository,
                                         MaterialUpdateCompletedTopic topic,
                                         MaterialService materialService,

--- a/server/src/main/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerFactory.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerFactory.java
@@ -15,7 +15,7 @@
  */
 package com.thoughtworks.go.server.materials;
 
-import com.thoughtworks.go.config.GoRepoConfigDataSource;
+import com.thoughtworks.go.config.GoConfigRepoConfigDataSource;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.service.MaterialService;
@@ -27,18 +27,18 @@ import static java.util.stream.IntStream.range;
 
 @Component
 public class ConfigMaterialUpdateListenerFactory {
-    private ConfigMaterialPostUpdateQueue configMaterialPostUpdateQueue;
-    private final GoRepoConfigDataSource repoConfigDataSource;
+    private final ConfigMaterialPostUpdateQueue configMaterialPostUpdateQueue;
+    private final GoConfigRepoConfigDataSource repoConfigDataSource;
     private final MaterialRepository materialRepository;
     private final MaterialUpdateCompletedTopic materialUpdateCompletedTopic;
     private final MaterialService materialService;
     private final SubprocessExecutionContext subprocessExecutionContext;
-    private SystemEnvironment systemEnvironment;
+    private final SystemEnvironment systemEnvironment;
 
     @Autowired
     public ConfigMaterialUpdateListenerFactory(SystemEnvironment systemEnvironment,
                                                ConfigMaterialPostUpdateQueue configMaterialPostUpdateQueue,
-                                               GoRepoConfigDataSource repoConfigDataSource,
+                                               GoConfigRepoConfigDataSource repoConfigDataSource,
                                                MaterialRepository materialRepository,
                                                MaterialUpdateCompletedTopic materialUpdateCompletedTopic,
                                                MaterialService materialService,

--- a/server/src/test-fast/java/com/thoughtworks/go/config/CachedGoPartialsTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/CachedGoPartialsTest.java
@@ -49,8 +49,8 @@ public class CachedGoPartialsTest {
         part1 = PartialConfigMother.withPipeline("p1", new RepoConfigOrigin(configRepo1, "1"));
         configRepo2 = ConfigRepoConfig.createConfigRepoConfig(git("url2"), "plugin", "id2");
         part2 = PartialConfigMother.withPipeline("p2", new RepoConfigOrigin(configRepo2, "1"));
-        partials.addOrUpdate(configRepo1.getRepo().getFingerprint(), part1);
-        partials.addOrUpdate(configRepo2.getRepo().getFingerprint(), part2);
+        partials.cacheAsLastKnown(configRepo1.getRepo().getFingerprint(), part1);
+        partials.cacheAsLastKnown(configRepo2.getRepo().getFingerprint(), part2);
         fingerprintForRepo1 = ((RepoConfigOrigin) part1.getOrigin()).getMaterial().getFingerprint();
         fingerprintForRepo2 = ((RepoConfigOrigin) part2.getOrigin()).getMaterial().getFingerprint();
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoConfigRepoConfigDataSourceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoConfigRepoConfigDataSourceTest.java
@@ -41,12 +41,12 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-public class GoRepoConfigDataSourceTest {
+public class GoConfigRepoConfigDataSourceTest {
     private GoConfigPluginService configPluginService;
     private GoConfigWatchList configWatchList;
     private PartialConfigProvider plugin;
 
-    private GoRepoConfigDataSource repoConfigDataSource;
+    private GoConfigRepoConfigDataSource repoConfigDataSource;
 
     private BasicCruiseConfig cruiseConfig;
     private ServerHealthService serverHealthService;
@@ -69,7 +69,7 @@ public class GoRepoConfigDataSourceTest {
         when(cachedGoConfig.currentConfig()).thenReturn(cruiseConfig);
 
         configWatchList = new GoConfigWatchList(cachedGoConfig, mock(GoConfigService.class));
-        repoConfigDataSource = new GoRepoConfigDataSource(configWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
+        repoConfigDataSource = new GoConfigRepoConfigDataSource(configWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
 
         ScmMaterialConfig material = git("http://my.git");
         ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
@@ -177,7 +177,7 @@ public class GoRepoConfigDataSourceTest {
     }
 
     private class AssertingConfigPlugin implements PartialConfigProvider {
-        private Configuration configuration;
+        private final Configuration configuration;
 
         public AssertingConfigPlugin(Configuration configuration) {
 
@@ -338,7 +338,7 @@ public class GoRepoConfigDataSourceTest {
         GitMaterialConfig material = git("http://my.git");
         ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
         GoConfigWatchList goConfigWatchList = mock(GoConfigWatchList.class);
-        repoConfigDataSource = new GoRepoConfigDataSource(goConfigWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
+        repoConfigDataSource = new GoConfigRepoConfigDataSource(goConfigWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
 
         when(goConfigWatchList.getConfigRepoForMaterial(material)).thenReturn(configRepoConfig);
 
@@ -352,7 +352,7 @@ public class GoRepoConfigDataSourceTest {
         GitMaterialConfig material = git("http://my.git");
         ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
         GoConfigWatchList goConfigWatchList = mock(GoConfigWatchList.class);
-        repoConfigDataSource = new GoRepoConfigDataSource(goConfigWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
+        repoConfigDataSource = new GoConfigRepoConfigDataSource(goConfigWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
 
         when(goConfigWatchList.getConfigRepoForMaterial(material)).thenReturn(configRepoConfig);
         when(goConfigWatchList.hasConfigRepoWithFingerprint(material.getFingerprint())).thenReturn(true);

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoPartialConfigTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoPartialConfigTest.java
@@ -44,7 +44,7 @@ public class GoPartialConfigTest {
     private GoConfigPluginService configPluginService;
     private GoConfigWatchList configWatchList;
     private PartialConfigProvider plugin;
-    private GoRepoConfigDataSource repoConfigDataSource;
+    private GoConfigRepoConfigDataSource repoConfigDataSource;
     private BasicCruiseConfig cruiseConfig;
     private GoPartialConfig partialConfig;
     private CachedGoConfig cachedGoConfig;
@@ -73,7 +73,7 @@ public class GoPartialConfigTest {
 
         configWatchList = new GoConfigWatchList(cachedGoConfig, mock(GoConfigService.class));
         goConfigService = mock(GoConfigService.class);
-        repoConfigDataSource = new GoRepoConfigDataSource(configWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
+        repoConfigDataSource = new GoConfigRepoConfigDataSource(configWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
         cachedGoPartials = new CachedGoPartials(serverHealthService);
         serverHealthService = mock(ServerHealthService.class);
 
@@ -251,7 +251,7 @@ public class GoPartialConfigTest {
         partialConfig = new GoPartialConfig(repoConfigDataSource, configWatchList, goConfigService, cachedGoPartials, serverHealthService, entityHashingService);
 
         partialConfig.onSuccessPartialConfig(configRepoConfig, PartialConfigMother.withEnvironment("env1"));
-        verify(cachedGoPartials, never()).addOrUpdate(any(String.class), any(PartialConfig.class));
+        verify(cachedGoPartials, never()).cacheAsLastKnown(any(String.class), any(PartialConfig.class));
     }
 
     @Test
@@ -271,7 +271,7 @@ public class GoPartialConfigTest {
 
         final PartialConfig partial = PartialConfigMother.withEnvironment("env2");
         partialConfig.onSuccessPartialConfig(configRepoConfig, partial);
-        verify(cachedGoPartials, times(1)).addOrUpdate(configRepoConfig.getRepo().getFingerprint(), partial);
+        verify(cachedGoPartials, times(1)).cacheAsLastKnown(configRepoConfig.getRepo().getFingerprint(), partial);
     }
 
     private Modification getModificationFor(String revision) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerTest.java
@@ -15,7 +15,7 @@
  */
 package com.thoughtworks.go.server.materials;
 
-import com.thoughtworks.go.config.GoRepoConfigDataSource;
+import com.thoughtworks.go.config.GoConfigRepoConfigDataSource;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
 import com.thoughtworks.go.config.materials.svn.SvnMaterial;
 import com.thoughtworks.go.domain.MaterialRevision;
@@ -36,18 +36,18 @@ import static com.thoughtworks.go.domain.materials.Modification.modifications;
 import static org.mockito.Mockito.*;
 
 public class ConfigMaterialUpdateListenerTest {
-    private GoRepoConfigDataSource repoConfigDataSource;
+    private GoConfigRepoConfigDataSource repoConfigDataSource;
     private MaterialRepository materialRepository;
     private MaterialUpdateCompletedTopic topic;
     private ConfigMaterialUpdateListener configUpdater;
     private MaterialService materialService;
     private Material material;
-    private File folder = new File("checkoutDir");
+    private final File folder = new File("checkoutDir");
     private Modification svnModification;
 
     @Before
     public void SetUp() {
-        repoConfigDataSource = mock(GoRepoConfigDataSource.class);
+        repoConfigDataSource = mock(GoConfigRepoConfigDataSource.class);
         materialRepository = mock(MaterialRepository.class);
         topic = mock(MaterialUpdateCompletedTopic.class);
         materialService = mock(MaterialService.class);

--- a/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
@@ -105,7 +105,7 @@ public class CachedGoConfigIntegrationTest {
     @Autowired
     private GoConfigWatchList configWatchList;
     @Autowired
-    private GoRepoConfigDataSource repoConfigDataSource;
+    private GoConfigRepoConfigDataSource repoConfigDataSource;
     @Autowired
     private CachedGoConfig cachedGoConfig;
     private GoConfigFileHelper configHelper;

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigRepoConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigRepoConfigDataSourceIntegrationTest.java
@@ -52,7 +52,7 @@ import static org.junit.Assert.assertThat;
         "classpath:/testPropertyConfigurer.xml",
         "classpath:/spring-all-servlet.xml",
 })
-public class GoRepoConfigDataSourceIntegrationTest {
+public class GoConfigRepoConfigDataSourceIntegrationTest {
 
     @Autowired
     private ServerHealthService serverHealthService;
@@ -85,7 +85,7 @@ public class GoRepoConfigDataSourceIntegrationTest {
         configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
         configHelper.onSetUp();
 
-        GoRepoConfigDataSource repoConfigDataSource = new GoRepoConfigDataSource(configWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
+        GoConfigRepoConfigDataSource repoConfigDataSource = new GoConfigRepoConfigDataSource(configWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
         repoConfigDataSource.registerListener(new GoPartialConfig(repoConfigDataSource, configWatchList, goConfigService, cachedGoPartials, serverHealthService, entityHashingService));
 
         configHelper.addTemplate("t1", "param1", "stage");

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
@@ -235,7 +235,7 @@ public class GoFileConfigDataSourceIntegrationTest {
         String remotePipeline = "remote_pipeline";
         RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin(this.repoConfig, "1");
         PartialConfig partialConfig = PartialConfigMother.pipelineWithDependencyMaterial(remotePipeline, upstream, repoConfigOrigin);
-        cachedGoPartials.addOrUpdate(this.repoConfig.getRepo().getFingerprint(), partialConfig);
+        cachedGoPartials.cacheAsLastKnown(this.repoConfig.getRepo().getFingerprint(), partialConfig);
         cachedGoPartials.markAllKnownAsValid();
         thrown.expect(RuntimeException.class);
         thrown.expectCause(Matchers.any(GoConfigInvalidException.class));
@@ -489,9 +489,9 @@ public class GoFileConfigDataSourceIntegrationTest {
         final String pipelineInMain = "pipeline_in_main";
         PartialConfig validPartialConfig = PartialConfigMother.withPipeline(pipelineOneFromConfigRepo, new RepoConfigOrigin(repoConfig, "1"));
         PartialConfig invalidPartialConfig = PartialConfigMother.invalidPartial(invalidPartial, new RepoConfigOrigin(repoConfig, "2"));
-        cachedGoPartials.addOrUpdate(repoConfig.getRepo().getFingerprint(), validPartialConfig);
+        cachedGoPartials.cacheAsLastKnown(repoConfig.getRepo().getFingerprint(), validPartialConfig);
         cachedGoPartials.markAllKnownAsValid();
-        cachedGoPartials.addOrUpdate(repoConfig.getRepo().getFingerprint(), invalidPartialConfig);
+        cachedGoPartials.cacheAsLastKnown(repoConfig.getRepo().getFingerprint(), invalidPartialConfig);
 
         GoFileConfigDataSource.GoConfigSaveResult result = dataSource.writeWithLock(cruiseConfig -> {
             cruiseConfig.addPipeline("default", PipelineConfigMother.createPipelineConfig(pipelineInMain, "stage", "job"));
@@ -512,7 +512,7 @@ public class GoFileConfigDataSourceIntegrationTest {
         String pipelineFromConfigRepo = "pipeline_from_config_repo";
         final String pipelineInMain = "pipeline_in_main";
         PartialConfig partialConfig = PartialConfigMother.withPipeline(pipelineFromConfigRepo, new RepoConfigOrigin(repoConfig, "r2"));
-        cachedGoPartials.addOrUpdate(repoConfig.getRepo().getFingerprint(), partialConfig);
+        cachedGoPartials.cacheAsLastKnown(repoConfig.getRepo().getFingerprint(), partialConfig);
         assertThat(cachedGoPartials.lastValidPartials().size(), is(1));
         assertThat(cachedGoPartials.lastValidPartials().get(0).getGroups().findGroup("group").hasPipeline(new CaseInsensitiveString(pipelineFromConfigRepo)), is(false));
 

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoPartialConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoPartialConfigIntegrationTest.java
@@ -69,7 +69,7 @@ public class GoPartialConfigIntegrationTest {
     @Autowired
     private GoConfigDao goConfigDao;
 
-    private GoConfigFileHelper configHelper = new GoConfigFileHelper();
+    private final GoConfigFileHelper configHelper = new GoConfigFileHelper();
     private ConfigRepoConfig repoConfig1;
     private ConfigRepoConfig repoConfig2;
 
@@ -125,7 +125,7 @@ public class GoPartialConfigIntegrationTest {
 
     @Test
     public void shouldTryToValidateMergeAndSaveAllKnownPartialsWhenAPartialChange() {
-        cachedGoPartials.addOrUpdate(repoConfig1.getRepo().getFingerprint(), PartialConfigMother.withPipeline("p1_repo1", new RepoConfigOrigin(repoConfig1, "1234")));
+        cachedGoPartials.cacheAsLastKnown(repoConfig1.getRepo().getFingerprint(), PartialConfigMother.withPipeline("p1_repo1", new RepoConfigOrigin(repoConfig1, "1234")));
         assertThat(goConfigDao.loadConfigHolder().config.getAllPipelineNames().contains(new CaseInsensitiveString("p1_repo1")), is(false));
 
         goPartialConfig.onSuccessPartialConfig(repoConfig2, PartialConfigMother.withPipeline("p2_repo2", new RepoConfigOrigin(repoConfig2, "4567")));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
@@ -148,7 +148,7 @@ public class ConfigSaveDeadlockDetectionIntegrationTest {
 
         for (int i = 0; i < configRepoDeletionThreadCount; i++) {
             ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("to-be-deleted-url" + i), "plugin", "to-be-deleted-" + i);
-            cachedGoPartials.addOrUpdate(configRepoConfig.getRepo().getFingerprint(), PartialConfigMother.withPipeline("to-be-deleted" + i, new RepoConfigOrigin(configRepoConfig, "plugin")));
+            cachedGoPartials.cacheAsLastKnown(configRepoConfig.getRepo().getFingerprint(), PartialConfigMother.withPipeline("to-be-deleted" + i, new RepoConfigOrigin(configRepoConfig, "plugin")));
             configRepos.add(configRepoConfig);
             Thread thread = configRepoDeleteThread(configRepoConfig, i);
             group4.add(thread);


### PR DESCRIPTION
Stop optimistically removing config repo merge/validation errors from ServerHealthState

The errors in ServerHealthState should only be removed when a) the
partial is marked as valid and b) when destroying a configrepo config.

This commit has a lot of noise from renaming classes and methods, but is
logically very short -- effictively a one line change.

The heart of this fix is removing the line `serverHealthService.removeByScope(...)`
from `GoConfigRepoConfigDataSource#onCheckoutComplete()`.
`CachedGoPartials#markAsValid()` already removes the error from `ServerHealthState`.

This should fix at least one of the regression failures around ConfigRepo validations.