### PR TITLE
Add ISC to the allowed license list

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
@@ -60,6 +60,7 @@ class LicenseReport {
     MPL_1_1,
     UNLICENSE,
     PUBLIC_DOMAIN,
+    ISC
   ].collect { it.id })
 
   private final Project project


### PR DESCRIPTION
Description:
 - [ISC license](https://opensource.org/licenses/ISC) is needed for using `lru-cache` package.

