### PR TITLE
Update Notification filters api v2 

### DIFF
--- a/api/api-notification-filter-v2/src/main/java/com/thoughtworks/go/apiv2/notificationfilter/representers/NotificationFilterRepresenter.java
+++ b/api/api-notification-filter-v2/src/main/java/com/thoughtworks/go/apiv2/notificationfilter/representers/NotificationFilterRepresenter.java
@@ -63,7 +63,7 @@ public class NotificationFilterRepresenter {
         NotificationFilter filter = new NotificationFilter(reader.getString("pipeline"),
             reader.getString("stage"),
             stageEvent,
-            reader.getBoolean("match_commits")
+            reader.getBooleanOrDefault("match_commits", false)
         );
         filter.setId(reader.optLong("id").orElse(NOT_PERSISTED));
         return filter;

--- a/api/api-notification-filter-v2/src/test/groovy/com/thoughtworks/go/apiv2/notificationfilter/representers/NotificationFilterRepresenterTest.groovy
+++ b/api/api-notification-filter-v2/src/test/groovy/com/thoughtworks/go/apiv2/notificationfilter/representers/NotificationFilterRepresenterTest.groovy
@@ -87,4 +87,22 @@ class NotificationFilterRepresenterTest {
       .isInstanceOf(UnprocessableEntityException)
       .hasMessage("Invalid event 'UnknownEventName'. It has to be one of [Fails, Passes, Breaks, Fixed, Cancelled, All].")
   }
+
+  @Test
+  void 'should deserialize even if match_commits is not present'() {
+    def reader = GsonTransformer.getInstance().jsonReaderFrom([
+      "id"      : 100,
+      "pipeline": "up42",
+      "stage"   : "unit-test",
+      "event"   : "Breaks"
+    ])
+
+    def filter = NotificationFilterRepresenter.fromJSON(reader)
+
+    assertThat(filter.getId()).isEqualTo(100)
+    assertThat(filter.getPipelineName()).isEqualTo("up42")
+    assertThat(filter.getStageName()).isEqualTo("unit-test")
+    assertThat(filter.getEvent()).isEqualTo(StageEvent.Breaks)
+    assertThat(filter.isMyCheckin()).isEqualTo(false)
+  }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/preferences/notification_filters.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/preferences/notification_filters.js
@@ -63,14 +63,14 @@ export function NotificationFilters(apiUrl, errors) {
   const redraw      = () => m.redraw();
 
   function fetchFilters() {
-    req("GET", apiUrl).done((data) => filters(data.filters)).fail(handleError).always(redraw);
+    req("GET", apiUrl).done((data) => filters(data._embedded.filters)).fail(handleError).always(redraw);
   }
 
   function createFilter(e) {
     e.preventDefault();
     errors(null);
 
-    req("POST", apiUrl, serialize(e.currentTarget)).done((data) => filters(data.filters)).fail(handleError).always(redraw);
+    req("POST", apiUrl, serialize(e.currentTarget)).done(fetchFilters).fail(handleError).always(redraw);
   }
 
   function deleteFilter(e) {
@@ -78,7 +78,7 @@ export function NotificationFilters(apiUrl, errors) {
     errors(null);
 
     const id = parseInt(e.currentTarget.getAttribute("data-filter-id"), 10);
-    req("DELETE", `${apiUrl}/${id}`).done((data) => filters(data.filters)).fail(handleError).always(redraw);
+    req("DELETE", `${apiUrl}/${id}`).done(fetchFilters).fail(handleError).always(redraw);
   }
 
   function reset() {


### PR DESCRIPTION
Issue: #8220

Description:
 - set a default value to `match_commits` as `false`. This is inline with our api docs which does not mention `MUST be provided` for this attribute.
 - updated the preferences page to respond to response data wrt v2 api

#### TODO
 - [ ] Add functional specs for preferences page