### PR TITLE
Fix regression failure for scheduled jobs feeds api (deprecated one)

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/helpers/api/feeds_helper.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/helpers/api/feeds_helper.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2019 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Api
+  module FeedsHelper
+    include JavaImports
+    def pretty_print_xml(doc)
+      stream = ByteArrayOutputStream.new
+      XMLWriter.new(stream, OutputFormat.createPrettyPrint()).write(doc)
+      stream.toString()
+    end
+  end
+end


### PR DESCRIPTION
Issue: #8321

Description:
The feeds_helper file which was deleted in #8321 was still in use for the deprecated scheduled jobs api.
The removal resulted in [regression failure](https://build.gocd.org/go/tab/build/detail/regression-SPAs/2113/Firefox/2/APIs). Hence bringing this back.


