### PR TITLE
Add allow_only_on_success_of_previous_stage field to the dashboard API stage

### DIFF
--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/GoDashboardPipelineMother.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/GoDashboardPipelineMother.groovy
@@ -15,10 +15,11 @@
  */
 package com.thoughtworks.go.apiv3.dashboard
 
-import com.thoughtworks.go.config.remote.FileConfigOrigin
+
 import com.thoughtworks.go.config.security.Permissions
 import com.thoughtworks.go.config.security.permissions.EveryonePermission
 import com.thoughtworks.go.config.security.users.Everyone
+import com.thoughtworks.go.helper.PipelineConfigMother
 import com.thoughtworks.go.server.dashboard.GoDashboardPipeline
 import com.thoughtworks.go.server.dashboard.TimeStampBasedCounter
 import com.thoughtworks.go.util.Clock
@@ -32,6 +33,6 @@ class GoDashboardPipelineMother {
   static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE), timestamp = 1000L) {
     def clock = mock(Clock.class)
     when(clock.currentTimeMillis()).thenReturn(timestamp)
-    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, null, new TimeStampBasedCounter(clock), new FileConfigOrigin(), 0)
+    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, new TimeStampBasedCounter(clock), PipelineConfigMother.pipelineConfig(pipeline_name))
   }
 }

--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/DashboardGroupRepresenterTest.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/DashboardGroupRepresenterTest.groovy
@@ -16,11 +16,11 @@
 package com.thoughtworks.go.apiv3.dashboard.representers
 
 import com.thoughtworks.go.config.CaseInsensitiveString
-import com.thoughtworks.go.config.remote.FileConfigOrigin
 import com.thoughtworks.go.config.security.Permissions
 import com.thoughtworks.go.config.security.permissions.EveryonePermission
 import com.thoughtworks.go.config.security.users.Everyone
 import com.thoughtworks.go.config.security.users.NoOne
+import com.thoughtworks.go.helper.PipelineConfigMother
 import com.thoughtworks.go.server.dashboard.GoDashboardEnvironment
 import com.thoughtworks.go.server.dashboard.GoDashboardPipeline
 import com.thoughtworks.go.server.dashboard.GoDashboardPipelineGroup
@@ -148,6 +148,6 @@ class DashboardGroupRepresenterTest {
   static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE), long timestamp = 1000) {
     def clock = mock(Clock.class)
     when(clock.currentTimeMillis()).thenReturn(timestamp)
-    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, null, new TimeStampBasedCounter(clock), new FileConfigOrigin(), 0)
+    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, new TimeStampBasedCounter(clock), PipelineConfigMother.pipelineConfig(pipeline_name))
   }
 }

--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/PipelineRepresenterTest.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/PipelineRepresenterTest.groovy
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.apiv3.dashboard.representers
 
 import com.thoughtworks.go.config.CaseInsensitiveString
+import com.thoughtworks.go.config.PipelineConfig
 import com.thoughtworks.go.config.TrackingTool
 import com.thoughtworks.go.config.remote.ConfigRepoConfig
 import com.thoughtworks.go.config.remote.FileConfigOrigin
@@ -26,6 +27,7 @@ import com.thoughtworks.go.config.security.permissions.NoOnePermission
 import com.thoughtworks.go.config.security.users.Everyone
 import com.thoughtworks.go.config.security.users.NoOne
 import com.thoughtworks.go.helper.MaterialConfigsMother
+import com.thoughtworks.go.helper.PipelineConfigMother
 import com.thoughtworks.go.server.dashboard.Counter
 import com.thoughtworks.go.server.dashboard.GoDashboardPipeline
 import com.thoughtworks.go.server.domain.Username
@@ -46,8 +48,12 @@ class PipelineRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
+    def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+    pipelineConfig.setTrackingTool(new TrackingTool("http://example.com/\${ID}", "##\\d+"))
+    pipelineConfig.setOrigin(new FileConfigOrigin())
+    pipelineConfig.setDisplayOrderWeight(0)
     def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'),
-      permissions, "grp", new TrackingTool("http://example.com/\${ID}", "##\\d+"), counter, new FileConfigOrigin(), 0)
+            permissions, "grp", counter, pipelineConfig)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
     def json = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })
@@ -90,7 +96,7 @@ class PipelineRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
-    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1'), permissions, "grp", null, counter, null, 0)
+    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1'), permissions, "grp", counter, PipelineConfigMother.pipelineConfig("p1"))
 
     def json = toObject({ PipelineRepresenter.toJSON(it, pipeline, new Username(new CaseInsensitiveString(SecureRandom.hex()))) })
 
@@ -102,7 +108,7 @@ class PipelineRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
-    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1', false, true, "under construction"), permissions, "grp", null, counter, null, 0)
+    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1', false, true, "under construction"), permissions, "grp", counter, PipelineConfigMother.pipelineConfig("p1"))
 
     def json = toObject({ PipelineRepresenter.toJSON(it, pipeline, new Username(new CaseInsensitiveString(SecureRandom.hex()))) })
 
@@ -123,7 +129,9 @@ class PipelineRepresenterTest {
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, EveryonePermission.INSTANCE)
       def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
-      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
+      def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+      pipelineConfig.setOrigin(origin)
+      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", counter, pipelineConfig)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
       def actualJson = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })
@@ -141,7 +149,9 @@ class PipelineRepresenterTest {
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE, NoOnePermission.INSTANCE)
       def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
-      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
+      def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+      pipelineConfig.setOrigin(origin)
+      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", counter, pipelineConfig)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
       def actualJson = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })
@@ -159,7 +169,9 @@ class PipelineRepresenterTest {
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
       def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
-      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
+      def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+      pipelineConfig.setOrigin(origin)
+      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", counter, pipelineConfig)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
       def actualJson = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })

--- a/api/api-dashboard-v4/src/main/java/com/thoughtworks/go/apiv4/dashboard/representers/StageRepresenter.java
+++ b/api/api-dashboard-v4/src/main/java/com/thoughtworks/go/apiv4/dashboard/representers/StageRepresenter.java
@@ -32,6 +32,7 @@ public class StageRepresenter {
                 .add("name", model.getName())
                 .add("counter", model.getCounter())
                 .add("status", model.getState().name())
+                .add("allow_only_on_success_of_previous_stage", goDashboardPipeline.isAllowOnlyOnSuccessOfPreviousStage(model.getName()))
                 .add("can_operate", goDashboardPipeline.isStageOperator(model.getName(), username.getUsername().toString()))
                 .add("approved_by", model.getApprovedBy())
                 .add("scheduled_at", model.getScheduledDate());

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/GoDashboardPipelineMother.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/GoDashboardPipelineMother.groovy
@@ -15,10 +15,11 @@
  */
 package com.thoughtworks.go.apiv4.dashboard
 
-import com.thoughtworks.go.config.remote.FileConfigOrigin
+
 import com.thoughtworks.go.config.security.Permissions
 import com.thoughtworks.go.config.security.permissions.EveryonePermission
 import com.thoughtworks.go.config.security.users.Everyone
+import com.thoughtworks.go.helper.PipelineConfigMother
 import com.thoughtworks.go.server.dashboard.GoDashboardPipeline
 import com.thoughtworks.go.server.dashboard.TimeStampBasedCounter
 import com.thoughtworks.go.util.Clock
@@ -32,6 +33,6 @@ class GoDashboardPipelineMother {
   static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE), timestamp = 1000L) {
     def clock = mock(Clock.class)
     when(clock.currentTimeMillis()).thenReturn(timestamp)
-    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, null, new TimeStampBasedCounter(clock), new FileConfigOrigin(), 0)
+    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, new TimeStampBasedCounter(clock), PipelineConfigMother.pipelineConfig(pipeline_name))
   }
 }

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/DashboardGroupRepresenterTest.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/DashboardGroupRepresenterTest.groovy
@@ -16,11 +16,11 @@
 package com.thoughtworks.go.apiv4.dashboard.representers
 
 import com.thoughtworks.go.config.CaseInsensitiveString
-import com.thoughtworks.go.config.remote.FileConfigOrigin
 import com.thoughtworks.go.config.security.Permissions
 import com.thoughtworks.go.config.security.permissions.EveryonePermission
 import com.thoughtworks.go.config.security.users.Everyone
 import com.thoughtworks.go.config.security.users.NoOne
+import com.thoughtworks.go.helper.PipelineConfigMother
 import com.thoughtworks.go.server.dashboard.GoDashboardEnvironment
 import com.thoughtworks.go.server.dashboard.GoDashboardPipeline
 import com.thoughtworks.go.server.dashboard.GoDashboardPipelineGroup
@@ -152,6 +152,6 @@ class DashboardGroupRepresenterTest {
   static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, EveryonePermission.INSTANCE), long timestamp = 1000) {
     def clock = mock(Clock.class)
     when(clock.currentTimeMillis()).thenReturn(timestamp)
-    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, null, new TimeStampBasedCounter(clock), new FileConfigOrigin(), 0)
+    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, new TimeStampBasedCounter(clock), PipelineConfigMother.pipelineConfig(pipeline_name))
   }
 }

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/PipelineInstanceRepresenterTest.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/PipelineInstanceRepresenterTest.groovy
@@ -21,6 +21,7 @@ import com.thoughtworks.go.config.remote.FileConfigOrigin
 import com.thoughtworks.go.config.security.Permissions
 import com.thoughtworks.go.config.security.permissions.NoOnePermission
 import com.thoughtworks.go.config.security.users.NoOne
+import com.thoughtworks.go.helper.PipelineConfigMother
 import com.thoughtworks.go.helpers.PipelineModelMother
 import com.thoughtworks.go.server.dashboard.Counter
 import com.thoughtworks.go.server.dashboard.GoDashboardPipeline
@@ -44,8 +45,12 @@ class PipelineInstanceRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
+    def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+    pipelineConfig.setOrigin(new FileConfigOrigin())
+    pipelineConfig.setTrackingTool(new TrackingTool("http://example.com/\${ID}", "##\\d+"))
+    pipelineConfig.setDisplayOrderWeight(0)
     def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'pipeline_label'),
-            permissions, "grp", new TrackingTool("http://example.com/\${ID}", "##\\d+"), counter, new FileConfigOrigin(), 0)
+            permissions, "grp", counter, pipelineConfig)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
     def json = toObject({ PipelineInstanceRepresenter.toJSON(it, pipelineInstance, pipeline, username) })
@@ -67,8 +72,12 @@ class PipelineInstanceRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
+    def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+    pipelineConfig.setOrigin(new FileConfigOrigin())
+    pipelineConfig.setTrackingTool(new TrackingTool("http://example.com/\${ID}", "##\\d+"))
+    pipelineConfig.setDisplayOrderWeight(0)
     def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'g1'),
-            permissions, "grp", new TrackingTool("http://example.com/\${ID}", "##\\d+"), counter, new FileConfigOrigin(), 0)
+            permissions, "grp", counter, pipelineConfig)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
     def actualJson = toObject({ PipelineInstanceRepresenter.toJSON(it, instance, pipeline, username) })

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenterTest.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenterTest.groovy
@@ -26,6 +26,7 @@ import com.thoughtworks.go.config.security.permissions.NoOnePermission
 import com.thoughtworks.go.config.security.users.Everyone
 import com.thoughtworks.go.config.security.users.NoOne
 import com.thoughtworks.go.helper.MaterialConfigsMother
+import com.thoughtworks.go.helper.PipelineConfigMother
 import com.thoughtworks.go.server.dashboard.Counter
 import com.thoughtworks.go.server.dashboard.GoDashboardPipeline
 import com.thoughtworks.go.server.domain.Username
@@ -46,8 +47,12 @@ class PipelineRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
+    def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+    pipelineConfig.setTrackingTool(new TrackingTool("http://example.com/\${ID}", "##\\d+"),)
+    pipelineConfig.setOrigin(new FileConfigOrigin())
+    pipelineConfig.setDisplayOrderWeight(0)
     def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'),
-      permissions, "grp", new TrackingTool("http://example.com/\${ID}", "##\\d+"), counter, new FileConfigOrigin(), 0)
+            permissions, "grp", counter, pipelineConfig)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
     def json = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })
@@ -90,7 +95,7 @@ class PipelineRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
-    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1'), permissions, "grp", null, counter, null, 0)
+    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1'), permissions, "grp", counter, PipelineConfigMother.pipelineConfig("p1"))
 
     def json = toObject({
       PipelineRepresenter.toJSON(it, pipeline, new Username(new CaseInsensitiveString(SecureRandom.hex())))
@@ -104,7 +109,7 @@ class PipelineRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
-    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1', false, true, "under construction"), permissions, "grp", null, counter, null, 0)
+    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1', false, true, "under construction"), permissions, "grp", counter, PipelineConfigMother.pipelineConfig("p1"))
 
     def json = toObject({
       PipelineRepresenter.toJSON(it, pipeline, new Username(new CaseInsensitiveString(SecureRandom.hex())))
@@ -124,7 +129,9 @@ class PipelineRepresenterTest {
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
     def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
-    def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'p1l1', false, true, null), permissions, "grp", null, counter, origin, 0)
+    def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+    pipelineConfig.setOrigin(origin)
+    def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'p1l1', false, true, null), permissions, "grp", counter, pipelineConfig)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
     def json = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })
@@ -143,7 +150,9 @@ class PipelineRepresenterTest {
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, EveryonePermission.INSTANCE)
       def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
-      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
+      def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+      pipelineConfig.setOrigin(origin)
+      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", counter, pipelineConfig)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
       def actualJson = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })
@@ -161,7 +170,9 @@ class PipelineRepresenterTest {
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE, NoOnePermission.INSTANCE)
       def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
-      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
+      def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+      pipelineConfig.setOrigin(origin)
+      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", counter, pipelineConfig)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
       def actualJson = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })
@@ -179,7 +190,9 @@ class PipelineRepresenterTest {
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
       def origin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
-      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
+      def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+      pipelineConfig.setOrigin(origin)
+      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", counter, pipelineConfig)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
       def actualJson = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/StageRepresenterTest.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/StageRepresenterTest.groovy
@@ -22,6 +22,7 @@ import com.thoughtworks.go.config.security.Permissions
 import com.thoughtworks.go.config.security.permissions.NoOnePermission
 import com.thoughtworks.go.config.security.users.NoOne
 import com.thoughtworks.go.domain.*
+import com.thoughtworks.go.helper.PipelineConfigMother
 import com.thoughtworks.go.presentation.pipelinehistory.JobHistory
 import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModel
 import com.thoughtworks.go.server.dashboard.Counter
@@ -53,8 +54,12 @@ class StageRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
+    def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+    pipelineConfig.setOrigin(new FileConfigOrigin())
+    pipelineConfig.setTrackingTool(new TrackingTool("http://example.com/\${ID}", "##\\d+"))
+    pipelineConfig.setDisplayOrderWeight(0)
     def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'pipeline_label'),
-            permissions, "grp", new TrackingTool("http://example.com/\${ID}", "##\\d+"), counter, new FileConfigOrigin(), 0)
+            permissions, "grp", counter, pipelineConfig)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
     def json = toObject({ StageRepresenter.toJSON(it, pipeline, stageInstance, username, "pipeline-name", "2") })
@@ -69,6 +74,7 @@ class StageRepresenterTest {
       can_operate   : false,
       approved_by   : 'go-user',
       scheduled_at  : jsonDate(date),
+      allow_only_on_success_of_previous_stage: false,
       previous_stage: [
         _links      : [
           self: [href: 'http://test.host/go/api/stages/pipeline-name/2/stage1/1']
@@ -79,6 +85,7 @@ class StageRepresenterTest {
         can_operate : false,
         approved_by : null,
         scheduled_at: null,
+        allow_only_on_success_of_previous_stage: false
       ]
     ]
     assertThatJson(json).isEqualTo(expectedJson)
@@ -91,8 +98,12 @@ class StageRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
+    def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+    pipelineConfig.setOrigin(new FileConfigOrigin())
+    pipelineConfig.setTrackingTool(new TrackingTool("http://example.com/\${ID}", "##\\d+"))
+    pipelineConfig.setDisplayOrderWeight(0)
     def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'pipeline_label'),
-            permissions, "grp", new TrackingTool("http://example.com/\${ID}", "##\\d+"), counter, new FileConfigOrigin(), 0)
+            permissions, "grp", counter, pipelineConfig)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
     def json = toObject({ StageRepresenter.toJSON(it, pipeline, stageInstance, username, "pipeline-name", "23") })
@@ -106,7 +117,8 @@ class StageRepresenterTest {
       status      : StageState.Unknown,
       can_operate : false,
       approved_by : null,
-      scheduled_at: null
+      scheduled_at: null,
+      allow_only_on_success_of_previous_stage: false
     ]
     assertThatJson(json).isEqualTo(expectedJson)
   }
@@ -119,8 +131,12 @@ class StageRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
+    def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+    pipelineConfig.setOrigin(new FileConfigOrigin())
+    pipelineConfig.setTrackingTool(new TrackingTool("http://example.com/\${ID}", "##\\d+"))
+    pipelineConfig.setDisplayOrderWeight(0)
     def pipeline = new GoDashboardPipeline(pipeline_model('pipeline-name', 'pipeline_label'),
-            permissions, "grp", new TrackingTool("http://example.com/\${ID}", "##\\d+"), counter, new FileConfigOrigin(), 0)
+            permissions, "grp", counter, pipelineConfig)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
     def json = toObject({ StageRepresenter.toJSON(it, pipeline, stageInstance, username, "pipeline-name", "23") })
@@ -134,7 +150,8 @@ class StageRepresenterTest {
       can_operate : false,
       approved_by : null,
       scheduled_at: "1970-01-01T00:00:12Z",
-      cancelled_by: "foo"
+      cancelled_by: "foo",
+      allow_only_on_success_of_previous_stage: false
     ]
 
     assertThatJson(json).isEqualTo(expectedJson)
@@ -146,8 +163,12 @@ class StageRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOnePermission.INSTANCE)
+    def pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline_name")
+    pipelineConfig.setOrigin(new FileConfigOrigin())
+    pipelineConfig.setTrackingTool(new TrackingTool("http://example.com/\${ID}", "##\\d+"))
+    pipelineConfig.setDisplayOrderWeight(0)
     def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'pipeline_label'),
-            permissions, "grp", new TrackingTool("http://example.com/\${ID}", "##\\d+"), counter, new FileConfigOrigin(), 0)
+            permissions, "grp", counter, pipelineConfig)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
     def json = toObject({ StageRepresenter.toJSON(it, pipeline, stageInstance, username, "pipeline-name", "23") })
@@ -161,7 +182,8 @@ class StageRepresenterTest {
       can_operate : false,
       approved_by : null,
       scheduled_at: "1970-01-01T00:00:12Z",
-      cancelled_by: "GoCD"
+      cancelled_by: "GoCD",
+      allow_only_on_success_of_previous_stage: false
     ]
 
     assertThatJson(json).isEqualTo(expectedJson)

--- a/api/api-server-maintenance-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/servermaintenancemode/ServerMaintenanceModeControllerV1Test.groovy
+++ b/api/api-server-maintenance-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/servermaintenancemode/ServerMaintenanceModeControllerV1Test.groovy
@@ -18,12 +18,12 @@ package com.thoughtworks.go.apiv1.servermaintenancemode
 import com.thoughtworks.go.api.SecurityTestTrait
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.apiv1.servermaintenancemode.representers.MaintenanceModeInfoRepresenter
-import com.thoughtworks.go.config.remote.FileConfigOrigin
 import com.thoughtworks.go.domain.JobIdentifier
 import com.thoughtworks.go.domain.JobInstance
 import com.thoughtworks.go.domain.JobResult
 import com.thoughtworks.go.domain.JobState
 import com.thoughtworks.go.helper.AgentInstanceMother
+import com.thoughtworks.go.helper.PipelineConfigMother
 import com.thoughtworks.go.presentation.pipelinehistory.*
 import com.thoughtworks.go.server.dashboard.GoDashboardCache
 import com.thoughtworks.go.server.dashboard.GoDashboardPipeline
@@ -341,7 +341,7 @@ class ServerMaintenanceModeControllerV1Test implements SecurityServiceTrait, Con
         allStages.add(new StageInstanceModel("stage1", "1", allJobs))
         def pipelineInstanceModel = new PipelineInstanceModel(pipelineName, 1, pipelineName, null, allStages)
         pipelineModel.addPipelineInstance(pipelineInstanceModel)
-        return new GoDashboardPipeline(pipelineModel, null, "group1", null, new TimeStampBasedCounter(testingClock), new FileConfigOrigin(), 0)
+        return new GoDashboardPipeline(pipelineModel, null, "group1", new TimeStampBasedCounter(testingClock), PipelineConfigMother.pipelineConfig(pipelineName))
       }
     }
   }

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoader.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoader.java
@@ -143,7 +143,7 @@ public class GoDashboardCurrentStateLoader {
 
     private GoDashboardPipeline createGoDashboardPipeline(PipelineConfig pipelineConfig, Permissions permissions, PipelineInstanceModels historyForDashboard, PipelineConfigs group) {
         PipelineModel pipelineModel = pipelineModelFor(pipelineConfig, historyForDashboard);
-        return new GoDashboardPipeline(pipelineModel, permissions, group.getGroup(), pipelineConfig.getTrackingTool(), timeStampBasedCounter, pipelineConfig.getOrigin(), pipelineConfig.getDisplayOrderWeight());
+        return new GoDashboardPipeline(pipelineModel, permissions, group.getGroup(), timeStampBasedCounter, pipelineConfig);
     }
 
     private PipelineModel pipelineModelFor(PipelineConfig pipelineConfig, PipelineInstanceModels historyForDashboard) {

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardPipeline.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardPipeline.java
@@ -16,6 +16,8 @@
 package com.thoughtworks.go.server.dashboard;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.config.StageConfig;
 import com.thoughtworks.go.config.TrackingTool;
 import com.thoughtworks.go.config.remote.ConfigOrigin;
 import com.thoughtworks.go.config.security.Permissions;
@@ -34,15 +36,17 @@ public class GoDashboardPipeline {
     private final long lastUpdatedTimeStamp;
     private ConfigOrigin origin;
     private int displayOrderWeight;
+    private PipelineConfig pipelineConfig;
 
-    public GoDashboardPipeline(PipelineModel pipelineModel, Permissions permissions, String groupName, TrackingTool trackingTool, Counter timeStampBasedCounter, ConfigOrigin origin, int displayOrderWeight) {
+    public GoDashboardPipeline(PipelineModel pipelineModel, Permissions permissions, String groupName, Counter timeStampBasedCounter, PipelineConfig pipelineConfig) {
         this.pipelineModel = pipelineModel;
         this.permissions = permissions;
         this.groupName = groupName;
-        this.trackingTool = trackingTool;
+        this.trackingTool = pipelineConfig.getTrackingTool();
         this.lastUpdatedTimeStamp = timeStampBasedCounter.getNext();
-        this.origin = origin;
-        this.displayOrderWeight = displayOrderWeight;
+        this.origin = pipelineConfig.getOrigin();
+        this.displayOrderWeight = pipelineConfig.getDisplayOrderWeight();
+        this.pipelineConfig = pipelineConfig;
     }
 
     public String groupName() {
@@ -59,6 +63,10 @@ public class GoDashboardPipeline {
 
     public Optional<TrackingTool> getTrackingTool() {
         return Optional.ofNullable(trackingTool);
+    }
+
+    public PipelineConfig pipelineConfig() {
+        return pipelineConfig;
     }
 
     public StageInstanceModel getLatestStage() {
@@ -139,5 +147,10 @@ public class GoDashboardPipeline {
 
     public ConfigOrigin getOrigin() {
         return origin;
+    }
+
+    public boolean isAllowOnlyOnSuccessOfPreviousStage(String stageName) {
+        StageConfig stage = this.pipelineConfig.getStage(stageName);
+        return stage != null && stage.getApproval().isAllowOnlyOnSuccess();
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelineMother.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelineMother.java
@@ -15,10 +15,10 @@
  */
 package com.thoughtworks.go.server.dashboard;
 
-import com.thoughtworks.go.config.remote.FileConfigOrigin;
 import com.thoughtworks.go.config.security.Permissions;
 import com.thoughtworks.go.config.security.permissions.EveryonePermission;
 import com.thoughtworks.go.config.security.users.Everyone;
+import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineModel;
 import com.thoughtworks.go.util.SystemTimeClock;
 
@@ -36,6 +36,6 @@ public class GoDashboardPipelineMother {
 
     public static GoDashboardPipeline pipeline(String pipelineName, String groupName, Permissions permissions) {
         return new GoDashboardPipeline(new PipelineModel(pipelineName, false, false, notPaused()),
-                permissions, groupName, null, new TimeStampBasedCounter(new SystemTimeClock()), new FileConfigOrigin(), 0);
+                permissions, groupName, new TimeStampBasedCounter(new SystemTimeClock()), PipelineConfigMother.pipelineConfig(pipelineName));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelineTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelineTest.java
@@ -16,7 +16,6 @@
 package com.thoughtworks.go.server.dashboard;
 
 import com.thoughtworks.go.config.PipelineConfig;
-import com.thoughtworks.go.config.remote.FileConfigOrigin;
 import com.thoughtworks.go.config.security.Permissions;
 import com.thoughtworks.go.config.security.permissions.EveryonePermission;
 import com.thoughtworks.go.config.security.permissions.NoOnePermission;
@@ -48,7 +47,7 @@ public class GoDashboardPipelineTest {
                 new AllowedUsers(s("admin", "root"), Collections.emptySet()),
                 EveryonePermission.INSTANCE);
 
-        GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()), permissions, "group1", null, mock(TimeStampBasedCounter.class), new FileConfigOrigin(), 0);
+        GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()), permissions, "group1", mock(TimeStampBasedCounter.class), PipelineConfigMother.pipelineConfig("pipeline1"));
 
         assertThat(pipeline.canBeViewedBy("viewer1"), is(true));
         assertThat(pipeline.canBeViewedBy("viewer2"), is(true));
@@ -66,7 +65,7 @@ public class GoDashboardPipelineTest {
                 NoOnePermission.INSTANCE);
 
         GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()),
-                permissions, "group1", null, mock(TimeStampBasedCounter.class), new FileConfigOrigin(), 0);
+                permissions, "group1", mock(TimeStampBasedCounter.class), PipelineConfigMother.pipelineConfig("pipeline1"));
 
         assertTrue(pipeline.canBeOperatedBy("operator1"));
         assertFalse(pipeline.canBeOperatedBy("viewer1"));
@@ -81,7 +80,7 @@ public class GoDashboardPipelineTest {
                 NoOnePermission.INSTANCE);
 
         GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()),
-                permissions, "group1", null, mock(TimeStampBasedCounter.class), new FileConfigOrigin(), 0);
+                permissions, "group1", mock(TimeStampBasedCounter.class), PipelineConfigMother.pipelineConfig("pipeline1"));
 
         assertTrue(pipeline.canBeAdministeredBy("admin1"));
         assertFalse(pipeline.canBeAdministeredBy("viewer1"));
@@ -97,7 +96,7 @@ public class GoDashboardPipelineTest {
                 PipelinePermission.from(pipelineConfig, new AllowedUsers(s("pipeline_operator"), Collections.emptySet())));
 
         GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()),
-                permissions, "group1", null, mock(TimeStampBasedCounter.class), new FileConfigOrigin(), 0);
+                permissions, "group1", mock(TimeStampBasedCounter.class), pipelineConfig);
 
         assertTrue(pipeline.isPipelineOperator("pipeline_operator"));
         assertFalse(pipeline.canBeAdministeredBy("viewer1"));
@@ -107,7 +106,7 @@ public class GoDashboardPipelineTest {
     public void shouldSetTheLastUpdateTime() throws Exception {
         TimeStampBasedCounter provider = mock(TimeStampBasedCounter.class);
         when(provider.getNext()).thenReturn(1000L);
-        GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()), null, "group1", null, provider, new FileConfigOrigin(), 0);
+        GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()), null, "group1", provider, PipelineConfigMother.pipelineConfig("pipeline1"));
 
         assertThat(pipeline.getLastUpdatedTimeStamp(), is(1000L));
     }


### PR DESCRIPTION
* Add `allow_only_on_success_of_previous_stage` information to enable/disable
  manual stage trigger option on pipeline tile.
