### PR TITLE
Fixing build - functional spec fails after 8372

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stage/add_stage_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stage/add_stage_modal.tsx
@@ -137,15 +137,12 @@ export class AddStageModal extends Modal {
   }
 
   private onSave() {
-    if (this.stageToCreate.isValid()) {
-      this.modalState = ModalState.LOADING;
-      this.jobToCreate.tasks([this.taskModal!.getTask()]);
-      this.stageToCreate.jobs(new NameableSet([this.jobToCreate]));
-      this.stages.add(this.stageToCreate);
+    this.modalState = ModalState.LOADING;
+    this.jobToCreate.tasks([this.taskModal!.getTask()]);
+    this.stageToCreate.jobs(new NameableSet([this.jobToCreate]));
+    this.stages.add(this.stageToCreate);
 
-      return this.performPipelineSave();
-    }
-    return Promise.reject();
+    return this.performPipelineSave();
   }
 
   private onClose() {
@@ -157,9 +154,9 @@ export class AddStageModal extends Modal {
     if (errorResponse && errorResponse.body) {
       const parsed = JSON.parse(errorResponse.body);
       this.stageToCreate.consumeErrorsResponse(parsed.data);
-      this.parentFlashMessage.clear();
     }
 
+    this.parentFlashMessage.clear();
     this.stages.delete(this.stageToCreate);
     m.redraw.sync();
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/jobs/add_job_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/jobs/add_job_modal.tsx
@@ -159,15 +159,12 @@ export class AddJobModal extends Modal {
   }
 
   private onSave() {
-    if(this.jobToCreate.isValid()) {
-      this.modalState = ModalState.LOADING;
-      this.jobToCreate.tasks([]);
-      this.jobToCreate.tasks().push(this.taskModal!.getTask());
-      this.stage.jobs().add(this.jobToCreate);
+    this.modalState = ModalState.LOADING;
+    this.jobToCreate.tasks([]);
+    this.jobToCreate.tasks().push(this.taskModal!.getTask());
+    this.stage.jobs().add(this.jobToCreate);
 
-      return this.performPipelineSave();
-    }
-    return Promise.reject();
+    return this.performPipelineSave();
   }
 
   private onClose() {
@@ -179,9 +176,9 @@ export class AddJobModal extends Modal {
     if (errorResponse) {
       const parsed = JSON.parse(JSON.parse(errorResponse).body);
       this.jobToCreate.consumeErrorsResponse(parsed.data);
-      this.flashMessage.clear();
     }
 
+    this.flashMessage.clear();
     this.stage.jobs().delete(this.jobToCreate);
     m.redraw.sync();
   }


### PR DESCRIPTION
Description:
The stage and job were being validated before adding the job and tasks respectively.
This caused the validation to occur but without the error getting mapped to the UI

Fixed this by removing the entity validation at modal level and clearing the global errors irrespective of presence of error response.


