### PR TITLE
Fix rule circumvention issue that allows partials to be merged even if rules are violated

### DIFF
--- a/api/api-config-repo-operations-v1/src/main/java/com/thoughtworks/go/apiv1/configrepooperations/ConfigRepoOperationsControllerV1.java
+++ b/api/api-config-repo-operations-v1/src/main/java/com/thoughtworks/go/apiv1/configrepooperations/ConfigRepoOperationsControllerV1.java
@@ -123,7 +123,7 @@ public class ConfigRepoOperationsControllerV1 extends ApiController implements S
             } else {
                 PartialConfig partialConfig = plugin.parseContent(contents, context);
                 partialConfig.setOrigins(adHocConfigOrigin(repo));
-                CruiseConfig config = partialConfigService.merge(partialConfig, context.configMaterial().getFingerprint(), gcs.clonedConfigForEdit(), repo);
+                CruiseConfig config = partialConfigService.merge(partialConfig, context.configMaterial().getFingerprint(), gcs.clonedConfigForEdit());
 
                 gcs.validateCruiseConfig(config);
                 result.update(Collections.emptyList(), true);

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/PartialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/PartialConfig.java
@@ -17,37 +17,55 @@ package com.thoughtworks.go.config.remote;
 
 
 import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
 import com.thoughtworks.go.config.preprocessor.SkipParameterResolution;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.PipelineGroups;
 import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.domain.scm.SCMs;
+import lombok.EqualsAndHashCode;
+
+import static com.thoughtworks.go.config.exceptions.EntityType.*;
+import static com.thoughtworks.go.config.rules.SupportedEntity.*;
 
 /**
- * Part of cruise configuration that can be stored outside of main cruise-config.xml.
- * It can be merged with others and main configuration.
+ * A config fragment that can be conceptually thought of as an external snippet of
+ * cruise-config.xml that can be merged into the main cruise-config.xml configuration.
+ * <p>
+ * More accurately, this is essentially a subtree of configuration domain objects, and
+ * not actual XML. A {@link PartialConfig} is typically the parsed and deserialized
+ * and parsed output of a {@link ConfigRepoConfig}'s definition files, which are written
+ * in whatever the specified language or syntax declared its associated plugin.
  */
 @ConfigTag("cruise")
+@EqualsAndHashCode
 public class PartialConfig implements Validatable, ConfigOriginTraceable {
-    // consider to include source of this part.
+    @ConfigSubtag(label = "groups")
+    private PipelineGroups pipelines = new PipelineGroups();
 
-    @ConfigSubtag(label = "groups") private PipelineGroups pipelines = new PipelineGroups();
-    @ConfigSubtag @SkipParameterResolution private EnvironmentsConfig environments = new EnvironmentsConfig();
-    @ConfigSubtag(label = "scms") private SCMs scms = new SCMs();
+    @ConfigSubtag
+    @SkipParameterResolution
+    private EnvironmentsConfig environments = new EnvironmentsConfig();
+
+    @ConfigSubtag(label = "scms")
+    private SCMs scms = new SCMs();
 
     private ConfigOrigin origin;
+    private final ConfigErrors errors = new ConfigErrors();
 
-    public PartialConfig(){
+    public PartialConfig() {
     }
-    public PartialConfig(PipelineGroups pipelines){
+
+    public PartialConfig(PipelineGroups pipelines) {
         this.pipelines = pipelines;
     }
-    public PartialConfig(EnvironmentsConfig environments,PipelineGroups pipelines){
+
+    public PartialConfig(EnvironmentsConfig environments, PipelineGroups pipelines) {
         this.environments = environments;
         this.pipelines = pipelines;
     }
 
-    public PartialConfig(EnvironmentsConfig environments,PipelineGroups pipelines, SCMs scms){
+    public PartialConfig(EnvironmentsConfig environments, PipelineGroups pipelines, SCMs scms) {
         this.environments = environments;
         this.pipelines = pipelines;
         this.scms = scms;
@@ -55,49 +73,74 @@ public class PartialConfig implements Validatable, ConfigOriginTraceable {
 
     @Override
     public String toString() {
-        return String.format("ConfigPartial: %s pipes, %s environments, %s scms; From %s",pipelines.size(),environments.size(), scms.size(),origin);
+        return String.format("ConfigPartial: %s pipes, %s environments, %s scms; From %s", pipelines.size(), environments.size(), scms.size(), origin);
     }
 
     @Override
     public void validate(ValidationContext validationContext) {
+        validatePermissionsOnSubtree();
+    }
 
+    public void validatePermissionsOnSubtree() {
+        errors.clear();
+
+        final ConfigRepoConfig repo = configRepoConfig();
+
+        if (null == repo) {
+            return;
+        }
+
+        getEnvironments().stream()
+                .filter(env -> !repo.canRefer(ENVIRONMENT, env.name()))
+                .forEach(this::addViolationOnForbiddenEnvironment);
+
+        getGroups().stream()
+                .filter(group -> !repo.canRefer(PIPELINE_GROUP, group.getGroup()))
+                .forEach(this::addViolationOnForbiddenPipelineGroup);
+
+        getGroups().forEach(g -> g.forEach(p -> p.dependencyMaterialConfigs().stream().
+                filter(this::upstreamPipelineNotDefinedInPartial).
+                filter(d -> !repo.canRefer(PIPELINE, d.getPipelineName())).
+                forEach(this::addViolationOnForbiddenPipeline)));
+
+        ErrorCollector.getAllErrors(this).forEach(this.errors::addAll);
+    }
+
+    public boolean hasErrors() {
+        return errors().present();
     }
 
     @Override
     public ConfigErrors errors() {
-        return new ConfigErrors();
+        return errors;
     }
 
     @Override
     public void addError(String fieldName, String message) {
-
+        errors.add(fieldName, message);
     }
-
 
     @Override
     public ConfigOrigin getOrigin() {
         return origin;
     }
 
+    public void setOrigin(ConfigOrigin origin) {
+        this.origin = origin;
+    }
+
     @Override
     public void setOrigins(ConfigOrigin origins) {
         this.origin = origins;
-        for(EnvironmentConfig env : this.environments)
-        {
+        for (EnvironmentConfig env : this.environments) {
             env.setOrigins(origins);
         }
-        for(PipelineConfigs pipes : this.pipelines)
-        {
+        for (PipelineConfigs pipes : this.pipelines) {
             pipes.setOrigins(origins);
         }
-        for(SCM scm: this.scms)
-        {
-           scm.setOrigins(origins);
+        for (SCM scm : this.scms) {
+            scm.setOrigins(origins);
         }
-    }
-
-    public void setOrigin(ConfigOrigin origin) {
-        this.origin = origin;
     }
 
     public EnvironmentsConfig getEnvironments() {
@@ -116,39 +159,37 @@ public class PartialConfig implements Validatable, ConfigOriginTraceable {
         this.pipelines = pipelines;
     }
 
-    /**
-     * Validate this part within its own scope.
-     */
-    public void validatePart() {
-
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        PartialConfig that = (PartialConfig) o;
-
-        if (!pipelines.equals(that.pipelines)) return false;
-        if (!getEnvironments().equals(that.getEnvironments())) return false;
-        return getOrigin() != null ? getOrigin().equals(that.getOrigin()) : that.getOrigin() == null;
-
-    }
-
-    @Override
-    public int hashCode() {
-        int result = pipelines.hashCode();
-        result = 31 * result + getEnvironments().hashCode();
-        result = 31 * result + (getOrigin() != null ? getOrigin().hashCode() : 0);
-        return result;
-    }
-
     public SCMs getScms() {
         return scms;
     }
 
     public void setScms(SCMs scms) {
         this.scms = scms;
+    }
+
+    private boolean upstreamPipelineNotDefinedInPartial(DependencyMaterialConfig dependency) {
+        return getGroups().stream().allMatch(group -> group.findBy(dependency.getPipelineName()) == null);
+    }
+
+    private void addViolationOnForbiddenPipelineGroup(PipelineConfigs forbidden) {
+        forbidden.addError(PIPELINE_GROUP.getType(), PipelineGroup.notAllowedToRefer(forbidden.getGroup()));
+    }
+
+    private void addViolationOnForbiddenPipeline(DependencyMaterialConfig forbidden) {
+        forbidden.addError(PIPELINE.getType(), Pipeline.notAllowedToRefer(forbidden.getPipelineName()));
+    }
+
+    private void addViolationOnForbiddenEnvironment(EnvironmentConfig forbidden) {
+        forbidden.addError(ENVIRONMENT.getType(), Environment.notAllowedToRefer(forbidden.name()));
+    }
+
+    private ConfigRepoConfig configRepoConfig() {
+        final ConfigOrigin origin = getOrigin();
+
+        if (origin instanceof RepoConfigOrigin) {
+            return ((RepoConfigOrigin) origin).getConfigRepo();
+        } else {
+            return null;
+        }
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/rules/Rules.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/rules/Rules.java
@@ -43,7 +43,7 @@ public class Rules extends BaseCollection<Directive> implements Validatable {
     }
 
     public void validateTree(ValidationContext validationContext) {
-        stream().forEach(directive -> directive.validate(validationContext));
+        this.forEach(directive -> directive.validate(validationContext));
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/rules/RulesAware.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/rules/RulesAware.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.config.rules;
 
+import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.Validatable;
 
 import java.util.List;
@@ -25,6 +26,15 @@ public interface RulesAware {
     List<String> allowedTypes();
 
     Rules getRules();
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    default boolean canRefer(SupportedEntity supportedEntity, CaseInsensitiveString resource) {
+        return canRefer(supportedEntity, resource.toString());
+    }
+
+    default boolean canRefer(SupportedEntity supportedEntity, String resource) {
+        return canRefer(supportedEntity.getEntityType(), resource);
+    }
 
     default boolean canRefer(Class<? extends Validatable> entityType, String resource) {
         Rules rules = getRules();

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/EnvironmentVariableConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/EnvironmentVariableConfigTest.java
@@ -253,7 +253,8 @@ class EnvironmentVariableConfigTest {
             PipelineConfigs group = mock(BasicPipelineConfigs.class);
 
             when(secretConfig.getId()).thenReturn("secret_config_id");
-            when(secretConfig.canRefer(any(), any())).thenReturn(true);
+            //noinspection unchecked
+            when(secretConfig.canRefer(any(Class.class), any(String.class))).thenReturn(true);
             when(validationContext.getCruiseConfig()).thenReturn(cruiseConfig);
             when(validationContext.isWithinPipelines()).thenReturn(true);
             when(validationContext.getPipelineGroup()).thenReturn(group);

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/remote/PartialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/remote/PartialConfigTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.remote;
+
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.materials.MaterialConfigs;
+import com.thoughtworks.go.config.rules.Allow;
+import com.thoughtworks.go.domain.PipelineGroups;
+import com.thoughtworks.go.helper.PipelineConfigMother;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.thoughtworks.go.helper.MaterialConfigsMother.dependencyMaterialConfig;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PartialConfigTest {
+    private PartialConfig partial;
+    private ConfigRepoConfig configRepo;
+
+    @BeforeEach
+    void setUp() {
+        partial = new PartialConfig();
+        configRepo = new ConfigRepoConfig();
+        partial.setOrigin(new RepoConfigOrigin(configRepo, "123"));
+    }
+
+    @Test
+    void validatePermissionsOnSubtreeFailsWhenNoRulesPresent() {
+        BasicPipelineConfigs group = new BasicPipelineConfigs("first", new Authorization());
+        group.add(PipelineConfigMother.pipelineConfig("up42"));
+        partial.setPipelines(new PipelineGroups(group));
+        partial.setOrigins(partial.getOrigin());
+
+        partial.validatePermissionsOnSubtree();
+
+        assertTrue(partial.hasErrors());
+        assertEquals(1, partial.errors().size());
+        assertEquals("Not allowed to refer to pipeline group 'first'. Check the 'Rules' of this config repository.", partial.errors().on("pipeline_group"));
+    }
+
+    @Test
+    void validatePermissionsOnSubtreeFailsWhenNoRuleMatchesGroups() {
+        configRepo.getRules().add(new Allow("refer", "pipeline_group", "team1"));
+
+        BasicPipelineConfigs team1 = new BasicPipelineConfigs("team1", new Authorization());
+        BasicPipelineConfigs first = new BasicPipelineConfigs("first", new Authorization());
+        first.add(PipelineConfigMother.pipelineConfig("up42"));
+        partial.setPipelines(new PipelineGroups(first, team1));
+        partial.setOrigins(partial.getOrigin());
+
+        partial.validatePermissionsOnSubtree();
+
+        assertTrue(partial.hasErrors());
+        assertEquals(1, partial.errors().size());
+        assertEquals("Not allowed to refer to pipeline group 'first'. Check the 'Rules' of this config repository.", partial.errors().on("pipeline_group"));
+    }
+
+    @Test
+    void validatePermissionsOnSubtreeFailsWhenNoRuleMatchesEnvironments() {
+        configRepo.getRules().add(new Allow("refer", "environment", "prod"));
+
+        EnvironmentsConfig allEnvs = new EnvironmentsConfig();
+        CaseInsensitiveString prodEnv = new CaseInsensitiveString("prod");
+        CaseInsensitiveString uatEnv = new CaseInsensitiveString("uat");
+        allEnvs.add(new BasicEnvironmentConfig(uatEnv));
+        allEnvs.add(new BasicEnvironmentConfig(prodEnv));
+        partial.setEnvironments(allEnvs);
+        partial.setOrigins(partial.getOrigin());
+
+        partial.validatePermissionsOnSubtree();
+
+        assertTrue(partial.hasErrors());
+        assertEquals(1, partial.errors().size());
+
+        assertEquals("Not allowed to refer to environment 'uat'. Check the 'Rules' of this config repository.", partial.errors().on("environment"));
+    }
+
+    @Test
+    void validatePermissionsOnSubtreeFailsWhenNoRuleMatchesUpstreamDependency() {
+        configRepo.getRules().add(new Allow("refer", "pipeline_group", "*"));
+        configRepo.getRules().add(new Allow("refer", "pipeline", "build"));
+
+        BasicPipelineConfigs group = new BasicPipelineConfigs("first", new Authorization());
+        group.add(PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs(dependencyMaterialConfig("build", "stage"), dependencyMaterialConfig("deploy", "stage"))));
+        partial.setPipelines(new PipelineGroups(group));
+        partial.setOrigins(partial.getOrigin());
+
+        partial.validatePermissionsOnSubtree();
+
+        assertTrue(partial.hasErrors());
+        assertEquals(1, partial.errors().size());
+        assertEquals("Not allowed to refer to pipeline 'deploy'. Check the 'Rules' of this config repository.", partial.errors().on("pipeline"));
+    }
+
+    @Test
+    @DisplayName("validatePermissionsOnSubtree() succeeds when preflighting ConfigRepos that do not yet exist")
+    void validatePermissionsOnSubtreeSucceedsWhenNoConfigRepositoryIsSpecified() {
+        BasicPipelineConfigs group = new BasicPipelineConfigs("first", new Authorization());
+        group.add(PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs(dependencyMaterialConfig("build", "stage"), dependencyMaterialConfig("deploy", "stage"))));
+        partial.setPipelines(new PipelineGroups(group));
+        partial.setOrigins(null);
+
+        partial.validatePermissionsOnSubtree();
+
+        assertFalse(partial.hasErrors());
+    }
+
+    @Test
+    void shouldAllowToDefineUpstreamDependencyFromTheSameConfigRepositoryRegardlessOfRules() {
+        configRepo.getRules().add(new Allow("refer", "pipeline_group", "*"));
+        configRepo.getRules().add(new Allow("refer", "pipeline", "build"));
+
+        BasicPipelineConfigs group = new BasicPipelineConfigs("first", new Authorization());
+        group.add(PipelineConfigMother.pipelineConfig("upstream", new MaterialConfigs(dependencyMaterialConfig("build", "stage"))));
+        group.add(PipelineConfigMother.pipelineConfig("downstream", new MaterialConfigs(dependencyMaterialConfig("upstream", "stage"))));
+        partial.setPipelines(new PipelineGroups(group));
+        partial.setOrigins(partial.getOrigin());
+
+        partial.validatePermissionsOnSubtree();
+
+        assertFalse(partial.hasErrors());
+    }
+}

--- a/config/config-server/src/main/java/com/thoughtworks/go/config/parts/XmlPartialConfigProvider.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/config/parts/XmlPartialConfigProvider.java
@@ -20,8 +20,8 @@ import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.domain.WildcardScanner;
 import com.thoughtworks.go.domain.config.Configuration;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
-import org.slf4j.Logger;
 import org.jdom2.input.JDOMParseException;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
@@ -35,7 +35,7 @@ public class XmlPartialConfigProvider implements PartialConfigProvider {
 
     private final String defaultPattern = "**/*.gocd.xml";
 
-    private MagicalGoConfigXmlLoader loader;
+    private final MagicalGoConfigXmlLoader loader;
 
     public XmlPartialConfigProvider(MagicalGoConfigXmlLoader loader) {
         this.loader = loader;
@@ -52,8 +52,6 @@ public class XmlPartialConfigProvider implements PartialConfigProvider {
         PartialConfig partialConfig = new PartialConfig();
 
         collectFragments(allFragments, partialConfig);
-
-        partialConfig.validatePart();
 
         return partialConfig;
     }

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
@@ -95,7 +95,6 @@ public class ConfigReposMaterialParseResultManager {
 
             if (!serverHealthErrors.isEmpty() || !result.isSuccessful()) {
                 result.setLatestParsedModification(null); // clear modification to allow a reparse to happen
-                serverHealthService.removeByScope(scope); // clear errors until next reparse
             }
         }
     }

--- a/server/src/main/java/com/thoughtworks/go/config/PartialConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/config/PartialConfigService.java
@@ -107,19 +107,19 @@ public class PartialConfigService implements PartialConfigUpdateCompletedListene
         }
     }
 
-    public CruiseConfig merge(PartialConfig partialConfig, String fingerprint, CruiseConfig cruiseConfig, ConfigRepoConfig repoConfig) {
-        PartialConfigUpdateCommand command = buildUpdateCommand(partialConfig, fingerprint, repoConfig);
+    public CruiseConfig merge(PartialConfig partialConfig, String fingerprint, CruiseConfig cruiseConfig) {
+        PartialConfigUpdateCommand command = buildUpdateCommand(partialConfig, fingerprint);
         command.update(cruiseConfig);
         return cruiseConfig;
     }
 
-    public PartialConfigUpdateCommand buildUpdateCommand(final PartialConfig partial, final String fingerprint, ConfigRepoConfig configRepoConfig) {
+    protected PartialConfigUpdateCommand buildUpdateCommand(final PartialConfig partial, final String fingerprint) {
         return new PartialConfigUpdateCommand(partial, fingerprint, cachedGoPartials);
     }
 
     private boolean updateConfig(final PartialConfig newPart, final String fingerprint, ConfigRepoConfig repoConfig) {
         try {
-            goConfigService.updateConfig(buildUpdateCommand(newPart, fingerprint, repoConfig));
+            goConfigService.updateConfig(buildUpdateCommand(newPart, fingerprint));
             return true;
         } catch (Exception e) {
             if (repoConfig != null) {

--- a/server/src/main/java/com/thoughtworks/go/config/PartialConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/config/PartialConfigService.java
@@ -69,6 +69,7 @@ public class PartialConfigService implements PartialConfigUpdateCompletedListene
 
         if (this.configWatchList.hasConfigRepoWithFingerprint(fingerprint)) {
             if (shouldMergePartial(incoming, fingerprint, repoConfig)) {
+                incoming.validatePermissionsOnSubtree();
                 cachedGoPartials.cacheAsLastKnown(fingerprint, incoming);
 
                 if (updateConfig(incoming, fingerprint, repoConfig)) {
@@ -102,7 +103,7 @@ public class PartialConfigService implements PartialConfigUpdateCompletedListene
     }
 
     public PartialConfigUpdateCommand buildUpdateCommand(final PartialConfig partial, final String fingerprint, ConfigRepoConfig configRepoConfig) {
-        return new PartialConfigUpdateCommand(partial, fingerprint, cachedGoPartials, configRepoConfig);
+        return new PartialConfigUpdateCommand(partial, fingerprint, cachedGoPartials);
     }
 
     private boolean updateConfig(final PartialConfig newPart, final String fingerprint, ConfigRepoConfig repoConfig) {

--- a/server/src/main/java/com/thoughtworks/go/config/PartialConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/config/PartialConfigService.java
@@ -69,11 +69,22 @@ public class PartialConfigService implements PartialConfigUpdateCompletedListene
 
         if (this.configWatchList.hasConfigRepoWithFingerprint(fingerprint)) {
             if (shouldMergePartial(incoming, fingerprint, repoConfig)) {
-                incoming.validatePermissionsOnSubtree();
+                // validate rules before attempting updateConfig() so that
+                // rule violations will be considered before accepting a merge;
+                // updateConfig() only considers structural validity.
+                final boolean violatesRules = hasRuleViolations(incoming);
+
                 cachedGoPartials.cacheAsLastKnown(fingerprint, incoming);
 
                 if (updateConfig(incoming, fingerprint, repoConfig)) {
                     cachedGoPartials.markAsValid(fingerprint, incoming);
+                } else {
+                    final PartialConfig previousValidPartial = cachedGoPartials.getValid(repoConfig.getRepo().getFingerprint());
+
+                    if (violatesRules && hasRuleViolations(previousValidPartial)) {
+                        // do not allow fallback to the last version of the partial if the current rules do not allow
+                        cachedGoPartials.removeValid(repoConfig.getRepo().getFingerprint());
+                    }
                 }
             }
         }
@@ -136,5 +147,14 @@ public class PartialConfigService implements PartialConfigUpdateCompletedListene
         final PartialConfig previous = cachedGoPartials.getKnown(fingerprint);
 
         return !partialConfigHelper.isEquivalent(previous, partial);
+    }
+
+    private boolean hasRuleViolations(PartialConfig partial) {
+        if (null == partial) {
+            return false;
+        }
+
+        partial.validatePermissionsOnSubtree();
+        return partial.hasErrors();
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/PartialConfigUpdateCompletedListener.java
+++ b/server/src/main/java/com/thoughtworks/go/config/PartialConfigUpdateCompletedListener.java
@@ -24,5 +24,4 @@ public interface PartialConfigUpdateCompletedListener {
 
     void onSuccessPartialConfig(ConfigRepoConfig repoConfig, PartialConfig newPart);
 
-
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommand.java
@@ -16,17 +16,8 @@
 package com.thoughtworks.go.config.update;
 
 import com.rits.cloning.Cloner;
-import com.thoughtworks.go.config.ErrorCollector;
 import com.thoughtworks.go.config.*;
-import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
-import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.PartialConfig;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.thoughtworks.go.config.exceptions.EntityType.*;
-import static com.thoughtworks.go.config.rules.SupportedEntity.*;
 
 public class PartialConfigUpdateCommand implements UpdateConfigCommand {
     private static final Cloner CLONER = new Cloner();
@@ -34,13 +25,11 @@ public class PartialConfigUpdateCommand implements UpdateConfigCommand {
     private final PartialConfig partial;
     private final String fingerprint;
     private final PartialConfigResolver resolver;
-    private final ConfigRepoConfig configRepoConfig;
 
-    public PartialConfigUpdateCommand(final PartialConfig partial, final String fingerprint, PartialConfigResolver resolver, ConfigRepoConfig configRepoConfig) {
+    public PartialConfigUpdateCommand(final PartialConfig partial, final String fingerprint, PartialConfigResolver resolver) {
         this.partial = partial;
         this.fingerprint = fingerprint;
         this.resolver = resolver;
-        this.configRepoConfig = configRepoConfig;
     }
 
     @Override
@@ -55,7 +44,7 @@ public class PartialConfigUpdateCommand implements UpdateConfigCommand {
             PartialConfig cloned = CLONER.deepClone(partial);
             cruiseConfig.getPartials().add(cloned);
 
-            if (!validateEntityForRules(cloned)) {
+            if (cloned.hasErrors()) {
                 return cruiseConfig;
             }
 
@@ -73,41 +62,5 @@ public class PartialConfigUpdateCommand implements UpdateConfigCommand {
             }
         }
         return cruiseConfig;
-    }
-
-    private boolean validateEntityForRules(PartialConfig partialConfig) {
-        //preflight check
-        if (configRepoConfig == null) {
-            return true;
-        }
-
-        partialConfig.getEnvironments().stream()
-                .filter(env -> !configRepoConfig.canRefer(ENVIRONMENT.getEntityType(), env.name().toString()))
-                .forEach(envThatCanNotBeReferred -> {
-                    envThatCanNotBeReferred.addError(ENVIRONMENT.getType(), Environment.notAllowedToRefer(envThatCanNotBeReferred.name()));
-                });
-
-        partialConfig.getGroups().stream()
-                .filter(pipelineGrp -> !configRepoConfig.canRefer(PIPELINE_GROUP.getEntityType(), pipelineGrp.getGroup()))
-                .forEach(pipelineGrpThatCannotBeReferred -> {
-                    pipelineGrpThatCannotBeReferred.addError(PIPELINE_GROUP.getType(), PipelineGroup.notAllowedToRefer(pipelineGrpThatCannotBeReferred.getGroup()));
-                });
-
-        List<DependencyMaterialConfig> dependencyMaterialConfigs = new ArrayList<>();
-        partialConfig.getGroups().forEach((pipelineGrp) -> {
-            pipelineGrp.forEach((pipelineConfig) -> dependencyMaterialConfigs.addAll(pipelineConfig.dependencyMaterialConfigs()));
-        });
-        dependencyMaterialConfigs.stream()
-                .filter(dependencyMaterialConfig -> !doesPipelineExistInPartialConfig(partialConfig, dependencyMaterialConfig.getPipelineName()))
-                .filter(dependencyMaterialConfig -> !configRepoConfig.canRefer(PIPELINE.getEntityType(), dependencyMaterialConfig.getPipelineName().toString()))
-                .forEach(dependencyMaterialConfigThatCannotBeReferred -> {
-                    dependencyMaterialConfigThatCannotBeReferred.addError(PIPELINE.getType(), Pipeline.notAllowedToRefer(dependencyMaterialConfigThatCannotBeReferred.getPipelineName()));
-                });
-
-        return ErrorCollector.getAllErrors(partialConfig).isEmpty();
-    }
-
-    private boolean doesPipelineExistInPartialConfig(PartialConfig partialConfig, CaseInsensitiveString pipelineName) {
-        return partialConfig.getGroups().stream().anyMatch(group -> group.findBy(pipelineName) != null);
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
@@ -42,7 +42,7 @@ import java.util.Collections;
 
 import static com.thoughtworks.go.config.ConfigReposMaterialParseResultManager.ConfigRepoReparseListener;
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -74,20 +74,19 @@ class ConfigReposMaterialParseResultManagerTest {
 
         when(serverHealthService.filterByScope(scope)).thenReturn(Collections.singletonList(error));
 
-
         Modification modification = modificationFor("rev1");
         manager.parseFailed(fingerprint, modification, new Exception());
 
         PartialConfigParseResult result = manager.get(fingerprint);
 
-        assertThat(result).isNotNull();
-        assertThat(result.isSuccessful()).isFalse();
-        assertThat(result.getLatestParsedModification()).isNotNull();
-        assertThat(modification).isEqualTo(result.getLatestParsedModification());
+        assertNotNull(result);
+        assertFalse(result.isSuccessful());
+        assertNotNull(result.getLatestParsedModification());
+        assertEquals(result.getLatestParsedModification(), modification);
 
         manager.markFailedResultsForReparse();
-        assertThat(result.getLatestParsedModification()).isNull();
-        verify(serverHealthService, times(1)).removeByScope(scope);
+        assertNull(result.getLatestParsedModification());
+        verify(serverHealthService, never()).removeByScope(scope);
     }
 
     @Test
@@ -101,8 +100,8 @@ class ConfigReposMaterialParseResultManagerTest {
 
         PartialConfigParseResult expectedParseResult = PartialConfigParseResult.parseSuccess(modification, partialConfig);
 
-        assertThat(manager.get(fingerprint)).isEqualTo(expectedParseResult);
-        assertThat(manager.get(fingerprint).isSuccessful()).isTrue();
+        assertEquals(expectedParseResult, manager.get(fingerprint));
+        assertTrue(manager.get(fingerprint).isSuccessful());
     }
 
     @Test
@@ -118,8 +117,8 @@ class ConfigReposMaterialParseResultManagerTest {
 
         String expectedBeautifiedMessage = String.format("%s\n%s", serverHealthState.getMessage().toUpperCase(), serverHealthState.getDescription());
 
-        assertThat(manager.get(fingerprint).isSuccessful()).isFalse();
-        assertThat(manager.get(fingerprint).getLastFailure().getMessage()).isEqualTo(expectedBeautifiedMessage);
+        assertFalse(manager.get(fingerprint).isSuccessful());
+        assertEquals(expectedBeautifiedMessage, manager.get(fingerprint).getLastFailure().getMessage());
     }
 
     @Test
@@ -133,9 +132,9 @@ class ConfigReposMaterialParseResultManagerTest {
         PartialConfig partialConfig = new PartialConfig();
         manager.parseSuccess(fingerprint, modification, partialConfig);
 
-        assertThat(manager.get(fingerprint).isSuccessful()).isFalse();
-        assertThat(manager.get(fingerprint).getGoodModification()).isNull();
-        assertThat(manager.get(fingerprint).lastGoodPartialConfig()).isNull();
+        assertFalse(manager.get(fingerprint).isSuccessful());
+        assertNull(manager.get(fingerprint).getGoodModification());
+        assertNull(manager.get(fingerprint).lastGoodPartialConfig());
     }
 
     @Test
@@ -144,11 +143,10 @@ class ConfigReposMaterialParseResultManagerTest {
         when(serverHealthService.filterByScope(any())).thenReturn(Arrays.asList(serverHealthState));
         String fingerprint = "repo1";
 
-
         String expectedBeautifiedMessage = String.format("%s\n%s", serverHealthState.getMessage().toUpperCase(), serverHealthState.getDescription());
 
-        assertThat(manager.get(fingerprint).isSuccessful()).isFalse();
-        assertThat(manager.get(fingerprint).getLastFailure().getMessage()).isEqualTo(expectedBeautifiedMessage);
+        assertFalse(manager.get(fingerprint).isSuccessful());
+        assertEquals(expectedBeautifiedMessage, manager.get(fingerprint).getLastFailure().getMessage());
     }
 
     @Test
@@ -157,11 +155,10 @@ class ConfigReposMaterialParseResultManagerTest {
         when(serverHealthService.filterByScope(any())).thenReturn(Arrays.asList(serverHealthState));
         String fingerprint = "repo1";
 
-
-        assertThat(manager.get(fingerprint).isSuccessful()).isFalse();
-        assertThat(manager.get(fingerprint).getGoodModification()).isNull();
-        assertThat(manager.get(fingerprint).getLatestParsedModification()).isNull();
-        assertThat(manager.get(fingerprint).lastGoodPartialConfig()).isNull();
+        assertFalse(manager.get(fingerprint).isSuccessful());
+        assertNull(manager.get(fingerprint).getGoodModification());
+        assertNull(manager.get(fingerprint).getLatestParsedModification());
+        assertNull(manager.get(fingerprint).lastGoodPartialConfig());
     }
 
     @Test
@@ -175,22 +172,20 @@ class ConfigReposMaterialParseResultManagerTest {
 
         PartialConfigParseResult expectedParseResult = PartialConfigParseResult.parseFailed(modification, exception);
 
-        assertThat(manager.get(fingerprint)).isEqualTo(expectedParseResult);
-        assertThat(manager.get(fingerprint).isSuccessful()).isFalse();
+        assertEquals(expectedParseResult, manager.get(fingerprint));
+        assertFalse(manager.get(fingerprint).isSuccessful());
     }
 
     @Test
     void shouldReturnNullIfManagerDoesNotContainResultForProvidedConfigRepoMaterialFingerprint() {
         String fingerprint = "repo1";
 
-
-        assertThat(manager.get(fingerprint)).isNull();
+        assertNull(manager.get(fingerprint));
     }
 
     @Test
     void shouldUpdateTheResultForAConfigRepoMaterialIfResultAlreadyExists_WhenMaterialParseFails() {
         String fingerprint = "repo1";
-
 
         Modification modification = modificationFor("rev1");
         PartialConfig partialConfig = new PartialConfig();
@@ -198,27 +193,25 @@ class ConfigReposMaterialParseResultManagerTest {
 
         PartialConfigParseResult expectedParseResult = PartialConfigParseResult.parseSuccess(modification, partialConfig);
 
-        assertThat(manager.get(fingerprint)).isEqualTo(expectedParseResult);
-        assertThat(manager.get(fingerprint).isSuccessful()).isTrue();
+        assertEquals(expectedParseResult, manager.get(fingerprint));
+        assertTrue(manager.get(fingerprint).isSuccessful());
 
         Modification modification2 = modificationFor("rev2");
         Exception exception = new Exception("Boom!");
         manager.parseFailed(fingerprint, modification2, exception);
 
-
         PartialConfigParseResult parseResult = manager.get(fingerprint);
 
-        assertThat(parseResult.isSuccessful()).isFalse();
-        assertThat(parseResult.getLatestParsedModification()).isEqualTo(modification2);
-        assertThat(parseResult.getGoodModification()).isEqualTo(modification);
-        assertThat(parseResult.lastGoodPartialConfig()).isEqualTo(partialConfig);
-        assertThat(parseResult.getLastFailure()).isEqualTo(exception);
+        assertFalse(parseResult.isSuccessful());
+        assertEquals(modification2, parseResult.getLatestParsedModification());
+        assertEquals(modification, parseResult.getGoodModification());
+        assertEquals(partialConfig, parseResult.lastGoodPartialConfig());
+        assertEquals(exception, parseResult.getLastFailure());
     }
 
     @Test
     void shouldUpdateTheResultForAConfigRepoMaterialIfResultAlreadyExists_WhenMaterialParseIsFixed() {
         String fingerprint = "repo1";
-
 
         Modification modification = modificationFor("rev1");
         Exception exception = new Exception("Boom!");
@@ -226,8 +219,8 @@ class ConfigReposMaterialParseResultManagerTest {
 
         PartialConfigParseResult expectedParseResult = PartialConfigParseResult.parseFailed(modification, exception);
 
-        assertThat(manager.get(fingerprint)).isEqualTo(expectedParseResult);
-        assertThat(manager.get(fingerprint).isSuccessful()).isFalse();
+        assertEquals(expectedParseResult, manager.get(fingerprint));
+        assertFalse(manager.get(fingerprint).isSuccessful());
 
         Modification modification2 = modificationFor("rev2");
         PartialConfig partialConfig = new PartialConfig();
@@ -235,11 +228,11 @@ class ConfigReposMaterialParseResultManagerTest {
 
         PartialConfigParseResult parseResult = manager.get(fingerprint);
 
-        assertThat(parseResult.isSuccessful()).isTrue();
-        assertThat(parseResult.getLatestParsedModification()).isEqualTo(modification2);
-        assertThat(parseResult.getGoodModification()).isEqualTo(modification2);
-        assertThat(parseResult.lastGoodPartialConfig()).isEqualTo(partialConfig);
-        assertThat(parseResult.getLastFailure()).isNull();
+        assertTrue(parseResult.isSuccessful());
+        assertEquals(modification2, parseResult.getLatestParsedModification());
+        assertEquals(modification2, parseResult.getGoodModification());
+        assertEquals(partialConfig, parseResult.lastGoodPartialConfig());
+        assertNull(parseResult.getLastFailure());
     }
 
     @Test
@@ -250,7 +243,7 @@ class ConfigReposMaterialParseResultManagerTest {
 
         final ArgumentCaptor<ConfigChangedListener> listenerArgumentCaptor = ArgumentCaptor.forClass(ConfigChangedListener.class);
         verify(goConfigService).register(listenerArgumentCaptor.capture());
-        assertThat(listenerArgumentCaptor.getValue()).isInstanceOf(ConfigRepoReparseListener.class);
+        assertTrue(listenerArgumentCaptor.getValue() instanceof ConfigRepoReparseListener);
     }
 
     @Nested
@@ -261,7 +254,7 @@ class ConfigReposMaterialParseResultManagerTest {
             final ConfigReposMaterialParseResultManager manager = mock(ConfigReposMaterialParseResultManager.class);
             final ConfigRepoReparseListener configRepoReparseListener = new ConfigRepoReparseListener(manager);
 
-            assertThat(configRepoReparseListener.shouldCareAbout(mock(configClassToCareAbout))).isTrue();
+            assertTrue(configRepoReparseListener.shouldCareAbout(mock(configClassToCareAbout)));
         }
 
         @ParameterizedTest
@@ -270,7 +263,7 @@ class ConfigReposMaterialParseResultManagerTest {
             final ConfigReposMaterialParseResultManager manager = mock(ConfigReposMaterialParseResultManager.class);
             final ConfigRepoReparseListener configRepoReparseListener = new ConfigRepoReparseListener(manager);
 
-            assertThat(configRepoReparseListener.shouldCareAbout(mock(configClassToCareAbout))).isFalse();
+            assertFalse(configRepoReparseListener.shouldCareAbout(mock(configClassToCareAbout)));
         }
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/PartialConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/PartialConfigServiceTest.java
@@ -78,9 +78,9 @@ public class PartialConfigServiceTest {
         updateCommand = null;
         service = new PartialConfigService(repoConfigDataSource, configWatchList, goConfigService, cachedGoPartials, serverHealthService, partialConfigHelper) {
             @Override
-            public PartialConfigUpdateCommand buildUpdateCommand(PartialConfig partial, String fingerprint, ConfigRepoConfig repoConfig) {
+            protected PartialConfigUpdateCommand buildUpdateCommand(PartialConfig partial, String fingerprint) {
                 if (null == updateCommand) {
-                    return super.buildUpdateCommand(partial, fingerprint, configRepoConfig);
+                    return super.buildUpdateCommand(partial, fingerprint);
                 }
                 return updateCommand;
             }
@@ -104,7 +104,7 @@ public class PartialConfigServiceTest {
         updateCommand = mock(PartialConfigUpdateCommand.class);
         PartialConfig partial = new PartialConfig();
 
-        service.merge(partial, "finger", cruiseConfig, configRepoConfig);
+        service.merge(partial, "finger", cruiseConfig);
         verify(updateCommand, times(1)).update(cruiseConfig);
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommandTest.java
@@ -16,30 +16,21 @@
 
 package com.thoughtworks.go.config.update;
 
-import com.thoughtworks.go.config.ErrorCollector;
 import com.thoughtworks.go.config.*;
-import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.config.rules.Allow;
-import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.PipelineGroups;
 import com.thoughtworks.go.helper.PipelineConfigMother;
-import com.thoughtworks.go.plugin.access.configrepo.InvalidPartialConfigException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-import java.util.List;
-
-import static com.thoughtworks.go.helper.MaterialConfigsMother.dependencyMaterialConfig;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 class PartialConfigUpdateCommandTest {
-
     private BasicCruiseConfig cruiseConfig;
     private ConfigRepoConfig configRepoConfig;
     private PartialConfig partial;
@@ -57,120 +48,45 @@ class PartialConfigUpdateCommandTest {
     }
 
     @Test
-    void shouldUpdateSuccessfully() {
+    void update() {
         configRepoConfig.getRules().add(new Allow("refer", "*", "*"));
 
         BasicPipelineConfigs group = new BasicPipelineConfigs("first", new Authorization());
         group.setOrigin(new RepoConfigOrigin());
         group.add(PipelineConfigMother.pipelineConfig("up42"));
         partial.setPipelines(new PipelineGroups(group));
-        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, configRepoConfig);
+        partial.setOrigins(new RepoConfigOrigin(configRepoConfig, "123"));
+
+        partial.validatePermissionsOnSubtree();
+        assertFalse(partial.hasErrors());
+
+        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver);
         CruiseConfig updated = command.update(cruiseConfig);
 
-        assertThat(ErrorCollector.getAllErrors(this.partial)).isEmpty();
-        assertThat(updated.hasPipelineGroup("first")).isTrue();
-        assertThat(updated.getPartials()).hasSize(1);
+        assertTrue(updated.hasPipelineGroup("first"));
+        assertEquals(1, updated.getPartials().size());
     }
 
     @Test
-    void shouldFailToUpdateWhenNoRulesAreConfigured() {
+    void updateWillNotCreateGroupsOrEnvironmentsIfRuleViolationsExist() {
         BasicPipelineConfigs group = new BasicPipelineConfigs("first", new Authorization());
         group.setOrigin(new RepoConfigOrigin());
         group.add(PipelineConfigMother.pipelineConfig("up42"));
         partial.setPipelines(new PipelineGroups(group));
-        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, configRepoConfig);
-
-        CruiseConfig updated = command.update(cruiseConfig);
-        List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
-        assertThat(allErrors).hasSize(1);
-        assertThat(allErrors.get(0).on("pipeline_group")).isEqualTo("Not allowed to refer to pipeline group 'first'. Check the 'Rules' of this config repository.");
-        assertThat(updated.hasPipelineGroup("first")).isFalse();
-    }
-
-    @Test
-    void shouldFailToDefinePipelineGroupWhenNoRuleMatches() {
-        configRepoConfig.getRules().add(new Allow("refer", "pipeline_group", "team1"));
-
-        BasicPipelineConfigs team1 = new BasicPipelineConfigs("team1", new Authorization());
-        BasicPipelineConfigs first = new BasicPipelineConfigs("first", new Authorization());
-        first.setOrigin(new RepoConfigOrigin());
-        first.add(PipelineConfigMother.pipelineConfig("up42"));
-        partial.setPipelines(new PipelineGroups(first, team1));
-        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, configRepoConfig);
-        CruiseConfig updated = command.update(cruiseConfig);
-
-        List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
-        assertThat(allErrors).hasSize(1);
-        assertThat(allErrors.get(0).on("pipeline_group")).isEqualTo("Not allowed to refer to pipeline group 'first'. Check the 'Rules' of this config repository.");
-        assertThat(updated.hasPipelineGroup("first")).isFalse();
-    }
-
-    @Test
-    void shouldFailToDefineEnvironmentWhenNoRuleMatches() {
-        configRepoConfig.getRules().add(new Allow("refer", "environment", "prod"));
-
         EnvironmentsConfig allEnvs = new EnvironmentsConfig();
         CaseInsensitiveString prodEnv = new CaseInsensitiveString("prod");
-        CaseInsensitiveString uatEnv = new CaseInsensitiveString("uat");
-        allEnvs.add(new BasicEnvironmentConfig(uatEnv));
         allEnvs.add(new BasicEnvironmentConfig(prodEnv));
         partial.setEnvironments(allEnvs);
-        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, configRepoConfig);
+        partial.setOrigins(new RepoConfigOrigin(configRepoConfig, "123"));
+
+        partial.validatePermissionsOnSubtree();
+        assertTrue(partial.hasErrors());
+
+        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver);
         CruiseConfig updated = command.update(cruiseConfig);
 
-        List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
-        assertThat(allErrors).hasSize(1);
-        assertThat(allErrors.get(0).on("environment")).isEqualTo("Not allowed to refer to environment 'uat'. Check the 'Rules' of this config repository.");
-        assertThat(updated.getEnvironments().hasEnvironmentNamed(uatEnv)).isFalse();
-    }
-
-    @Test
-    void shouldFailToDefineUpstreamDependencyWhenNoRuleMatches() {
-        configRepoConfig.getRules().add(new Allow("refer", "pipeline_group", "*"));
-        configRepoConfig.getRules().add(new Allow("refer", "pipeline", "build"));
-
-        BasicPipelineConfigs group = new BasicPipelineConfigs("first", new Authorization());
-        group.setOrigin(new RepoConfigOrigin());
-        group.add(PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs(dependencyMaterialConfig("build", "stage"), dependencyMaterialConfig("deploy", "stage"))));
-        partial.setPipelines(new PipelineGroups(group));
-        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, configRepoConfig);
-        CruiseConfig updated = command.update(cruiseConfig);
-
-        List<ConfigErrors> allErrors = ErrorCollector.getAllErrors(cruiseConfig.getPartials().get(0));
-        assertThat(allErrors).hasSize(1);
-        assertThat(allErrors.get(0).on("pipeline")).isEqualTo("Not allowed to refer to pipeline 'deploy'. Check the 'Rules' of this config repository.");
-        assertThat(updated.hasPipelineGroup("first")).isFalse();
-    }
-
-    @Test
-    void shouldAllowToDefineUpstreamDependencyFromTheSameConfigRepositoryRegardlessOfRules() {
-        configRepoConfig.getRules().add(new Allow("refer", "pipeline_group", "*"));
-        configRepoConfig.getRules().add(new Allow("refer", "pipeline", "build"));
-
-        BasicPipelineConfigs group = new BasicPipelineConfigs("first", new Authorization());
-        group.setOrigin(new RepoConfigOrigin());
-        group.add(PipelineConfigMother.pipelineConfig("upstream", new MaterialConfigs(dependencyMaterialConfig("build", "stage"))));
-        group.add(PipelineConfigMother.pipelineConfig("downstream", new MaterialConfigs(dependencyMaterialConfig("upstream", "stage"))));
-        partial.setPipelines(new PipelineGroups(group));
-        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, configRepoConfig);
-        CruiseConfig updated = command.update(cruiseConfig);
-
-        assertThat(ErrorCollector.getAllErrors(this.partial)).isEmpty();
-        assertThat(updated.hasPipelineGroup("first")).isTrue();
-        assertThat(updated.getPartials()).hasSize(1);
-    }
-
-    @Test
-    void shouldNotApplyRulesForPreflightCheck_WhenNoConfigRepositoryIsSpecified() {
-        BasicPipelineConfigs group = new BasicPipelineConfigs("first", new Authorization());
-        group.setOrigin(new RepoConfigOrigin());
-        group.add(PipelineConfigMother.pipelineConfig("up42", new MaterialConfigs(dependencyMaterialConfig("build", "stage"), dependencyMaterialConfig("deploy", "stage"))));
-        partial.setPipelines(new PipelineGroups(group));
-        PartialConfigUpdateCommand command = new PartialConfigUpdateCommand(partial, fingerprint, resolver, null);
-        CruiseConfig updated = command.update(cruiseConfig);
-
-        assertThat(ErrorCollector.getAllErrors(this.partial)).isEmpty();
-        assertThat(updated.hasPipelineGroup("first")).isTrue();
-        assertThat(updated.getPartials()).hasSize(1);
+        assertEquals(1, updated.getPartials().size());
+        assertFalse(updated.hasPipelineGroup("first"));
+        assertFalse(updated.getEnvironments().hasEnvironmentNamed(prodEnv));
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.ConfigReposConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
+import com.thoughtworks.go.config.rules.Allow;
 import com.thoughtworks.go.config.update.FullConfigUpdateCommand;
 import com.thoughtworks.go.helper.ConfigFileFixture;
 import com.thoughtworks.go.helper.GoConfigMother;
@@ -141,6 +142,7 @@ public class ConfigSaveDeadlockDetectionIntegrationTest {
         ConfigReposConfig configRepos = new ConfigReposConfig();
         for (int i = 0; i < configRepoAdditionThreadCount; i++) {
             ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(git("url" + i), "plugin", "id-" + i);
+            configRepoConfig.getRules().add(new Allow("refer", "*", "*"));
             configRepos.add(configRepoConfig);
             Thread thread = configRepoSaveThread(configRepoConfig, i);
             group3.add(thread);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceRunOnAllAgentIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceRunOnAllAgentIntegrationTest.java
@@ -53,6 +53,7 @@ import static com.thoughtworks.go.helper.ModificationsMother.modifySomeFiles;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {
         "classpath:/applicationContext-global.xml",
@@ -64,19 +65,29 @@ public class ScheduleServiceRunOnAllAgentIntegrationTest {
     @ClassRule
     public static final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    @Autowired private GoConfigService goConfigService;
+    @Autowired
+    private GoConfigService goConfigService;
     @Autowired
     private ServerHealthService serverHealthService;
-    @Autowired private GoConfigDao goConfigDao;
-    @Autowired private PipelineScheduler buildCauseProducer;
-    @Autowired private PipelineService pipelineService;
-    @Autowired private ScheduleService scheduleService;
-    @Autowired private PipelineScheduleQueue pipelineScheduleQueue;
-    @Autowired private AgentAssignment agentAssignment;
-    @Autowired private GoCache goCache;
-    @Autowired private DependencyMaterialUpdateNotifier notifier;
+    @Autowired
+    private GoConfigDao goConfigDao;
+    @Autowired
+    private PipelineScheduler buildCauseProducer;
+    @Autowired
+    private PipelineService pipelineService;
+    @Autowired
+    private ScheduleService scheduleService;
+    @Autowired
+    private PipelineScheduleQueue pipelineScheduleQueue;
+    @Autowired
+    private AgentAssignment agentAssignment;
+    @Autowired
+    private GoCache goCache;
+    @Autowired
+    private DependencyMaterialUpdateNotifier notifier;
 
-    @Autowired private DatabaseAccessHelper dbHelper;
+    @Autowired
+    private DatabaseAccessHelper dbHelper;
     private GoConfigFileHelper CONFIG_HELPER;
     public Subversion repository;
     public static TestRepo testRepo;
@@ -135,7 +146,7 @@ public class ScheduleServiceRunOnAllAgentIntegrationTest {
     }
 
     @Test
-    public void shouldUpdateServerHealthWhenSchedulePipelineFails() throws Exception {
+    public void shouldUpdateServerHealthWhenSchedulePipelineFails() {
         pipelineScheduleQueue.schedule(new CaseInsensitiveString("blahPipeline"), saveMaterials(modifySomeFiles(goConfigService.pipelineConfigNamed(new CaseInsensitiveString("blahPipeline")))));
         scheduleService.autoSchedulePipelinesFromRequestBuffer();
         List<ServerHealthState> stateList = serverHealthService.filterByScope(HealthStateScope.forStage("blahPipeline", "blahStage"));


### PR DESCRIPTION
### Prerequisite PR: #8241

This PR is built atop of that one ☝️, so one can review and merge that first to make the diff smaller in this PR.

<hr/>

# `PartialConfig`s should retain their records of `Rules` violations

Context
-------

This fixes an issue, discovered by @kritika-singh3, wherein a `PartialConfig` may be merged despite violating rules. This merging happens when 2 conditions are true:

  1. `PartialConfig` in question is otherwise structurally valid, only failing to meet the rule criteria.
  2. There is a second `PartialConfig` that is also in an error state, owned by another `ConfigRepoConfig`.

Fixing the errors in the other `PartialConfig` will inadvertently cause the first PartialConfig (which violates rules but is elsewise valid) to merge. In fact, even the error disappears, despite no permissive rules present.

This has to do with the fact that rule violations are checked only once for a partial before it is added as a merge candidate AND that we do not persist these violations over time.

Now, the config merge and save process is deep, complicated, and aneurysm-inducing, so I will highlight some key events involved in this issue with the hopes that one can understand enough to get the gist.

The First Time Around
---------------------

When we merge partials, GoCD keeps cached copies of partials. There are two cache lines for partials: the "last (i.e., previously) valid"and the "last attempted" (actually called "lastKnown". The very first thing that happens to our candidate partials is that they are cached to `lastKnown`, and if after all merging and validation they make it through the whole process successfully, they are promoted to the `lastValid` cache. That is, on success: `lastValid == lastKnown`.

The actual merge process happens via "update commands" to the main config.  In this case, the `PartialConfigUpdateCommand` validates config domain object references against the `Rules` of the owning `ConfigRepoConfig`. This validation operates on a *deep-clone* of the original `PartialConfig`, and is passed further down the merge and save process. It's worth noting that because this happens on a deep-clone, the cached partials do not retain the rule violations.

Further down the line, the partial, *along with every other partial*, is merged into a deep-clone of the main config during a "preprocess"step. This merged clone is then validated by a tree traverser. At the end of the validation step, all errors are collected from the nested hierarchy, including those rule violations that were attached by `PartialConfigUpdateCommand#update()`. The validation fails, and the partials are not merged, and the world is seemingly happy.

But alas, it is not.

The Second Time Around
----------------------

What happens when we fix the other `PartialConfig`? We start the merge process all over again. Partials are collected from the caches along to be merge candidates, while the newly fixed partial is passed to `PartialConfigUpdateCommand#update()`. This is the only partial that will have its rules evaluated; the other candidates have not been updated, so GoCD does not wrap them in `PartialConfigUpdateCommand`s. The fixed partial is passed down the line.

Fast-forward to the the preprocess and validation steps. Again, partials are merged into a cloned copy for validation. The key here is that the *other* partials, including our original `PartialConfig` that failed rule validation in the previous merge were pulled from the cache and have not had rules evaluated again. The cached copies retained no rule violations because all violations were attached to copies that were later discarded. As such, when structural validations run, previous rule violations are not detected, and the merge AND validation succeeds. The newly merged config becomes the active config, and all partials are promoted to `lastValid` -- a process that also removes errors from server health messages.

The end result? The partial, which should not have been merged, was merged and the user-visible errors have been wiped away.

Oops!

Which Brings Us to the Fix
--------------------------

Yes, this is probably the longest you've read before getting to the details of this commit. Sorry.

This fix does the following to address the aforementioned issue:

  - Validate rules on the original copies of the partials so that any violations survive to the next generation of merge attempts. This makes visible the rule violations of non-primary partials (i.e., the partials that are not the subject of the update command) so as to be considered before approving a config merge.
  - Move the rule validation logic to live under `PartialConfig` so that it is easily shared and callable in case we need to do this elsewhere.
  - Ensure server health error removal and `markAsValid()` promotion happens only downstream of an update command.
