### PR TITLE
Missed adding the materials toggle value to status reports SPA

### DIFF
--- a/spark/spark-spa/src/main/resources/freemarker/layouts/rails_compatible_page.ftlh
+++ b/spark/spark-spa/src/main/resources/freemarker/layouts/rails_compatible_page.ftlh
@@ -58,6 +58,7 @@
           data-maintenance-mode-updated-on="${maintenanceModeService.updatedOn()}"
           data-maintenance-mode-updated-by="${maintenanceModeService.updatedBy()}"
         </#if>
+      data-show-materials-spa="${show_materials_spa?c}"
 >
 <div class="page-wrap">
   <header id="app-menu">


### PR DESCRIPTION
Issue: Header missing on status reports SPA

Description:
 - introduced a materials SPA behind a toggle
 - added this toggle value in all pages which determines whether or not the link is visible
 - this was missed for status reports SPA. This PR fixes that.

