### PR TITLE
Access token fix npe

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
+++ b/server/src/main/java/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
@@ -86,6 +86,7 @@ public class ApplicationInitializer implements ApplicationListener<ContextRefres
     @Autowired private PipelineLabelCorrector pipelineLabelCorrector;
     @Autowired private BackupService backupService;
     @Autowired private DataSource dataSource;
+    @Autowired private RevokeStaleAccessTokenService revokeStaleAccessTokenService;
 
     @Value("${cruise.daemons.enabled}")
     private boolean daemonsEnabled;
@@ -151,6 +152,8 @@ public class ApplicationInitializer implements ApplicationListener<ContextRefres
             dependencyMaterialUpdateNotifier.initialize();
             scmMaterialSource.initialize();
             backupService.initialize();
+
+            revokeStaleAccessTokenService.initialize();
         } catch (Throwable throwable) {
             throw new RuntimeException(throwable);
         }

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/AccessTokenAuthenticationFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/AccessTokenAuthenticationFilter.java
@@ -141,7 +141,13 @@ public class AccessTokenAuthenticationFilter extends OncePerRequestFilter {
                     , new Timestamp(System.currentTimeMillis()));
 
             try {
-                SecurityAuthConfig authConfig = securityAuthConfigService.findProfile(accessTokenCredential.getAccessToken().getAuthConfigId());
+                String authConfigId = accessTokenCredential.getAccessToken().getAuthConfigId();
+                SecurityAuthConfig authConfig = securityAuthConfigService.findProfile(authConfigId);
+                if(authConfig == null) {
+                    String errorMessage = String.format("Can not find authorization configuration \"%s\" to which the requested personal access token belongs. Authorization Configuration \"%s\" might have been renamed or deleted. Please revoke the existing token and create a new one for the same.", authConfigId, authConfigId);
+                    onAuthenticationFailure(request, response, errorMessage);
+                    return;
+                }
                 final AuthenticationToken<AccessTokenCredential> authenticationToken = authenticationProvider.authenticateUser(accessTokenCredential, authConfig);
                 if (authenticationToken == null) {
                     onAuthenticationFailure(request, response, BAD_CREDENTIALS_MSG);

--- a/server/src/main/java/com/thoughtworks/go/server/service/RevokeStaleAccessTokenService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/RevokeStaleAccessTokenService.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.PluginProfile;
+import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.config.SecurityAuthConfigs;
+import com.thoughtworks.go.domain.AccessToken;
+import com.thoughtworks.go.listener.EntityConfigChangedListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class RevokeStaleAccessTokenService extends EntityConfigChangedListener<SecurityAuthConfig> {
+    private GoConfigService goConfigService;
+    private AccessTokenService accessTokenService;
+    private SecurityAuthConfigs existingSecurityAuthConfigs;
+
+    @Autowired
+    public RevokeStaleAccessTokenService(GoConfigService goConfigService, AccessTokenService accessTokenService) {
+        this.goConfigService = goConfigService;
+        this.accessTokenService = accessTokenService;
+
+        this.goConfigService.register(this);
+    }
+
+    public void initialize() {
+        this.existingSecurityAuthConfigs = this.goConfigService.getConfigForEditing().server().security().securityAuthConfigs();
+        List<String> authConfigIdsFromConfig = this.getIds(existingSecurityAuthConfigs);
+        this.accessTokenService.findAllTokensForAllUsers(AccessTokenFilter.active).forEach(token -> {
+            if (!authConfigIdsFromConfig.contains(token.getAuthConfigId())) {
+                this.revokeAccessTokenDueToRemovalOfAuthConfig(token);
+            }
+        });
+    }
+
+    @Override
+    public void onEntityConfigChange(SecurityAuthConfig securityAuthConfig) {
+        this.removeAccessTokensFromStaleAuthConfigs(goConfigService.getConfigForEditing().server().security().securityAuthConfigs());
+    }
+
+    @Override
+    public void onConfigChange(CruiseConfig cruiseConfig) {
+        SecurityAuthConfigs updatedSecurityAuthConfigs = cruiseConfig.server().security().securityAuthConfigs();
+        this.removeAccessTokensFromStaleAuthConfigs(updatedSecurityAuthConfigs);
+    }
+
+    private void removeAccessTokensFromStaleAuthConfigs(SecurityAuthConfigs updatedSecurityAuthConfigs) {
+        if (this.existingSecurityAuthConfigs != null && !this.existingSecurityAuthConfigs.equals(updatedSecurityAuthConfigs)) {
+            List<String> existing = getIds(existingSecurityAuthConfigs);
+            List<String> updated = getIds(updatedSecurityAuthConfigs);
+            List<String> removed = existing.stream().filter(id -> !updated.contains(id)).collect(Collectors.toList());
+
+            this.accessTokenService.findAllTokensForAllUsers(AccessTokenFilter.active).forEach(token -> {
+                if (removed.contains(token.getAuthConfigId())) {
+                    this.revokeAccessTokenDueToRemovalOfAuthConfig(token);
+                }
+            });
+        }
+
+        this.existingSecurityAuthConfigs = updatedSecurityAuthConfigs;
+    }
+
+    private void revokeAccessTokenDueToRemovalOfAuthConfig(AccessToken token) {
+        String revokeReason = String.format("Revoked by GoCD: The authorization configuration '%s' referenced from the current access token is deleted from GoCD.", token.getAuthConfigId());
+        this.accessTokenService.revokeAccessTokenByGoCD(token.getId(), revokeReason);
+    }
+
+    private List<String> getIds(SecurityAuthConfigs securityAuthConfigs) {
+        return securityAuthConfigs.stream().map(PluginProfile::getId).collect(Collectors.toList());
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/initializers/ApplicationInitializerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/initializers/ApplicationInitializerTest.java
@@ -125,6 +125,8 @@ public class ApplicationInitializerTest {
     @Mock
     private EntityHashingService entityHashingService;
     @Mock
+    private RevokeStaleAccessTokenService revokeStaleAccessTokenService;
+    @Mock
     private DependencyMaterialUpdateNotifier dependencyMaterialUpdateNotifier;
     @Mock
     private SCMMaterialSource scmMaterialSource;

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthenticationFilterChainTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthenticationFilterChainTest.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.server.newsecurity.filterchains;
 
+import com.thoughtworks.go.config.SecurityAuthConfig;
 import com.thoughtworks.go.domain.AccessToken;
 import com.thoughtworks.go.http.mocks.HttpRequestBuilder;
 import com.thoughtworks.go.http.mocks.MockHttpServletRequest;
@@ -229,6 +230,7 @@ public class AuthenticationFilterChainTest {
                     .withBearerAuth("some-access-token")
                     .build();
 
+            when(securityAuthConfigService.findProfile(anyString())).thenReturn(new SecurityAuthConfig());
             HttpSession originalSession = request.getSession();
             when(accessTokenService.findByAccessToken("some-access-token")).thenReturn(accessToken);
             final AuthenticationToken authenticationToken = mock(AuthenticationToken.class);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/RevokeStaleAccessTokenServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/RevokeStaleAccessTokenServiceTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.BasicCruiseConfig;
+import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.domain.AccessToken;
+import com.thoughtworks.go.util.TestingClock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+class RevokeStaleAccessTokenServiceTest {
+    @Mock
+    private GoConfigService goConfigService;
+    @Mock
+    private AccessTokenService accessTokenService;
+
+    private RevokeStaleAccessTokenService service;
+
+    private SecurityAuthConfig authConfig1;
+    private SecurityAuthConfig authConfig2;
+
+    private AccessToken.AccessTokenWithDisplayValue authConfig1_token1;
+    private AccessToken.AccessTokenWithDisplayValue authConfig1_token2;
+    private AccessToken.AccessTokenWithDisplayValue authConfig2_token1;
+
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+        service = new RevokeStaleAccessTokenService(goConfigService, accessTokenService);
+
+        authConfig1 = new SecurityAuthConfig("authConfig1", "ldap");
+        authConfig2 = new SecurityAuthConfig("authConfig2", "ldap");
+
+        authConfig1_token1 = AccessToken.create(null, null, "authConfig1", new TestingClock());
+        authConfig1_token1.setId(0);
+        authConfig1_token2 = AccessToken.create(null, null, "authConfig1", new TestingClock());
+        authConfig1_token2.setId(1);
+        authConfig2_token1 = AccessToken.create(null, null, "authConfig2", new TestingClock());
+        authConfig2_token1.setId(2);
+    }
+
+    @Test
+    void shouldDoNothingWhenAuthConfigHasNotChangedDuringStartup() {
+        BasicCruiseConfig config = new BasicCruiseConfig();
+        config.server().security().securityAuthConfigs().add(authConfig1);
+        config.server().security().securityAuthConfigs().add(authConfig2);
+
+        when(goConfigService.getConfigForEditing()).thenReturn(config);
+        when(accessTokenService.findAllTokensForAllUsers(AccessTokenFilter.active)).thenReturn(Arrays.asList(authConfig1_token1, authConfig1_token2, authConfig2_token1));
+
+        service.initialize();
+        verify(accessTokenService, never()).revokeAccessTokenByGoCD(anyInt(), anyString());
+    }
+
+    @Test
+    void shouldDoNothingWhenThereAreNoAccessTokens() {
+        BasicCruiseConfig config = new BasicCruiseConfig();
+        config.server().security().securityAuthConfigs().add(authConfig1);
+        config.server().security().securityAuthConfigs().add(authConfig2);
+
+        when(goConfigService.getConfigForEditing()).thenReturn(config);
+        when(accessTokenService.findAllTokensForAllUsers(AccessTokenFilter.active)).thenReturn(Collections.emptyList());
+
+        service.initialize();
+        verify(accessTokenService, never()).revokeAccessTokenByGoCD(anyInt(), anyString());
+    }
+
+    @Test
+    void shouldRevokeAllTheTokensWhenAllTheAuthConfigsAreRemovedDuringStartup() {
+        BasicCruiseConfig config = new BasicCruiseConfig();
+        when(goConfigService.getConfigForEditing()).thenReturn(config);
+        when(accessTokenService.findAllTokensForAllUsers(AccessTokenFilter.active)).thenReturn(Arrays.asList(authConfig1_token1, authConfig1_token2, authConfig2_token1));
+
+        service.initialize();
+
+        verify(accessTokenService).revokeAccessTokenByGoCD(0, "Revoked by GoCD: The authorization configuration 'authConfig1' referenced from the current access token is deleted from GoCD.");
+        verify(accessTokenService).revokeAccessTokenByGoCD(1, "Revoked by GoCD: The authorization configuration 'authConfig1' referenced from the current access token is deleted from GoCD.");
+        verify(accessTokenService).revokeAccessTokenByGoCD(2, "Revoked by GoCD: The authorization configuration 'authConfig2' referenced from the current access token is deleted from GoCD.");
+    }
+
+    @Test
+    void shouldRevokeTheTokensWhenTheBelongingAuthConfigIsRemovedDuringStartup() {
+        BasicCruiseConfig config = new BasicCruiseConfig();
+        config.server().security().securityAuthConfigs().add(authConfig1);
+
+        when(goConfigService.getConfigForEditing()).thenReturn(config);
+        when(accessTokenService.findAllTokensForAllUsers(AccessTokenFilter.active)).thenReturn(Arrays.asList(authConfig1_token1, authConfig1_token2, authConfig2_token1));
+
+        service.initialize();
+
+        verify(accessTokenService).revokeAccessTokenByGoCD(2, "Revoked by GoCD: The authorization configuration 'authConfig2' referenced from the current access token is deleted from GoCD.");
+    }
+
+    // on config update
+    @Test
+    void shouldDoNothingWhenAuthConfigHasNotChangedDuringFullConfigUpdate() {
+        BasicCruiseConfig config = new BasicCruiseConfig();
+        config.server().security().securityAuthConfigs().add(authConfig1);
+        config.server().security().securityAuthConfigs().add(authConfig2);
+
+        when(goConfigService.getConfigForEditing()).thenReturn(config);
+        when(accessTokenService.findAllTokensForAllUsers(AccessTokenFilter.active)).thenReturn(Arrays.asList(authConfig1_token1, authConfig1_token2, authConfig2_token1));
+
+        service.initialize();
+        verify(accessTokenService, never()).revokeAccessTokenByGoCD(anyInt(), anyString());
+
+        service.onConfigChange(config);
+
+        verify(accessTokenService, never()).revokeAccessTokenByGoCD(anyInt(), anyString());
+    }
+
+
+    @Test
+    void shouldRevokeAllTheTokensWhenAllTheAuthConfigsAreRemovedDuringFullConfigUpdate() {
+        BasicCruiseConfig config = new BasicCruiseConfig();
+        config.server().security().securityAuthConfigs().add(authConfig1);
+        config.server().security().securityAuthConfigs().add(authConfig2);
+
+        when(goConfigService.getConfigForEditing()).thenReturn(config);
+        when(accessTokenService.findAllTokensForAllUsers(AccessTokenFilter.active)).thenReturn(Arrays.asList(authConfig1_token1, authConfig1_token2, authConfig2_token1));
+
+        service.initialize();
+        verify(accessTokenService, never()).revokeAccessTokenByGoCD(anyInt(), anyString());
+
+        BasicCruiseConfig updated = new BasicCruiseConfig();
+        updated.server().security().securityAuthConfigs().add(authConfig1);
+
+        service.onConfigChange(updated);
+
+        verify(accessTokenService).revokeAccessTokenByGoCD(2, "Revoked by GoCD: The authorization configuration 'authConfig2' referenced from the current access token is deleted from GoCD.");
+    }
+
+    // on entity update
+    @Test
+    void shouldDoNothingWhenAuthConfigHasNotChangedDuringUpdateAuthConfig() {
+        BasicCruiseConfig config = new BasicCruiseConfig();
+        config.server().security().securityAuthConfigs().add(authConfig1);
+        config.server().security().securityAuthConfigs().add(authConfig2);
+
+        when(goConfigService.getConfigForEditing()).thenReturn(config);
+        when(accessTokenService.findAllTokensForAllUsers(AccessTokenFilter.active)).thenReturn(Arrays.asList(authConfig1_token1, authConfig1_token2, authConfig2_token1));
+
+        service.initialize();
+        verify(accessTokenService, never()).revokeAccessTokenByGoCD(anyInt(), anyString());
+
+        service.onEntityConfigChange(new SecurityAuthConfig());
+
+        verify(accessTokenService, never()).revokeAccessTokenByGoCD(anyInt(), anyString());
+    }
+
+    @Test
+    void shouldRevokeTheTokensWhenTheAuthConfigsIsDeletedFromTheConfig() {
+        BasicCruiseConfig config = new BasicCruiseConfig();
+        config.server().security().securityAuthConfigs().add(authConfig1);
+        config.server().security().securityAuthConfigs().add(authConfig2);
+
+        when(goConfigService.getConfigForEditing()).thenReturn(config);
+        when(accessTokenService.findAllTokensForAllUsers(AccessTokenFilter.active)).thenReturn(Arrays.asList(authConfig1_token1, authConfig1_token2, authConfig2_token1));
+
+        service.initialize();
+        verify(accessTokenService, never()).revokeAccessTokenByGoCD(anyInt(), anyString());
+
+        BasicCruiseConfig updated = new BasicCruiseConfig();
+        updated.server().security().securityAuthConfigs().add(authConfig1);
+
+        when(goConfigService.getConfigForEditing()).thenReturn(updated);
+
+        service.onEntityConfigChange(new SecurityAuthConfig());
+
+        verify(accessTokenService).revokeAccessTokenByGoCD(2, "Revoked by GoCD: The authorization configuration 'authConfig2' referenced from the current access token is deleted from GoCD.");
+    }
+}

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/AccessTokenServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/AccessTokenServiceIntegrationTest.java
@@ -175,6 +175,22 @@ public class AccessTokenServiceIntegrationTest {
     }
 
     @Test
+    public void shouldRevokeAccessTokenWithinGoCD() {
+        String tokenDescription = "This is my first Token";
+        AccessToken createdToken = accessTokenService.create(tokenDescription, "BOB", authConfigId);
+
+        assertThat(createdToken.isRevoked()).isFalse();
+        assertThat(createdToken.getRevokeCause()).isBlank();
+
+        accessTokenService.revokeAccessTokenByGoCD(createdToken.getId(), "from GoCD");
+
+        AccessToken tokenAfterRevoking = accessTokenService.find(createdToken.getId(), "bOb");
+        assertThat(tokenAfterRevoking.isRevoked()).isTrue();
+        assertThat(tokenAfterRevoking.getRevokedBy()).isEqualTo("GoCD");
+        assertThat(tokenAfterRevoking.getRevokeCause()).isEqualTo("from GoCD");
+    }
+
+    @Test
     public void shouldFailToRevokeAnAlreadyRevokedAccessToken() {
         String tokenDescription = "This is my first Token";
         AccessToken createdToken = accessTokenService.create(tokenDescription, "BOB", authConfigId);


### PR DESCRIPTION
Issue: #8335

Description:

#### 1. Revoke access token when belonging auth config id is removed (#8335)

* Revoke personal access token when the auth config id changed by modifying
  the cruise-config.xml from UI or directly editing the config on disk.

* Revoke the personal access tokens when the auth config is deleted from the
  UI or using API.

* Revoke the personal access tokens which belongs to the auth config which
  is not anymore in the config after a restart.
  Steps:
        - Create an Auth Config.
        - Create a personal access token.
        - Stop the server.
        - Rename the auth config id to a new value by directly modifying the
          cruise-config.xml
        - Start the server.
  On server startup, the created personal access token must be revoked.


#### 2. Do not fail with NPE when auth config is null

* Render 401 error along with appropriate error when the auth config
      belonging to the access token is null.