### PR TITLE
Pipeline config spa fixes (#8141)

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/pipeline_config.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/pipeline_config.tsx
@@ -67,6 +67,7 @@ export class PipelineConfigPage<T> extends TabHandler<T> {
 
   reset() {
     this.setEntity(PipelineConfig.fromJSON(this.originalJSON));
+    this.tab().onPipelineConfigReset();
   }
 
   getAssociatedTemplateWithPipeline(): TemplateConfig | undefined {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/job_settings_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/job_settings_tab_content.tsx
@@ -144,6 +144,10 @@ export class JobSettingsTabContentWidget extends MithrilViewComponent<Attrs> {
     </div>;
   }
 
+  onupdate(vnode: m.Vnode<Attrs, this>) {
+    vnode.attrs.resourcesSuggestions.updateProperty(vnode.attrs.entity.resources);
+  }
+
   private isResourcesInputOnFocus(): boolean {
     return document.activeElement?.getAttribute("data-test-id") === "resources-input";
   }
@@ -242,6 +246,10 @@ export class ResourcesSuggestionsProvider extends SuggestionProvider {
     return new Promise<Awesomplete.Suggestion[]>((resolve) => {
       resolve(this.allResources());
     });
+  }
+
+  updateProperty(prop: Stream<string>) {
+    this.property = prop;
   }
 
   replace(suggestion: any) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stages_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stages_tab_content.tsx
@@ -96,6 +96,13 @@ export class StagesTabContent extends TabContent<PipelineConfig | TemplateConfig
     this.originalStages       = undefined;
   }
 
+  onPipelineConfigReset() {
+    this.isPipelineDefinedOriginallyFromTemplate = Stream();
+    this.stageOrTemplateProperty                = Stream();
+    this.entityReOrderHandler                   = undefined;
+    this.originalStages                         = undefined;
+  }
+
   protected selectedEntity(pipelineConfig: PipelineConfig | TemplateConfig, routeParams: PipelineConfigRouteParams) {
     //initialize only once
     if (this.isPipelineDefinedOriginallyFromTemplate() === undefined) {
@@ -183,7 +190,14 @@ interface StagesOrTemplatesState {
 
 export class StagesOrTemplatesWidget extends MithrilComponent<StagesOrTemplatesAttrs, StagesOrTemplatesState> {
   oninit(vnode: m.Vnode<StagesOrTemplatesAttrs, StagesOrTemplatesState>) {
+    this.initialize(vnode);
+  }
 
+  onupdate(vnode: m.Vnode<StagesOrTemplatesAttrs, StagesOrTemplatesState>) {
+    this.initialize(vnode);
+  }
+
+  initialize(vnode: m.Vnode<StagesOrTemplatesAttrs, StagesOrTemplatesState>) {
     vnode.state.stageOrTemplatePropertyStream = (value?: string) => {
       if (value) {
         vnode.attrs.stageOrTemplateProperty((value === "template") ? "template" : "stage");

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/tab_content.tsx
@@ -93,6 +93,10 @@ export abstract class TabContent<T> {
     //do nothing
   }
 
+  public onPipelineConfigReset() {
+    //do nothing
+  }
+
   protected abstract renderer(entity: T,
                               templateConfig: TemplateConfig,
                               flashMessage: FlashMessageModelWithTimeout,

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/template_config.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/template_config.tsx
@@ -38,6 +38,7 @@ export class TemplateConfigPage<T> extends TabHandler<T> {
 
   reset() {
     this.setEntity(TemplateConfig.fromJSON(this.originalJSON));
+    this.tab().onPipelineConfigReset();
   }
 
   //this method is only required for pipeline config.


### PR DESCRIPTION
Issue: #8141

Description:
* On Job Settings Tab, allow selecting resources from autocomplete list.
* On Stages Tab, reset the page state to the original (define stages),
  when user toggles to use template and clicks reset.