### PR TITLE
Fix NPE during config repo migration 11 (#8352)

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/AddEmptyTaskJoltTransformer.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/AddEmptyTaskJoltTransformer.java
@@ -62,6 +62,7 @@ public class AddEmptyTaskJoltTransformer implements ContextualTransform {
             return Collections.emptyList();
         }
 
-        return ((LinkedHashMap<String, List<?>>) input).get(field);
+        List<?> result = ((LinkedHashMap<String, List<?>>) input).get(field);
+        return result == null ? Collections.emptyList() : result;
     }
 }

--- a/plugin-infra/go-plugin-access/src/test/resources/v10_pipeline_with_no_tasks.json
+++ b/plugin-infra/go-plugin-access/src/test/resources/v10_pipeline_with_no_tasks.json
@@ -2,6 +2,29 @@
   "target_version": "10",
   "pipelines": [
     {
+      "group": "first",
+      "name": "up42",
+      "display_order_weight": -1.0,
+      "label_template": "${COUNT}",
+      "lock_behavior": "none",
+      "environment_variables": [],
+      "parameters": [],
+      "materials": [
+        {
+          "url": "test-repo",
+          "branch": "master",
+          "shallow_clone": false,
+          "filter": {
+            "ignore": [],
+            "includes": []
+          },
+          "auto_update": true,
+          "type": "git"
+        }
+      ],
+      "template": "build-template"
+    },
+    {
       "name": "firstpipe",
       "environment_variables": [
         {

--- a/plugin-infra/go-plugin-access/src/test/resources/v11_pipeline_with_default_task.json
+++ b/plugin-infra/go-plugin-access/src/test/resources/v11_pipeline_with_default_task.json
@@ -2,6 +2,29 @@
   "target_version": "11",
   "pipelines": [
     {
+      "group": "first",
+      "name": "up42",
+      "display_order_weight": -1.0,
+      "label_template": "${COUNT}",
+      "lock_behavior": "none",
+      "environment_variables": [],
+      "parameters": [],
+      "materials": [
+        {
+          "url": "test-repo",
+          "branch": "master",
+          "shallow_clone": false,
+          "filter": {
+            "ignore": [],
+            "includes": []
+          },
+          "auto_update": true,
+          "type": "git"
+        }
+      ],
+      "template": "build-template"
+    },
+    {
       "name": "firstpipe",
       "environment_variables": [
         {


### PR DESCRIPTION
Issue: #8352

Description:

* Do not fail to parse when config repo pipelines are defined using templates