### PR TITLE
Dashboard Manual Stage Trigger Fixes

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -586,7 +586,11 @@ body {
     }
   }
 
-  .pipeline_stage {
+  .pipeline_stage_manual_gate_wrapper {
+    display: flex;
+  }
+
+  .pipeline_stage_manual_gate_wrapper .pipeline_stage {
     width:       34px;
     height:      16px;
     line-height: 13px;
@@ -768,6 +772,26 @@ body {
       opacity:    0.5;
       cursor:     not-allowed;
     }
+  }
+}
+
+.pipeline_stage_manual_gate_wrapper {
+  .tooltip {
+    left:       -60px;
+    margin-top: 7px;
+    width:      150px;
+  }
+
+  .tooltip:before {
+    left: 68px;
+  }
+}
+
+.stage_manual_gate_tooltip {
+  color: #000;
+
+  &:hover {
+    color: #000;
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/stages_instance_widget_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/stages_instance_widget_spec.js
@@ -156,7 +156,7 @@ describe("Dashboard Stages Instance Widget", () => {
     m.redraw.sync();
 
     expect(helper.q('.manual_gate')).toHaveClass('disabled');
-    expect(helper.q('.manual_gate').title).toEqual('Can not schedule next stage - Either the previous stage hasn\'t run or is in progress.');
+    expect(helper.q('.tooltip')).toContainText('Can not schedule next stage - Either the previous stage hasn\'t run or is in progress.');
   });
 
   it("should render disabled manual gate when user does not have permission to operate on the pipeline", () => {
@@ -164,7 +164,7 @@ describe("Dashboard Stages Instance Widget", () => {
     m.redraw.sync();
 
     expect(helper.q('.manual_gate')).toHaveClass('disabled');
-    expect(helper.q('.manual_gate').title).toEqual('Can not schedule next stage - You don\'t have permissions to schedule the next stage.');
+    expect(helper.q('.tooltip')).toContainText('Can not schedule next stage - You don\'t have permissions to schedule the next stage.');
   });
 
   it("should render disabled manual gate when the stage has already been scheduled", () => {
@@ -173,7 +173,7 @@ describe("Dashboard Stages Instance Widget", () => {
     m.redraw.sync();
 
     expect(helper.q('.manual_gate')).toHaveClass('disabled');
-    expect(helper.q('.manual_gate').title).toEqual('Approved by \'admin\'.');
+    expect(helper.q('.tooltip')).toContainText('Approved by \'admin\'.');
   });
 
   it("should render disabled manual gate when previous stage is failed and allow_only_on_success_of_previous_stage is set to true", () => {
@@ -182,7 +182,7 @@ describe("Dashboard Stages Instance Widget", () => {
     m.redraw.sync();
 
     expect(helper.q('.manual_gate')).toHaveClass('disabled');
-    expect(helper.q('.manual_gate').title).toEqual('Can not schedule next stage - stage \'up42_stage2\' is set to run only on success of previous stage, whereas, the previous stage \'up42_stage\' has Failed.');
+    expect(helper.q('.tooltip')).toContainText('Can not schedule next stage - stage \'up42_stage2\' is set to run only on success of previous stage, whereas, the previous stage \'up42_stage\' has Failed.');
   });
 
   it("should render disabled manual gate when previous stage is cancelled and allow_only_on_success_of_previous_stage is set to true", () => {
@@ -191,6 +191,6 @@ describe("Dashboard Stages Instance Widget", () => {
     m.redraw.sync();
 
     expect(helper.q('.manual_gate')).toHaveClass('disabled');
-    expect(helper.q('.manual_gate').title).toEqual('Can not schedule next stage - stage \'up42_stage2\' is set to run only on success of previous stage, whereas, the previous stage \'up42_stage\' has Cancelled.');
+    expect(helper.q('.tooltip')).toContainText('Can not schedule next stage - stage \'up42_stage2\' is set to run only on success of previous stage, whereas, the previous stage \'up42_stage\' has Cancelled.');
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stages_instance_widget.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stages_instance_widget.js.msx
@@ -16,6 +16,8 @@
 import m from "mithril";
 import _ from "lodash";
 
+import {f} from "helpers/form_helper";
+
 export const StagesInstanceWidget = {
   oninit(vnode) {
     const self = vnode.state;
@@ -34,7 +36,7 @@ export const StagesInstanceWidget = {
   view: (vnode) => {
     const stages = vnode.attrs.stages;
     const stageInstance = _.map(stages, (stage, index) => {
-      const previousStage = stages[index-1];
+      const previousStage = stages[index - 1];
       const isPreviousStageInProgress = previousStage ? !previousStage.isCompleted() : false;
       let stageStatus = `${stage.name} (${stage.status})`;
       if (stage.isCancelled()) {
@@ -42,28 +44,35 @@ export const StagesInstanceWidget = {
       }
 
       let manualGate;
-      if (stage.isManual()) {
+      if (index !== 0 && stage.isManual()) {
         const canUserOperateOnStage = stage.canOperate;
         const triggerOnCompletionOfPreviousStage = stage.triggerOnlyOnSuccessOfPreviousStage() && previousStage && (previousStage.isFailed() || previousStage.isCancelled());
         const isTriggerDisabled = isPreviousStageInProgress || !canUserOperateOnStage || triggerOnCompletionOfPreviousStage || stage.isBuildingOrCompleted();
 
-        manualGate = <span onclick={isTriggerDisabled ? undefined : vnode.state.triggerStage.bind(vnode.state, stage)}
-                           title={getHelpText(stage, previousStage)}
-                           class={`manual_gate ${isTriggerDisabled ? "disabled" : ""}`} />;
+        if(isTriggerDisabled) {
+          manualGate = (<f.linkWithTooltip class="stage_manual_gate_tooltip" tooltipText={getHelpText(stage, previousStage)}>
+            <span class={`manual_gate disabled`}/>
+          </f.linkWithTooltip>);
+        } else {
+          manualGate = <span onclick={vnode.state.triggerStage.bind(vnode.state, stage)} title={getHelpText(stage, previousStage)} class={`manual_gate`}/>;
+        }
       }
 
       if (stage.isBuildingOrCompleted()) {
-        return [ manualGate,
+        return (<div class="pipeline_stage_manual_gate_wrapper">
+          {manualGate}
           <a href={stage.stageDetailTabPath}
              className={`pipeline_stage ${stage.status.toLowerCase()}`}
              title={stageStatus} aria-label={stageStatus}>
-          </a>];
+          </a>
+        </div>);
       }
 
-      return [
-        manualGate,
+      return (<div class="pipeline_stage_manual_gate_wrapper">
+        {manualGate}
         <span className={`pipeline_stage ${stage.status.toLowerCase()}`}
-              title={stageStatus} aria-label={stageStatus}/>];
+              title={stageStatus} aria-label={stageStatus}/>
+      </div>);
     });
 
     return (
@@ -76,23 +85,23 @@ export const StagesInstanceWidget = {
 
 function getHelpText(stage, previousStage) {
   let helpText;
-  if(stage.isManual()) {
+  if (stage.isManual()) {
     helpText = `Awaiting approval. Waiting for users with the operate permission to schedule '${stage.name}' stage`;
   }
 
-  if(stage.isBuildingOrCompleted()) {
+  if (stage.isBuildingOrCompleted()) {
     helpText = `Approved by '${stage.approvedBy}'.`;
   }
 
-  if(previousStage && !previousStage.isCompleted()) {
+  if (previousStage && !previousStage.isCompleted()) {
     helpText = `Can not schedule next stage - Either the previous stage hasn't run or is in progress.`;
   }
 
-  if(!stage.canOperate) {
+  if (!stage.canOperate) {
     helpText = `Can not schedule next stage - You don't have permissions to schedule the next stage.`;
   }
 
-  if(stage.triggerOnlyOnSuccessOfPreviousStage() && previousStage && (previousStage.isFailed() || previousStage.isCancelled())) {
+  if (stage.triggerOnlyOnSuccessOfPreviousStage() && previousStage && (previousStage.isFailed() || previousStage.isCancelled())) {
     helpText = `Can not schedule next stage - stage '${stage.name}' is set to run only on success of previous stage, whereas, the previous stage '${previousStage.name}' has ${previousStage.status}.`;
   }
 


### PR DESCRIPTION
Description:

* Do not render manual gate for the first stage in the pipeline.

* Align stage manual gate to the left of the stage.  Do not render manual gate and stage on two different rows.

<img width="333" alt="Screen Shot 2020-07-31 at 10 30 48 AM" src="https://user-images.githubusercontent.com/15275847/89001915-40060180-d319-11ea-9f98-9c0c6b4a124c.png">

In the above screenshot, in the first row, even if there is enough space to render the manual trigger icon, it is rendered on the next row, next to the belonging stage.

* Use custom tooltip when manual gate is disabled.
<img width="286" alt="Screen Shot 2020-07-31 at 10 30 54 AM" src="https://user-images.githubusercontent.com/15275847/89001949-67f56500-d319-11ea-9991-17bee7650117.png">

This is done to keep it consistent with the pipeline tile action disabled message.


