### PR TITLE
Remove new_pipeline_dropdown toggle, finally.

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -19,7 +19,6 @@ public class Toggles {
     public static String BROWSER_CONSOLE_LOG_WS = "browser_console_log_ws_key";
     public static String ALLOW_EMPTY_PIPELINE_GROUPS_DASHBOARD = "allow_empty_pipeline_groups_dashboard";
     public static String TEST_DRIVE = "test_drive";
-    public static String NEW_PIPELINE_DROPDOWN = "new_pipeline_dropdown";
     public static String FAST_PIPELINE_SAVE = "fast_pipeline_save";
     public static String SHOW_OLD_PKG_REPOS_SPA = "show_old_pkg_repos_spa";
     public static String SHOW_OLD_COMPARISON_SPA = "show_old_comparison_spa";

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -12,11 +12,6 @@
       "value": false
     },
     {
-      "key": "new_pipeline_dropdown",
-      "description": "Makes the button for new pipeline on the dashboard a dropdown so can select add pipeline with pipelines as code",
-      "value": false
-    },
-    {
       "key": "allow_empty_pipeline_groups_dashboard",
       "description": "Coupled with queryParam allowEmpty=true will show empty pipeline groups on the dashboard.",
       "value": false

--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/new_dashboard.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/new_dashboard.js
@@ -27,7 +27,6 @@ import {PluginInfos} from "../models/shared/plugin_infos";
 $(() => {
   const dashboardElem              = $('#dashboard');
   const showEmptyPipelineGroups    = JSON.parse(dashboardElem.attr('data-show-empty-pipeline-groups'));
-  const newPipelineDropdown        = JSON.parse(dashboardElem.attr('data-new-pipeline-dropdown'));
   const shouldShowAnalyticsIcon    = JSON.parse(dashboardElem.attr('data-should-show-analytics-icon'));
   const testDrive                  = JSON.parse(dashboardElem.attr('data-test-drive'));
   const pluginsSupportingAnalytics = {};
@@ -205,7 +204,6 @@ $(() => {
           showSpinner,
           pluginsSupportingAnalytics,
           shouldShowAnalyticsIcon,
-          newPipelineDropdown,
           testDrive,
           vm:                   dashboardVM,
           doCancelPolling:      () => repeater().stop(),

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/dashboard_groups_widget.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/dashboard_groups_widget.js.msx
@@ -32,16 +32,7 @@ const GroupHeading = {
     let addPipeline = "";
 
     if (vm.canAdminister && paths.new) {
-      vnode.attrs.newPipelineDropdown ?
-        addPipeline = <Dropdown vm={vm}/> :
-        addPipeline = <Buttons.Primary align="right"
-            icon={Buttons.ButtonIcon.ADD}
-            disabled={!vm.canAdminister}
-            aria-label={vm.ariaLabelForNewPipeline()}
-            title={vm.titleForNewPipeline()}
-            onclick={this.goToAddPipeline.bind(null, paths.new)}>
-            New Pipeline
-          </Buttons.Primary>;
+      addPipeline = <Dropdown vm={vm}/>;
     }
 
     return <div class="dashboard-group_title">

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/dashboard_widget.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/dashboard_widget.js.msx
@@ -85,7 +85,6 @@ export const DashboardWidget = {
 
           {messageView}
           <DashboardGroupsWidget scheme={vm.scheme()}
-                                 newPipelineDropdown={args.newPipelineDropdown}
                                  testDrive={args.testDrive}
                                  invalidateEtag={vm.invalidateEtag}
                                  resolver={dashboard} {...sharedGroupArgs}

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/NewDashboardController.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/NewDashboardController.java
@@ -71,7 +71,6 @@ public class NewDashboardController implements SparkController {
         HashMap<Object, Object> object = new HashMap<Object, Object>() {{
             put("viewTitle", "Dashboard");
             put("showEmptyPipelineGroups", Toggles.isToggleOn(Toggles.ALLOW_EMPTY_PIPELINE_GROUPS_DASHBOARD));
-            put("newPipelineDropdown", Toggles.isToggleOn(Toggles.NEW_PIPELINE_DROPDOWN));
             put("shouldShowAnalyticsIcon", showAnalyticsIcon());
             put("testDrive", Toggles.isToggleOn(Toggles.TEST_DRIVE));
         }};

--- a/spark/spark-spa/src/main/resources/freemarker/new_dashboard/index.ftlh
+++ b/spark/spark-spa/src/main/resources/freemarker/new_dashboard/index.ftlh
@@ -15,7 +15,6 @@
   -->
 <div id="dashboard" class="dashboard"
   data-show-empty-pipeline-groups="${showEmptyPipelineGroups?c}"
-  data-new-pipeline-dropdown="${newPipelineDropdown?c}"
   data-should-show-analytics-icon="${shouldShowAnalyticsIcon?c}"
   data-test-drive="${testDrive?c}">
   <span class="page-spinner"/>


### PR DESCRIPTION
It's about damned time.

Now the new Pipelines as Code creation page is discoverable by users.