### PR TITLE
Update materials spa

### DIFF
--- a/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/representers/materials/MaterialsRepresenter.java
+++ b/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/representers/materials/MaterialsRepresenter.java
@@ -15,13 +15,9 @@
  */
 package com.thoughtworks.go.apiv1.internalmaterials.representers.materials;
 
-import com.thoughtworks.go.api.base.OutputListWriter;
 import com.thoughtworks.go.api.base.OutputWriter;
-import com.thoughtworks.go.api.representers.ErrorGetter;
-import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.materials.PackageMaterialConfig;
 import com.thoughtworks.go.config.materials.PluggableSCMMaterialConfig;
-import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
 import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig;
 import com.thoughtworks.go.config.materials.perforce.P4MaterialConfig;
@@ -29,7 +25,6 @@ import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
 import com.thoughtworks.go.config.materials.tfs.TfsMaterialConfig;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 
-import java.util.HashMap;
 import java.util.function.Consumer;
 
 import static java.util.Arrays.stream;

--- a/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/representers/materials/PerforceMaterialRepresenter.java
+++ b/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/representers/materials/PerforceMaterialRepresenter.java
@@ -28,7 +28,6 @@ public class PerforceMaterialRepresenter extends ScmMaterialRepresenter<P4Materi
         return super.toJSON(p4MaterialConfig).andThen(
                 jsonWriter -> {
                     jsonWriter.add("port", p4MaterialConfig.getServerAndPort());
-                    jsonWriter.add("use_tickets", p4MaterialConfig.getUseTickets());
                     jsonWriter.add("view", p4MaterialConfig.getView());
                 }
         );

--- a/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/representers/materials/PerforceMaterialRepresenterTest.groovy
+++ b/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/representers/materials/PerforceMaterialRepresenterTest.groovy
@@ -39,7 +39,6 @@ class PerforceMaterialRepresenterTest implements MaterialRepresenterTrait<P4Mate
       fingerprint: existingMaterial().fingerprint,
       attributes : [
         port              : "host:9876",
-        use_tickets       : true,
         view              : "view",
         name              : "p4-material",
         auto_update       : true

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipeline_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipeline_spec.js
@@ -34,7 +34,7 @@ describe("Dashboard", () => {
       expect(pipeline.name).toBe(pipelineJson.name);
 
       expect(pipeline.canAdminister).toBe(true);
-      expect(pipeline.settingsPath).toBe(`/go/admin/pipelines/${pipelineJson.name}/general`);
+      expect(pipeline.settingsPath).toBe(`/go/admin/pipelines/${pipelineJson.name}/edit#!${pipelineJson.name}/general`);
 
       expect(pipeline.historyPath).toBe(`/go/pipeline/activity/${pipelineJson.name}`);
       expect(pipeline.instances.length).toEqual(pipelineJson._embedded.instances.length);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -588,6 +588,14 @@ export class SparkRoutes {
   }
 
   static getAllMaterials(): string {
-    return '/go/api/config/materials';
+    return '/go/api/internal/materials';
+  }
+
+  static getMaterialUsages(fingerprint: string) {
+    return `/go/api/internal/materials/${fingerprint}/usages`;
+  }
+
+  static materialsVsmLink(fingerprint: string, revision:string) {
+    return `/go/materials/value_stream_map/${fingerprint}/${revision}`;
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -584,7 +584,7 @@ export class SparkRoutes {
   }
 
   static pipelineEditPath(stageParent: string, pipelineName: string, tab: string ): string {
-    return `/go/admin/${stageParent}/${pipelineName}/${tab}`;
+    return `/go/admin/${stageParent}/${pipelineName}/edit#!${pipelineName}/${tab}`;
   }
 
   static getAllMaterials(): string {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -555,7 +555,13 @@ export class SparkRoutes {
     return '/go/api/admin/internal/scms/verify_connection';
   }
 
-  static packageRepositoriesSPA() {
+  static packageRepositoriesSPA(repo?: string, pkg?: string) {
+    if (repo) {
+      if (pkg) {
+        return `/go/admin/package_repositories#!${repo}/packages/${pkg}`;
+      }
+      return `/go/admin/package_repositories#!${repo}`;
+    }
     return '/go/admin/package_repositories';
   }
 
@@ -575,7 +581,10 @@ export class SparkRoutes {
     return `/go/api/admin/scms/${scm_name}/usages`;
   }
 
-  static pluggableScmSPA() {
+  static pluggableScmSPA(scm?: string) {
+    if (scm) {
+      return `/go/admin/scms#!${scm}`;
+    }
     return '/go/admin/scms';
   }
 
@@ -583,7 +592,7 @@ export class SparkRoutes {
     return `/go/api/admin/templates/${id}/authorization`;
   }
 
-  static pipelineEditPath(stageParent: string, pipelineName: string, tab: string ): string {
+  static pipelineEditPath(stageParent: string, pipelineName: string, tab: string): string {
     return `/go/admin/${stageParent}/${pipelineName}/edit#!${pipelineName}/${tab}`;
   }
 
@@ -595,7 +604,7 @@ export class SparkRoutes {
     return `/go/api/internal/materials/${fingerprint}/usages`;
   }
 
-  static materialsVsmLink(fingerprint: string, revision:string) {
+  static materialsVsmLink(fingerprint: string, revision: string) {
     return `/go/materials/value_stream_map/${fingerprint}/${revision}`;
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/materials.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/materials.ts
@@ -28,13 +28,13 @@ export interface MaterialWithFingerprintJSON extends MaterialJSON {
   fingerprint: string;
 }
 
-interface MaterialWithModificationsJSON {
+interface MaterialWithModificationJSON {
   config: MaterialWithFingerprintJSON;
   modification: MaterialModificationJSON;
 }
 
 interface MaterialsJSON {
-  materials: MaterialWithModificationsJSON[];
+  materials: MaterialWithModificationJSON[];
 }
 
 export class MaterialWithFingerprint extends Material {
@@ -94,7 +94,7 @@ export class MaterialWithFingerprint extends Material {
   }
 }
 
-export class MaterialWithModifications {
+export class MaterialWithModification {
   config: MaterialWithFingerprint;
   modification: MaterialModification | null;
 
@@ -103,20 +103,20 @@ export class MaterialWithModifications {
     this.modification = modification;
   }
 
-  static fromJSON(data: MaterialWithModificationsJSON): MaterialWithModifications {
+  static fromJSON(data: MaterialWithModificationJSON): MaterialWithModification {
     const mod = data.modification === null ? null : MaterialModification.fromJSON(data.modification);
-    return new MaterialWithModifications(MaterialWithFingerprint.fromJSON(data.config), mod);
+    return new MaterialWithModification(MaterialWithFingerprint.fromJSON(data.config), mod);
   }
 }
 
-export class Materials extends Array<MaterialWithModifications> {
-  constructor(...vals: MaterialWithModifications[]) {
+export class Materials extends Array<MaterialWithModification> {
+  constructor(...vals: MaterialWithModification[]) {
     super(...vals);
     Object.setPrototypeOf(this, Object.create(Materials.prototype));
   }
 
-  static fromJSON(data: MaterialWithModificationsJSON[]): Materials {
-    return new Materials(...data.map((a) => MaterialWithModifications.fromJSON(a)));
+  static fromJSON(data: MaterialWithModificationJSON[]): Materials {
+    return new Materials(...data.map((a) => MaterialWithModification.fromJSON(a)));
   }
 
   sortOnType() {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/materials.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/materials.ts
@@ -50,9 +50,31 @@ export class MaterialWithFingerprint extends Material {
   }
 
   attributesAsMap(): Map<string, any> {
-    const map = new Map();
-    map.set("Fingerprint", this.fingerprint());
-    return _.reduce(this.attributes(), MaterialWithFingerprint.resolveKeyValueForAttribute, map);
+    const map: Map<string, string> = new Map();
+    let keys: string[]             = [];
+    switch (this.type()) {
+      case "git":
+      case "hg":
+        keys = ["url", "branch"];
+        break;
+      case "p4":
+        keys = ["port", "view"];
+        break;
+      case "tfs":
+        keys = ["url", "domain", "projectPath"];
+        break;
+      case "svn":
+        keys = ["url"];
+        break;
+    }
+    const reducer = (map: Map<any, any>, value: any, key: string) => {
+      if (keys.includes(key)) {
+        MaterialWithFingerprint.resolveKeyValueForAttribute(map, value, key);
+      }
+      return map;
+    };
+    _.reduce(this.attributes(), reducer, map);
+    return map;
   }
 
   matches(textToMatch: string): boolean {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/materials_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/materials_spec.ts
@@ -17,7 +17,7 @@
 import {ApiResult, SuccessResponse} from "helpers/api_request_builder";
 import {SparkRoutes} from "helpers/spark_routes";
 import {Filter} from "models/maintenance_mode/material";
-import {MaterialAPIs, Materials, MaterialWithFingerprint, MaterialWithModifications} from "../materials";
+import {MaterialAPIs, Materials, MaterialWithFingerprint, MaterialWithModification} from "../materials";
 import {
   DependencyMaterialAttributes,
   GitMaterialAttributes,
@@ -137,14 +137,14 @@ describe('MaterialWithFingerPrintSpec', () => {
 describe('MaterialsWithModificationsSpec', () => {
   it('should sort based on type', () => {
     const materials = new Materials();
-    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("git", "some", new GitMaterialAttributes()), null));
-    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("hg", "some", new HgMaterialAttributes()), null));
-    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("svn", "some", new SvnMaterialAttributes()), null));
-    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("p4", "some", new P4MaterialAttributes()), null));
-    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("tfs", "some", new TfsMaterialAttributes()), null));
-    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("dependency", "some", new DependencyMaterialAttributes()), null));
-    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("package", "some", new PackageMaterialAttributes()), null));
-    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("plugin", "some", new PluggableScmMaterialAttributes(undefined, undefined, "", "", new Filter([]))), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("git", "some", new GitMaterialAttributes()), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("hg", "some", new HgMaterialAttributes()), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("svn", "some", new SvnMaterialAttributes()), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("p4", "some", new P4MaterialAttributes()), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("tfs", "some", new TfsMaterialAttributes()), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("dependency", "some", new DependencyMaterialAttributes()), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("package", "some", new PackageMaterialAttributes()), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("plugin", "some", new PluggableScmMaterialAttributes(undefined, undefined, "", "", new Filter([]))), null));
 
     materials.sortOnType();
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/materials_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/materials_spec.ts
@@ -17,7 +17,7 @@
 import {ApiResult, SuccessResponse} from "helpers/api_request_builder";
 import {SparkRoutes} from "helpers/spark_routes";
 import {Filter} from "models/maintenance_mode/material";
-import {MaterialAPIs, MaterialWithFingerprint, MaterialWithFingerprints} from "../materials";
+import {MaterialAPIs, Materials, MaterialWithFingerprint, MaterialWithModifications} from "../materials";
 import {
   DependencyMaterialAttributes,
   GitMaterialAttributes,
@@ -39,16 +39,23 @@ describe('MaterialsAPISpec', () => {
 
     const onResponse = jasmine.createSpy().and.callFake((response: ApiResult<any>) => {
       const responseJSON = response.unwrap() as SuccessResponse<any>;
-      const materials    = (responseJSON.body as MaterialWithFingerprints);
+      const materials    = (responseJSON.body as Materials);
 
       expect(materials).toHaveLength(1);
 
       const material = materials[0];
-      expect(material.type()).toBe('git');
-      expect(material.name()).toBe('some-name');
-      expect(material.fingerprint()).toBe('4879d548d34a4f3ba7ed4a532bc1b02');
+      expect(material.config.type()).toBe('git');
+      expect(material.config.name()).toBe('some-name');
+      expect(material.config.fingerprint()).toBe('4879d548d34a4f3ba7ed4a532bc1b02');
 
-      expect(material.attributes()).toBeInstanceOf(GitMaterialAttributes);
+      expect(material.config.attributes()).toBeInstanceOf(GitMaterialAttributes);
+
+      expect(material.modification).not.toBeNull();
+      expect(material.modification!.modifiedTime).toBe("2019-12-23T10:25:52Z");
+      expect(material.modification!.username).toBe("GoCD test user");
+      expect(material.modification!.comment).toBe("Dummy commit");
+      expect(material.modification!.emailAddress).toBe("gocd@test.com");
+      expect(material.modification!.revision).toBe("abcd1234");
       done();
     });
 
@@ -62,8 +69,8 @@ describe('MaterialsAPISpec', () => {
 
   function materialsResponse() {
     const data = {
-      _embedded: {
-        materials: [{
+      materials: [{
+        config:       {
           type:        "git",
           fingerprint: "4879d548d34a4f3ba7ed4a532bc1b02",
           attributes:  {
@@ -77,13 +84,20 @@ describe('MaterialsAPISpec', () => {
             submodule_folder: null,
             shallow_clone:    false
           }
-        }]
-      }
+        },
+        modification: {
+          username:      "GoCD test user",
+          email_address: "gocd@test.com",
+          revision:      "abcd1234",
+          comment:       "Dummy commit",
+          modified_time: "2019-12-23T10:25:52Z"
+        }
+      }]
     };
     return {
       status:          200,
       responseHeaders: {
-        "Content-Type": "application/vnd.go.cd.v2+json; charset=utf-8",
+        "Content-Type": "application/vnd.go.cd.v1+json; charset=utf-8",
       },
       responseText:    JSON.stringify(data)
     };
@@ -96,7 +110,8 @@ describe('MaterialWithFingerPrintSpec', () => {
 
     const attrs = material.attributesAsMap();
 
-    expect(attrs.size).toBe(9);
+    expect(attrs.size).toBe(10);
+    expect(attrs.has("Fingerprint")).toBeTrue();
     expect(attrs.has("name")).toBeFalse();
   });
 
@@ -119,27 +134,27 @@ describe('MaterialWithFingerPrintSpec', () => {
   });
 });
 
-describe('MaterialWithFingerprintsSpec', () => {
+describe('MaterialsWithModificationsSpec', () => {
   it('should sort based on type', () => {
-    const materials = new MaterialWithFingerprints();
-    materials.push(new MaterialWithFingerprint("git", "some", new GitMaterialAttributes()));
-    materials.push(new MaterialWithFingerprint("hg", "some", new HgMaterialAttributes()));
-    materials.push(new MaterialWithFingerprint("svn", "some", new SvnMaterialAttributes()));
-    materials.push(new MaterialWithFingerprint("p4", "some", new P4MaterialAttributes()));
-    materials.push(new MaterialWithFingerprint("tfs", "some", new TfsMaterialAttributes()));
-    materials.push(new MaterialWithFingerprint("dependency", "some", new DependencyMaterialAttributes()));
-    materials.push(new MaterialWithFingerprint("package", "some", new PackageMaterialAttributes()));
-    materials.push(new MaterialWithFingerprint("plugin", "some", new PluggableScmMaterialAttributes(undefined, undefined, "", "", new Filter([]))));
+    const materials = new Materials();
+    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("git", "some", new GitMaterialAttributes()), null));
+    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("hg", "some", new HgMaterialAttributes()), null));
+    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("svn", "some", new SvnMaterialAttributes()), null));
+    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("p4", "some", new P4MaterialAttributes()), null));
+    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("tfs", "some", new TfsMaterialAttributes()), null));
+    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("dependency", "some", new DependencyMaterialAttributes()), null));
+    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("package", "some", new PackageMaterialAttributes()), null));
+    materials.push(new MaterialWithModifications(new MaterialWithFingerprint("plugin", "some", new PluggableScmMaterialAttributes(undefined, undefined, "", "", new Filter([]))), null));
 
     materials.sortOnType();
 
-    expect(materials[0].type()).toBe('dependency');
-    expect(materials[1].type()).toBe('git');
-    expect(materials[2].type()).toBe('hg');
-    expect(materials[3].type()).toBe('p4');
-    expect(materials[4].type()).toBe('package');
-    expect(materials[5].type()).toBe('plugin');
-    expect(materials[6].type()).toBe('svn');
-    expect(materials[7].type()).toBe('tfs');
+    expect(materials[0].config.type()).toBe('dependency');
+    expect(materials[1].config.type()).toBe('git');
+    expect(materials[2].config.type()).toBe('hg');
+    expect(materials[3].config.type()).toBe('p4');
+    expect(materials[4].config.type()).toBe('package');
+    expect(materials[5].config.type()).toBe('plugin');
+    expect(materials[6].config.type()).toBe('svn');
+    expect(materials[7].config.type()).toBe('tfs');
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/materials_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/materials_spec.ts
@@ -105,22 +105,64 @@ describe('MaterialsAPISpec', () => {
 });
 
 describe('MaterialWithFingerPrintSpec', () => {
-  it('should convert attributes into Map', () => {
-    const material = new MaterialWithFingerprint("git", "fingerprint", new GitMaterialAttributes("name", false, "some-url", "master"));
+  describe('MaterialAttrsAsMapSpec', () => {
+    it('should convert git attributes into Map', () => {
+      const material = new MaterialWithFingerprint("git", "fingerprint", new GitMaterialAttributes("name", false, "some-url", "master"));
 
-    const attrs = material.attributesAsMap();
+      const attrs = material.attributesAsMap();
+      const keys  = Array.from(attrs.keys());
 
-    expect(attrs.size).toBe(10);
-    expect(attrs.has("Fingerprint")).toBeTrue();
-    expect(attrs.has("name")).toBeFalse();
-  });
+      expect(keys.length).toBe(2);
+      expect(keys).toEqual(['URL', 'Branch']);
+    });
 
-  it('should render filters', () => {
-    const attrs = new GitMaterialAttributes();
-    attrs.filter(new Filter(["abc"]));
-    const material = new MaterialWithFingerprint("git", "fingerprint", attrs);
+    it('should convert hg attributes into Map', () => {
+      const material = new MaterialWithFingerprint("hg", "fingerprint", new HgMaterialAttributes("name", false, "some-url"));
 
-    expect(material.attributesAsMap().get("Filter")).toEqual(['abc']);
+      const attrs = material.attributesAsMap();
+      const keys  = Array.from(attrs.keys());
+
+      expect(keys.length).toBe(2);
+      expect(keys).toEqual(['URL', 'Branch']);
+    });
+
+    it('should convert svn attributes into Map', () => {
+      const material = new MaterialWithFingerprint("svn", "fingerprint", new SvnMaterialAttributes("name", false, "some-url"));
+
+      const attrs = material.attributesAsMap();
+      const keys  = Array.from(attrs.keys());
+
+      expect(keys.length).toBe(1);
+      expect(keys).toEqual(['URL']);
+    });
+
+    it('should convert p4 attributes into Map', () => {
+      const material = new MaterialWithFingerprint("p4", "fingerprint", new P4MaterialAttributes("name", false, "some-url", false, "view"));
+
+      const attrs = material.attributesAsMap();
+      const keys  = Array.from(attrs.keys());
+
+      expect(keys.length).toBe(2);
+      expect(keys).toEqual(['Host and Port', 'View']);
+    });
+
+    it('should convert tfs attributes into Map', () => {
+      const material = new MaterialWithFingerprint("tfs", "fingerprint", new TfsMaterialAttributes("name", false, "some-url", "domain", "view"));
+
+      const attrs = material.attributesAsMap();
+      const keys  = Array.from(attrs.keys());
+
+      expect(keys.length).toBe(3);
+      expect(keys).toEqual(['URL', 'Domain', 'Project Path']);
+    });
+
+    it('should return empty attributes for non-scm materials', () => {
+      const material = new MaterialWithFingerprint("dependency", "fingerprint", new DependencyMaterialAttributes("name", false, "some-url", "domain"));
+
+      const attrs = material.attributesAsMap();
+
+      expect(attrs.size).toBe(0);
+    });
   });
 
   it('should return true if search string matches name, type or display url', () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials.tsx
@@ -17,7 +17,7 @@
 import _ from "lodash";
 import m from "mithril";
 import Stream from "mithril/stream";
-import {MaterialAPIs, MaterialWithFingerprint, MaterialWithFingerprints} from "models/materials/materials";
+import {MaterialAPIs, Materials, MaterialWithModifications} from "models/materials/materials";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {SearchField} from "views/components/forms/input_fields";
 import {HeaderPanel} from "views/components/header_panel";
@@ -26,7 +26,7 @@ import {Page, PageState} from "views/pages/page";
 import configRepoStyles from "./config_repos/index.scss";
 
 export interface MaterialsAttrs {
-  materials: Stream<MaterialWithFingerprints>;
+  materials: Stream<Materials>;
 }
 
 interface State extends MaterialsAttrs {
@@ -43,9 +43,9 @@ export class MaterialsPage extends Page<null, State> {
   }
 
   componentToDisplay(vnode: m.Vnode<null, State>): m.Children {
-    const filteredMaterials: Stream<MaterialWithFingerprints> = Stream(vnode.state.materials());
+    const filteredMaterials: Stream<Materials> = Stream(vnode.state.materials());
     if (vnode.state.searchText()) {
-      const results = _.filter(filteredMaterials(), (vm: MaterialWithFingerprint) => vm.matches(vnode.state.searchText()));
+      const results = _.filter(filteredMaterials(), (vm: MaterialWithModifications) => vm.config.matches(vnode.state.searchText()));
 
       if (_.isEmpty(results)) {
         return <div>
@@ -53,7 +53,7 @@ export class MaterialsPage extends Page<null, State> {
             string: <em>{vnode.state.searchText()}</em></FlashMessage>
         </div>;
       }
-      filteredMaterials(new MaterialWithFingerprints(...results));
+      filteredMaterials(new Materials(...results));
     }
     return <MaterialsWidget materials={filteredMaterials}/>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials.tsx
@@ -17,16 +17,17 @@
 import _ from "lodash";
 import m from "mithril";
 import Stream from "mithril/stream";
-import {MaterialAPIs, Materials, MaterialWithModifications} from "models/materials/materials";
+import {MaterialAPIs} from "models/materials/materials";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {SearchField} from "views/components/forms/input_fields";
 import {HeaderPanel} from "views/components/header_panel";
 import {MaterialsWidget} from "views/pages/materials/materials_widget";
+import {MaterialVM, MaterialVMs} from "views/pages/materials/models/material_view_model";
 import {Page, PageState} from "views/pages/page";
 import configRepoStyles from "./config_repos/index.scss";
 
 export interface MaterialsAttrs {
-  materials: Stream<Materials>;
+  materialVMs: Stream<MaterialVMs>;
 }
 
 interface State extends MaterialsAttrs {
@@ -38,14 +39,14 @@ export class MaterialsPage extends Page<null, State> {
   oninit(vnode: m.Vnode<null, State>) {
     super.oninit(vnode);
 
-    vnode.state.materials  = Stream();
-    vnode.state.searchText = Stream();
+    vnode.state.materialVMs = Stream();
+    vnode.state.searchText  = Stream();
   }
 
   componentToDisplay(vnode: m.Vnode<null, State>): m.Children {
-    const filteredMaterials: Stream<Materials> = Stream(vnode.state.materials());
+    const filteredMaterials: Stream<MaterialVMs> = Stream(vnode.state.materialVMs());
     if (vnode.state.searchText()) {
-      const results = _.filter(filteredMaterials(), (vm: MaterialWithModifications) => vm.config.matches(vnode.state.searchText()));
+      const results = _.filter(filteredMaterials(), (vm: MaterialVM) => vm.matches(vnode.state.searchText()));
 
       if (_.isEmpty(results)) {
         return <div>
@@ -53,9 +54,9 @@ export class MaterialsPage extends Page<null, State> {
             string: <em>{vnode.state.searchText()}</em></FlashMessage>
         </div>;
       }
-      filteredMaterials(new Materials(...results));
+      filteredMaterials(new MaterialVMs(...results));
     }
-    return <MaterialsWidget materials={filteredMaterials}/>;
+    return <MaterialsWidget materialVMs={filteredMaterials}/>;
   }
 
   pageName(): string {
@@ -67,8 +68,8 @@ export class MaterialsPage extends Page<null, State> {
     return Promise.resolve(MaterialAPIs.all()).then((result) => {
       result.do((successResponse) => {
         this.pageState = PageState.OK;
-        vnode.state.materials(successResponse.body);
-        vnode.state.materials().sortOnType();
+        vnode.state.materialVMs(MaterialVMs.fromMaterials(successResponse.body));
+        vnode.state.materialVMs().sortOnType();
       }, this.setErrorState);
     });
   }
@@ -79,7 +80,7 @@ export class MaterialsPage extends Page<null, State> {
 
   protected headerPanel(vnode: m.Vnode<null, State>): any {
     const buttons = [];
-    if (!_.isEmpty(vnode.state.materials())) {
+    if (!_.isEmpty(vnode.state.materialVMs())) {
       const searchBox = <div className={configRepoStyles.wrapperForSearchBox}>
         <SearchField property={vnode.state.searchText} dataTestId={"search-box"}
                      placeholder="Search for a material name or url"/>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials.tsx
@@ -18,6 +18,10 @@ import _ from "lodash";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {MaterialAPIs} from "models/materials/materials";
+import {Scms} from "models/materials/pluggable_scm";
+import {PluggableScmCRUD} from "models/materials/pluggable_scm_crud";
+import {PackagesCRUD} from "models/package_repositories/packages_crud";
+import {Packages} from "models/package_repositories/package_repositories";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {SearchField} from "views/components/forms/input_fields";
 import {HeaderPanel} from "views/components/header_panel";
@@ -26,7 +30,12 @@ import {MaterialVM, MaterialVMs} from "views/pages/materials/models/material_vie
 import {Page, PageState} from "views/pages/page";
 import configRepoStyles from "./config_repos/index.scss";
 
-export interface MaterialsAttrs {
+export interface AdditionalInfoAttrs {
+  scms: Stream<Scms>;
+  packages: Stream<Packages>;
+}
+
+export interface MaterialsAttrs extends AdditionalInfoAttrs {
   materialVMs: Stream<MaterialVMs>;
 }
 
@@ -40,6 +49,8 @@ export class MaterialsPage extends Page<null, State> {
     super.oninit(vnode);
 
     vnode.state.materialVMs = Stream();
+    vnode.state.scms        = Stream();
+    vnode.state.packages    = Stream();
     vnode.state.searchText  = Stream();
   }
 
@@ -56,7 +67,7 @@ export class MaterialsPage extends Page<null, State> {
       }
       filteredMaterials(new MaterialVMs(...results));
     }
-    return <MaterialsWidget materialVMs={filteredMaterials}/>;
+    return <MaterialsWidget materialVMs={filteredMaterials} scms={vnode.state.scms} packages={vnode.state.packages}/>;
   }
 
   pageName(): string {
@@ -65,11 +76,21 @@ export class MaterialsPage extends Page<null, State> {
 
   fetchData(vnode: m.Vnode<null, State>): Promise<any> {
     this.pageState = PageState.LOADING;
-    return Promise.resolve(MaterialAPIs.all()).then((result) => {
-      result.do((successResponse) => {
+    return Promise.all([MaterialAPIs.all(), PluggableScmCRUD.all(), PackagesCRUD.all()]).then((result) => {
+      result[0].do((successResponse) => {
         this.pageState = PageState.OK;
         vnode.state.materialVMs(MaterialVMs.fromMaterials(successResponse.body));
         vnode.state.materialVMs().sortOnType();
+      }, this.setErrorState);
+
+      result[1].do((successResponse) => {
+        this.pageState = PageState.OK;
+        vnode.state.scms(successResponse.body);
+      }, this.setErrorState);
+
+      result[2].do((successResponse) => {
+        this.pageState = PageState.OK;
+        vnode.state.packages(successResponse.body);
       }, this.setErrorState);
     });
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_header_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_header_widget.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classnames from "classnames";
+import {SparkRoutes} from "helpers/spark_routes";
+import {MithrilViewComponent} from "jsx/mithril-component";
+import _ from "lodash";
+import m from "mithril";
+import {MaterialModification} from "models/config_repos/types";
+import {MaterialWithModifications} from "models/materials/materials";
+import {Link} from "views/components/link";
+import headerStyles from "views/pages/config_repos/index.scss";
+import styles from "./index.scss";
+import {MaterialAttrs} from "./materials_widget";
+
+export class MaterialHeaderWidget extends MithrilViewComponent<MaterialAttrs> {
+  private static readonly MAX_COMMIT_MSG_LENGTH: number            = 84;
+  private static readonly MAX_USERNAME_AND_REVISION_LENGTH: number = 40;
+
+  view(vnode: m.Vnode<MaterialAttrs, this>): m.Children | void | null {
+    const material = vnode.attrs.material;
+    return [
+      MaterialHeaderWidget.getIcon(material),
+      <div className={headerStyles.headerTitle}>
+        <h4 data-test-id="material-type" className={headerStyles.headerTitleText}>{material.config.typeForDisplay()}</h4>
+        <span data-test-id="material-display-name" className={headerStyles.headerTitleUrl}>{material.config.displayName()}</span>
+      </div>,
+      <div data-test-id="latest-mod-in-header">{this.showLatestModificationDetails(material.config.fingerprint(), material.modification)}</div>
+    ];
+  }
+
+  private static getIcon(material: MaterialWithModifications) {
+    let style = styles.unknown;
+    switch (material.config.type()) {
+      case "git":
+        style = styles.git;
+        break;
+      case "hg":
+        style = styles.mercurial;
+        break;
+      case "svn":
+        style = styles.subversion;
+        break;
+      case "p4":
+        style = styles.perforce;
+        break;
+      case "tfs":
+        style = styles.tfs;
+        break;
+      case "package":
+        style = styles.package;
+        break;
+    }
+    return <div data-test-id="material-icon" className={classnames(styles.material, style)}/>;
+  }
+
+  private showLatestModificationDetails(fingerprint: string, modification: MaterialModification | null) {
+    if (modification === null) {
+      return "This material was never parsed";
+    }
+
+    const comment         = _.truncate(modification.comment, {length: MaterialHeaderWidget.MAX_COMMIT_MSG_LENGTH});
+    const username        = _.truncate(modification.username, {length: MaterialHeaderWidget.MAX_USERNAME_AND_REVISION_LENGTH});
+    const revision        = _.truncate(modification.revision, {length: MaterialHeaderWidget.MAX_USERNAME_AND_REVISION_LENGTH});
+    const usernameElement = _.isEmpty(username)
+      ? undefined
+      : <span>
+      <span className={headerStyles.committer}>{username}</span> | </span>;
+
+    const revisionLink = <Link dataTestId={"vsm-link"} href={SparkRoutes.materialsVsmLink(fingerprint, modification.revision)}
+                               title={"VSM"} onclick={e => e.stopPropagation()}>{revision}</Link>;
+    return <div
+      className={headerStyles.commitInfo}>
+      <span className={headerStyles.comment}>
+        {comment}
+      </span>
+      <div className={headerStyles.committerInfo}>
+        {usernameElement}{revisionLink}
+      </div>
+    </div>;
+  }
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_header_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_header_widget.tsx
@@ -20,7 +20,7 @@ import {MithrilViewComponent} from "jsx/mithril-component";
 import _ from "lodash";
 import m from "mithril";
 import {MaterialModification} from "models/config_repos/types";
-import {MaterialWithModifications} from "models/materials/materials";
+import {MaterialWithModification} from "models/materials/materials";
 import {Link} from "views/components/link";
 import headerStyles from "views/pages/config_repos/index.scss";
 import styles from "./index.scss";
@@ -31,7 +31,7 @@ export class MaterialHeaderWidget extends MithrilViewComponent<MaterialAttrs> {
   private static readonly MAX_USERNAME_AND_REVISION_LENGTH: number = 40;
 
   view(vnode: m.Vnode<MaterialAttrs, this>): m.Children | void | null {
-    const material = vnode.attrs.material;
+    const material = vnode.attrs.materialVM.material;
     return [
       MaterialHeaderWidget.getIcon(material),
       <div className={headerStyles.headerTitle}>
@@ -42,7 +42,7 @@ export class MaterialHeaderWidget extends MithrilViewComponent<MaterialAttrs> {
     ];
   }
 
-  private static getIcon(material: MaterialWithModifications) {
+  private static getIcon(material: MaterialWithModification) {
     let style = styles.unknown;
     switch (material.config.type()) {
       case "git":

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_usage_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_usage_widget.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classnames from "classnames";
+import {override} from "helpers/css_proxies";
+import {SparkRoutes} from "helpers/spark_routes";
+import {MithrilViewComponent} from "jsx/mithril-component";
+import _ from "lodash";
+import m from "mithril";
+import {treeMap} from "models/base/traversable";
+import {DefinedGroup, DefinedPipeline, NamedTree} from "models/config_repos/defined_structures";
+import {FlashMessage, MessageType} from "views/components/flash_message";
+import {Tree} from "views/components/hierarchy/tree";
+import css from "views/pages/config_repos/defined_structs.scss";
+import {MaterialUsagesVM} from "views/pages/materials/models/material_usages_view_model";
+import {MaterialAttrs} from "./materials_widget";
+
+type Styles = typeof css;
+
+export class MaterialUsageWidget extends MithrilViewComponent<MaterialAttrs> {
+  view(vnode: m.Vnode<MaterialAttrs, this>): m.Children | void | null {
+    const vm = vnode.attrs.materialVM;
+
+    if (vm.results.failed()) {
+      return <FlashMessage type={MessageType.alert}>
+        Failed to load pipelines: {vm.results.failureReason()}
+      </FlashMessage>;
+    }
+
+    if (vm.results.ready() || vm.results.contents()) {
+      const root = vm.results.contents();
+
+      if (!root.children.length) {
+        return <FlashMessage type={MessageType.alert} message="This material is not used in any pipeline"/>;
+      }
+
+      return treeMap<NamedTree, m.Vnode>(root, tree);
+    }
+    return <div className={css.loading}><i className={css.spin}/>Loading pipelines &hellip;</div>;
+  }
+}
+
+class Css {
+  static readonly groups: Styles = override<Styles>(css, {
+    ["tree"]:      classnames(css.group, css.tree),
+    ["treeDatum"]: classnames(css.groupDatum, css.treeDatum),
+  });
+
+  static readonly pipelines: Styles = override<Styles>(css, {
+    ["tree"]:      classnames(css.pipeline, css.tree),
+    ["treeDatum"]: classnames(css.pipelineDatum, css.treeDatum),
+  });
+
+  static for(node: NamedTree): Styles | undefined {
+    if (node instanceof DefinedGroup) {
+      return Css.groups;
+    }
+
+    if (node instanceof DefinedPipeline) {
+      return Css.pipelines;
+    }
+
+    return css;
+  }
+}
+
+class Link {
+  static for(node: NamedTree): m.Child {
+    if (node instanceof MaterialUsagesVM) {
+      return "Pipelines using this material:";
+    }
+
+    if (node instanceof DefinedGroup) {
+      return <a data-test-id={_.snakeCase("group " + node.name())} href={SparkRoutes.pipelineGroupsSPAPath(node.name())}>{node.name()}</a>;
+    }
+
+    if (node instanceof DefinedPipeline) {
+      return <a data-test-id={_.snakeCase("pipeline " + node.name())}
+                href={SparkRoutes.pipelineEditPath('pipelines', node.name(), 'materials')}>{node.name()}</a>;
+    }
+    return node.name();
+  }
+}
+
+function tree(n: NamedTree): m.Vnode {
+  return <Tree css={Css.for(n)} datum={Link.for(n)}/>;
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/models/material_usages_view_model.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/models/material_usages_view_model.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from "lodash";
+import {DefinedGroup, NamedTree} from "models/config_repos/defined_structures";
+import {MaterialUsageJSON} from "./material_view_model";
+
+export class MaterialUsagesVM implements NamedTree {
+  children: NamedTree[];
+
+  constructor(groups: DefinedGroup[]) {
+    this.children = groups;
+  }
+
+  static fromJSON(data: MaterialUsageJSON[]): MaterialUsagesVM {
+    const mapPipeline = (pipe: string) => {
+      return {name: pipe};
+    };
+    const results     = _.map(data, (usage) => new DefinedGroup(usage.group, _.map(usage.pipelines, mapPipeline)));
+    return new MaterialUsagesVM(results);
+  }
+
+  name(): string {
+    return "Usages";
+  }
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/models/material_view_model.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/models/material_view_model.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ApiRequestBuilder, ApiVersion} from "helpers/api_request_builder";
+import {SparkRoutes} from "helpers/spark_routes";
+import _ from "lodash";
+import m from "mithril";
+import {AbstractObjCache, ObjectCache, rejectAsString} from "models/base/cache";
+import {Materials, MaterialWithModification} from "models/materials/materials";
+import {EventAware} from "models/mixins/event_aware";
+import {MaterialUsagesVM} from "./material_usages_view_model";
+
+interface MaterialUsagesJSON {
+  usages: MaterialUsageJSON[];
+}
+
+export interface MaterialUsageJSON {
+  group: string;
+  pipelines: string[];
+}
+
+class MaterialUsageCache extends AbstractObjCache<MaterialUsagesVM> {
+  fingerprint: string;
+
+  constructor(fingerprint: string) {
+    super();
+    this.fingerprint = fingerprint;
+  }
+
+  doFetch(resolve: (data: MaterialUsagesVM) => void, reject: (reason: string) => void): void {
+    ApiRequestBuilder.GET(SparkRoutes.getMaterialUsages(this.fingerprint), ApiVersion.latest)
+                     .then((result) => {
+                       if (304 === result.getStatusCode()) {
+                         resolve(this.contents()); // no change
+                         return;
+                       }
+
+                       result.do((successResponse) => {
+                         const data = JSON.parse(successResponse.body) as MaterialUsagesJSON;
+                         resolve(MaterialUsagesVM.fromJSON(data.usages));
+                       }, (error) => {
+                         reject(error.message);
+                       });
+                     }).catch(rejectAsString(reject));
+  }
+}
+
+export class MaterialVM {
+  material: MaterialWithModification;
+  results: ObjectCache<MaterialUsagesVM>;
+
+  constructor(material: MaterialWithModification, results?: ObjectCache<MaterialUsagesVM>) {
+    this.material = material;
+    const cache   = results || new MaterialUsageCache(material.config.fingerprint());
+
+    Object.assign(MaterialVM.prototype, EventAware.prototype);
+    EventAware.call(this);
+
+    this.results = cache;
+
+    this.on("expand", () => !cache.failed() && cache.prime(m.redraw));
+  }
+
+  matches(query: string) {
+    return this.material.config.matches(query);
+  }
+
+  type() {
+    return this.material.config.type();
+  }
+}
+
+export class MaterialVMs extends Array<MaterialVM> {
+  constructor(...vals: MaterialVM[]) {
+    super(...vals);
+    Object.setPrototypeOf(this, Object.create(MaterialVMs.prototype));
+  }
+
+  static fromMaterials(materials: Materials): MaterialVMs {
+    const models = _.map(materials, (mat) => new MaterialVM(mat));
+    return new MaterialVMs(...models);
+  }
+
+  sortOnType() {
+    this.sort((m1, m2) => m1.type()!.localeCompare(m2.type()!));
+  }
+}
+
+// tslint:disable-next-line
+export interface MaterialVM extends EventAware {}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/models/spec/material_usages_view_model_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/models/spec/material_usages_view_model_spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {DefinedPipeline} from "models/config_repos/defined_structures";
+import {usagesJSON} from "views/pages/materials/spec/material_usage_widget_spec";
+import {MaterialUsagesVM} from "../material_usages_view_model";
+
+describe('MaterialUsagesVMSpec', () => {
+  it('should map materials json to vm', () => {
+    const vm = MaterialUsagesVM.fromJSON(usagesJSON());
+
+    expect(vm.children.length).toBe(2);
+    expect(vm.children[0].name()).toBe('group1');
+    expect(vm.children[1].name()).toBe('group2');
+
+    expect(vm.children[0].children).toBeInstanceOf(Array);
+
+    const children = vm.children[0].children as DefinedPipeline[];
+
+    expect(children.length).toBe(2);
+    expect(children[0].name()).toBe('pipeline1');
+    expect(children[0].children.length).toBe(0);
+    expect(children[1].name()).toBe('pipeline2');
+  });
+});

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/models/spec/material_view_model_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/models/spec/material_view_model_spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Filter} from "models/maintenance_mode/material";
+import {Materials, MaterialWithFingerprint, MaterialWithModification} from "models/materials/materials";
+import {
+  DependencyMaterialAttributes,
+  GitMaterialAttributes,
+  HgMaterialAttributes,
+  P4MaterialAttributes,
+  PackageMaterialAttributes,
+  PluggableScmMaterialAttributes,
+  SvnMaterialAttributes,
+  TfsMaterialAttributes
+} from "models/materials/types";
+import {DummyCache} from "../../spec/material_usage_widget_spec";
+import {MaterialVM, MaterialVMs} from "../material_view_model";
+
+describe('MaterialVMSpec', () => {
+  it('should fetch data when expand is notified', () => {
+    const vm = new MaterialVM(new MaterialWithModification(new MaterialWithFingerprint("git", "fingerprint", new GitMaterialAttributes()), null), new DummyCache({}));
+    expect(vm.results.prime).not.toHaveBeenCalled();
+
+    vm.notify("expand");
+
+    expect(vm.results.prime).toHaveBeenCalled();
+  });
+
+  it('should return true if search string matches name, type or display url of the config', () => {
+    const material   = new MaterialWithFingerprint("git", "fingerprint", new GitMaterialAttributes("some-name", false, "http://svn.com/gocd/gocd", "master"));
+    const materialVM = new MaterialVM(new MaterialWithModification(material, null));
+
+    expect(materialVM.matches("git")).toBeTrue();
+    expect(materialVM.matches("name")).toBeTrue();
+    expect(materialVM.matches("gocd")).toBeTrue();
+    expect(materialVM.matches("mas")).toBeTrue();
+    expect(materialVM.matches("abc")).toBeFalse();
+  });
+
+  it('should return type as config.type', () => {
+    const material   = new MaterialWithFingerprint("git", "fingerprint", new GitMaterialAttributes("some-name", false, "http://svn.com/gocd/gocd", "master"));
+    const materialVM = new MaterialVM(new MaterialWithModification(material, null));
+
+    expect(materialVM.type()).toBe(material.type());
+  });
+});
+
+describe('MaterialsVMsSpec', () => {
+  it('should sort based on type', () => {
+    const materials = new Materials();
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("git", "some", new GitMaterialAttributes()), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("hg", "some", new HgMaterialAttributes()), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("svn", "some", new SvnMaterialAttributes()), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("p4", "some", new P4MaterialAttributes()), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("tfs", "some", new TfsMaterialAttributes()), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("dependency", "some", new DependencyMaterialAttributes()), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("package", "some", new PackageMaterialAttributes()), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("plugin", "some", new PluggableScmMaterialAttributes(undefined, undefined, "", "", new Filter([]))), null));
+
+    const materialVMs = MaterialVMs.fromMaterials(materials);
+    materialVMs.sortOnType();
+
+    expect(materialVMs[0].type()).toBe('dependency');
+    expect(materialVMs[1].type()).toBe('git');
+    expect(materialVMs[2].type()).toBe('hg');
+    expect(materialVMs[3].type()).toBe('p4');
+    expect(materialVMs[4].type()).toBe('package');
+    expect(materialVMs[5].type()).toBe('plugin');
+    expect(materialVMs[6].type()).toBe('svn');
+    expect(materialVMs[7].type()).toBe('tfs');
+  });
+});

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_header_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_header_widget_spec.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SparkRoutes} from "helpers/spark_routes";
+import m from "mithril";
+import {MaterialModification} from "models/config_repos/types";
+import {MaterialWithFingerprint, MaterialWithModifications} from "models/materials/materials";
+import headerStyles from "views/pages/config_repos/index.scss";
+import {TestHelper} from "views/pages/spec/test_helper";
+import styles from "../index.scss";
+import {MaterialHeaderWidget} from "../material_header_widget";
+import {git} from "./materials_widget_spec";
+
+describe('MaterialHeaderWidgetSpec', () => {
+  const helper = new TestHelper();
+  let material: MaterialWithModifications;
+
+  afterEach((done) => helper.unmount(done));
+  beforeEach(() => {
+    material = new MaterialWithModifications(MaterialWithFingerprint.fromJSON(git()), null);
+  });
+
+  it('should display the name of the material with type', () => {
+    mount();
+
+    expect(helper.byTestId("material-type")).toBeInDOM();
+    expect(helper.textByTestId("material-type")).toBe('Git');
+    expect(helper.textByTestId("material-display-name")).toBe('some-name');
+  });
+
+  [
+    {type: "git", classname: styles.git},
+    {type: "hg", classname: styles.mercurial},
+    {type: "p4", classname: styles.perforce},
+    {type: "svn", classname: styles.subversion},
+    {type: "tfs", classname: styles.tfs},
+    {type: "dependency", classname: styles.unknown},
+    {type: "package", classname: styles.package},
+    {type: "plugin", classname: styles.unknown}
+  ].forEach((parameter) => {
+    it(`should display icon for ${parameter.type} `, () => {
+      material.config.type(parameter.type);
+      mount();
+
+      expect(helper.byTestId("material-icon")).toHaveClass(parameter.classname);
+    });
+  });
+
+  it('should show never parsed if no modifications are present', () => {
+    mount();
+
+    expect(helper.byTestId("latest-mod-in-header")).toBeInDOM();
+    expect(helper.textByTestId("latest-mod-in-header")).toBe("This material was never parsed");
+  });
+
+  it('should show latest modification details', () => {
+    material.modification
+      = new MaterialModification("A_Long_username_with_a_long_long_long_long_long_text", null, "b07d423864ec120362b3584635cb07d423864ec120362b3584635c", "A very long comment to be shown on the header which should be trimmed and rest part should not be shown", "");
+    mount();
+
+    expect(helper.byTestId("latest-mod-in-header")).toBeInDOM();
+    expect(helper.q(`.${headerStyles.comment}`).textContent).toBe("A very long comment to be shown on the header which should be trimmed and rest pa...");
+    expect(helper.q(`.${headerStyles.committerInfo}`).textContent).toBe("A_Long_username_with_a_long_long_long... | b07d423864ec120362b3584635cb07d423864...");
+  });
+
+  it('should not show username or separator if empty', () => {
+    material.modification = new MaterialModification("", null, "b07d423864ec120362b3584635c", "A very long comment to be shown on the header", "");
+    mount();
+
+    expect(helper.byTestId("latest-mod-in-header")).toBeInDOM();
+    expect(helper.q(`.${headerStyles.committerInfo}`).textContent).toBe("b07d423864ec120362b3584635c");
+  });
+
+  it('should render revision as a link to VSM', () => {
+    material.modification
+      = new MaterialModification("username", null, "b07d423864ec120362b3584635cb07d423864ec120362b3584635c", "dummy comment", "");
+    mount();
+
+    expect(helper.byTestId("vsm-link")).toBeInDOM();
+    expect(helper.textByTestId("vsm-link")).toBe('b07d423864ec120362b3584635cb07d423864...');
+    expect(helper.byTestId("vsm-link")).toHaveAttr('href', SparkRoutes.materialsVsmLink(material.config.fingerprint(), material.modification.revision));
+    expect(helper.byTestId("vsm-link")).toHaveAttr('title', 'VSM');
+  });
+
+  function mount() {
+    helper.mount(() => <MaterialHeaderWidget material={material}/>);
+  }
+});

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_header_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_header_widget_spec.tsx
@@ -17,20 +17,21 @@
 import {SparkRoutes} from "helpers/spark_routes";
 import m from "mithril";
 import {MaterialModification} from "models/config_repos/types";
-import {MaterialWithFingerprint, MaterialWithModifications} from "models/materials/materials";
+import {MaterialWithFingerprint, MaterialWithModification} from "models/materials/materials";
 import headerStyles from "views/pages/config_repos/index.scss";
 import {TestHelper} from "views/pages/spec/test_helper";
 import styles from "../index.scss";
 import {MaterialHeaderWidget} from "../material_header_widget";
+import {MaterialVM} from "../models/material_view_model";
 import {git} from "./materials_widget_spec";
 
 describe('MaterialHeaderWidgetSpec', () => {
   const helper = new TestHelper();
-  let material: MaterialWithModifications;
+  let material: MaterialWithModification;
 
   afterEach((done) => helper.unmount(done));
   beforeEach(() => {
-    material = new MaterialWithModifications(MaterialWithFingerprint.fromJSON(git()), null);
+    material = new MaterialWithModification(MaterialWithFingerprint.fromJSON(git()), null);
   });
 
   it('should display the name of the material with type', () => {
@@ -96,6 +97,6 @@ describe('MaterialHeaderWidgetSpec', () => {
   });
 
   function mount() {
-    helper.mount(() => <MaterialHeaderWidget material={material}/>);
+    helper.mount(() => <MaterialHeaderWidget materialVM={new MaterialVM(material)}/>);
   }
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_usage_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_usage_widget_spec.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {asSelector} from "helpers/css_proxies";
+import m from "mithril";
+import {ObjectCache} from "models/base/cache";
+import {MaterialWithFingerprint, MaterialWithModification} from "models/materials/materials";
+import {GitMaterialAttributes} from "models/materials/types";
+import css from "views/pages/config_repos/defined_structs.scss";
+import {emptyTree,} from "views/pages/config_repos/spec/test_data";
+import {MaterialUsagesVM} from "views/pages/materials/models/material_usages_view_model";
+import {MaterialVM} from "views/pages/materials/models/material_view_model";
+import {TestHelper} from "views/pages/spec/test_helper";
+import {MaterialUsageWidget} from "../material_usage_widget";
+
+interface MockedResultsData {
+  content?: MaterialUsagesVM;
+  failureReason?: string;
+  ready?: boolean;
+}
+
+export class DummyCache implements ObjectCache<MaterialUsagesVM> {
+  ready: () => boolean;
+  contents: () => MaterialUsagesVM;
+  failureReason: () => string | undefined;
+  prime: (onSuccess: () => void, onError?: () => void) => void = jasmine.createSpy("cache.prime");
+  invalidate: () => void                                       = jasmine.createSpy("cache.invalidate");
+
+  constructor(options: MockedResultsData) {
+    this.failureReason = () => options.failureReason;
+    this.contents      = () => ("content" in options) ? options.content! : emptyTree();
+    this.ready         = () => ("ready" in options) ? !!options.ready : true;
+  }
+
+  failed(): boolean {
+    return !!this.failureReason();
+  }
+}
+
+describe('MaterialUsageWidgetSpec', () => {
+  const sel    = asSelector<typeof css>(css);
+  const helper = new TestHelper();
+  let materialVM: MaterialVM;
+
+  afterEach((done) => helper.unmount(done));
+  beforeEach(() => {
+    materialVM
+      = new MaterialVM(new MaterialWithModification(new MaterialWithFingerprint("git", "some", new GitMaterialAttributes()), null));
+  });
+
+  it('should showcase failed to load pipelines message', () => {
+    materialVM.results = new DummyCache({failureReason: "Some failure reason"});
+    mount();
+
+    expect(helper.byTestId("flash-message-alert")).toBeInDOM();
+    expect(helper.textByTestId("flash-message-alert")).toBe('Failed to load pipelines: Some failure reason');
+  });
+
+  it('should render loading message', () => {
+    materialVM.results = new DummyCache({ready: false, content: undefined});
+    mount();
+
+    expect(helper.q(sel.tree)).not.toBeInDOM();
+    expect(helper.q(sel.treeDatum)).not.toBeInDOM();
+    expect(helper.q(sel.loading)).toBeInDOM();
+    expect(helper.q(sel.spin)).toBeInDOM();
+    expect(helper.text(sel.loading)).toBe('Loading pipelines …');
+  });
+
+  it('should render tree structure for material usages', () => {
+    materialVM.results = new DummyCache({ready: true, content: MaterialUsagesVM.fromJSON(usagesJSON())});
+    mount();
+
+    const expectedTextResult = [
+      'Pipelines using this material:',
+      'group1',
+      'pipeline1',
+      'pipeline2',
+      'group2',
+      'pipeline3',
+      'pipeline4'
+    ];
+
+    expect(helper.q(sel.loading)).not.toBeInDOM();
+    expect(helper.q(sel.tree)).toBeInDOM();
+    expect(helper.textAll(sel.treeDatum)).toEqual(expectedTextResult);
+  });
+
+  it('should assign correct styles', () => {
+    materialVM.results = new DummyCache({ready: true, content: MaterialUsagesVM.fromJSON(usagesJSON())});
+    mount();
+
+    const groupTreeNode = helper.byTestId('tree-node-group1');
+    expect(groupTreeNode).toHaveClass(css.groupDatum);
+    expect(groupTreeNode).toHaveClass(css.treeDatum);
+    expect(groupTreeNode.parentElement).toHaveClass(css.tree);
+    expect(groupTreeNode.parentElement).toHaveClass(css.group);
+
+    const pipelineTreeNode = helper.byTestId('tree-node-pipeline1');
+    expect(pipelineTreeNode).toHaveClass(css.pipelineDatum);
+    expect(pipelineTreeNode).toHaveClass(css.treeDatum);
+    expect(pipelineTreeNode.parentElement).toHaveClass(css.tree);
+    expect(pipelineTreeNode.parentElement).toHaveClass(css.pipeline);
+  });
+
+  it('should render pipelines and groups as link', () => {
+    materialVM.results = new DummyCache({ready: true, content: MaterialUsagesVM.fromJSON(usagesJSON())});
+    mount();
+
+    expect(helper.byTestId('group_group_1')).toHaveAttr('href', '/go/admin/pipelines/#!group1');
+    expect(helper.byTestId('pipeline_pipeline_1')).toHaveAttr('href', '/go/admin/pipelines/pipeline1/edit#!pipeline1/materials');
+  });
+
+  function mount() {
+    helper.mount(() => <MaterialUsageWidget materialVM={materialVM}/>);
+  }
+});
+
+export function usagesJSON() {
+  return [{
+    group:     "group1",
+    pipelines: ["pipeline1", "pipeline2"]
+  }, {
+    group:     "group2",
+    pipelines: ["pipeline3", "pipeline4"]
+  }];
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/materials_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/materials_widget_spec.tsx
@@ -16,72 +16,76 @@
 import {docsUrl} from "gen/gocd_version";
 import m from "mithril";
 import Stream from "mithril/stream";
-import {MaterialWithFingerprint, MaterialWithFingerprintJSON, MaterialWithFingerprints} from "models/materials/materials";
+import {MaterialModification} from "models/config_repos/types";
+import {Materials, MaterialWithFingerprint, MaterialWithFingerprintJSON, MaterialWithModifications} from "models/materials/materials";
 import {TestHelper} from "views/pages/spec/test_helper";
-import styles from "../index.scss";
 import {MaterialsWidget, MaterialWidget} from "../materials_widget";
 
 describe('MaterialWidgetSpec', () => {
   const helper = new TestHelper();
-  let material: MaterialWithFingerprint;
+  let material: MaterialWithModifications;
 
   afterEach((done) => helper.unmount(done));
   beforeEach(() => {
-    material = MaterialWithFingerprint.fromJSON(git());
+    material = new MaterialWithModifications(MaterialWithFingerprint.fromJSON(git()), null);
   });
 
-  it('should display the name of the material with type', () => {
+  it('should display the header', () => {
     mount();
 
-    expect(helper.byTestId("material-type")).toBeInDOM();
-    expect(helper.textByTestId("material-type")).toBe('Git');
-    expect(helper.textByTestId("material-display-name")).toBe('some-name');
+    expect(helper.byTestId("material-icon")).toBeInDOM();
   });
 
-  [
-    {type: "git", classname: styles.git},
-    {type: "hg", classname: styles.mercurial},
-    {type: "p4", classname: styles.perforce},
-    {type: "svn", classname: styles.subversion},
-    {type: "tfs", classname: styles.tfs},
-    {type: "dependency", classname: styles.unknown},
-    {type: "package", classname: styles.package},
-    {type: "plugin", classname: styles.unknown}
-  ].forEach((parameter) => {
-    it(`should display icon for ${parameter.type} `, () => {
-      material.type(parameter.type);
-      mount();
+  it('should render material attributes in the panel body', () => {
+    mount();
 
-      expect(helper.byTestId("material-icon")).toHaveClass(parameter.classname);
-    });
+    expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
+
+    const attrsElement = helper.byTestId('material-attributes');
+
+    expect(attrsElement).toBeInDOM();
+    expect(helper.qa('li', attrsElement).length).toBe(10);
+  });
+
+  it('should display info message if no modifications are present', () => {
+    mount();
+
+    expect(helper.byTestId('flash-message-info')).toBeInDOM();
+    expect(helper.textByTestId('flash-message-info')).toBe("This material was never parsed");
+  });
+
+  it('should display latest modifications', () => {
+    material.modification
+      = new MaterialModification("GoCD Test User <devnull@example.com>", null, "b9b4f4b758e91117d70121a365ba0f8e37f89a9d", "Initial commit", "2019-12-23T10:25:52Z");
+    mount();
+
+    expect(helper.q('h3').textContent).toBe("Latest Modification Details");
+    expect(helper.byTestId('latest-modification-details')).toBeInDOM();
+
+    const attrs = helper.qa('li', helper.byTestId('latest-modification-details'));
+
+    expect(attrs.length).toBe(5);
+    expect(attrs[0].textContent).toBe("UsernameGoCD Test User <devnull@example.com>");
+    expect(attrs[1].textContent).toBe("Email(Not specified)");
+    expect(attrs[2].textContent).toBe("Revisionb9b4f4b758e91117d70121a365ba0f8e37f89a9d");
+    expect(attrs[3].textContent).toBe("CommentInitial commit");
+    expect(attrs[4].textContent).toBe("Modified Time23 Dec, 2019 at 15:55:52 Local Time");
+
+    expect(helper.q('span span', attrs[4])).toHaveAttr('title', '23 Dec, 2019 at 10:25:52 +00:00 Server Time');
   });
 
   function mount() {
     helper.mount(() => <MaterialWidget material={material}/>);
   }
-
-  function git() {
-    return {
-      type:        "git",
-      fingerprint: "some-fingerprint",
-      attributes:  {
-        name:          "some-name",
-        auto_update:   true,
-        url:           "git@github.com:sample_repo/example.git",
-        branch:        "master",
-        shallow_clone: false
-      }
-    } as MaterialWithFingerprintJSON;
-  }
 });
 
 describe('MaterialsWidgetSpec', () => {
   const helper = new TestHelper();
-  let materials: MaterialWithFingerprints;
+  let materials: Materials;
 
   afterEach((done) => helper.unmount(done));
   beforeEach(() => {
-    materials = new MaterialWithFingerprints();
+    materials = new Materials();
   });
 
   it('should display help text when no materials have been defined', () => {
@@ -102,3 +106,17 @@ describe('MaterialsWidgetSpec', () => {
     helper.mount(() => <MaterialsWidget materials={Stream(materials)}/>);
   }
 });
+
+export function git() {
+  return {
+    type:        "git",
+    fingerprint: "some-fingerprint",
+    attributes:  {
+      name:          "some-name",
+      auto_update:   true,
+      url:           "git@github.com:sample_repo/example.git",
+      branch:        "master",
+      shallow_clone: false
+    }
+  } as MaterialWithFingerprintJSON;
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/materials_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/materials_widget_spec.tsx
@@ -17,17 +17,18 @@ import {docsUrl} from "gen/gocd_version";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {MaterialModification} from "models/config_repos/types";
-import {Materials, MaterialWithFingerprint, MaterialWithFingerprintJSON, MaterialWithModifications} from "models/materials/materials";
+import {MaterialWithFingerprint, MaterialWithFingerprintJSON, MaterialWithModification} from "models/materials/materials";
 import {TestHelper} from "views/pages/spec/test_helper";
 import {MaterialsWidget, MaterialWidget} from "../materials_widget";
+import {MaterialVM, MaterialVMs} from "../models/material_view_model";
 
 describe('MaterialWidgetSpec', () => {
   const helper = new TestHelper();
-  let material: MaterialWithModifications;
+  let materialVM: MaterialVM;
 
   afterEach((done) => helper.unmount(done));
   beforeEach(() => {
-    material = new MaterialWithModifications(MaterialWithFingerprint.fromJSON(git()), null);
+    materialVM = new MaterialVM(new MaterialWithModification(MaterialWithFingerprint.fromJSON(git()), null));
   });
 
   it('should display the header', () => {
@@ -55,7 +56,7 @@ describe('MaterialWidgetSpec', () => {
   });
 
   it('should display latest modifications', () => {
-    material.modification
+    materialVM.material.modification
       = new MaterialModification("GoCD Test User <devnull@example.com>", null, "b9b4f4b758e91117d70121a365ba0f8e37f89a9d", "Initial commit", "2019-12-23T10:25:52Z");
     mount();
 
@@ -75,17 +76,17 @@ describe('MaterialWidgetSpec', () => {
   });
 
   function mount() {
-    helper.mount(() => <MaterialWidget material={material}/>);
+    helper.mount(() => <MaterialWidget materialVM={materialVM}/>);
   }
 });
 
 describe('MaterialsWidgetSpec', () => {
   const helper = new TestHelper();
-  let materials: Materials;
+  let materialVMs: MaterialVMs;
 
   afterEach((done) => helper.unmount(done));
   beforeEach(() => {
-    materials = new Materials();
+    materialVMs = new MaterialVMs();
   });
 
   it('should display help text when no materials have been defined', () => {
@@ -103,7 +104,7 @@ describe('MaterialsWidgetSpec', () => {
   });
 
   function mount() {
-    helper.mount(() => <MaterialsWidget materials={Stream(materials)}/>);
+    helper.mount(() => <MaterialsWidget materialVMs={Stream(materialVMs)}/>);
   }
 });
 


### PR DESCRIPTION
Issue: #8331

Description:
 - Use the internal materials API to render the config (only necessary attributes) and the latest modification for the same.
 - We no longer show the dependency materials as the same is visible via VSM page
 - Added links to VSM for the given modification: revision and fingerprint
 - Showed the material usages in various pipelines in a tree structure.

Preview:

![materials_spa_updated](https://user-images.githubusercontent.com/41165891/89373425-4378fe80-d706-11ea-8380-213451a5f2af.gif)

