### PR TITLE
Added title to disabled plugin role selector

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/index.scss
@@ -68,6 +68,10 @@ $warning-wrapper-width: 170px;
 label.disabled, input[type='radio'][disabled] + label[for] { //sass-lint:disable-line no-qualifying-elements
   color:  $disabled-text-color;
   cursor: not-allowed;
+
+  i, p {
+    color: $black;
+  }
 }
 
 .add-user-to-role {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/role_modal_body.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/role_modal_body.tsx
@@ -25,6 +25,8 @@ import {PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import * as Buttons from "views/components/buttons";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {Spinner} from "views/components/spinner";
+import * as Tooltip from "views/components/tooltip";
+import {TooltipSize} from "views/components/tooltip";
 import * as foundationStyles from "views/pages/new_plugins/foundation_hax.scss";
 import {GoCDRoleModalBodyWidget, PluginRoleModalBodyWidget} from "views/pages/roles/role_modal_body_widget";
 import styles from "./index.scss";
@@ -59,6 +61,12 @@ export class RoleModalBody extends MithrilViewComponent<RoleModalAttrs> {
 
     let mayBeTypeSelector: any;
     if (vnode.attrs.action === Action.NEW) {
+      const canAddPluginRole = RoleModalBody.hasAuthConfigs(vnode);
+      let icon;
+      if (!canAddPluginRole) {
+        const title = "Either no plugin has authorization capability or there are no authorization configs defined for the same.";
+        icon        = <Tooltip.Help size={TooltipSize.small} content={title}/>;
+      }
       mayBeTypeSelector = (
         <div data-test-id="role-type-selector">
           <label class="inline">Select type of role:&nbsp;&nbsp;&nbsp;</label>
@@ -76,11 +84,14 @@ export class RoleModalBody extends MithrilViewComponent<RoleModalAttrs> {
             name="role-type-selector"
             id="plugin-role"
             type="radio"
-            disabled={!RoleModalBody.hasAuthConfigs(vnode)}
+            disabled={!canAddPluginRole}
             checked={vnode.attrs.role().isPluginRole()}
             onclick={vnode.attrs.changeRoleType && vnode.attrs.changeRoleType.bind(this, RoleType.plugin)}/>
-          <label class={!RoleModalBody.hasAuthConfigs(vnode) ? `${styles.disabled} inline` : "inline"}
-                 disabled={!RoleModalBody.hasAuthConfigs(vnode)} for="plugin-role">Plugin Role</label>
+          <label class={!canAddPluginRole ? `${styles.disabled} inline` : "inline"}
+                 disabled={!canAddPluginRole} for="plugin-role">
+            Plugin Role
+            {icon}
+          </label>
         </div>
       );
     }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/role_modal_body.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/role_modal_body.tsx
@@ -64,7 +64,7 @@ export class RoleModalBody extends MithrilViewComponent<RoleModalAttrs> {
       const canAddPluginRole = RoleModalBody.hasAuthConfigs(vnode);
       let icon;
       if (!canAddPluginRole) {
-        const title = "Either no plugin has authorization capability or there are no authorization configs defined for the same.";
+        const title = "Cannot add Plugin Role. Either no plugin has authorization capability or there are no authorization configs defined for the same.";
         icon        = <Tooltip.Help size={TooltipSize.small} content={title}/>;
       }
       mayBeTypeSelector = (

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/role_modal_body_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/spec/role_modal_body_spec.tsx
@@ -104,6 +104,8 @@ describe("RoleModalBody", () => {
                                         resourceAutocompleteHelper={new Map()}/>);
       expect(helper.q("#plugin-role")).toBeInDOM();
       expect(helper.q("#plugin-role")).toBeDisabled();
+      expect(helper.byTestId("tooltip-wrapper")).toBeInDOM();
+      expect(helper.textByTestId("tooltip-content")).toBe('Either no plugin has authorization capability or there are no authorization configs defined for the same.');
     });
 
     it("should enable when auth configs are defined", () => {


### PR DESCRIPTION
There were a few concerns raised around disabled plugin role selector on add new role modal
 - to make sure that the users understand why it is disabled  - added a title


<img width="1105" alt="Screen Shot 2020-07-06 at 12 38 29 PM" src="https://user-images.githubusercontent.com/41165891/86566097-b1ef6300-bf86-11ea-9e64-e99fa3887c52.png">
