### PR TITLE
Update materials spa 

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/materials.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/materials.ts
@@ -77,18 +77,6 @@ export class MaterialWithFingerprint extends Material {
     return map;
   }
 
-  matches(textToMatch: string): boolean {
-    if (!textToMatch) {
-      return true;
-    }
-    const searchableStrings = [
-      this.type(),
-      this.name(),
-      this.materialUrl()
-    ];
-    return searchableStrings.some((value) => value ? value.toLowerCase().includes(textToMatch.trim().toLowerCase()) : false);
-  }
-
   private static resolveKeyValueForAttribute(accumulator: Map<string, string>, value: any, key: string) {
     if (key.startsWith("__") || ["name"].includes(key)) {
       return accumulator;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/materials_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/materials_spec.ts
@@ -164,16 +164,6 @@ describe('MaterialWithFingerPrintSpec', () => {
       expect(attrs.size).toBe(0);
     });
   });
-
-  it('should return true if search string matches name, type or display url', () => {
-    const material = new MaterialWithFingerprint("git", "fingerprint", new GitMaterialAttributes("some-name", false, "http://svn.com/gocd/gocd", "master"));
-
-    expect(material.matches("git")).toBeTrue();
-    expect(material.matches("name")).toBeTrue();
-    expect(material.matches("gocd")).toBeTrue();
-    expect(material.matches("mas")).toBeTrue();
-    expect(material.matches("abc")).toBeFalse();
-  });
 });
 
 describe('MaterialsWithModificationsSpec', () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_header_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_header_widget.tsx
@@ -27,8 +27,9 @@ import styles from "./index.scss";
 import {MaterialAttrs} from "./material_widget";
 
 export class MaterialHeaderWidget extends MithrilViewComponent<MaterialAttrs> {
-  private static readonly MAX_COMMIT_MSG_LENGTH: number            = 84;
-  private static readonly MAX_USERNAME_AND_REVISION_LENGTH: number = 40;
+  private static readonly MAX_COMMIT_MSG_LENGTH: number = 90;
+  private static readonly MAX_USERNAME_LENGTH: number   = 35;
+  private static readonly MAX_REVISION_LENGTH: number   = 40;
 
   view(vnode: m.Vnode<MaterialAttrs, this>): m.Children | void | null {
     const material = vnode.attrs.materialVM.material;
@@ -74,23 +75,21 @@ export class MaterialHeaderWidget extends MithrilViewComponent<MaterialAttrs> {
       return "This material was never parsed";
     }
 
-    const comment         = _.truncate(modification.comment, {length: MaterialHeaderWidget.MAX_COMMIT_MSG_LENGTH});
-    const username        = _.truncate(modification.username, {length: MaterialHeaderWidget.MAX_USERNAME_AND_REVISION_LENGTH});
-    const revision        = _.truncate(modification.revision, {length: MaterialHeaderWidget.MAX_USERNAME_AND_REVISION_LENGTH});
-    const usernameElement = _.isEmpty(username)
-      ? undefined
-      : <span>
-      <span className={headerStyles.committer}>{username}</span> | </span>;
+    const comment               = _.truncate(modification.comment, {length: MaterialHeaderWidget.MAX_COMMIT_MSG_LENGTH});
+    const username              = _.truncate(modification.username, {length: MaterialHeaderWidget.MAX_USERNAME_LENGTH});
+    const revision              = _.truncate(modification.revision, {length: MaterialHeaderWidget.MAX_REVISION_LENGTH});
+    const usernameAndRevElement = _.isEmpty(username)
+      ? revision
+      : <span><span className={headerStyles.committer}>{username}</span> | {revision} </span>;
 
-    const revisionLink = <Link dataTestId={"vsm-link"} href={SparkRoutes.materialsVsmLink(fingerprint, modification.revision)}
-                               title={"VSM"} onclick={e => e.stopPropagation()}>{revision}</Link>;
-    return <div
-      className={headerStyles.commitInfo}>
+    const vsmLink = <Link dataTestId={"vsm-link"} href={SparkRoutes.materialsVsmLink(fingerprint, modification.revision)}
+                          title={"Value Stream Map"} onclick={e => e.stopPropagation()}>VSM</Link>;
+    return <div className={headerStyles.commitInfo}>
       <span className={headerStyles.comment}>
         {comment}
       </span>
       <div className={headerStyles.committerInfo}>
-        {usernameElement}{revisionLink}
+        {usernameAndRevElement} | {vsmLink}
       </div>
     </div>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_header_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_header_widget.tsx
@@ -24,7 +24,7 @@ import {MaterialWithModification} from "models/materials/materials";
 import {Link} from "views/components/link";
 import headerStyles from "views/pages/config_repos/index.scss";
 import styles from "./index.scss";
-import {MaterialAttrs} from "./materials_widget";
+import {MaterialAttrs} from "./material_widget";
 
 export class MaterialHeaderWidget extends MithrilViewComponent<MaterialAttrs> {
   private static readonly MAX_COMMIT_MSG_LENGTH: number            = 84;
@@ -38,7 +38,9 @@ export class MaterialHeaderWidget extends MithrilViewComponent<MaterialAttrs> {
         <h4 data-test-id="material-type" className={headerStyles.headerTitleText}>{material.config.typeForDisplay()}</h4>
         <span data-test-id="material-display-name" className={headerStyles.headerTitleUrl}>{material.config.displayName()}</span>
       </div>,
-      <div data-test-id="latest-mod-in-header">{this.showLatestModificationDetails(material.config.fingerprint(), material.modification)}</div>
+      <div data-test-id="latest-mod-in-header">
+        {MaterialHeaderWidget.showLatestModificationDetails(material.config.fingerprint(), material.modification)}
+      </div>
     ];
   }
 
@@ -67,7 +69,7 @@ export class MaterialHeaderWidget extends MithrilViewComponent<MaterialAttrs> {
     return <div data-test-id="material-icon" className={classnames(styles.material, style)}/>;
   }
 
-  private showLatestModificationDetails(fingerprint: string, modification: MaterialModification | null) {
+  private static showLatestModificationDetails(fingerprint: string, modification: MaterialModification | null) {
     if (modification === null) {
       return "This material was never parsed";
     }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_usage_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_usage_widget.tsx
@@ -26,7 +26,7 @@ import {FlashMessage, MessageType} from "views/components/flash_message";
 import {Tree} from "views/components/hierarchy/tree";
 import css from "views/pages/config_repos/defined_structs.scss";
 import {MaterialUsagesVM} from "views/pages/materials/models/material_usages_view_model";
-import {MaterialAttrs} from "./materials_widget";
+import {MaterialAttrs} from "./material_widget";
 
 type Styles = typeof css;
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_widget.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SparkRoutes} from "helpers/spark_routes";
+import {timeFormatter} from "helpers/time_formatter";
+import {MithrilViewComponent} from "jsx/mithril-component";
+import m from "mithril";
+import {MaterialModification} from "models/config_repos/types";
+import {MaterialWithFingerprint} from "models/materials/materials";
+import {Scms} from "models/materials/pluggable_scm";
+import {PackageMaterialAttributes, PluggableScmMaterialAttributes} from "models/materials/types";
+import {Packages} from "models/package_repositories/package_repositories";
+import {CollapsiblePanel} from "views/components/collapsible_panel";
+import {FlashMessage, MessageType} from "views/components/flash_message";
+import {KeyValuePair} from "views/components/key_value_pair";
+import {Link} from "views/components/link";
+import headerStyles from "views/pages/config_repos/index.scss";
+import {AdditionalInfoAttrs} from "../materials";
+import {MaterialHeaderWidget} from "./material_header_widget";
+import {MaterialUsageWidget} from "./material_usage_widget";
+import {MaterialVM} from "./models/material_view_model";
+
+export interface MaterialAttrs {
+  materialVM: MaterialVM;
+}
+
+interface MaterialWithInfoAttrs extends MaterialAttrs, AdditionalInfoAttrs {
+}
+
+export class MaterialWidget extends MithrilViewComponent<MaterialWithInfoAttrs> {
+
+  public static showModificationDetails(modification: MaterialModification) {
+    const attrs = new Map();
+    attrs.set("Username", modification.username);
+    attrs.set("Email", modification.emailAddress);
+    attrs.set("Revision", modification.revision);
+    attrs.set("Comment", modification.comment);
+    attrs.set("Modified Time", <span
+      title={timeFormatter.formatInServerTime(modification.modifiedTime)}>{timeFormatter.format(modification.modifiedTime)}</span>);
+
+    return <KeyValuePair data={attrs}/>;
+  }
+
+  view(vnode: m.Vnode<MaterialWithInfoAttrs, this>): m.Children | void | null {
+    const vm                  = vnode.attrs.materialVM;
+    const material            = vm.material;
+    const modificationDetails = material.modification === null
+      ? <FlashMessage type={MessageType.info}>This material was never parsed</FlashMessage>
+      : MaterialWidget.showModificationDetails(material.modification);
+
+    return <CollapsiblePanel header={<MaterialHeaderWidget {...vnode.attrs} />} onexpand={() => vm.notify("expand")}>
+      <MaterialUsageWidget materialVM={vm}/>
+      <h3>Latest Modification Details</h3>
+      <div data-test-id="latest-modification-details" className={headerStyles.configRepoProperties}>
+        {modificationDetails}
+      </div>
+      <h3>Material Attributes</h3>
+      <KeyValuePair data-test-id={"material-attributes"} data={this.getMaterialData(material.config, vnode.attrs.packages(), vnode.attrs.scms())}/>
+    </CollapsiblePanel>;
+  }
+
+  private getMaterialData(material: MaterialWithFingerprint, packages: Packages, scms: Scms): Map<string, m.Children> {
+    let map = new Map();
+    if (material.type() === "package") {
+      const pkgAttrs = material.attributes() as PackageMaterialAttributes;
+      const pkgInfo  = packages.find((pkg) => pkg.id() === pkgAttrs.ref())!;
+
+      const link = <Link href={SparkRoutes.packageRepositoriesSPA(pkgInfo.packageRepo().name(), pkgInfo.name())}>
+        {pkgInfo.name()}
+      </Link>;
+
+      map.set("Ref", link);
+    } else if (material.type() === "plugin") {
+      const pluginAttrs = material.attributes() as PluggableScmMaterialAttributes;
+      const scmMaterial = scms.find((scm) => scm.id() === pluginAttrs.ref())!;
+
+      const value = <Link href={SparkRoutes.pluggableScmSPA(scmMaterial.name())}>
+        {scmMaterial.name()}
+      </Link>;
+
+      map.set("Ref", value);
+    } else {
+      map = material.attributesAsMap();
+    }
+    return map;
+  }
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/models/material_view_model.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/models/material_view_model.ts
@@ -75,7 +75,19 @@ export class MaterialVM {
   }
 
   matches(query: string) {
-    return this.material.config.matches(query);
+    if (!query) {
+      return true;
+    }
+    const searchableStrings = [
+      this.material.config.type(),
+      this.material.config.name(),
+      this.material.config.materialUrl()
+    ];
+    const modification      = this.material.modification;
+    if (modification !== null) {
+      searchableStrings.push(modification.username, modification.revision, modification.comment);
+    }
+    return searchableStrings.some((value) => value ? value.toLowerCase().includes(query.trim().toLowerCase()) : false);
   }
 
   type() {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/models/spec/material_view_model_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/models/spec/material_view_model_spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {MaterialModification} from "models/config_repos/types";
 import {Filter} from "models/maintenance_mode/material";
 import {Materials, MaterialWithFingerprint, MaterialWithModification} from "models/materials/materials";
 import {
@@ -48,6 +49,17 @@ describe('MaterialVMSpec', () => {
     expect(materialVM.matches("gocd")).toBeTrue();
     expect(materialVM.matches("mas")).toBeTrue();
     expect(materialVM.matches("abc")).toBeFalse();
+  });
+
+  it('should return true if search string matches username, revision or comment for the latest modification', () => {
+    const material   = new MaterialWithFingerprint("git", "fingerprint", new GitMaterialAttributes("", false, "some-url", "master"));
+    const materialVM = new MaterialVM(new MaterialWithModification(material, new MaterialModification("username", "email_address", "some-revision", "a very very long comment with abc", "")));
+
+    expect(materialVM.matches("revision")).toBeTrue();
+    expect(materialVM.matches("comment")).toBeTrue();
+    expect(materialVM.matches("name")).toBeTrue();
+    expect(materialVM.matches("abc")).toBeTrue();
+    expect(materialVM.matches("123")).toBeFalse();
   });
 
   it('should return type as config.type', () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_header_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_header_widget_spec.tsx
@@ -73,8 +73,8 @@ describe('MaterialHeaderWidgetSpec', () => {
     mount();
 
     expect(helper.byTestId("latest-mod-in-header")).toBeInDOM();
-    expect(helper.q(`.${headerStyles.comment}`).textContent).toBe("A very long comment to be shown on the header which should be trimmed and rest pa...");
-    expect(helper.q(`.${headerStyles.committerInfo}`).textContent).toBe("A_Long_username_with_a_long_long_long... | b07d423864ec120362b3584635cb07d423864...");
+    expect(helper.q(`.${headerStyles.comment}`).textContent).toBe("A very long comment to be shown on the header which should be trimmed and rest part sho...");
+    expect(helper.q(`.${headerStyles.committerInfo}`).textContent).toBe("A_Long_username_with_a_long_long... | b07d423864ec120362b3584635cb07d423864...  | VSM");
   });
 
   it('should not show username or separator if empty', () => {
@@ -82,18 +82,19 @@ describe('MaterialHeaderWidgetSpec', () => {
     mount();
 
     expect(helper.byTestId("latest-mod-in-header")).toBeInDOM();
-    expect(helper.q(`.${headerStyles.committerInfo}`).textContent).toBe("b07d423864ec120362b3584635c");
+    expect(helper.q(`.${headerStyles.committerInfo}`).textContent).toBe("b07d423864ec120362b3584635c | VSM");
   });
 
-  it('should render revision as a link to VSM', () => {
+  it('should render link to VSM', () => {
     material.modification
-      = new MaterialModification("username", null, "b07d423864ec120362b3584635cb07d423864ec120362b3584635c", "dummy comment", "");
+      = new MaterialModification("username", null, "b07d423864ec120362b3584635cb07", "dummy comment", "");
     mount();
 
+    expect(helper.q(`.${headerStyles.committerInfo}`).textContent).toBe("username | b07d423864ec120362b3584635cb07  | VSM");
     expect(helper.byTestId("vsm-link")).toBeInDOM();
-    expect(helper.textByTestId("vsm-link")).toBe('b07d423864ec120362b3584635cb07d423864...');
+    expect(helper.textByTestId("vsm-link")).toBe('VSM');
     expect(helper.byTestId("vsm-link")).toHaveAttr('href', SparkRoutes.materialsVsmLink(material.config.fingerprint(), material.modification.revision));
-    expect(helper.byTestId("vsm-link")).toHaveAttr('title', 'VSM');
+    expect(helper.byTestId("vsm-link")).toHaveAttr('title', 'Value Stream Map');
   });
 
   function mount() {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
@@ -121,6 +121,37 @@ describe('MaterialWidgetSpec', () => {
     expect(helper.q('span span', attrs[4])).toHaveAttr('title', '23 Dec, 2019 at 10:25:52 +00:00 Server Time');
   });
 
+  it('should display message if scm information is not present', () => {
+    const scm = Scm.fromJSON(getPluggableScm());
+    scms.push(scm);
+    material.config = new MaterialWithFingerprint("plugin", "fingerprint",
+                                                  new PluggableScmMaterialAttributes(undefined, true, "some-id", "", new Filter([])));
+    mount();
+
+    expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
+
+    const attrsElement = helper.byTestId('material-attributes');
+
+    expect(attrsElement).toBeInDOM();
+    expect(helper.qa('li', attrsElement).length).toBe(1);
+    expect(helper.textByTestId('key-value-value-ref')).toBe("No SCM found for 'some-id'!");
+  });
+
+  it('should display message if package information is not present', () => {
+    const pkg = Package.fromJSON(getPackage());
+    packages.push(pkg);
+    material.config = new MaterialWithFingerprint("package", "fingerprint", new PackageMaterialAttributes(undefined, true, "some-pkg-id"));
+    mount();
+
+    expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
+
+    const attrsElement = helper.byTestId('material-attributes');
+
+    expect(attrsElement).toBeInDOM();
+    expect(helper.qa('li', attrsElement).length).toBe(1);
+    expect(helper.textByTestId('key-value-value-ref')).toBe("No package found for 'some-pkg-id'!");
+  });
+
   function mount() {
     helper.mount(() => <MaterialWidget materialVM={new MaterialVM(material)} packages={Stream(packages)} scms={Stream(scms)}/>);
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {timeFormatter} from "helpers/time_formatter";
+import m from "mithril";
+import Stream from "mithril/stream";
+import {MaterialModification} from "models/config_repos/types";
+import {Filter} from "models/maintenance_mode/material";
+import {MaterialWithFingerprint, MaterialWithModification} from "models/materials/materials";
+import {Scm, Scms} from "models/materials/pluggable_scm";
+import {PackageMaterialAttributes, PluggableScmMaterialAttributes} from "models/materials/types";
+import {Package, Packages} from "models/package_repositories/package_repositories";
+import {getPackage} from "models/package_repositories/spec/test_data";
+import {TestHelper} from "views/pages/spec/test_helper";
+import {getPluggableScm} from "../../pluggable_scms/spec/test_data";
+import {MaterialWidget} from "../material_widget";
+import {MaterialVM} from "../models/material_view_model";
+import {git} from "./materials_widget_spec";
+
+describe('MaterialWidgetSpec', () => {
+  const helper = new TestHelper();
+  let material: MaterialWithModification;
+  let packages: Packages;
+  let scms: Scms;
+
+  afterEach((done) => helper.unmount(done));
+  beforeEach(() => {
+    material = new MaterialWithModification(MaterialWithFingerprint.fromJSON(git()), null);
+    packages = new Packages();
+    scms     = new Scms();
+  });
+
+  it('should display the header', () => {
+    mount();
+
+    expect(helper.byTestId("material-icon")).toBeInDOM();
+  });
+
+  it('should render git material attributes in the panel body', () => {
+    mount();
+
+    expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
+
+    const attrsElement = helper.byTestId('material-attributes');
+
+    expect(attrsElement).toBeInDOM();
+    expect(helper.qa('li', attrsElement).length).toBe(2);
+  });
+
+  it('should render ref with link for plugin', () => {
+    const scm = Scm.fromJSON(getPluggableScm());
+    scms.push(scm);
+    material.config
+      = new MaterialWithFingerprint("plugin", "fingerprint", new PluggableScmMaterialAttributes(undefined, true, scm.id(), "", new Filter([])));
+    mount();
+
+    expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
+
+    const attrsElement = helper.byTestId('material-attributes');
+
+    expect(attrsElement).toBeInDOM();
+    expect(helper.qa('li', attrsElement).length).toBe(1);
+    expect(helper.q('a', helper.byTestId('key-value-value-ref')).textContent).toBe('pluggable.scm.material.name');
+    expect(helper.q('a', helper.byTestId('key-value-value-ref'))).toHaveAttr('href', '/go/admin/scms#!pluggable.scm.material.name');
+  });
+
+  it('should render ref with link for package', () => {
+    const pkg = Package.fromJSON(getPackage());
+    packages.push(pkg);
+    material.config
+      = new MaterialWithFingerprint("package", "fingerprint", new PackageMaterialAttributes(undefined, true, pkg.id()));
+    mount();
+
+    expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
+
+    const attrsElement = helper.byTestId('material-attributes');
+
+    expect(attrsElement).toBeInDOM();
+    expect(helper.qa('li', attrsElement).length).toBe(1);
+    expect(helper.q('a', helper.byTestId('key-value-value-ref')).textContent).toBe('pkg-name');
+    expect(helper.q('a', helper.byTestId('key-value-value-ref'))).toHaveAttr('href', '/go/admin/package_repositories#!pkg-repo-name/packages/pkg-name');
+  });
+
+  it('should display info message if no modifications are present', () => {
+    mount();
+
+    expect(helper.byTestId('flash-message-info')).toBeInDOM();
+    expect(helper.textByTestId('flash-message-info')).toBe("This material was never parsed");
+  });
+
+  it('should display latest modifications', () => {
+    material.modification
+      = new MaterialModification("GoCD Test User <devnull@example.com>", null, "b9b4f4b758e91117d70121a365ba0f8e37f89a9d", "Initial commit", "2019-12-23T10:25:52Z");
+    mount();
+
+    expect(helper.q('h3').textContent).toBe("Latest Modification Details");
+    expect(helper.byTestId('latest-modification-details')).toBeInDOM();
+
+    const attrs = helper.qa('li', helper.byTestId('latest-modification-details'));
+
+    expect(attrs.length).toBe(5);
+    expect(attrs[0].textContent).toBe("UsernameGoCD Test User <devnull@example.com>");
+    expect(attrs[1].textContent).toBe("Email(Not specified)");
+    expect(attrs[2].textContent).toBe("Revisionb9b4f4b758e91117d70121a365ba0f8e37f89a9d");
+    expect(attrs[3].textContent).toBe("CommentInitial commit");
+    expect(attrs[4].textContent).toBe("Modified Time" + timeFormatter.format(material.modification.modifiedTime));
+
+    expect(helper.q('span span', attrs[4])).toHaveAttr('title', '23 Dec, 2019 at 10:25:52 +00:00 Server Time');
+  });
+
+  function mount() {
+    helper.mount(() => <MaterialWidget materialVM={new MaterialVM(material)} packages={Stream(packages)} scms={Stream(scms)}/>);
+  }
+});

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/materials_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/materials_widget_spec.tsx
@@ -14,116 +14,14 @@
  * limitations under the License.
  */
 import {docsUrl} from "gen/gocd_version";
-import {timeFormatter} from "helpers/time_formatter";
 import m from "mithril";
 import Stream from "mithril/stream";
-import {MaterialModification} from "models/config_repos/types";
-import {Filter} from "models/maintenance_mode/material";
-import {MaterialWithFingerprint, MaterialWithFingerprintJSON, MaterialWithModification} from "models/materials/materials";
-import {Scm, Scms} from "models/materials/pluggable_scm";
-import {PackageMaterialAttributes, PluggableScmMaterialAttributes} from "models/materials/types";
-import {Package, Packages} from "models/package_repositories/package_repositories";
-import {getPackage} from "models/package_repositories/spec/test_data";
-import {getPluggableScm} from "views/pages/pluggable_scms/spec/test_data";
+import {MaterialWithFingerprintJSON} from "models/materials/materials";
+import {Scms} from "models/materials/pluggable_scm";
+import {Packages} from "models/package_repositories/package_repositories";
 import {TestHelper} from "views/pages/spec/test_helper";
-import {MaterialsWidget, MaterialWidget} from "../materials_widget";
-import {MaterialVM, MaterialVMs} from "../models/material_view_model";
-
-describe('MaterialWidgetSpec', () => {
-  const helper = new TestHelper();
-  let material: MaterialWithModification;
-  let packages: Packages;
-  let scms: Scms;
-
-  afterEach((done) => helper.unmount(done));
-  beforeEach(() => {
-    material = new MaterialWithModification(MaterialWithFingerprint.fromJSON(git()), null);
-    packages = new Packages();
-    scms     = new Scms();
-  });
-
-  it('should display the header', () => {
-    mount();
-
-    expect(helper.byTestId("material-icon")).toBeInDOM();
-  });
-
-  it('should render git material attributes in the panel body', () => {
-    mount();
-
-    expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
-
-    const attrsElement = helper.byTestId('material-attributes');
-
-    expect(attrsElement).toBeInDOM();
-    expect(helper.qa('li', attrsElement).length).toBe(2);
-  });
-
-  it('should render ref with link for plugin', () => {
-    const scm = Scm.fromJSON(getPluggableScm());
-    scms.push(scm);
-    material.config
-      = new MaterialWithFingerprint("plugin", "fingerprint", new PluggableScmMaterialAttributes(undefined, true, scm.id(), "", new Filter([])));
-    mount();
-
-    expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
-
-    const attrsElement = helper.byTestId('material-attributes');
-
-    expect(attrsElement).toBeInDOM();
-    expect(helper.qa('li', attrsElement).length).toBe(1);
-    expect(helper.q('a', helper.byTestId('key-value-value-ref')).textContent).toBe('pluggable.scm.material.name');
-    expect(helper.q('a', helper.byTestId('key-value-value-ref'))).toHaveAttr('href', '/go/admin/scms#!pluggable.scm.material.name');
-  });
-
-  it('should render ref with link for package', () => {
-    const pkg = Package.fromJSON(getPackage());
-    packages.push(pkg);
-    material.config
-      = new MaterialWithFingerprint("package", "fingerprint", new PackageMaterialAttributes(undefined, true, pkg.id()));
-    mount();
-
-    expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
-
-    const attrsElement = helper.byTestId('material-attributes');
-
-    expect(attrsElement).toBeInDOM();
-    expect(helper.qa('li', attrsElement).length).toBe(1);
-    expect(helper.q('a', helper.byTestId('key-value-value-ref')).textContent).toBe('pkg-name');
-    expect(helper.q('a', helper.byTestId('key-value-value-ref'))).toHaveAttr('href', '/go/admin/package_repositories#!pkg-repo-name/packages/pkg-name');
-  });
-
-  it('should display info message if no modifications are present', () => {
-    mount();
-
-    expect(helper.byTestId('flash-message-info')).toBeInDOM();
-    expect(helper.textByTestId('flash-message-info')).toBe("This material was never parsed");
-  });
-
-  it('should display latest modifications', () => {
-    material.modification
-      = new MaterialModification("GoCD Test User <devnull@example.com>", null, "b9b4f4b758e91117d70121a365ba0f8e37f89a9d", "Initial commit", "2019-12-23T10:25:52Z");
-    mount();
-
-    expect(helper.q('h3').textContent).toBe("Latest Modification Details");
-    expect(helper.byTestId('latest-modification-details')).toBeInDOM();
-
-    const attrs = helper.qa('li', helper.byTestId('latest-modification-details'));
-
-    expect(attrs.length).toBe(5);
-    expect(attrs[0].textContent).toBe("UsernameGoCD Test User <devnull@example.com>");
-    expect(attrs[1].textContent).toBe("Email(Not specified)");
-    expect(attrs[2].textContent).toBe("Revisionb9b4f4b758e91117d70121a365ba0f8e37f89a9d");
-    expect(attrs[3].textContent).toBe("CommentInitial commit");
-    expect(attrs[4].textContent).toBe("Modified Time" + timeFormatter.format(material.modification.modifiedTime));
-
-    expect(helper.q('span span', attrs[4])).toHaveAttr('title', '23 Dec, 2019 at 10:25:52 +00:00 Server Time');
-  });
-
-  function mount() {
-    helper.mount(() => <MaterialWidget materialVM={new MaterialVM(material)} packages={Stream(packages)} scms={Stream(scms)}/>);
-  }
-});
+import {MaterialsWidget} from "../materials_widget";
+import {MaterialVMs} from "../models/material_view_model";
 
 describe('MaterialsWidgetSpec', () => {
   const helper = new TestHelper();


### PR DESCRIPTION
Issue: #8331

Description:
 - updated the material header to explicitly call out the link to VSM instead of rendering it as revision
 - updated the material panel body to render a warning message if the package or scm details are not found
 - extend search on materials spa by also considering the modification in the search

Preview:

<img width="1231" alt="Screen Shot 2020-08-06 at 12 08 22 PM" src="https://user-images.githubusercontent.com/41165891/89499393-91146a80-d7dd-11ea-93a4-a54b76320289.png">
