### PR TITLE
Add user can_operate field on individual stages of the dashboard pipeline

### DIFF
--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/DashboardControllerV3Test.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/DashboardControllerV3Test.groovy
@@ -20,6 +20,7 @@ import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.apiv3.dashboard.representers.DashboardFor
 import com.thoughtworks.go.apiv3.dashboard.representers.DashboardRepresenter
 import com.thoughtworks.go.config.security.Permissions
+import com.thoughtworks.go.config.security.permissions.EveryonePermission
 import com.thoughtworks.go.config.security.users.Everyone
 import com.thoughtworks.go.server.dashboard.GoDashboardEnvironment
 import com.thoughtworks.go.server.dashboard.GoDashboardPipelineGroup
@@ -159,7 +160,7 @@ class DashboardControllerV3Test implements SecurityServiceTrait, ControllerTrait
         loginAsUser()
 
         def pipelineSelections = PipelineSelections.ALL
-        def pipelineGroup = new GoDashboardPipelineGroup('group1', new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE), true)
+        def pipelineGroup = new GoDashboardPipelineGroup('group1', new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE), true)
         pipelineGroup.addPipeline(GoDashboardPipelineMother.dashboardPipeline('pipeline1'))
         pipelineGroup.addPipeline(GoDashboardPipelineMother.dashboardPipeline('pipeline2'))
         when(pipelineSelectionsService.load((String) isNull(), any(Long.class))).thenReturn(pipelineSelections)
@@ -199,7 +200,7 @@ class DashboardControllerV3Test implements SecurityServiceTrait, ControllerTrait
   }
 
   private static Permissions permissions() {
-    new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE)
+    new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE)
   }
 
   private String computeEtag(List<GoDashboardPipelineGroup> pipelineGroups, List<GoDashboardEnvironment> envs) {

--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/GoDashboardPipelineMother.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/GoDashboardPipelineMother.groovy
@@ -17,6 +17,7 @@ package com.thoughtworks.go.apiv3.dashboard
 
 import com.thoughtworks.go.config.remote.FileConfigOrigin
 import com.thoughtworks.go.config.security.Permissions
+import com.thoughtworks.go.config.security.permissions.EveryonePermission
 import com.thoughtworks.go.config.security.users.Everyone
 import com.thoughtworks.go.server.dashboard.GoDashboardPipeline
 import com.thoughtworks.go.server.dashboard.TimeStampBasedCounter
@@ -28,7 +29,7 @@ import static org.mockito.Mockito.when
 
 class GoDashboardPipelineMother {
 
-  static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE), timestamp = 1000L) {
+  static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE), timestamp = 1000L) {
     def clock = mock(Clock.class)
     when(clock.currentTimeMillis()).thenReturn(timestamp)
     new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, null, new TimeStampBasedCounter(clock), new FileConfigOrigin(), 0)

--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/DashboardGroupRepresenterTest.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/DashboardGroupRepresenterTest.groovy
@@ -18,6 +18,7 @@ package com.thoughtworks.go.apiv3.dashboard.representers
 import com.thoughtworks.go.config.CaseInsensitiveString
 import com.thoughtworks.go.config.remote.FileConfigOrigin
 import com.thoughtworks.go.config.security.Permissions
+import com.thoughtworks.go.config.security.permissions.EveryonePermission
 import com.thoughtworks.go.config.security.users.Everyone
 import com.thoughtworks.go.config.security.users.NoOne
 import com.thoughtworks.go.server.dashboard.GoDashboardEnvironment
@@ -52,7 +53,7 @@ class DashboardGroupRepresenterTest {
 
     @Test
     void 'renders pipeline group with hal representation'() {
-      def permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE)
+      def permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE)
       def pipeline1 = dashboardPipeline('pipeline1')
       def pipeline2 = dashboardPipeline('pipeline2')
 
@@ -74,7 +75,7 @@ class DashboardGroupRepresenterTest {
 
     @Test
     void 'renders pipeline group authorization information'() {
-      def noAdminPermissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE)
+      def noAdminPermissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE, EveryonePermission.INSTANCE)
 
       def pipeline1 = dashboardPipeline('pipeline1')
       def pipeline2 = dashboardPipeline('pipeline2')
@@ -144,7 +145,7 @@ class DashboardGroupRepresenterTest {
     }
   }
 
-  static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE), long timestamp = 1000) {
+  static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE), long timestamp = 1000) {
     def clock = mock(Clock.class)
     when(clock.currentTimeMillis()).thenReturn(timestamp)
     new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, null, new TimeStampBasedCounter(clock), new FileConfigOrigin(), 0)

--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/DashboardRepresenterTest.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/DashboardRepresenterTest.groovy
@@ -18,6 +18,7 @@ package com.thoughtworks.go.apiv3.dashboard.representers
 import com.thoughtworks.go.apiv3.dashboard.GoDashboardPipelineMother
 import com.thoughtworks.go.config.CaseInsensitiveString
 import com.thoughtworks.go.config.security.Permissions
+import com.thoughtworks.go.config.security.permissions.EveryonePermission
 import com.thoughtworks.go.config.security.users.Everyone
 import com.thoughtworks.go.server.dashboard.GoDashboardEnvironment
 import com.thoughtworks.go.server.dashboard.GoDashboardPipelineGroup
@@ -35,7 +36,7 @@ class DashboardRepresenterTest {
   void 'renders pipeline dashboard with hal representation'() {
     def personalizationEtag = "sha256hash"
     def user = new Username(new CaseInsensitiveString(SecureRandom.hex()))
-    def permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE)
+    def permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE)
 
     def group1 = new GoDashboardPipelineGroup('group1', permissions, true)
     def group2 = new GoDashboardPipelineGroup('group2', permissions, true)

--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/PipelineRepresenterTest.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/PipelineRepresenterTest.groovy
@@ -21,6 +21,8 @@ import com.thoughtworks.go.config.remote.ConfigRepoConfig
 import com.thoughtworks.go.config.remote.FileConfigOrigin
 import com.thoughtworks.go.config.remote.RepoConfigOrigin
 import com.thoughtworks.go.config.security.Permissions
+import com.thoughtworks.go.config.security.permissions.EveryonePermission
+import com.thoughtworks.go.config.security.permissions.NoOnePermission
 import com.thoughtworks.go.config.security.users.Everyone
 import com.thoughtworks.go.config.security.users.NoOne
 import com.thoughtworks.go.helper.MaterialConfigsMother
@@ -43,7 +45,7 @@ class PipelineRepresenterTest {
   void 'renders pipeline with hal representation'() {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
-    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
+    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
     def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'),
       permissions, "grp", new TrackingTool("http://example.com/\${ID}", "##\\d+"), counter, new FileConfigOrigin(), 0)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
@@ -87,7 +89,7 @@ class PipelineRepresenterTest {
   void 'should consider pipelines with null origin as local'() {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
-    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
+    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
     def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1'), permissions, "grp", null, counter, null, 0)
 
     def json = toObject({ PipelineRepresenter.toJSON(it, pipeline, new Username(new CaseInsensitiveString(SecureRandom.hex()))) })
@@ -99,7 +101,7 @@ class PipelineRepresenterTest {
   void 'should render pause info'() {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
-    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
+    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
     def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1', false, true, "under construction"), permissions, "grp", null, counter, null, 0)
 
     def json = toObject({ PipelineRepresenter.toJSON(it, pipeline, new Username(new CaseInsensitiveString(SecureRandom.hex()))) })
@@ -119,7 +121,7 @@ class PipelineRepresenterTest {
     void 'user can operate a pipeline if user is pipeline_level operator'() {
       def counter = mock(Counter.class)
       when(counter.getNext()).thenReturn(1l)
-      def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE)
+      def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, EveryonePermission.INSTANCE)
       def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
       def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
@@ -137,7 +139,7 @@ class PipelineRepresenterTest {
     void 'user can administer a pipeline if user is admin of pipeline'() {
       def counter = mock(Counter.class)
       when(counter.getNext()).thenReturn(1l)
-      def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE)
+      def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE, NoOnePermission.INSTANCE)
       def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
       def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
@@ -155,7 +157,7 @@ class PipelineRepresenterTest {
     void 'user can unlock and pause a pipeline if user is operator of pipeline'() {
       def counter = mock(Counter.class)
       when(counter.getNext()).thenReturn(1l)
-      def permissions = new Permissions(NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
+      def permissions = new Permissions(NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
       def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
       def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))

--- a/api/api-dashboard-v4/src/main/java/com/thoughtworks/go/apiv4/dashboard/representers/PipelineInstanceRepresenter.java
+++ b/api/api-dashboard-v4/src/main/java/com/thoughtworks/go/apiv4/dashboard/representers/PipelineInstanceRepresenter.java
@@ -19,13 +19,15 @@ import com.thoughtworks.go.api.base.OutputLinkWriter;
 import com.thoughtworks.go.api.base.OutputListWriter;
 import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
+import com.thoughtworks.go.server.dashboard.GoDashboardPipeline;
+import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.spark.Routes;
 
 import java.util.function.Consumer;
 
 public class PipelineInstanceRepresenter {
 
-    public static void toJSON(OutputWriter jsonOutputWriter, PipelineInstanceModel model) {
+    public static void toJSON(OutputWriter jsonOutputWriter, PipelineInstanceModel model, GoDashboardPipeline goDashboardPipeline, Username username) {
         jsonOutputWriter
                 .addLinks(addLinks(model))
                 .add("label", model.getLabel())
@@ -33,7 +35,7 @@ public class PipelineInstanceRepresenter {
                 .add("triggered_by", model.getApprovedByForDisplay())
                 .add("scheduled_at", model.getScheduledDate())
                 .addChild("_embedded", childWriter -> {
-                    childWriter.addChildList("stages", getStages(model));
+                    childWriter.addChildList("stages", getStages(model, goDashboardPipeline, username));
                 });
     }
 
@@ -41,11 +43,11 @@ public class PipelineInstanceRepresenter {
         return linkWriter -> linkWriter.addLink("self", Routes.PipelineInstance.instance(model.getName(), model.getCounter()));
     }
 
-    private static Consumer<OutputListWriter> getStages(PipelineInstanceModel model) {
+    private static Consumer<OutputListWriter> getStages(PipelineInstanceModel model, GoDashboardPipeline goDashboardPipeline, Username username) {
         return writer -> {
             model.getStageHistory().forEach(stage -> {
                 writer.addChild(childWriter -> {
-                    StageRepresenter.toJSON(childWriter, stage, model.getName(), String.valueOf(model.getCounter()));
+                    StageRepresenter.toJSON(childWriter, goDashboardPipeline, stage, username, model.getName(), String.valueOf(model.getCounter()));
                 });
             });
         };

--- a/api/api-dashboard-v4/src/main/java/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenter.java
+++ b/api/api-dashboard-v4/src/main/java/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenter.java
@@ -65,16 +65,16 @@ public class PipelineRepresenter {
         }
 
         jsonOutputWriter.addChild("_embedded", childWriter -> {
-            childWriter.addChildList("instances", writeInstances(model));
+            childWriter.addChildList("instances", writeInstances(model, username));
         });
     }
 
-    private static Consumer<OutputListWriter> writeInstances(GoDashboardPipeline model) {
+    private static Consumer<OutputListWriter> writeInstances(GoDashboardPipeline model, Username username) {
         return listWriter -> {
             model.model().getActivePipelineInstances().stream()
                     .filter(instanceModel -> !(instanceModel instanceof EmptyPipelineInstanceModel))
                     .forEach(instanceModel -> {
-                        listWriter.addChild(childWriter -> PipelineInstanceRepresenter.toJSON(childWriter, instanceModel));
+                        listWriter.addChild(childWriter -> PipelineInstanceRepresenter.toJSON(childWriter, instanceModel, model, username));
                     });
         };
     }

--- a/api/api-dashboard-v4/src/main/java/com/thoughtworks/go/apiv4/dashboard/representers/StageRepresenter.java
+++ b/api/api-dashboard-v4/src/main/java/com/thoughtworks/go/apiv4/dashboard/representers/StageRepresenter.java
@@ -18,11 +18,13 @@ package com.thoughtworks.go.apiv4.dashboard.representers;
 import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.domain.StageResult;
 import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModel;
+import com.thoughtworks.go.server.dashboard.GoDashboardPipeline;
+import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.spark.Routes;
 
 public class StageRepresenter {
 
-    public static void toJSON(OutputWriter jsonOutputWriter, StageInstanceModel model, String pipelineName, String pipelineCounter) {
+    public static void toJSON(OutputWriter jsonOutputWriter, GoDashboardPipeline goDashboardPipeline, StageInstanceModel model, Username username, String pipelineName, String pipelineCounter) {
         jsonOutputWriter
                 .addLinks(linkWriter -> {
                     linkWriter.addLink("self", Routes.Stage.self(pipelineName, pipelineCounter, model.getName(), model.getCounter()));
@@ -30,15 +32,17 @@ public class StageRepresenter {
                 .add("name", model.getName())
                 .add("counter", model.getCounter())
                 .add("status", model.getState().name())
+                .add("can_operate", goDashboardPipeline.isStageOperator(model.getName(), username.getUsername().toString()))
                 .add("approved_by", model.getApprovedBy())
                 .add("scheduled_at", model.getScheduledDate());
 
         if (model.getState().stageResult() == StageResult.Cancelled) {
             jsonOutputWriter.add("cancelled_by", model.getCancelledBy() == null ? "GoCD" : model.getCancelledBy());
         }
+
         if (model.getPreviousStage() != null) {
             jsonOutputWriter.addChild("previous_stage", childWriter -> {
-                StageRepresenter.toJSON(childWriter, model.getPreviousStage(), pipelineName, pipelineCounter);
+                StageRepresenter.toJSON(childWriter, goDashboardPipeline, model.getPreviousStage(), username, pipelineName, pipelineCounter);
             });
         }
     }

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/DashboardControllerV4Test.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/DashboardControllerV4Test.groovy
@@ -20,6 +20,7 @@ import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.apiv4.dashboard.representers.DashboardFor
 import com.thoughtworks.go.apiv4.dashboard.representers.DashboardRepresenter
 import com.thoughtworks.go.config.security.Permissions
+import com.thoughtworks.go.config.security.permissions.EveryonePermission
 import com.thoughtworks.go.config.security.users.Everyone
 import com.thoughtworks.go.server.dashboard.GoDashboardEnvironment
 import com.thoughtworks.go.server.dashboard.GoDashboardPipelineGroup
@@ -170,7 +171,7 @@ class DashboardControllerV4Test implements SecurityServiceTrait, ControllerTrait
         loginAsUser()
 
         def pipelineSelections = PipelineSelections.ALL
-        def pipelineGroup = new GoDashboardPipelineGroup('group1', new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE), true)
+        def pipelineGroup = new GoDashboardPipelineGroup('group1', new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE), true)
         pipelineGroup.addPipeline(GoDashboardPipelineMother.dashboardPipeline('pipeline1'))
         pipelineGroup.addPipeline(GoDashboardPipelineMother.dashboardPipeline('pipeline2'))
         when(pipelineSelectionsService.load((String) isNull(), any(Long.class))).thenReturn(pipelineSelections)
@@ -210,7 +211,7 @@ class DashboardControllerV4Test implements SecurityServiceTrait, ControllerTrait
   }
 
   private static Permissions permissions() {
-    new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE)
+    new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE)
   }
 
   private String computeEtag(List<GoDashboardPipelineGroup> pipelineGroups, List<GoDashboardEnvironment> envs) {

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/GoDashboardPipelineMother.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/GoDashboardPipelineMother.groovy
@@ -17,6 +17,7 @@ package com.thoughtworks.go.apiv4.dashboard
 
 import com.thoughtworks.go.config.remote.FileConfigOrigin
 import com.thoughtworks.go.config.security.Permissions
+import com.thoughtworks.go.config.security.permissions.EveryonePermission
 import com.thoughtworks.go.config.security.users.Everyone
 import com.thoughtworks.go.server.dashboard.GoDashboardPipeline
 import com.thoughtworks.go.server.dashboard.TimeStampBasedCounter
@@ -28,7 +29,7 @@ import static org.mockito.Mockito.when
 
 class GoDashboardPipelineMother {
 
-  static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE), timestamp = 1000L) {
+  static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE), timestamp = 1000L) {
     def clock = mock(Clock.class)
     when(clock.currentTimeMillis()).thenReturn(timestamp)
     new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, null, new TimeStampBasedCounter(clock), new FileConfigOrigin(), 0)

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/DashboardGroupRepresenterTest.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/DashboardGroupRepresenterTest.groovy
@@ -18,6 +18,7 @@ package com.thoughtworks.go.apiv4.dashboard.representers
 import com.thoughtworks.go.config.CaseInsensitiveString
 import com.thoughtworks.go.config.remote.FileConfigOrigin
 import com.thoughtworks.go.config.security.Permissions
+import com.thoughtworks.go.config.security.permissions.EveryonePermission
 import com.thoughtworks.go.config.security.users.Everyone
 import com.thoughtworks.go.config.security.users.NoOne
 import com.thoughtworks.go.server.dashboard.GoDashboardEnvironment
@@ -52,7 +53,7 @@ class DashboardGroupRepresenterTest {
 
     @Test
     void 'renders pipeline group with hal representation'() {
-      def permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE)
+      def permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE)
       def pipeline1 = dashboardPipeline('pipeline1')
       def pipeline2 = dashboardPipeline('pipeline2')
 
@@ -75,7 +76,7 @@ class DashboardGroupRepresenterTest {
 
     @Test
     void 'renders pipeline group authorization information'() {
-      def noAdminPermissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE)
+      def noAdminPermissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE, EveryonePermission.INSTANCE)
 
       def pipeline1 = dashboardPipeline('pipeline1')
       def pipeline2 = dashboardPipeline('pipeline2')
@@ -148,7 +149,7 @@ class DashboardGroupRepresenterTest {
     }
   }
 
-  static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE), long timestamp = 1000) {
+  static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE), long timestamp = 1000) {
     def clock = mock(Clock.class)
     when(clock.currentTimeMillis()).thenReturn(timestamp)
     new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, null, new TimeStampBasedCounter(clock), new FileConfigOrigin(), 0)

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/DashboardRepresenterTest.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/DashboardRepresenterTest.groovy
@@ -18,6 +18,7 @@ package com.thoughtworks.go.apiv4.dashboard.representers
 import com.thoughtworks.go.apiv4.dashboard.GoDashboardPipelineMother
 import com.thoughtworks.go.config.CaseInsensitiveString
 import com.thoughtworks.go.config.security.Permissions
+import com.thoughtworks.go.config.security.permissions.EveryonePermission
 import com.thoughtworks.go.config.security.users.Everyone
 import com.thoughtworks.go.server.dashboard.GoDashboardEnvironment
 import com.thoughtworks.go.server.dashboard.GoDashboardPipelineGroup
@@ -35,7 +36,7 @@ class DashboardRepresenterTest {
   void 'renders pipeline dashboard with hal representation'() {
     def personalizationEtag = "sha256hash"
     def user = new Username(new CaseInsensitiveString(SecureRandom.hex()))
-    def permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE)
+    def permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE)
 
     def group1 = new GoDashboardPipelineGroup('group1', permissions, true)
     def group2 = new GoDashboardPipelineGroup('group2', permissions, true)

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenterTest.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenterTest.groovy
@@ -21,6 +21,8 @@ import com.thoughtworks.go.config.remote.ConfigRepoConfig
 import com.thoughtworks.go.config.remote.FileConfigOrigin
 import com.thoughtworks.go.config.remote.RepoConfigOrigin
 import com.thoughtworks.go.config.security.Permissions
+import com.thoughtworks.go.config.security.permissions.EveryonePermission
+import com.thoughtworks.go.config.security.permissions.NoOnePermission
 import com.thoughtworks.go.config.security.users.Everyone
 import com.thoughtworks.go.config.security.users.NoOne
 import com.thoughtworks.go.helper.MaterialConfigsMother
@@ -43,7 +45,7 @@ class PipelineRepresenterTest {
   void 'renders pipeline with hal representation'() {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
-    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
+    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
     def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'),
       permissions, "grp", new TrackingTool("http://example.com/\${ID}", "##\\d+"), counter, new FileConfigOrigin(), 0)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
@@ -58,7 +60,7 @@ class PipelineRepresenterTest {
       _embedded             : [
         instances: [
           toObject({
-            PipelineInstanceRepresenter.toJSON(it, pipeline.model().activePipelineInstances.first())
+            PipelineInstanceRepresenter.toJSON(it, pipeline.model().activePipelineInstances.first(), pipeline, username)
           })
         ]
       ],
@@ -87,7 +89,7 @@ class PipelineRepresenterTest {
   void 'should consider pipelines with null origin as local'() {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
-    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
+    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
     def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1'), permissions, "grp", null, counter, null, 0)
 
     def json = toObject({
@@ -101,7 +103,7 @@ class PipelineRepresenterTest {
   void 'should render pause info'() {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
-    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
+    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
     def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1', false, true, "under construction"), permissions, "grp", null, counter, null, 0)
 
     def json = toObject({
@@ -120,7 +122,7 @@ class PipelineRepresenterTest {
   void 'should render config repo details if the pipeline is defined using config repo'() {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
-    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
+    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
     def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
     def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'p1l1', false, true, null), permissions, "grp", null, counter, origin, 0)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
@@ -139,7 +141,7 @@ class PipelineRepresenterTest {
     void 'user can operate a pipeline if user is pipeline_level operator'() {
       def counter = mock(Counter.class)
       when(counter.getNext()).thenReturn(1l)
-      def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE)
+      def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, EveryonePermission.INSTANCE)
       def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
       def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
@@ -157,7 +159,7 @@ class PipelineRepresenterTest {
     void 'user can administer a pipeline if user is admin of pipeline'() {
       def counter = mock(Counter.class)
       when(counter.getNext()).thenReturn(1l)
-      def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE)
+      def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE, NoOnePermission.INSTANCE)
       def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
       def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
@@ -175,7 +177,7 @@ class PipelineRepresenterTest {
     void 'user can unlock and pause a pipeline if user is operator of pipeline'() {
       def counter = mock(Counter.class)
       when(counter.getNext()).thenReturn(1l)
-      def permissions = new Permissions(NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
+      def permissions = new Permissions(NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
       def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
       def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))

--- a/server/src/main/java/com/thoughtworks/go/config/security/GroupSecurity.java
+++ b/server/src/main/java/com/thoughtworks/go/config/security/GroupSecurity.java
@@ -15,10 +15,7 @@
  */
 package com.thoughtworks.go.config.security;
 
-import com.thoughtworks.go.config.PipelineConfig;
-import com.thoughtworks.go.config.PipelineConfigs;
-import com.thoughtworks.go.config.PluginRoleConfig;
-import com.thoughtworks.go.config.SecurityConfig;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.security.users.AllowedUsers;
 
 import java.util.*;
@@ -100,18 +97,18 @@ class GroupSecurity {
         return this.viewers;
     }
 
-    AllowedUsers operatorsForPipeline(PipelineConfig pipeline) {
-        if (!pipeline.first().hasOperatePermissionDefined()) {
+    AllowedUsers operatorsForStage(StageConfig stage) {
+        if (!stage.hasOperatePermissionDefined()) {
             return effectiveOperators();
         }
 
-        Set<String> approversOfFirstStage = namesOf(pipeline.first().getApproval().getAuthConfig(), rolesToUsers);
-        Set<PluginRoleConfig> roleApproverOfFirstStage = pluginRolesFor(security, pipeline.first().getApproval().getAuthConfig().getRoles());
+        Set<String> approversOfStage = namesOf(stage.getApproval().getAuthConfig(), rolesToUsers);
+        Set<PluginRoleConfig> roleApproverOfStage = pluginRolesFor(security, stage.getApproval().getAuthConfig().getRoles());
 
-        Set<String> pipelineOperators = new HashSet<>();
-        pipelineOperators.addAll(configuredAdmins());
-        pipelineOperators.addAll(approversOfFirstStage);
+        Set<String> stageOperators = new HashSet<>();
+        stageOperators.addAll(configuredAdmins());
+        stageOperators.addAll(approversOfStage);
 
-        return new AllowedUsers(pipelineOperators, roleApproverOfFirstStage);
+        return new AllowedUsers(stageOperators, roleApproverOfStage);
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/security/Permissions.java
+++ b/server/src/main/java/com/thoughtworks/go/config/security/Permissions.java
@@ -15,19 +15,20 @@
  */
 package com.thoughtworks.go.config.security;
 
+import com.thoughtworks.go.config.security.permissions.PipelinePermission;
 import com.thoughtworks.go.config.security.users.Users;
 
 public class Permissions {
     private final Users viewers;
     private final Users operators;
     private final Users admins;
-    private final Users pipelineOperators;
+    private final PipelinePermission pipelinePermission;
 
-    public Permissions(Users viewers, Users operators, Users admins, Users pipelineOperators) {
+    public Permissions(Users viewers, Users operators, Users admins, PipelinePermission pipelinePermission) {
         this.viewers = viewers;
         this.operators = operators;
         this.admins = admins;
-        this.pipelineOperators = pipelineOperators;
+        this.pipelinePermission = pipelinePermission;
     }
 
     public Users viewers() {
@@ -43,7 +44,12 @@ public class Permissions {
     }
 
     public Users pipelineOperators() {
-        return pipelineOperators;
+        return pipelinePermission.getPipelineOperators();
+    }
+
+    public Users stageOperators(String stageName) {
+        Users stageOperators = this.pipelinePermission.getStageOperators(stageName);
+        return stageOperators == null ? operators : stageOperators;
     }
 
     @Override
@@ -56,7 +62,7 @@ public class Permissions {
         if (viewers != null ? !viewers.equals(that.viewers) : that.viewers != null) return false;
         if (operators != null ? !operators.equals(that.operators) : that.operators != null) return false;
         if (admins != null ? !admins.equals(that.admins) : that.admins != null) return false;
-        return pipelineOperators != null ? pipelineOperators.equals(that.pipelineOperators) : that.pipelineOperators == null;
+        return pipelinePermission != null ? pipelinePermission.equals(that.pipelinePermission) : that.pipelinePermission == null;
     }
 
     @Override
@@ -64,7 +70,7 @@ public class Permissions {
         int result = viewers != null ? viewers.hashCode() : 0;
         result = 31 * result + (operators != null ? operators.hashCode() : 0);
         result = 31 * result + (admins != null ? admins.hashCode() : 0);
-        result = 31 * result + (pipelineOperators != null ? pipelineOperators.hashCode() : 0);
+        result = 31 * result + (pipelinePermission != null ? pipelinePermission.hashCode() : 0);
         return result;
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/security/permissions/EveryonePermission.java
+++ b/server/src/main/java/com/thoughtworks/go/config/security/permissions/EveryonePermission.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.security.permissions;
+
+import com.thoughtworks.go.config.security.users.Everyone;
+import com.thoughtworks.go.config.security.users.Users;
+
+public class EveryonePermission extends PipelinePermission {
+    public static EveryonePermission INSTANCE = new EveryonePermission();
+
+    private EveryonePermission() {
+    }
+
+    public Users getPipelineOperators() {
+        return Everyone.INSTANCE;
+    }
+
+    @Override
+    public Users getStageOperators(String stageName) {
+        return Everyone.INSTANCE;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/config/security/permissions/NoOnePermission.java
+++ b/server/src/main/java/com/thoughtworks/go/config/security/permissions/NoOnePermission.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.security.permissions;
+
+import com.thoughtworks.go.config.security.users.Everyone;
+import com.thoughtworks.go.config.security.users.NoOne;
+import com.thoughtworks.go.config.security.users.Users;
+
+public class NoOnePermission extends PipelinePermission {
+    public static NoOnePermission INSTANCE = new NoOnePermission();
+
+    private NoOnePermission() {
+    }
+
+    public Users getPipelineOperators() {
+        return NoOne.INSTANCE;
+    }
+
+    @Override
+    public Users getStageOperators(String stageName) {
+        return NoOne.INSTANCE;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/config/security/permissions/PipelinePermission.java
+++ b/server/src/main/java/com/thoughtworks/go/config/security/permissions/PipelinePermission.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.security.permissions;
+
+import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.config.security.users.Users;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@EqualsAndHashCode
+@ToString
+public class PipelinePermission extends ArrayList<StagePermission> {
+
+    public PipelinePermission(List<StagePermission> permissions) {
+        super(permissions);
+    }
+
+    public PipelinePermission() {
+        super();
+    }
+
+    public Users getPipelineOperators() {
+        return this.get(0).getStageOperators();
+    }
+
+    public Users getStageOperators(String stageName) {
+        return this.stream().filter(s -> s.getStageName().equals(stageName)).findFirst().map(StagePermission::getStageOperators).orElse(null);
+    }
+
+    public static PipelinePermission from(PipelineConfig pipeline, Users operators) {
+        List<StagePermission> permissions = pipeline.stream().map(stage -> new StagePermission(stage.name().toString(), operators)).collect(Collectors.toList());
+        return new PipelinePermission(permissions);
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/config/security/permissions/StagePermission.java
+++ b/server/src/main/java/com/thoughtworks/go/config/security/permissions/StagePermission.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.security.permissions;
+
+import com.thoughtworks.go.config.security.users.Users;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@EqualsAndHashCode
+@ToString
+public class StagePermission {
+    private final String stageName;
+    private final Users stageOperators;
+
+    public StagePermission(String stageName, Users stageOperators) {
+        this.stageName = stageName;
+        this.stageOperators = stageOperators;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoader.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoader.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Sets;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.security.GoConfigPipelinePermissionsAuthority;
 import com.thoughtworks.go.config.security.Permissions;
+import com.thoughtworks.go.config.security.permissions.NoOnePermission;
 import com.thoughtworks.go.config.security.users.NoOne;
 import com.thoughtworks.go.domain.PipelineGroupVisitor;
 import com.thoughtworks.go.domain.PipelinePauseInfo;
@@ -202,7 +203,7 @@ public class GoDashboardCurrentStateLoader {
         if (pipelinesAndTheirPermissions.containsKey(pipelineConfig.name())) {
             return pipelinesAndTheirPermissions.get(pipelineConfig.name());
         }
-        return new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE);
+        return new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE);
     }
 
     public void reset() {

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardPipeline.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardPipeline.java
@@ -89,6 +89,10 @@ public class GoDashboardPipeline {
         return permissions.pipelineOperators().contains(userName);
     }
 
+    public boolean isStageOperator(String stageName, String userName) {
+        return permissions.stageOperators(stageName).contains(userName);
+    }
+
     public long getLastUpdatedTimeStamp() {
         return lastUpdatedTimeStamp;
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/security/permissions/PipelinePermissionTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/security/permissions/PipelinePermissionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.security.permissions;
+
+import com.thoughtworks.go.config.security.users.AllowedUsers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PipelinePermissionTest {
+
+    PipelinePermission pipelinePermission;
+
+    @BeforeEach
+    void setUp() {
+
+        StagePermission stage1 = new StagePermission("stage1", new AllowedUsers(Set.of("admin", "operator1", "operator2"), Collections.emptySet()));
+        StagePermission stage2 = new StagePermission("stage2", new AllowedUsers(Set.of("admin", "operator1"), Collections.emptySet()));
+
+        pipelinePermission = new PipelinePermission(Arrays.asList(stage1, stage2));
+    }
+
+    @Test
+    void shouldReturnStage1PermissionsAsPipelinePermissions() {
+        assertEquals(pipelinePermission.getPipelineOperators(), new AllowedUsers(Set.of("admin", "operator1", "operator2"), Collections.emptySet()));
+    }
+
+    @Test
+    void shouldReturnStagePermissionsProvidedStageName() {
+        assertEquals(pipelinePermission.getStageOperators("stage1"), new AllowedUsers(Set.of("admin", "operator1", "operator2"), Collections.emptySet()));
+        assertEquals(pipelinePermission.getStageOperators("stage2"), new AllowedUsers(Set.of("admin", "operator1"), Collections.emptySet()));
+    }
+
+    @Test
+    void shouldNotFailWhenInvalidStageNameIsSpecified() {
+        assertEquals(pipelinePermission.getStageOperators("stageX"), null);
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/domain/cctray/CcTrayConfigChangeHandlerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/domain/cctray/CcTrayConfigChangeHandlerTest.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.domain.cctray;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.security.GoConfigPipelinePermissionsAuthority;
 import com.thoughtworks.go.config.security.Permissions;
+import com.thoughtworks.go.config.security.permissions.NoOnePermission;
 import com.thoughtworks.go.config.security.users.AllowedUsers;
 import com.thoughtworks.go.config.security.users.NoOne;
 import com.thoughtworks.go.config.security.users.Users;
@@ -230,8 +231,8 @@ public class CcTrayConfigChangeHandlerTest {
         PluginRoleConfig admin = new PluginRoleConfig("admin", "ldap");
         pluginRoleUsersStore.assignRole("user4", admin);
 
-        Permissions pipeline1Permissions = new Permissions(viewers("user1", "user2"), NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE);
-        Permissions pipeline2Permissions = new Permissions(new AllowedUsers(s("user3"), Collections.singleton(admin)), NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE);
+        Permissions pipeline1Permissions = new Permissions(viewers("user1", "user2"), NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE);
+        Permissions pipeline2Permissions = new Permissions(new AllowedUsers(s("user3"), Collections.singleton(admin)), NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE);
         when(pipelinePermissionsAuthority.pipelinesAndTheirPermissions()).thenReturn(m(new CaseInsensitiveString("pipeline1"), pipeline1Permissions, new CaseInsensitiveString("pipeline2"), pipeline2Permissions));
 
         CruiseConfig config = GoConfigMother.defaultCruiseConfig();

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoaderTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoaderTest.java
@@ -20,6 +20,8 @@ import com.thoughtworks.go.config.remote.FileConfigOrigin;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.config.security.GoConfigPipelinePermissionsAuthority;
 import com.thoughtworks.go.config.security.Permissions;
+import com.thoughtworks.go.config.security.permissions.EveryonePermission;
+import com.thoughtworks.go.config.security.permissions.NoOnePermission;
 import com.thoughtworks.go.config.security.users.Everyone;
 import com.thoughtworks.go.config.security.users.NoOne;
 import com.thoughtworks.go.domain.PipelinePauseInfo;
@@ -299,8 +301,8 @@ public class GoDashboardCurrentStateLoaderTest {
         PipelineInstanceModel pimForP1 = pim(p1Config);
         PipelineInstanceModel pimForP2 = pim(p2Config);
 
-        Permissions permissionsForP1 = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE);
-        Permissions permissionsForP2 = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE);
+        Permissions permissionsForP1 = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE);
+        Permissions permissionsForP2 = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE, NoOnePermission.INSTANCE);
 
         when(pipelineSqlMapDao.loadHistoryForDashboard(Arrays.asList("pipeline1", "pipeline2"))).thenReturn(createPipelineInstanceModels(pimForP1, pimForP2));
         when(permissionsAuthority.pipelinesAndTheirPermissions()).thenReturn(m(p1Config.name(), permissionsForP1, p2Config.name(), permissionsForP2));
@@ -332,7 +334,7 @@ public class GoDashboardCurrentStateLoaderTest {
     public void shouldGetAGoDashboardPipelineGivenASinglePipelineConfigAndItsGroupConfig() throws Exception {
         String pipelineNameStr = "pipeline1";
         CaseInsensitiveString pipelineName = new CaseInsensitiveString(pipelineNameStr);
-        Permissions permissions = new Permissions(Everyone.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE);
+        Permissions permissions = new Permissions(Everyone.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE, NoOnePermission.INSTANCE);
         PipelineConfig p1Config = goConfigMother.addPipelineWithGroup(config, "group1", pipelineNameStr, "stage1", "job1");
         PipelineInstanceModels pipelineInstanceModels = createPipelineInstanceModels(pim(p1Config));
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelineGroupTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelineGroupTest.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.server.dashboard;
 
 import com.thoughtworks.go.config.security.Permissions;
+import com.thoughtworks.go.config.security.permissions.NoOnePermission;
 import com.thoughtworks.go.config.security.users.AllowedUsers;
 import com.thoughtworks.go.config.security.users.NoOne;
 import com.thoughtworks.go.server.domain.Username;
@@ -34,7 +35,7 @@ public class GoDashboardPipelineGroupTest {
                 NoOne.INSTANCE,
                 NoOne.INSTANCE,
                 new AllowedUsers(s("admin1"), Collections.emptySet()),
-                NoOne.INSTANCE);
+                NoOnePermission.INSTANCE);
 
         GoDashboardPipelineGroup pipelineGroup = new GoDashboardPipelineGroup("group1", permissions, true);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelineMother.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelineMother.java
@@ -17,6 +17,7 @@ package com.thoughtworks.go.server.dashboard;
 
 import com.thoughtworks.go.config.remote.FileConfigOrigin;
 import com.thoughtworks.go.config.security.Permissions;
+import com.thoughtworks.go.config.security.permissions.EveryonePermission;
 import com.thoughtworks.go.config.security.users.Everyone;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineModel;
 import com.thoughtworks.go.util.SystemTimeClock;
@@ -29,7 +30,7 @@ public class GoDashboardPipelineMother {
     }
 
     public static GoDashboardPipeline pipeline(String pipelineName, String groupName) {
-        Permissions permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE);
+        Permissions permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE);
         return pipeline(pipelineName, groupName, permissions);
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelineTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelineTest.java
@@ -15,11 +15,16 @@
  */
 package com.thoughtworks.go.server.dashboard;
 
+import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.remote.FileConfigOrigin;
 import com.thoughtworks.go.config.security.Permissions;
+import com.thoughtworks.go.config.security.permissions.EveryonePermission;
+import com.thoughtworks.go.config.security.permissions.NoOnePermission;
+import com.thoughtworks.go.config.security.permissions.PipelinePermission;
 import com.thoughtworks.go.config.security.users.AllowedUsers;
 import com.thoughtworks.go.config.security.users.Everyone;
 import com.thoughtworks.go.config.security.users.NoOne;
+import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineModel;
 import org.junit.Test;
 
@@ -41,7 +46,7 @@ public class GoDashboardPipelineTest {
                 new AllowedUsers(s("viewer1", "viewer2"), Collections.emptySet()),
                 Everyone.INSTANCE,
                 new AllowedUsers(s("admin", "root"), Collections.emptySet()),
-                Everyone.INSTANCE);
+                EveryonePermission.INSTANCE);
 
         GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()), permissions, "group1", null, mock(TimeStampBasedCounter.class), new FileConfigOrigin(), 0);
 
@@ -58,7 +63,7 @@ public class GoDashboardPipelineTest {
                 NoOne.INSTANCE,
                 new AllowedUsers(s("operator1"), Collections.emptySet()),
                 NoOne.INSTANCE,
-                NoOne.INSTANCE);
+                NoOnePermission.INSTANCE);
 
         GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()),
                 permissions, "group1", null, mock(TimeStampBasedCounter.class), new FileConfigOrigin(), 0);
@@ -73,7 +78,7 @@ public class GoDashboardPipelineTest {
                 NoOne.INSTANCE,
                 NoOne.INSTANCE,
                 new AllowedUsers(s("admin1"), Collections.emptySet()),
-                NoOne.INSTANCE);
+                NoOnePermission.INSTANCE);
 
         GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()),
                 permissions, "group1", null, mock(TimeStampBasedCounter.class), new FileConfigOrigin(), 0);
@@ -84,11 +89,12 @@ public class GoDashboardPipelineTest {
 
     @Test
     public void shouldKnowWhetherAUserIsPipelineLevelOperator() throws Exception {
+        PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline1");
         Permissions permissions = new Permissions(
                 NoOne.INSTANCE,
                 NoOne.INSTANCE,
                 NoOne.INSTANCE,
-                new AllowedUsers(s("pipeline_operator"), Collections.emptySet()));
+                PipelinePermission.from(pipelineConfig, new AllowedUsers(s("pipeline_operator"), Collections.emptySet())));
 
         GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()),
                 permissions, "group1", null, mock(TimeStampBasedCounter.class), new FileConfigOrigin(), 0);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/GoDashboardServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/GoDashboardServiceTest.java
@@ -18,6 +18,8 @@ package com.thoughtworks.go.server.service;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.security.GoConfigPipelinePermissionsAuthority;
 import com.thoughtworks.go.config.security.Permissions;
+import com.thoughtworks.go.config.security.permissions.EveryonePermission;
+import com.thoughtworks.go.config.security.permissions.NoOnePermission;
 import com.thoughtworks.go.config.security.users.AllowedUsers;
 import com.thoughtworks.go.config.security.users.Everyone;
 import com.thoughtworks.go.config.security.users.NoOne;
@@ -153,10 +155,10 @@ public class GoDashboardServiceTest {
     public void allPipelineGroupsForDashboard_shouldRetrieveOnlyPipelineGroupsViewableByTheUser() {
         configMother.addPipelineWithGroup(config, "group1", "pipeline1", "stage1A", "job1A1");
         GoDashboardPipeline pipeline1 = pipeline("pipeline1", "group1", new Permissions(new AllowedUsers(Collections.singleton("user1"), Collections.emptySet()),
-                NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE));
+                NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE));
 
         configMother.addPipelineWithGroup(config, "group2", "pipeline2", "stage1A", "job1A1");
-        GoDashboardPipeline pipeline2 = pipeline("pipeline2", "group2", new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE));
+        GoDashboardPipeline pipeline2 = pipeline("pipeline2", "group2", new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE));
 
         addPipelinesToCache(pipeline1, pipeline2);
 
@@ -170,10 +172,10 @@ public class GoDashboardServiceTest {
     public void allEnvironmentsForDashboard_shouldRetrieveOnlyPipelinesViewableByTheUser() {
         configMother.addPipelineWithGroup(config, "group1", "pipeline1", "stage1A", "job1A1");
         GoDashboardPipeline pipeline1 = pipeline("pipeline1", "group1", new Permissions(new AllowedUsers(Collections.singleton("user1"), Collections.emptySet()),
-                NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE));
+                NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE));
 
         configMother.addPipelineWithGroup(config, "group2", "pipeline2", "stage1A", "job1A1");
-        GoDashboardPipeline pipeline2 = pipeline("pipeline2", "group2", new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE));
+        GoDashboardPipeline pipeline2 = pipeline("pipeline2", "group2", new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE));
 
         addPipelinesToCache(pipeline1, pipeline2);
 
@@ -240,7 +242,7 @@ public class GoDashboardServiceTest {
     @Test
     public void allPipelineGroupsForDashboard_shouldNotListEmptyPipelineGroup() {
         configMother.addPipelineWithGroup(config, "group1", "pipeline1", "stage1A", "job1A1");
-        addPipelinesToCache(pipeline("pipeline1", "group1", new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)));
+        addPipelinesToCache(pipeline("pipeline1", "group1", new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)));
 
         List<GoDashboardPipelineGroup> pipelineGroups = allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user1"));
 
@@ -250,7 +252,7 @@ public class GoDashboardServiceTest {
     @Test
     public void allEnvironmentsForDashboard_shouldNotListEmptyPipelineGroup() {
         configMother.addPipelineWithGroup(config, "group1", "pipeline1", "stage1A", "job1A1");
-        addPipelinesToCache(pipeline("pipeline1", "group1", new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)));
+        addPipelinesToCache(pipeline("pipeline1", "group1", new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)));
 
         configMother.addEnvironmentConfig(config, "env1", "pipeline1");
         List<GoDashboardEnvironment> pipelineGroups = allEnvironmentsForDashboard(Filters.WILDCARD_FILTER, new Username("user1"));
@@ -264,7 +266,7 @@ public class GoDashboardServiceTest {
 
         configMother.addPipelineWithGroup(config, "group1", "pipeline1", "stage1A", "job1A1");
         GoDashboardPipeline pipeline1 = pipeline("pipeline1", "group1", new Permissions(Everyone.INSTANCE,
-                Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE));
+                Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE));
 
         addPipelinesToCache(pipeline1);
 
@@ -281,7 +283,7 @@ public class GoDashboardServiceTest {
 
         configMother.addPipelineWithGroup(config, "group1", "pipeline1", "stage1A", "job1A1");
         GoDashboardPipeline pipeline1 = pipeline("pipeline1", "group1", new Permissions(Everyone.INSTANCE,
-                Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE));
+                Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE));
 
         addPipelinesToCache(pipeline1);
         configMother.addEnvironmentConfig(config, "env1", "pipeline1", "pipeline2");


### PR DESCRIPTION
Description:

* Add an ability to compute individual stage operate permissions as part of dashboard pipeline permissions
* Add can_operate field to the dashboard API.

