### PR TITLE
Fix chrome install instructions

### DIFF
--- a/server/jasmine.gradle
+++ b/server/jasmine.gradle
@@ -124,16 +124,16 @@ task downloadChromeDriver(type: DownloaderTask) { thisTask ->
 
   switch (currentOS) {
     case org.gradle.internal.os.OperatingSystem.MacOs:
-      osURIPart = 'mac';
+      osURIPart = 'mac64';
       break
     case org.gradle.internal.os.OperatingSystem.Windows:
-      osURIPart = 'win'
+      osURIPart = 'win32'
       break
     default:
-      osURIPart = 'linux'
+      osURIPart = 'linux64'
       break;
   }
-  url = "https://chromedriver.storage.googleapis.com/${packageVersion}/chromedriver_${osURIPart}64.zip"
+  url = "https://chromedriver.storage.googleapis.com/${packageVersion}/chromedriver_${osURIPart}.zip"
 }
 
 task karma(type: Exec) {


### PR DESCRIPTION
The chrome download api does not contain a windows 64 bit installer for chrome only 32.

For linux and mac it is 64

Url: https://chromedriver.storage.googleapis.com/

