### PR TITLE
Git 2.26 changes unshallowing behavior for submodules on failure.

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/EnabledOnGitVersionCondition.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/EnabledOnGitVersionCondition.java
@@ -23,28 +23,88 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.File;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
+import static com.thoughtworks.go.domain.materials.git.EnabledOnGitVersions.WILDCARD;
+import static java.lang.String.format;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
 public class EnabledOnGitVersionCondition implements ExecutionCondition {
-
+    private static final Pattern IS_VERSION = Pattern.compile("^\\d+\\.\\d+\\.\\d+$");
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-        Optional<EnabledOnGitVersionsAbove> annotation = findAnnotation(context.getElement(), EnabledOnGitVersionsAbove.class);
-        if (annotation.isPresent()) {
-            String version = annotation.get().value();
-            Version requiredVersion = Version.parseVersion(version);
-            GitCommand git = new GitCommand(null, new File(""), GitMaterialConfig.DEFAULT_BRANCH, false, null);
-            Version gitVersion = git.version().getVersion();
-            if (gitVersion.compareTo(requiredVersion) >= 0) {
-                return ConditionEvaluationResult.enabled(String.format(
-                        "Git version required for this test is %s or later. Detected Version is %s", requiredVersion, gitVersion));
+        Optional<EnabledOnGitVersions> maybe = findAnnotation(context.getElement(), EnabledOnGitVersions.class);
+        if (maybe.isPresent()) {
+            final EnabledOnGitVersions annotation = maybe.get();
+            final Version gitVersion = fetchGitVersion();
+
+            if (noneSpecified(annotation)) {
+                return ConditionEvaluationResult.enabled("Version requirements not provided. Running by default.");
+            }
+
+            if (atLeast(annotation.from(), gitVersion) && atMost(annotation.through(), gitVersion)) {
+                return ConditionEvaluationResult.enabled(
+                        format("Git version %s satisfies %s", gitVersion, criteria(annotation))
+                );
             } else {
-                return ConditionEvaluationResult.disabled(String.format(
-                        "Git version required for this test is %s or later. Detected Version is %s", requiredVersion, gitVersion));
+                return ConditionEvaluationResult.disabled(
+                        format("Git version %s does not satisfy %s", gitVersion, criteria(annotation))
+                );
             }
         }
-        return ConditionEvaluationResult.enabled("Version not provided. Running by default");
+
+        return ConditionEvaluationResult.enabled("Version requirements not provided. Running by default.");
+    }
+
+    private boolean atLeast(final String required, Version actual) {
+        if (WILDCARD.equals(required)) {
+            return true;
+        }
+
+        if (!IS_VERSION.matcher(required).matches()) {
+            throw new IllegalArgumentException(format("Bad version [%s]; `from` must be in major.minor.patch format!", required));
+        }
+        return actual.compareTo(Version.parseVersion(required)) >= 0;
+    }
+
+    private boolean atMost(final String required, Version actual) {
+        if (WILDCARD.equals(required)) {
+            return true;
+        }
+
+        if (!IS_VERSION.matcher(required).matches()) {
+            throw new IllegalArgumentException(format("Bad version [%s]; `through` must be in major.minor.patch format!", required));
+        }
+        return actual.compareTo(Version.parseVersion(required)) <= 0;
+    }
+
+    private boolean bothSpecified(EnabledOnGitVersions annotation) {
+        return !WILDCARD.equals(annotation.from()) && !WILDCARD.equals(annotation.through());
+    }
+
+    private boolean noneSpecified(EnabledOnGitVersions annotation) {
+        return WILDCARD.equals(annotation.from()) && WILDCARD.equals(annotation.through());
+    }
+
+    private String criteria(EnabledOnGitVersions annotation) {
+        if (noneSpecified(annotation)) {
+            return "<any version>";
+        }
+
+        if (bothSpecified(annotation)) {
+            return format("[from: %s, through: %s]", annotation.from(), annotation.through());
+        }
+
+        if (!WILDCARD.equals(annotation.from())) {
+            return format("[from: %s]", annotation.from());
+        }
+
+        return format("[through: %s]", annotation.through());
+    }
+
+    private Version fetchGitVersion() {
+        return new GitCommand(null, new File(""), GitMaterialConfig.DEFAULT_BRANCH, false, null).
+                version().getVersion();
     }
 }

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/EnabledOnGitVersions.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/EnabledOnGitVersions.java
@@ -22,10 +22,22 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ ElementType.TYPE, ElementType.METHOD })
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(EnabledOnGitVersionCondition.class)
-public @interface EnabledOnGitVersionsAbove {
+public @interface EnabledOnGitVersions {
+    /**
+     * Matches any version
+     */
+    String WILDCARD = "any";
 
-    String value(); //use the format: major.minor.rev
+    /**
+     * @return Semantic `major.minor.patch` version declaring minimum supported version
+     */
+    String from() default WILDCARD;
+
+    /**
+     * @return Semantic `major.minor.patch` version declaring maximum supported version
+     */
+    String through() default WILDCARD;
 }

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
@@ -661,7 +661,7 @@ public class GitCommandTest {
     }
 
     @Test
-    @EnabledOnGitVersionsAbove("2.10.0")
+    @EnabledOnGitVersions(from = "2.10.0")
     void shouldShallowCloneSubmodulesWhenSpecified() throws Exception {
         InMemoryStreamConsumer outputStreamConsumer = inMemoryConsumer();
         GitRepoContainingSubmodule repoContainingSubmodule = new GitRepoContainingSubmodule(temporaryFolder);
@@ -678,7 +678,7 @@ public class GitCommandTest {
     }
 
     @Test
-    @EnabledOnGitVersionsAbove("2.10.0")
+    @EnabledOnGitVersions(from = "2.10.0", through = "2.25.4")
     void shouldUnshallowSubmodulesIfSubmoduleUpdateFails() throws Exception {
         InMemoryStreamConsumer outputStreamConsumer = inMemoryConsumer();
         GitRepoContainingSubmodule repoContainingSubmodule = new GitRepoContainingSubmodule(temporaryFolder);
@@ -699,7 +699,7 @@ public class GitCommandTest {
     void shouldCleanIgnoredFilesIfToggleIsDisabled() throws IOException {
         InMemoryStreamConsumer output = inMemoryConsumer();
         File gitIgnoreFile = new File(repoLocation, ".gitignore");
-        FileUtils.writeStringToFile(gitIgnoreFile, "*.foo", Charset.forName("UTF-8"));
+        FileUtils.writeStringToFile(gitIgnoreFile, "*.foo", UTF_8);
         gitRepo.addFileAndPush(gitIgnoreFile, "added gitignore");
         git.fetchAndResetToHead(output);
 
@@ -714,7 +714,7 @@ public class GitCommandTest {
         System.setProperty("toggle.agent.git.clean.keep.ignored.files", "Y");
         InMemoryStreamConsumer output = inMemoryConsumer();
         File gitIgnoreFile = new File(repoLocation, ".gitignore");
-        FileUtils.writeStringToFile(gitIgnoreFile, "*.foo", Charset.forName("UTF-8"));
+        FileUtils.writeStringToFile(gitIgnoreFile, "*.foo", UTF_8);
         gitRepo.addFileAndPush(gitIgnoreFile, "added gitignore");
         git.fetchAndResetToHead(output);
 


### PR DESCRIPTION
Updates the `EnabledOnGitVersionCondition` annotation to take a version range.

This really only updates some test code to address new versions of `git` introduced after updating our elastic agent images.