### PR TITLE
Fix hash generation for pipeline config export #000

### DIFF
--- a/api/api-export-v1/src/main/java/com/thoughtworks/go/apiv1/export/ExportControllerV1.java
+++ b/api/api-export-v1/src/main/java/com/thoughtworks/go/apiv1/export/ExportControllerV1.java
@@ -25,6 +25,7 @@ import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
 import com.thoughtworks.go.plugin.access.configrepo.ExportedConfig;
+import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.spark.Routes.Export;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
@@ -44,13 +45,16 @@ public class ExportControllerV1 extends ApiController implements SparkSpringCont
     private final ApiAuthenticationHelper apiAuthenticationHelper;
     private final GoConfigPluginService crPluginService;
     private final GoConfigService configService;
+    private EntityHashingService entityHashingService;
 
     @Autowired
-    public ExportControllerV1(ApiAuthenticationHelper apiAuthenticationHelper, GoConfigPluginService crPluginService, GoConfigService configService) {
+    public ExportControllerV1(ApiAuthenticationHelper apiAuthenticationHelper, GoConfigPluginService crPluginService, GoConfigService configService,
+                              EntityHashingService entityHashingService) {
         super(ApiVersion.v1);
         this.apiAuthenticationHelper = apiAuthenticationHelper;
         this.crPluginService = crPluginService;
         this.configService = configService;
+        this.entityHashingService = entityHashingService;
     }
 
     @Override
@@ -87,7 +91,7 @@ public class ExportControllerV1 extends ApiController implements SparkSpringCont
         }
 
         ConfigRepoPlugin repoPlugin = crPlugin(pluginId);
-        String etag = repoPlugin.etagForExport(pipelineConfig, groupName);
+        String etag = entityHashingService.hashForEntity(pipelineConfig, groupName, pluginId);
 
         if (fresh(req, etag)) {
             return notModified(res);

--- a/api/api-export-v1/src/test/groovy/com/thoughtworks/go/apiv1/export/ExportControllerV1Test.groovy
+++ b/api/api-export-v1/src/test/groovy/com/thoughtworks/go/apiv1/export/ExportControllerV1Test.groovy
@@ -24,6 +24,7 @@ import com.thoughtworks.go.config.PipelineConfig
 import com.thoughtworks.go.config.exceptions.EntityType
 import com.thoughtworks.go.config.remote.FileConfigOrigin
 import com.thoughtworks.go.helper.PipelineConfigMother
+import com.thoughtworks.go.server.service.EntityHashingService
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.GroupAdminUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
@@ -45,9 +46,12 @@ class ExportControllerV1Test implements SecurityServiceTrait, ControllerTrait<Ex
   @Mock
   private ConfigRepoPlugin configRepoPlugin
 
+  @Mock
+  private EntityHashingService entityHashingService
+
   @Override
   ExportControllerV1 createControllerInstance() {
-    new ExportControllerV1(new ApiAuthenticationHelper(securityService, goConfigService), goConfigPluginService, goConfigService)
+    new ExportControllerV1(new ApiAuthenticationHelper(securityService, goConfigService), goConfigPluginService, goConfigService, entityHashingService)
   }
 
   @BeforeEach
@@ -99,7 +103,7 @@ class ExportControllerV1Test implements SecurityServiceTrait, ControllerTrait<Ex
         when(goConfigPluginService.isConfigRepoPlugin(pluginId)).thenReturn(true)
         when(goConfigPluginService.supportsPipelineExport(pluginId)).thenReturn(true)
         when(goConfigPluginService.partialConfigProviderFor(pluginId)).thenReturn(configRepoPlugin)
-        when(configRepoPlugin.etagForExport(pipeline, groupName)).thenReturn(exportEtag)
+        when(entityHashingService.hashForEntity(pipeline, groupName, pluginId)).thenReturn(exportEtag)
         Map<String, String> headers = new HashMap<String, String>() {
           {
             put("Content-Type", "text/plain")
@@ -177,7 +181,7 @@ class ExportControllerV1Test implements SecurityServiceTrait, ControllerTrait<Ex
         when(goConfigPluginService.isConfigRepoPlugin(pluginId)).thenReturn(true)
         when(goConfigPluginService.supportsPipelineExport(pluginId)).thenReturn(true)
         when(goConfigPluginService.partialConfigProviderFor(pluginId)).thenReturn(configRepoPlugin)
-        when(configRepoPlugin.etagForExport(pipeline, groupName)).thenReturn(exportEtag)
+        when(entityHashingService.hashForEntity(pipeline, groupName, pluginId)).thenReturn(exportEtag)
 
         getWithApiHeader(controller.controllerPath("${pipelinePath("pipeline1")}?plugin_id=${pluginId}"), ['if-none-match': "\"$exportEtag\""])
 

--- a/api/api-pipelines-as-code-internal-v1/src/main/java/com/thoughtworks/go/apiv1/pipelinesascodeinternal/PipelinesAsCodeInternalControllerV1.java
+++ b/api/api-pipelines-as-code-internal-v1/src/main/java/com/thoughtworks/go/apiv1/pipelinesascodeinternal/PipelinesAsCodeInternalControllerV1.java
@@ -79,6 +79,7 @@ public class PipelinesAsCodeInternalControllerV1 extends ApiController implement
     private final SubprocessExecutionContext subprocessExecutionContext;
     private SystemEnvironment systemEnvironment;
     private ConfigRepoService configRepoService;
+    private EntityHashingService entityHashingService;
 
     @Autowired
     public PipelinesAsCodeInternalControllerV1(
@@ -91,7 +92,8 @@ public class PipelinesAsCodeInternalControllerV1 extends ApiController implement
             MaterialConfigConverter materialConfigConverter,
             SubprocessExecutionContext subprocessExecutionContext,
             SystemEnvironment systemEnvironment,
-            ConfigRepoService configRepoService) {
+            ConfigRepoService configRepoService,
+            EntityHashingService entityHashingService) {
         super(ApiVersion.v1);
         this.apiAuthenticationHelper = apiAuthenticationHelper;
         this.passwordDeserializer = passwordDeserializer;
@@ -103,6 +105,7 @@ public class PipelinesAsCodeInternalControllerV1 extends ApiController implement
         this.subprocessExecutionContext = subprocessExecutionContext;
         this.systemEnvironment = systemEnvironment;
         this.configRepoService = configRepoService;
+        this.entityHashingService = entityHashingService;
     }
 
     @Override
@@ -192,7 +195,7 @@ public class PipelinesAsCodeInternalControllerV1 extends ApiController implement
             return MessageJson.create(format("Please fix the validation errors for pipeline %s.", pipeline.name()), jsonWriter(pipeline));
         }
 
-        String etag = repoPlugin.etagForExport(pipeline, groupName);
+        String etag = entityHashingService.hashForEntity(pipeline, groupName, pluginId);
 
         if (fresh(req, etag)) {
             return notModified(res);

--- a/api/api-pipelines-as-code-internal-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelinesascodeinternal/PipelinesAsCodeInternalControllerV1Test.groovy
+++ b/api/api-pipelines-as-code-internal-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelinesascodeinternal/PipelinesAsCodeInternalControllerV1Test.groovy
@@ -28,6 +28,7 @@ import com.thoughtworks.go.config.update.CreatePipelineConfigCommand
 import com.thoughtworks.go.domain.materials.MaterialConfig
 import com.thoughtworks.go.plugin.access.configrepo.ConfigFileList
 import com.thoughtworks.go.server.service.ConfigRepoService
+import com.thoughtworks.go.server.service.EntityHashingService
 import com.thoughtworks.go.server.service.MaterialConfigConverter
 import com.thoughtworks.go.server.service.MaterialService
 import com.thoughtworks.go.server.service.PipelineConfigService
@@ -88,6 +89,9 @@ class PipelinesAsCodeInternalControllerV1Test implements SecurityServiceTrait, C
   @Mock
   SystemEnvironment systemEnvironment
 
+  @Mock
+  EntityHashingService entityHashingService
+
   @BeforeEach
   void setUp() {
     initMocks(this)
@@ -105,7 +109,8 @@ class PipelinesAsCodeInternalControllerV1Test implements SecurityServiceTrait, C
       materialConfigConverter,
       subprocessExecutionContext,
       systemEnvironment,
-      configRepoService
+      configRepoService,
+      entityHashingService
     )
   }
 
@@ -310,7 +315,7 @@ class PipelinesAsCodeInternalControllerV1Test implements SecurityServiceTrait, C
 
       @Test
       void 'should be able to export pipeline config if user is admin and etag is stale'() {
-        when(configRepoPlugin.etagForExport(any(PipelineConfig), eq(GROUP_NAME))).thenReturn(ETAG)
+        when(entityHashingService.hashForEntity(any(PipelineConfig), eq(GROUP_NAME), eq(PLUGIN_ID))).thenReturn(ETAG)
         when(configRepoPlugin.pipelineExport(any(PipelineConfig), eq(GROUP_NAME))).thenReturn(from("message from plugin", [
           "Content-Type"     : "text/plain",
           "X-Export-Filename": "foo.txt"
@@ -360,7 +365,7 @@ class PipelinesAsCodeInternalControllerV1Test implements SecurityServiceTrait, C
 
       @Test
       void "should return 304 for export pipeline config if etag matches"() {
-        when(configRepoPlugin.etagForExport(any(PipelineConfig), eq(GROUP_NAME))).thenReturn(ETAG)
+        when(entityHashingService.hashForEntity(any(PipelineConfig), eq(GROUP_NAME), eq(PLUGIN_ID))).thenReturn(ETAG)
         when(pluginService.isConfigRepoPlugin(PLUGIN_ID)).thenReturn(true)
         when(pluginService.supportsPipelineExport(PLUGIN_ID)).thenReturn(true)
         when(pluginService.partialConfigProviderFor(PLUGIN_ID)).thenReturn(configRepoPlugin)

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigRepoPlugin.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigRepoPlugin.java
@@ -95,8 +95,4 @@ public class ConfigRepoPlugin implements PartialConfigProvider {
             throw new InvalidPartialConfigException(crParseResult, crParseResult.getErrors().getErrorsAsText());
         return crParseResult;
     }
-
-    public String etagForExport(PipelineConfig pipelineConfig, String groupName) {
-        return sha512_256Hex(Integer.toString(Objects.hash(pipelineConfig, groupName, crExtension.pluginDescriptorFor(pluginId))));
-    }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/EntityHashingService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EntityHashingService.java
@@ -366,6 +366,14 @@ public class EntityHashingService implements ConfigChangedListener, Initializer 
         );
     }
 
+    public String hashForEntity(PipelineConfig pipelineConfig, String groupName, String pluginId) {
+        return hashes.digestMany(
+                hashes.digestDomainConfigEntity(pipelineConfig),
+                groupName,
+                pluginId
+        );
+    }
+
     public String hashForEntity(PipelineConfigs pipelineConfigs) {
         String cacheKey = cacheKey(pipelineConfigs, pipelineConfigs.getGroup());
         return getConfigEntityDigestFromCache(cacheKey, pipelineConfigs);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/EntityHashingServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/EntityHashingServiceTest.java
@@ -210,6 +210,16 @@ public class EntityHashingServiceTest {
         verify(goCache).remove(ETAG_CACHE_KEY, (artifactConfig.getClass().getName() + ".cacheKey"));
     }
 
+    @Test
+    void hashesForAPipelineConfigDiffersForDifferentPlugins() {
+        PipelineConfig test = PipelineConfigMother.pipelineConfig("test");
+
+        String hashForPlugin1 = service.hashForEntity(test, "group1", "plugin_1");
+        String hashForPlugin2 = service.hashForEntity(test, "group1", "plugin_2");
+
+        assertNotEquals(hashForPlugin1, hashForPlugin2);
+    }
+
     private PluginSettings pluginSettings(String id, String key, String secret) {
         final PluginSettings p = new PluginSettings(id);
         final ConfigurationProperty cp = new ConfigurationProperty(new ConfigurationKey(key), new ConfigurationValue(secret));


### PR DESCRIPTION
* ConfigRepoPlugin#etagForExport relied on Objects.hash to generate
  hash for a pipelineconfig and plugin. It was observered, a change
  in material for a  pipeline did not generate a new hash and hence
  PipelineExport and PipelineAsCode preview endpoints relied on a invalid etag 
  returned stale responses.
* EntityHashingService generates hash for a PipelineConfig for a given
  plugin.

