### PR TITLE
Add support for denylist for plugin SCM materials

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -376,6 +376,15 @@ describe('PluginFieldsSpec', () => {
     expect(helper.byTestId('selected-scm-details')).toBeInDOM();
   });
 
+  it('should render advanced settings', () => {
+    helper.mount(() => <PluginFields material={material} pluginInfos={pluginInfos} scms={scms} showLocalWorkingCopyOptions={true}/>);
+
+    assertLabelledInputsPresent(helper, {
+      "alternate-checkout-path": "Alternate Checkout Path",
+      "denylist":                "Denylist"
+    });
+  });
+
   function assertConfigsPresent(helper: TestHelper, parentElementSelector: string, idsToValueMap: { [key: string]: string }) {
     const keys = Object.keys(idsToValueMap);
     expect(keys.length > 0).toBe(true);


### PR DESCRIPTION
Description:
The API has support for providing `filters` for a SCM material. However, the UI was missing that.
This PR adds the same.

Preview:

<img width="775" alt="Screen Shot 2020-07-22 at 5 04 07 PM" src="https://user-images.githubusercontent.com/41165891/88171735-7a96dc80-cc3d-11ea-9674-f492cf703d03.png">


