### PR TITLE
Fix Version Infos Updater

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -17,11 +17,13 @@ package com.thoughtworks.go.util;
 
 import ch.qos.logback.classic.Level;
 import com.thoughtworks.go.utils.Timeout;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.nio.charset.Charset;
@@ -660,6 +662,11 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public String getUpdateServerPublicKeyPath() {
         return String.format("%s/%s", getConfigDir(), GO_UPDATE_SERVER_PUBLIC_KEY_FILE_NAME.getValue());
+    }
+
+    //used in rails
+    public String getUpdateServerPublicKey() throws IOException {
+        return FileUtils.readFileToString(new File(this.getUpdateServerPublicKeyPath()), "utf8");
     }
 
     public boolean isGOUpdateCheckEnabled() {

--- a/server/src/main/webapp/WEB-INF/rails/app/models/api_v1/go_latest_version.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/models/api_v1/go_latest_version.rb
@@ -39,7 +39,7 @@ module ApiV1
     end
 
     def signing_public_key_tampered?
-      public_key = File.read(@system_environment.getUpdateServerPublicKeyPath())
+      public_key = @system_environment.getUpdateServerPublicKey()
 
       !MessageVerifier.verify(@signing_public_key, @signing_public_key_signature, public_key)
     end


### PR DESCRIPTION
PROBLEM:

* Version infos update check has been failing from GoCD v19.10.0
  after changes done as part of PR #6932

* Changing the rails root from 'server' to 'server/src/main/WEB-INF/rails'
  causes the rails version infos controller to fail reading the resource
  from path 'config/go_update_server.pub'

FIX:

* Read the 'config/go_update_server.pub' certificate at java side.