### PR TITLE
Fix bug with material password field

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.scss
@@ -16,7 +16,7 @@
 
 .material-input-wrapper {
   input {
-    &[type="text"] {
+    &[type="text"]:not([aria-label="password"]) {
       width:     25vw;
       max-width: 350px;
     }


### PR DESCRIPTION
Issue: #8261

Description: 
When a password field is set as show value, the style is applied which increased its size.
Added a selector which will negate this



