### PR TITLE
Agent info on server

### DIFF
--- a/agent-bootstrapper/src/main/java/com/thoughtworks/go/agent/bootstrapper/AgentBootstrapper.java
+++ b/agent-bootstrapper/src/main/java/com/thoughtworks/go/agent/bootstrapper/AgentBootstrapper.java
@@ -141,4 +141,9 @@ public class AgentBootstrapper {
     AgentLauncherCreator getLauncherCreator() {
         return new DefaultAgentLauncherCreatorImpl();
     }
+
+    public String version() {
+        String version = getClass().getPackage().getImplementationVersion();
+        return version == null ? "UNKNOWN" : version;
+    }
 }

--- a/agent-bootstrapper/src/main/java/com/thoughtworks/go/agent/bootstrapper/DefaultAgentLaunchDescriptorImpl.java
+++ b/agent-bootstrapper/src/main/java/com/thoughtworks/go/agent/bootstrapper/DefaultAgentLaunchDescriptorImpl.java
@@ -17,6 +17,7 @@ package com.thoughtworks.go.agent.bootstrapper;
 
 import com.thoughtworks.cruise.agent.common.launcher.AgentLaunchDescriptor;
 import com.thoughtworks.go.agent.common.AgentBootstrapperArgs;
+import com.thoughtworks.go.util.GoConstants;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,6 +34,7 @@ class DefaultAgentLaunchDescriptorImpl implements AgentLaunchDescriptor {
 
     private void buildContext(AgentBootstrapperArgs bootstrapperArgs) {
         context.putAll(bootstrapperArgs.toProperties());
+        context.put(GoConstants.AGENT_BOOTSTRAPPER_VERSION, bootstrapper.version());
     }
 
     @Override

--- a/agent-bootstrapper/src/test/java/com/thoughtworks/go/agent/bootstrapper/DefaultAgentLaunchDescriptorImplTest.java
+++ b/agent-bootstrapper/src/test/java/com/thoughtworks/go/agent/bootstrapper/DefaultAgentLaunchDescriptorImplTest.java
@@ -16,12 +16,16 @@
 package com.thoughtworks.go.agent.bootstrapper;
 
 import com.thoughtworks.go.agent.common.AgentBootstrapperArgs;
+import com.thoughtworks.go.util.GoConstants;
 import org.junit.Test;
 
 import java.net.URL;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DefaultAgentLaunchDescriptorImplTest {
 
@@ -33,6 +37,24 @@ public class DefaultAgentLaunchDescriptorImplTest {
         DefaultAgentLaunchDescriptorImpl launchDescriptor = new DefaultAgentLaunchDescriptorImpl(bootstrapperArgs, new AgentBootstrapper());
         Map context = launchDescriptor.context();
 
-        assertEquals(context, bootstrapperArgs.toProperties());
+        assertContainsAll(bootstrapperArgs.toProperties(), context);
+    }
+
+    @Test
+    public void contextShouldContainBootstrapperVersionInformation() throws Exception {
+        AgentBootstrapper bootstrapper = mock(AgentBootstrapper.class);
+        when(bootstrapper.version()).thenReturn("1.2.3-1234");
+
+        DefaultAgentLaunchDescriptorImpl launchDescriptor = new DefaultAgentLaunchDescriptorImpl(new AgentBootstrapperArgs().setServerUrl(new URL("https://www.example.com")), bootstrapper);
+        Map context = launchDescriptor.context();
+
+        assertEquals("1.2.3-1234", context.get(GoConstants.AGENT_BOOTSTRAPPER_VERSION));
+    }
+
+    private void assertContainsAll(Map<String, String> expected, Map actual) {
+        for (Map.Entry<String, String> keyValuePair : expected.entrySet()) {
+            String key = keyValuePair.getKey();
+            assertEquals(actual.get(key), expected.get(key));
+        }
     }
 }

--- a/agent-launcher/src/main/java/com/thoughtworks/go/agent/launcher/AgentLauncherImpl.java
+++ b/agent-launcher/src/main/java/com/thoughtworks/go/agent/launcher/AgentLauncherImpl.java
@@ -84,8 +84,6 @@ public class AgentLauncherImpl implements AgentLauncher {
 
             AgentBootstrapperArgs bootstrapperArgs = AgentBootstrapperArgs.fromProperties(context);
             ServerUrlGenerator urlGenerator = new UrlConstructor(bootstrapperArgs.getServerUrl().toExternalForm());
-            File rootCertFile = bootstrapperArgs.getRootCertFile();
-            SslVerificationMode sslVerificationMode = SslVerificationMode.valueOf(bootstrapperArgs.getSslVerificationMode().name());
 
             ServerBinaryDownloader launcherDownloader = new ServerBinaryDownloader(urlGenerator, bootstrapperArgs);
             if (launcherDownloader.downloadIfNecessary(DownloadableFile.LAUNCHER)) {

--- a/agent-process-launcher/src/main/java/com/thoughtworks/go/agent/AgentProcessParentImpl.java
+++ b/agent-process-launcher/src/main/java/com/thoughtworks/go/agent/AgentProcessParentImpl.java
@@ -53,8 +53,6 @@ public class AgentProcessParentImpl implements AgentProcessParent {
 
         try {
             AgentBootstrapperArgs bootstrapperArgs = AgentBootstrapperArgs.fromProperties(context);
-//            File rootCertFile = bootstrapperArgs.getRootCertFile();
-//            SslVerificationMode sslVerificationMode = SslVerificationMode.valueOf(bootstrapperArgs.getSslVerificationMode().name());
 
             ServerBinaryDownloader agentDownloader = new ServerBinaryDownloader(urlGenerator, bootstrapperArgs);
             agentDownloader.downloadIfNecessary(DownloadableFile.AGENT);
@@ -137,6 +135,7 @@ public class AgentProcessParentImpl implements AgentProcessParent {
         commandSnippets.add(property(GoConstants.AGENT_JAR_MD5, agentMD5));
         commandSnippets.add(property(GoConstants.GIVEN_AGENT_LAUNCHER_JAR_MD5, launcherMd5));
         commandSnippets.add(property(GoConstants.TFS_IMPL_MD5, tfsImplMd5));
+        commandSnippets.add(property(GoConstants.AGENT_BOOTSTRAPPER_VERSION, (String) context.getOrDefault(GoConstants.AGENT_BOOTSTRAPPER_VERSION, "UNKNOWN")));
         commandSnippets.add("-jar");
 
         commandSnippets.add(Downloader.AGENT_BINARY);

--- a/agent/src/main/java/com/thoughtworks/go/agent/AgentController.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/AgentController.java
@@ -27,6 +27,7 @@ import com.thoughtworks.go.plugin.infra.PluginManagerReference;
 import com.thoughtworks.go.remote.AgentIdentifier;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 import com.thoughtworks.go.server.service.ElasticAgentRuntimeInfo;
+import com.thoughtworks.go.util.GoConstants;
 import com.thoughtworks.go.util.SubprocessLogger;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.SystemUtil;
@@ -38,6 +39,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 import static com.thoughtworks.go.util.SystemUtil.currentWorkingDirectory;
+import static com.thoughtworks.go.util.SystemUtil.getClientIp;
 
 public abstract class AgentController {
     private static final Logger LOG = LoggerFactory.getLogger(AgentController.class);
@@ -149,11 +151,15 @@ public abstract class AgentController {
 
     private void initRuntimeInfo() {
         agentAutoRegistrationProperties = new AgentAutoRegistrationPropertiesImpl(new File("config", "autoregister.properties"));
+        String bootstrapperVersion = System.getProperty(GoConstants.AGENT_BOOTSTRAPPER_VERSION, "UNKNOWN");
+        String agentVersion = getClass().getPackage().getImplementationVersion();
 
         if (agentAutoRegistrationProperties.isElastic()) {
-            agentRuntimeInfo = ElasticAgentRuntimeInfo.fromAgent(identifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), agentAutoRegistrationProperties.agentAutoRegisterElasticAgentId(), agentAutoRegistrationProperties.agentAutoRegisterElasticPluginId());
+            agentRuntimeInfo = ElasticAgentRuntimeInfo.fromAgent(identifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(),
+                    agentAutoRegistrationProperties.agentAutoRegisterElasticAgentId(), agentAutoRegistrationProperties.agentAutoRegisterElasticPluginId(),
+                    bootstrapperVersion, agentVersion);
         } else {
-            agentRuntimeInfo = AgentRuntimeInfo.fromAgent(identifier, AgentStatus.Idle.getRuntimeStatus(), currentWorkingDirectory());
+            agentRuntimeInfo = AgentRuntimeInfo.fromAgent(identifier, AgentStatus.Idle.getRuntimeStatus(), currentWorkingDirectory(), bootstrapperVersion, agentVersion);
         }
     }
 

--- a/api/api-agents-v6/src/test/groovy/com/thoughtworks/go/apiv6/agents/AgentsControllerV6Test.groovy
+++ b/api/api-agents-v6/src/test/groovy/com/thoughtworks/go/apiv6/agents/AgentsControllerV6Test.groovy
@@ -326,7 +326,7 @@ class AgentsControllerV6Test implements SecurityServiceTrait, ControllerTrait<Ag
     @Test
     void 'should update agent information'() {
       loginAsAdmin()
-      AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"))
+      AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"), "20.3.0-1234", "20.5.0-2345")
       updatedAgentInstance.getAgent().setEnvironments("env1,unknown-env")
 
       def envsConfig = new EnvironmentsConfig()
@@ -428,7 +428,7 @@ class AgentsControllerV6Test implements SecurityServiceTrait, ControllerTrait<Ag
     void 'should reset agents environment attribute value to null in db when environments is specified as empty string in the request payload'() {
       loginAsAdmin()
       def resources = asList("psql", "java")
-      AgentInstance agentWithoutEnvs = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", resources)
+      AgentInstance agentWithoutEnvs = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", resources, "20.3.0-1234", "20.5.0-2345")
 
       when(environmentConfigService.getAgentEnvironments("uuid2")).thenReturn(emptySet())
       when(agentService.updateAgentAttributes(
@@ -481,7 +481,7 @@ class AgentsControllerV6Test implements SecurityServiceTrait, ControllerTrait<Ag
       loginAsAdmin()
 
       def resources = emptyList()
-      AgentInstance agentWithoutEnvsAndResources = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", resources)
+      AgentInstance agentWithoutEnvsAndResources = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", resources, "20.3.0-1234", "20.5.0-2345s")
 
       def emptyEnvsConfig = new EnvironmentsConfig()
       when(environmentConfigService.getAgentEnvironments("uuid2")).thenReturn(emptySet())
@@ -645,7 +645,7 @@ class AgentsControllerV6Test implements SecurityServiceTrait, ControllerTrait<Ag
       @Test
       void 'should pass empty environments string to service given empty comma separated list of environments'() {
         loginAsAdmin()
-        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"))
+        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"), "20.3.0-1234", "20.5.0-2345")
 
         def commaSeparatedEnvs = "             "
 
@@ -705,7 +705,7 @@ class AgentsControllerV6Test implements SecurityServiceTrait, ControllerTrait<Ag
       @Test
       void 'should pass null as environments string to service given null comma separated list of environments'() {
         loginAsAdmin()
-        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"))
+        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"), "20.3.0-1234", "20.5.0-2345")
         when(agentService.updateAgentAttributes(
           eq("uuid2"),
           eq("agent02.example.com"),
@@ -760,7 +760,7 @@ class AgentsControllerV6Test implements SecurityServiceTrait, ControllerTrait<Ag
       @Test
       void 'should filter out environments which are associated via config-repo'() {
         loginAsAdmin()
-        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"))
+        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"), "20.3.0-1234", "20.5.0-2345")
         updatedAgentInstance.getAgent().setEnvironments("env1,config-repo-env")
 
         def localEnvName = "env1"
@@ -867,7 +867,7 @@ class AgentsControllerV6Test implements SecurityServiceTrait, ControllerTrait<Ag
       @Test
       void 'should pass in the env name even if it is not defined'() {
         loginAsAdmin()
-        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"))
+        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"), "20.3.0-1234", "20.5.0-2345")
         updatedAgentInstance.getAgent().setEnvironments("env1,non-existent-env")
 
         def localEnvName = "env1"

--- a/api/api-agents-v6/src/test/groovy/com/thoughtworks/go/apiv6/agents/representers/AgentRepresenterTest.groovy
+++ b/api/api-agents-v6/src/test/groovy/com/thoughtworks/go/apiv6/agents/representers/AgentRepresenterTest.groovy
@@ -52,7 +52,7 @@ class AgentRepresenterTest {
 
   @Test
   void 'renders an agent with hal representation'() {
-    AgentInstance agentInstance = idleWith("some-uuid", "agent01.example.com", "127.0.0.1", "/var/lib/go-server", 10l, "Linux", Arrays.asList("linux", "firefox"))
+    AgentInstance agentInstance = idleWith("some-uuid", "agent01.example.com", "127.0.0.1", "/var/lib/go-server", 10l, "Linux", Arrays.asList("linux", "firefox"), "20.3.0-1234", "20.5.0-2345")
     agentInstance.getAgent().setEnvironments("uat,load_test,non-existent-env")
     def envFromConfigRepo = environment("dev")
     envFromConfigRepo.setOrigins(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(null, "yaml", "foo"), "revision"))
@@ -145,7 +145,7 @@ class AgentRepresenterTest {
 
   @Test
   void 'renders the elastic agent properties correctly'() {
-    AgentInstance agentInstance = idleWith("some-uuid", "agent01.example.com", "127.0.0.1", "/var/lib/go-server", 10l, "Linux", Arrays.asList("linux", "firefox"))
+    AgentInstance agentInstance = idleWith("some-uuid", "agent01.example.com", "127.0.0.1", "/var/lib/go-server", 10l, "Linux", Arrays.asList("linux", "firefox"), "20.3.0-1234", "20.5.0-2345")
     updateElasticAgentId(agentInstance, "docker-elastic-agent")
     updateElasticPluginId(agentInstance, "cd.go.docker")
 
@@ -162,7 +162,7 @@ class AgentRepresenterTest {
 
   @Test
   void 'should render environments associated through config-repo'() {
-    AgentInstance agentInstance = idleWith("some-uuid", "agent01.example.com", "127.0.0.1", "/var/lib/go-server", 10l, "Linux", Arrays.asList("linux", "firefox"))
+    AgentInstance agentInstance = idleWith("some-uuid", "agent01.example.com", "127.0.0.1", "/var/lib/go-server", 10l, "Linux", Arrays.asList("linux", "firefox"), "20.3.0-1234", "20.5.0-2345")
     agentInstance.getAgent().setEnvironments("uat")
     def envFromConfigRepo = environment("dev")
     envFromConfigRepo.setOrigins(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(null, "yaml", "foo"), "revision"))

--- a/api/api-agents-v7/src/main/java/com/thoughtworks/go/apiv7/agents/representers/AgentRepresenter.java
+++ b/api/api-agents-v7/src/main/java/com/thoughtworks/go/apiv7/agents/representers/AgentRepresenter.java
@@ -40,6 +40,8 @@ public class AgentRepresenter {
                 .add("operating_system", agentInstance.getOperatingSystem())
                 .add("agent_config_state", agentInstance.getAgentConfigStatus().toString())
                 .add("agent_state", agentInstance.getRuntimeStatus().agentState().toString())
+                .add("agent_version", agentInstance.getAgentVersion())
+                .add("agent_bootstrapper_version", agentInstance.getAgentBootstrapperVersion())
                 .addChildList("environments", envWriter -> EnvironmentsRepresenter.toJSON(envWriter, environments, agentInstance))
                 .add("build_state", agentInstance.getRuntimeStatus().buildState().toString());
 

--- a/api/api-agents-v7/src/test/groovy/com/thoughtworks/go/apiv7/agents/AgentsControllerV7Test.groovy
+++ b/api/api-agents-v7/src/test/groovy/com/thoughtworks/go/apiv7/agents/AgentsControllerV7Test.groovy
@@ -137,6 +137,8 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
               "free_space"        : 10240,
               "agent_config_state": "Enabled",
               "agent_state"       : "Idle",
+              "agent_version"     : "UNKNOWN",
+              "agent_bootstrapper_version" : "UNKNOWN",
               "resources"         : [],
               "environments"      : [
                 [
@@ -255,6 +257,8 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
         "free_space"        : 10240,
         "agent_config_state": "Enabled",
         "agent_state"       : "Idle",
+        "agent_version"     : "UNKNOWN",
+        "agent_bootstrapper_version" : "UNKNOWN",
         "resources"         : [],
         "environments"      : [
           [
@@ -327,7 +331,7 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
     @Test
     void 'should update agent information'() {
       loginAsAdmin()
-      AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"))
+      AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"), "20.3.0-1234", "20.5.0-2345")
       updatedAgentInstance.getAgent().setEnvironments("env1,unknown-env")
 
       def envsConfig = new EnvironmentsConfig()
@@ -375,6 +379,8 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
         "free_space"        : 10,
         "agent_config_state": "Enabled",
         "agent_state"       : "Idle",
+        "agent_version"     : "20.5.0-2345",
+        "agent_bootstrapper_version" : "20.3.0-1234",
         "resources"         : ["java", "psql"],
         "environments"      : [
           [
@@ -429,7 +435,7 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
     void 'should reset agents environment attribute value to null in db when environments is specified as empty string in the request payload'() {
       loginAsAdmin()
       def resources = asList("psql", "java")
-      AgentInstance agentWithoutEnvs = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", resources)
+      AgentInstance agentWithoutEnvs = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", resources, "20.3.0-1234", "20.5.0-2345")
 
       when(environmentConfigService.getAgentEnvironments("uuid2")).thenReturn(emptySet())
       when(agentService.updateAgentAttributes(
@@ -471,6 +477,8 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
         "free_space"        : 10,
         "agent_config_state": "Enabled",
         "agent_state"       : "Idle",
+        "agent_version"     : "20.5.0-2345",
+        "agent_bootstrapper_version" : "20.3.0-1234",
         "resources"         : ["java", "psql"],
         "environments"      : [],
         "build_state"       : "Idle"
@@ -482,7 +490,7 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
       loginAsAdmin()
 
       def resources = emptyList()
-      AgentInstance agentWithoutEnvsAndResources = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", resources)
+      AgentInstance agentWithoutEnvsAndResources = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", resources, "20.3.0-1234", "20.5.0-2345")
 
       def emptyEnvsConfig = new EnvironmentsConfig()
       when(environmentConfigService.getAgentEnvironments("uuid2")).thenReturn(emptySet())
@@ -527,6 +535,8 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
         "free_space"        : 10,
         "agent_config_state": "Enabled",
         "agent_state"       : "Idle",
+        "agent_version"     : "20.5.0-2345",
+        "agent_bootstrapper_version" : "20.3.0-1234",
         "resources"         : [],
         "environments"      : [],
         "build_state"       : "Idle"
@@ -627,6 +637,8 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
           "free_space"        : "unknown",
           "agent_config_state": "Enabled",
           "agent_state"       : "Missing",
+          "agent_version"     : "UNKNOWN",
+          "agent_bootstrapper_version" : "UNKNOWN",
           "resources"         : ["bar\$", "foo%"],
           "environments"      : [],
           "build_state"       : "Unknown",
@@ -646,7 +658,7 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
       @Test
       void 'should pass empty environments string to service given empty comma separated list of environments'() {
         loginAsAdmin()
-        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"))
+        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"), "20.3.0-1234", "20.5.0-2345")
 
         def commaSeparatedEnvs = "             "
 
@@ -697,6 +709,8 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
           "free_space"        : 10,
           "agent_config_state": "Enabled",
           "agent_state"       : "Idle",
+          "agent_version"     : "20.5.0-2345",
+          "agent_bootstrapper_version" : "20.3.0-1234",
           "resources"         : ["java", "psql"],
           "environments"      : [],
           "build_state"       : "Idle"
@@ -706,7 +720,7 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
       @Test
       void 'should pass null as environments string to service given null comma separated list of environments'() {
         loginAsAdmin()
-        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"))
+        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"), "20.3.0-1234", "20.5.0-2345")
         when(agentService.updateAgentAttributes(
           eq("uuid2"),
           eq("agent02.example.com"),
@@ -752,6 +766,8 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
           "free_space"        : 10,
           "agent_config_state": "Enabled",
           "agent_state"       : "Idle",
+          "agent_version"     : "20.5.0-2345",
+          "agent_bootstrapper_version" : "20.3.0-1234",
           "resources"         : ["java", "psql"],
           "environments"      : [],
           "build_state"       : "Idle"
@@ -761,7 +777,7 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
       @Test
       void 'should filter out environments which are associated via config-repo'() {
         loginAsAdmin()
-        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"))
+        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"), "20.3.0-1234", "20.5.0-2345")
         updatedAgentInstance.getAgent().setEnvironments("env1,config-repo-env")
 
         def localEnvName = "env1"
@@ -823,6 +839,8 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
           "free_space"        : 10,
           "agent_config_state": "Enabled",
           "agent_state"       : "Idle",
+          "agent_version"     : "20.5.0-2345",
+          "agent_bootstrapper_version" : "20.3.0-1234",
           "resources"         : ["java", "psql"],
           "environments"      : [
             [
@@ -868,7 +886,7 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
       @Test
       void 'should pass in the env name even if it is not defined'() {
         loginAsAdmin()
-        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"))
+        AgentInstance updatedAgentInstance = idleWith("uuid2", "agent02.example.com", "10.0.0.1", "/var/lib/bar", 10, "", asList("psql", "java"), "20.3.0-1234", "20.5.0-2345")
         updatedAgentInstance.getAgent().setEnvironments("env1,non-existent-env")
 
         def localEnvName = "env1"
@@ -924,6 +942,8 @@ class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<Ag
           "free_space"        : 10,
           "agent_config_state": "Enabled",
           "agent_state"       : "Idle",
+          "agent_version"     : "20.5.0-2345",
+          "agent_bootstrapper_version" : "20.3.0-1234",
           "resources"         : ["java", "psql"],
           "environments"      : [
             [

--- a/api/api-agents-v7/src/test/groovy/com/thoughtworks/go/apiv7/agents/representers/AgentRepresenterTest.groovy
+++ b/api/api-agents-v7/src/test/groovy/com/thoughtworks/go/apiv7/agents/representers/AgentRepresenterTest.groovy
@@ -52,7 +52,7 @@ class AgentRepresenterTest {
 
   @Test
   void 'renders an agent with hal representation'() {
-    AgentInstance agentInstance = idleWith("some-uuid", "agent01.example.com", "127.0.0.1", "/var/lib/go-server", 10l, "Linux", Arrays.asList("linux", "firefox"))
+    AgentInstance agentInstance = idleWith("some-uuid", "agent01.example.com", "127.0.0.1", "/var/lib/go-server", 10l, "Linux", Arrays.asList("linux", "firefox"), "20.3.0-1234", "20.5.0-2345")
     agentInstance.getAgent().setEnvironments("uat,load_test,non-existent-env")
     def envFromConfigRepo = environment("dev")
     envFromConfigRepo.setOrigins(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(null, "yaml", "foo"), "revision"))
@@ -83,6 +83,8 @@ class AgentRepresenterTest {
       "free_space"        : 10,
       "agent_config_state": "Enabled",
       "agent_state"       : "Idle",
+      "agent_version"     : "20.5.0-2345",
+      "agent_bootstrapper_version" : "20.3.0-1234",
       "resources"         : ["firefox", "linux"],
       "environments"      : [
         [
@@ -145,7 +147,7 @@ class AgentRepresenterTest {
 
   @Test
   void 'renders the elastic agent properties correctly'() {
-    AgentInstance agentInstance = idleWith("some-uuid", "agent01.example.com", "127.0.0.1", "/var/lib/go-server", 10l, "Linux", Arrays.asList("linux", "firefox"))
+    AgentInstance agentInstance = idleWith("some-uuid", "agent01.example.com", "127.0.0.1", "/var/lib/go-server", 10l, "Linux", Arrays.asList("linux", "firefox"), "20.3.0-1234", "20.5.0-2345")
     updateElasticAgentId(agentInstance, "docker-elastic-agent")
     updateElasticPluginId(agentInstance, "cd.go.docker")
 
@@ -162,7 +164,7 @@ class AgentRepresenterTest {
 
   @Test
   void 'should render environments associated through config-repo'() {
-    AgentInstance agentInstance = idleWith("some-uuid", "agent01.example.com", "127.0.0.1", "/var/lib/go-server", 10l, "Linux", Arrays.asList("linux", "firefox"))
+    AgentInstance agentInstance = idleWith("some-uuid", "agent01.example.com", "127.0.0.1", "/var/lib/go-server", 10l, "Linux", Arrays.asList("linux", "firefox"), "20.3.0-1234", "20.5.0-2345")
     agentInstance.getAgent().setEnvironments("uat")
     def envFromConfigRepo = environment("dev")
     envFromConfigRepo.setOrigins(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(null, "yaml", "foo"), "revision"))
@@ -193,6 +195,8 @@ class AgentRepresenterTest {
       "free_space"        : 10,
       "agent_config_state": "Enabled",
       "agent_state"       : "Idle",
+      "agent_version"     : "20.5.0-2345",
+      "agent_bootstrapper_version" : "20.3.0-1234",
       "resources"         : ["firefox", "linux"],
       "environments"      : [
         [

--- a/api/api-agents-v7/src/test/groovy/com/thoughtworks/go/apiv7/agents/representers/AgentsRepresenterTest.groovy
+++ b/api/api-agents-v7/src/test/groovy/com/thoughtworks/go/apiv7/agents/representers/AgentsRepresenterTest.groovy
@@ -99,6 +99,8 @@ class AgentsRepresenterTest {
             "free_space"        : 10240,
             "agent_config_state": "Enabled",
             "agent_state"       : "Idle",
+            "agent_version"     : "UNKNOWN",
+            "agent_bootstrapper_version" : "UNKNOWN",
             "resources"         : [],
             "environments"      : [
               [
@@ -152,6 +154,8 @@ class AgentsRepresenterTest {
             "free_space"        : "unknown",
             "agent_config_state": "Enabled",
             "agent_state"       : "Missing",
+            "agent_version"     : "UNKNOWN",
+            "agent_bootstrapper_version" : "UNKNOWN",
             "resources"         : [],
             "environments"      : [
               [
@@ -191,6 +195,8 @@ class AgentsRepresenterTest {
             "free_space"        : "unknown",
             "agent_config_state": "Enabled",
             "agent_state"       : "Building",
+            "agent_version"     : "UNKNOWN",
+            "agent_bootstrapper_version" : "UNKNOWN",
             "resources"         : [
               "java"
             ],

--- a/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
@@ -71,6 +71,7 @@ public class GoConstants {
     public static final String ZIP_MULTIPART_FILENAME = "zipfile";
     public static final String AGENT_JAR_MD5 = "agent.binary.md5";
     public static final String AGENT_PLUGINS_MD5 = "agent.plugins.md5";
+    public static final String AGENT_BOOTSTRAPPER_VERSION = "agent.bootstrapper.version";
     public static final String TFS_IMPL_MD5 = "agent.tfs.md5";
     public static final String GIVEN_AGENT_LAUNCHER_JAR_MD5 = "agent.launcher.md5";
     public static final String ANY_PIPELINE = "[Any Pipeline]";

--- a/common/src/main/java/com/thoughtworks/go/domain/AgentInstance.java
+++ b/common/src/main/java/com/thoughtworks/go/domain/AgentInstance.java
@@ -532,6 +532,14 @@ public class AgentInstance implements Comparable<AgentInstance> {
         }
     }
 
+    public String getAgentVersion() {
+        return agentRuntimeInfo.getAgentVersion();
+    }
+
+    public String getAgentBootstrapperVersion() {
+        return agentRuntimeInfo.getAgentBootstrapperVersion();
+    }
+
     private void updateConfigStatus(AgentConfigStatus agentConfigStatus) {
         if (this.agentConfigStatus != agentConfigStatus) {
             this.agentConfigStatus = agentConfigStatus;

--- a/common/src/main/java/com/thoughtworks/go/server/service/AgentRuntimeInfo.java
+++ b/common/src/main/java/com/thoughtworks/go/server/service/AgentRuntimeInfo.java
@@ -206,12 +206,12 @@ public class AgentRuntimeInfo implements Serializable {
         return this;
     }
 
-    protected AgentRuntimeInfo updateBootstrapperVersion(String agentBootstrapperVersion) {
+    public AgentRuntimeInfo updateBootstrapperVersion(String agentBootstrapperVersion) {
         this.agentBootstrapperVersion = agentBootstrapperVersion;
         return this;
     }
 
-    protected AgentRuntimeInfo updateAgentVersion(String agentVersion) {
+    public AgentRuntimeInfo updateAgentVersion(String agentVersion) {
         this.agentVersion = agentVersion;
         return this;
     }

--- a/common/src/main/java/com/thoughtworks/go/server/service/AgentRuntimeInfo.java
+++ b/common/src/main/java/com/thoughtworks/go/server/service/AgentRuntimeInfo.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.Objects;
 
 import static com.thoughtworks.go.domain.AgentRuntimeStatus.Building;
 import static com.thoughtworks.go.domain.AgentRuntimeStatus.Cancelled;
@@ -53,6 +54,10 @@ public class AgentRuntimeInfo implements Serializable {
     @Expose
     private volatile String operatingSystemName;
     @Expose
+    private volatile String agentBootstrapperVersion = "UNKNOWN";
+    @Expose
+    private volatile String agentVersion = "UNKNOWN";
+    @Expose
     private volatile String cookie;
 
     public AgentRuntimeInfo(AgentIdentifier identifier, AgentRuntimeStatus runtimeStatus, String location, String cookie) {
@@ -63,8 +68,12 @@ public class AgentRuntimeInfo implements Serializable {
         this.cookie = cookie;
     }
 
-    public static AgentRuntimeInfo fromAgent(AgentIdentifier identifier, AgentRuntimeStatus runtimeStatus, String currentWorkingDirectory) {
-        return new AgentRuntimeInfo(identifier, runtimeStatus, currentWorkingDirectory, null).refreshOperatingSystem().refreshUsableSpace();
+    public static AgentRuntimeInfo fromAgent(AgentIdentifier identifier, AgentRuntimeStatus runtimeStatus, String currentWorkingDirectory, String agentBootstrapperVersion, String agentVersion) {
+        return new AgentRuntimeInfo(identifier, runtimeStatus, currentWorkingDirectory, null)
+                .refreshOperatingSystem()
+                .refreshUsableSpace()
+                .updateBootstrapperVersion(agentBootstrapperVersion)
+                .updateAgentVersion(agentVersion);
     }
 
     public static AgentRuntimeInfo fromServer(Agent agent, boolean registeredAlready, String location,
@@ -125,29 +134,21 @@ public class AgentRuntimeInfo implements Serializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         AgentRuntimeInfo that = (AgentRuntimeInfo) o;
-
-        if (identifier != null ? !identifier.equals(that.identifier) : that.identifier != null) return false;
-        if (runtimeStatus != that.runtimeStatus) return false;
-        if (buildingInfo != null ? !buildingInfo.equals(that.buildingInfo) : that.buildingInfo != null) return false;
-        if (location != null ? !location.equals(that.location) : that.location != null) return false;
-        if (usableSpace != null ? !usableSpace.equals(that.usableSpace) : that.usableSpace != null) return false;
-        if (operatingSystemName != null ? !operatingSystemName.equals(that.operatingSystemName) : that.operatingSystemName != null)
-            return false;
-        return cookie != null ? cookie.equals(that.cookie) : that.cookie == null;
+        return Objects.equals(identifier, that.identifier) &&
+                runtimeStatus == that.runtimeStatus &&
+                Objects.equals(buildingInfo, that.buildingInfo) &&
+                Objects.equals(location, that.location) &&
+                Objects.equals(usableSpace, that.usableSpace) &&
+                Objects.equals(operatingSystemName, that.operatingSystemName) &&
+                Objects.equals(agentBootstrapperVersion, that.agentBootstrapperVersion) &&
+                Objects.equals(agentVersion, that.agentVersion) &&
+                Objects.equals(cookie, that.cookie);
     }
 
     @Override
     public int hashCode() {
-        int result = identifier != null ? identifier.hashCode() : 0;
-        result = 31 * result + (runtimeStatus != null ? runtimeStatus.hashCode() : 0);
-        result = 31 * result + (buildingInfo != null ? buildingInfo.hashCode() : 0);
-        result = 31 * result + (location != null ? location.hashCode() : 0);
-        result = 31 * result + (usableSpace != null ? usableSpace.hashCode() : 0);
-        result = 31 * result + (operatingSystemName != null ? operatingSystemName.hashCode() : 0);
-        result = 31 * result + (cookie != null ? cookie.hashCode() : 0);
-        return result;
+        return Objects.hash(identifier, runtimeStatus, buildingInfo, location, usableSpace, operatingSystemName, agentBootstrapperVersion, agentVersion, cookie);
     }
 
     @Override
@@ -202,6 +203,16 @@ public class AgentRuntimeInfo implements Serializable {
 
     public AgentRuntimeInfo refreshUsableSpace() {
         setUsableSpace(usableSpace(location));
+        return this;
+    }
+
+    protected AgentRuntimeInfo updateBootstrapperVersion(String agentBootstrapperVersion) {
+        this.agentBootstrapperVersion = agentBootstrapperVersion;
+        return this;
+    }
+
+    protected AgentRuntimeInfo updateAgentVersion(String agentVersion) {
+        this.agentVersion = agentVersion;
         return this;
     }
 
@@ -280,9 +291,19 @@ public class AgentRuntimeInfo implements Serializable {
         this.location = newRuntimeInfo.getLocation();
         this.usableSpace = newRuntimeInfo.getUsableSpace();
         this.operatingSystemName = newRuntimeInfo.getOperatingSystem();
+        this.agentBootstrapperVersion = newRuntimeInfo.agentBootstrapperVersion;
+        this.agentVersion = newRuntimeInfo.agentVersion;
     }
 
     public boolean isElastic() {
         return false;
+    }
+
+    public String getAgentVersion() {
+        return this.agentVersion;
+    }
+
+    public String getAgentBootstrapperVersion() {
+        return this.agentBootstrapperVersion;
     }
 }

--- a/common/src/main/java/com/thoughtworks/go/server/service/ElasticAgentRuntimeInfo.java
+++ b/common/src/main/java/com/thoughtworks/go/server/service/ElasticAgentRuntimeInfo.java
@@ -46,9 +46,14 @@ public class ElasticAgentRuntimeInfo extends AgentRuntimeInfo implements Seriali
     }
 
     public static ElasticAgentRuntimeInfo fromAgent(AgentIdentifier identifier, AgentRuntimeStatus runtimeStatus,
-                                                    String workingDir, String elasticAgentId, String pluginId) {
+                                                    String workingDir, String elasticAgentId, String pluginId,
+                                                    String agentBootstrapperVersion, String agentVersion) {
         ElasticAgentRuntimeInfo runtimeInfo = new ElasticAgentRuntimeInfo(identifier, runtimeStatus, workingDir, null, elasticAgentId, pluginId);
-        return (ElasticAgentRuntimeInfo) runtimeInfo.refreshOperatingSystem().refreshUsableSpace();
+        return (ElasticAgentRuntimeInfo) runtimeInfo
+                .refreshOperatingSystem()
+                .refreshUsableSpace()
+                .updateBootstrapperVersion(agentBootstrapperVersion)
+                .updateAgentVersion(agentVersion);
     }
 
     @Override

--- a/common/src/test/java/com/thoughtworks/go/domain/AgentInstanceTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/AgentInstanceTest.java
@@ -774,6 +774,19 @@ public class AgentInstanceTest {
         verify(mockAgentStatusChangeListener).onAgentStatusChange(agentInstance);
     }
 
+    @Test
+    void shouldGetAgentAndBootstrapperVersions() {
+        AgentInstance agentInstance = AgentInstanceMother.idle();
+
+        AgentRuntimeInfo newRuntimeInfo = new AgentRuntimeInfo(agentInstance.getAgentIdentifier(), agentInstance.getRuntimeStatus(), "some-location", "some-cookie");
+        newRuntimeInfo.updateBootstrapperVersion("20.3.0-1234").updateAgentVersion("20.5.0-2345");
+
+        agentInstance.update(newRuntimeInfo);
+
+        assertThat(agentInstance.getAgentBootstrapperVersion()).isEqualTo("20.3.0-1234");
+        assertThat(agentInstance.getAgentVersion()).isEqualTo("20.5.0-2345");
+    }
+
     @Nested
     class Matches {
         @Test

--- a/common/src/test/java/com/thoughtworks/go/helper/AgentInstanceMother.java
+++ b/common/src/test/java/com/thoughtworks/go/helper/AgentInstanceMother.java
@@ -68,7 +68,7 @@ public class AgentInstanceMother {
         return disabled;
     }
 
-    public static AgentInstance idleWith(String uuid, String hostname, String ipAddress, String location, long space, String os, List<String> resourceList) {
+    public static AgentInstance idleWith(String uuid, String hostname, String ipAddress, String location, long space, String os, List<String> resourceList, String agentBootstrapperVersion, String agentVersion) {
 
         Agent agent = new Agent(uuid, hostname, ipAddress);
         agent.setResourcesFromList(resourceList);
@@ -77,6 +77,8 @@ public class AgentInstanceMother {
         agentRuntimeInfo.idle();
         agentRuntimeInfo.setUsableSpace(space);
         agentRuntimeInfo.setOperatingSystem(os);
+        agentRuntimeInfo.updateAgentVersion(agentVersion);
+        agentRuntimeInfo.updateBootstrapperVersion(agentBootstrapperVersion);
 
         AgentInstance agentInstance = createFromLiveAgent(agentRuntimeInfo, new SystemEnvironment(), mock(AgentStatusChangeListener.class));
         agentInstance.idle();

--- a/common/src/test/java/com/thoughtworks/go/server/service/AgentRuntimeInfoTest.java
+++ b/common/src/test/java/com/thoughtworks/go/server/service/AgentRuntimeInfoTest.java
@@ -29,9 +29,9 @@ import java.io.File;
 
 import static com.thoughtworks.go.domain.AgentRuntimeStatus.Idle;
 import static com.thoughtworks.go.util.SystemUtil.currentWorkingDirectory;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 
 public class AgentRuntimeInfoTest {
     private File pipelinesFolder;
@@ -127,6 +127,15 @@ public class AgentRuntimeInfoTest {
     }
 
     @Test
+    public void shouldBeAbleToUpdateAgentAndAgentBootstrapperVersions() {
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(new AgentIdentifier("localhost", "127.0.0.1", "uuid"), Idle, currentWorkingDirectory(), "cookie");
+
+        agentRuntimeInfo.updateAgentVersion("20.5.0-2345").updateBootstrapperVersion("20.3.0-1234");
+        assertThat(agentRuntimeInfo.getAgentVersion(), is("20.5.0-2345"));
+        assertThat(agentRuntimeInfo.getAgentBootstrapperVersion(), is("20.3.0-1234"));
+    }
+
+    @Test
     public void shouldUpdateSelfForAnIdleAgent() {
         AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(new AgentIdentifier("localhost", "127.0.0.1", "uuid"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), null);
         AgentRuntimeInfo newRuntimeInfo = new AgentRuntimeInfo(new AgentIdentifier("go02", "10.10.10.1", "uuid"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie");
@@ -134,6 +143,8 @@ public class AgentRuntimeInfoTest {
         newRuntimeInfo.setLocation("home");
         newRuntimeInfo.setUsableSpace(10L);
         newRuntimeInfo.setOperatingSystem("Linux");
+        newRuntimeInfo.updateAgentVersion("20.5.0-2345");
+        newRuntimeInfo.updateBootstrapperVersion("20.3.0-1234");
 
         agentRuntimeInfo.updateSelf(newRuntimeInfo);
 
@@ -141,6 +152,8 @@ public class AgentRuntimeInfoTest {
         assertThat(agentRuntimeInfo.getLocation(), is(newRuntimeInfo.getLocation()));
         assertThat(agentRuntimeInfo.getUsableSpace(), is(newRuntimeInfo.getUsableSpace()));
         assertThat(agentRuntimeInfo.getOperatingSystem(), is(newRuntimeInfo.getOperatingSystem()));
+        assertThat(agentRuntimeInfo.getAgentVersion(), is("20.5.0-2345"));
+        assertThat(agentRuntimeInfo.getAgentBootstrapperVersion(), is("20.3.0-1234"));
     }
 
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/AgentServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/AgentServiceTest.java
@@ -235,7 +235,7 @@ class AgentServiceTest {
             @Test
             void shouldBulkEnableAgents() {
                 Username username = new Username(new CaseInsensitiveString("test"));
-                AgentRuntimeInfo agentRuntimeInfo = AgentRuntimeInfo.fromAgent(agentIdentifier, AgentRuntimeStatus.Unknown, "cookie");
+                AgentRuntimeInfo agentRuntimeInfo = AgentRuntimeInfo.fromAgent(agentIdentifier, AgentRuntimeStatus.Unknown, "cookie", "20.3.0-1234", "20.5.0-2345");
                 AgentInstance pending = createFromLiveAgent(agentRuntimeInfo, new SystemEnvironment(), null);
 
                 Agent agent = new Agent("UUID2", "remote-host", "50.40.30.20");


### PR DESCRIPTION
Issue: #150

Description:
  - Include agent version and agent boostrapper version in the agents API on the server side.

#### Todos:

- [ ] API documentation + changelog update.
- [ ] Check if any functional tests exist for this.
    - Look into [specs/agents_api.rb](https://github.com/gocd/ruby-functional-tests/blob/c2cb808c271b40d706af2138c8637b6ea8111bdc/step_implementations/specs/agents_api.rb).

#### Scenarios to verify:

 - [x] Scenario 1: 20.4.0 server, 20.4.0 agent bootstrapper:
    - Agents API v7 does not even exist.

- [x] Scenario 2: 20.4.0 server, 20.5.0 agent bootstrapper:
    - 20.4.0 server pushes 20.4.0 launcher and 20.4.0 agent JAR to 20.5.0 agent bootstrapper.
    - ~20.5.0 agent bootstrapper invokes 20.4.0 agent with the `-Dagent.bootstrapper.version=20.5.0` argument, but 20.4.0 agent does not use it.~
    - The above was wrong. The 20.5.0 bootstrapper calls out to the 20.4.0 launcher, which does not know to pass in that argument.
    - On the server side, Agents API v7 does not even exist.

- [x] Scenario 3: 20.5.0 server, 20.4.0 agent bootstrapper:
    - 20.5.0 server pushes 20.5.0 launcher and 20.5.0 agent JAR to the 20.4.0 agent bootstrapper.
    - 20.4.0 agent bootstrapper won't know to find its own version and send it to the 20.5.0 agent it starts.
    - No `-Dagent.bootstrapper.version=20.4.0` is sent to the agent when it is invoked.
    - 20.5.0 agents sends its version to the 20.5.0 server.
    - On the server side, Agents API v7 returns `20.5.0` for agent version and `UNKNOWN` for bootstrapper version.
    <details>
      <summary>API call</summary>
      <br>

    ```bash
    $ curl http://localhost:8153/go/api/agents -H 'Accept: application/vnd.go.cd.v7+json'
    {
      "_links" : {
        "self" : {
          "href" : "http://localhost:8153/go/api/agents"
        },
        "doc" : {
          "href" : "https://api.gocd.org/20.5.0/#agents"
        }
      },
      "_embedded" : {
        "agents" : [ {
          "_links" : {
            "self" : {
              "href" : "http://localhost:8153/go/api/agents/8e038824-a84a-497c-82c1-31997232ab5b"
            },
            "doc" : {
              "href" : "https://api.gocd.org/20.5.0/#agents"
            },
            "find" : {
              "href" : "http://localhost:8153/go/api/agents/:uuid"
            }
          },
          "uuid" : "8e038824-a84a-497c-82c1-31997232ab5b",
          "hostname" : "localhost",
          "ip_address" : "127.0.0.1",
          "sandbox" : "/path/to/go-agent-20.4.0",
          "operating_system" : "Mac OS X",
          "agent_config_state" : "Enabled",
          "agent_state" : "Idle",
          "agent_version" : "20.5.0-11786",
          "agent_bootstrapper_version" : "UNKNOWN",
          "environments" : [ ],
          "build_state" : "Idle",
          "free_space" : 67213606912,
          "resources" : [ ]
        } ]
      }
    }
    ```

    </details>

- [x] Scenario 4: 20.5.0 server, 20.5.0 agent bootstrapper:
    - 20.5.0 server pushes 20.5.0 launcher and 20.5.0 agent JAR to the 20.5.0 agent bootstrapper.
    - 20.5.0 bootstrapper find its own version and sends it to the 20.5.0 agent it starts.
    - The argument `-Dagent.bootstrapper.version=20.5.0` is sent to the agent when it is invoked.
    - 20.5.0 agents sends its version to the 20.5.0 server.
    - On the server side, Agents API v7 returns `20.5.0` for agent version and `20.5.0` for bootstrapper version.

    <details>
      <summary>API call</summary>
      <br>

    ```bash
    $ curl http://localhost:8153/go/api/agents -H 'Accept: application/vnd.go.cd.v7+json'
    {
      "_links" : {
        "self" : {
          "href" : "http://localhost:8153/go/api/agents"
        },
        "doc" : {
          "href" : "https://api.gocd.org/20.5.0/#agents"
        }
      },
      "_embedded" : {
        "agents" : [ {
          "_links" : {
            "self" : {
              "href" : "http://localhost:8153/go/api/agents/98fbb0d9-eefe-485b-aee2-4bfa71277292"
            },
            "doc" : {
              "href" : "https://api.gocd.org/20.5.0/#agents"
            },
            "find" : {
              "href" : "http://localhost:8153/go/api/agents/:uuid"
            }
          },
          "uuid" : "98fbb0d9-eefe-485b-aee2-4bfa71277292",
          "hostname" : "localhost",
          "ip_address" : "127.0.0.1",
          "sandbox" : "/path/to/go-agent-20.5.0",
          "operating_system" : "Mac OS X",
          "agent_config_state" : "Enabled",
          "agent_state" : "Idle",
          "agent_version" : "20.5.0-11786",
          "agent_bootstrapper_version" : "20.5.0-11786",
          "environments" : [ ],
          "build_state" : "Idle",
          "free_space" : 67382562,
          "resources" : [ ]
        } ]
      }
    }
    ```

    </details>

- [x] Scenario 5: GoCD docker images use a different bootstrapper, which won't know to send this information. Expectation: ~Agent version will show up in API v7, but not bootstrapper version.~ Wrong: It works fine.
    - Checked with docker server and agent both at 20.5.0 and it worked, with the caveat mentioned in [this comment](https://github.com/gocd/gocd/pull/8221#issuecomment-642732419).