### PR TITLE
[Materials SPA] Fix bug with rendering pipeline usage for a searched material.

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials.tsx
@@ -67,7 +67,7 @@ export class MaterialsPage extends Page<null, State> {
       }
       filteredMaterials(new MaterialVMs(...results));
     }
-    return <MaterialsWidget materialVMs={filteredMaterials} scms={vnode.state.scms} packages={vnode.state.packages}/>;
+    return [<MaterialsWidget key={filteredMaterials().length} materialVMs={filteredMaterials} scms={vnode.state.scms} packages={vnode.state.packages}/>];
   }
 
   pageName(): string {


### PR DESCRIPTION
#### Issue

The MaterialVMs model passed to the view in a normal render and in the searched render are different.
Every time a search string is specified, a new MaterialVMs is created with the filtered MaterialVMs.
Mithril views are cached and works with references. Even when the individual materialVM are same, the refering
MaterialVMs are different. And the newly fetched usage data was stored in the old referenced MaterialVMs,
causing pipeline usage to be always rendered as loading.

#### Fix

Add Mithril key to the MaterialsWidget which forces mithril to redraw the entire view with the updated MaterialVMs.