### PR TITLE
Launch agent with all SSL properties if provided #8416

### DIFF
--- a/agent-process-launcher/src/main/java/com/thoughtworks/go/agent/AgentProcessParentImpl.java
+++ b/agent-process-launcher/src/main/java/com/thoughtworks/go/agent/AgentProcessParentImpl.java
@@ -153,6 +153,21 @@ public class AgentProcessParentImpl implements AgentProcessParent {
             commandSnippets.add(bootstrapperArgs.getRootCertFile().getAbsolutePath());
         }
 
+        if (bootstrapperArgs.getSslCertificateFile() != null) {
+            commandSnippets.add("-sslCertificateFile");
+            commandSnippets.add(bootstrapperArgs.getSslCertificateFile().getAbsolutePath());
+        }
+
+        if (bootstrapperArgs.getSslPrivateKeyFile() != null) {
+            commandSnippets.add("-sslPrivateKeyFile");
+            commandSnippets.add(bootstrapperArgs.getSslPrivateKeyFile().getAbsolutePath());
+        }
+
+        if (bootstrapperArgs.getSslPrivateKeyPassphraseFile() != null) {
+            commandSnippets.add("-sslPrivateKeyPassphraseFile");
+            commandSnippets.add(bootstrapperArgs.getSslPrivateKeyPassphraseFile().getAbsolutePath());
+        }
+
         return commandSnippets.toArray(new String[]{});
     }
 


### PR DESCRIPTION
Issue: #8416

* The agent launcher while starting an agent did not pass all the configured
  SSL properties in the wrapper config. The agents were not able to
  connect to a reverse proxy which used to terminate SSL connections.
* This PR ensures all the configured SSL properties are passed to
  the agent.





