### PR TITLE
Fix dashboard api call when empty pipeline group exists

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/security/permissions/PipelinePermission.java
+++ b/server/src/main/java/com/thoughtworks/go/config/security/permissions/PipelinePermission.java
@@ -53,6 +53,10 @@ public class PipelinePermission extends ArrayList<StagePermission> {
     }
 
     public static PipelinePermission from(PipelineConfig pipeline, Users operators) {
+        if(pipeline == null) {
+            return EveryonePermission.INSTANCE;
+        }
+
         List<StagePermission> permissions = pipeline.stream().map(stage -> new StagePermission(stage.name().toString(), operators)).collect(Collectors.toList());
         return new PipelinePermission(permissions);
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/security/permissions/PipelinePermissionTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/security/permissions/PipelinePermissionTest.java
@@ -54,4 +54,9 @@ class PipelinePermissionTest {
     void shouldNotFailWhenInvalidStageNameIsSpecified() {
         assertEquals(pipelinePermission.getStageOperators("stageX"), null);
     }
+
+    @Test
+    void shouldReturnEveryonePermissionWhenPipelineIsNull() {
+        assertEquals(PipelinePermission.from(null, new AllowedUsers(Collections.emptySet(), Collections.emptySet())), EveryonePermission.INSTANCE);
+    }
 }


### PR DESCRIPTION
Description:

* Return everyone permissions for null pipeline