### PR TITLE
Fix duplicate error message from the Stage Trigger API

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/server/service/result/HttpOperationResult.java
+++ b/common/src/main/java/com/thoughtworks/go/server/service/result/HttpOperationResult.java
@@ -146,7 +146,11 @@ public class HttpOperationResult implements OperationResult {
 
     public String fullMessage() {
         ServerHealthState serverHealthState = serverHealthStateOperationResult.getServerHealthState();
-        String desc = serverHealthState == null ? BLANK_STRING : serverHealthState.getDescription();
+        String desc = BLANK_STRING;
+        if(serverHealthState != null && !StringUtils.equals(serverHealthState.getDescription(), message)) {
+            desc = serverHealthState.getDescription();
+        }
+
         return StringUtils.isBlank(desc) ? message : String.format("%s { %s }", message, desc);
     }
 

--- a/common/src/test/java/com/thoughtworks/go/server/service/result/HttpOperationResultTest.java
+++ b/common/src/test/java/com/thoughtworks/go/server/service/result/HttpOperationResultTest.java
@@ -108,6 +108,14 @@ public class HttpOperationResultTest {
         assertThat(httpOperationResult.detailedMessage(), is("message { desc }\n"));
     }
 
+    @Test
+    public void shouldOmitDescriptionFromServerHealthStateWhenMessageAndDescriptionIsSame() {
+        httpOperationResult.error("message", "message", HealthStateType.general(HealthStateScope.GLOBAL));
+        assertThat(httpOperationResult.httpCode(), is(400));
+        assertThat(httpOperationResult.message(), is("message"));
+        assertThat(httpOperationResult.detailedMessage(), is("message\n"));
+    }
+
     @Test public void shouldReturn500WhenInternalServerErrorOccurs() throws Exception {
         httpOperationResult.internalServerError("error occurred during deletion of agent. Could not delete.", null);
         assertThat(httpOperationResult.httpCode(), is(500));


### PR DESCRIPTION

#### Description:

* Do not add description from the server health state when the
  server health state description is same as the result message.

#### Before

```json
{
  "message" : "User does not have operate permissions for stage [up42_stage2] of pipeline [up42] { User does not have operate permissions for stage [up42_stage2] of pipeline [up42] }"
}
```

<img width="294" alt="Screen Shot 2020-07-01 at 2 24 48 PM" src="https://user-images.githubusercontent.com/15275847/86229527-7717b480-bbad-11ea-9583-0c581e4f05a4.png">


#### After

```json
{
  "message" : "User does not have operate permissions for stage [up42_stage2] of pipeline [up42]"
}
```

<img width="294" alt="Screen Shot 2020-07-01 at 3 06 07 PM" src="https://user-images.githubusercontent.com/15275847/86229614-9c0c2780-bbad-11ea-9262-3d7eba65f362.png">



