### PR TITLE
Adding stringtype JDBC connection property for postgres #000

### DIFF
--- a/db-support/db-support-base/src/main/java/com/thoughtworks/go/server/database/DbProperties.java
+++ b/db-support/db-support-base/src/main/java/com/thoughtworks/go/server/database/DbProperties.java
@@ -66,7 +66,15 @@ public class DbProperties {
                 connectionProperties.put(key.replace(DB_CONNECTION_PROPERTIES_PREFIX, ""), properties.getProperty(key));
             }
         }
+        if (isPostgres(this.url)) {
+            connectionProperties.put("stringtype", "unspecified");
+        }
+
         return this;
+    }
+
+    private boolean isPostgres(String url) {
+        return isNotBlank(url) && url.startsWith("jdbc:postgresql:");
     }
 
     private String findPassword(Properties properties, Function<String, String> decrypter) {


### PR DESCRIPTION
* For case-insensitive coloumns we use citext in postgres.
  While citext allowed case-insensitive queries in db, it looks
  like JDBC casts String parameter to varchar and forcing
  a case-sensitive search. To change this behaviour the 'stringtype'
  connection property has to be set to 'unspecified'.
* These changes are in sync with the postgres addon.


