### PR TITLE
More fixes for pipeline config spa

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/job.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/job.ts
@@ -133,7 +133,9 @@ export class Job extends ValidatableMixin {
       .split(",")
       .map((r: string) => r.trim())
       .filter((r: string) => !!r);
-
+    if (_.isEmpty(json.elastic_profile_id)) {
+      delete json.elastic_profile_id;
+    }
     return json;
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/spec/job_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/spec/job_spec.ts
@@ -93,4 +93,39 @@ describe("Job model", () => {
       }]
     });
   });
+
+  it('should not serialize empty elastic profile id', () => {
+    const job = validJob();
+    job.elasticProfileId("some-value");
+    expect(job.toApiPayload())
+      .toEqual({
+                 name:                  "name",
+                 elastic_profile_id:    'some-value',
+                 environment_variables: [],
+                 resources:             [],
+                 tasks:                 [{
+                   type:       "exec",
+                   attributes: {
+                     command:   "ls",
+                     arguments: ["-lA"],
+                     run_if:    []
+                   }
+                 }]
+               });
+    job.elasticProfileId("");
+    expect(job.toApiPayload())
+      .toEqual({
+                 name:                  "name",
+                 environment_variables: [],
+                 resources:             [],
+                 tasks:                 [{
+                   type:       "exec",
+                   attributes: {
+                     command:   "ls",
+                     arguments: ["-lA"],
+                     run_if:    []
+                   }
+                 }]
+               });
+  });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/spec/tab_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/spec/tab_spec.ts
@@ -23,8 +23,14 @@ describe('TabSpec', () => {
     expect(tab.isValid()).toBeFalse();
     expect(tab.errors().errorsForDisplay('path')).toBe('Path must be present.');
   });
+  it('should throw error when path is specified but not name', () => {
+    const tab = new Tab("", "path");
 
-  it('should not error out if name is not specified', () => {
+    expect(tab.isValid()).toBeFalse();
+    expect(tab.errors().errorsForDisplay('name')).toBe('Name must be present.');
+  });
+
+  it('should not error out if both are empty', () => {
     const tab = new Tab("", "");
 
     expect(tab.isValid()).toBeTrue();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/spec/template_config_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/spec/template_config_spec.ts
@@ -32,6 +32,26 @@ describe("TemplateConfig model", () => {
       });
     });
   });
+
+  it("should include a name", () => {
+    let pip = new TemplateConfig("name", []);
+    expect(pip.isValid()).toBe(true);
+    expect(pip.errors().count()).toBe(0);
+
+    pip = new TemplateConfig("", []);
+    expect(pip.isValid()).toBe(false);
+    expect(pip.errors().count()).toBe(1);
+  });
+
+  it("validate name format", () => {
+    const pip = new TemplateConfig("my awesome pipeline that has a terrible name", []);
+    expect(pip.isValid()).toBe(false);
+    expect(pip.errors().count()).toBe(1);
+    expect(pip.errors().keys()).toEqual(["name"]);
+    expect(pip.errors().errorsForDisplay("name"))
+      .toBe(
+        "Invalid name. This must be alphanumeric and can contain hyphens, underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.");
+  });
 });
 
 function stubGetSuccess() {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/tab.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/tab.ts
@@ -44,6 +44,7 @@ export class Tab extends ValidatableMixin {
     this.path(path);
 
     this.validatePresenceOf("path", {condition: () => !_.isEmpty(this.name())});
+    this.validatePresenceOf("name", {condition: () => !_.isEmpty(this.path())});
   }
 
   static fromJSON(json: TabJSON) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/template_config.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/pipeline_configs/template_config.ts
@@ -38,6 +38,10 @@ export class TemplateConfig extends ValidatableMixin {
     super();
     this.name       = Stream(name);
     this.parameters = Stream(parameters);
+
+    this.validatePresenceOf("name");
+    this.validateIdFormat("name");
+    this.validateAssociated("stages");
   }
 
   static getTemplate(name: string, onSuccess: (result: TemplateConfig) => void) {


### PR DESCRIPTION
Issue: #8141 

Description:
 - do not send elastic profile id in post if empty
 - should not validate name or path in custom tab if both of them are empty. otherwise, do validate the presense
 - added validation for name and stages for template config


