### PR TITLE
Allow non admin user to access materials spa

### DIFF
--- a/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/representers/materials/PackageMaterialRepresenter.java
+++ b/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/representers/materials/PackageMaterialRepresenter.java
@@ -25,6 +25,8 @@ public class PackageMaterialRepresenter implements MaterialRepresenter<PackageMa
     @Override
     public Consumer<OutputWriter> toJSON(PackageMaterialConfig packageMaterialConfig) {
         return jsonWriter -> jsonWriter.add("ref", packageMaterialConfig.getPackageId())
-                .add("auto_update", packageMaterialConfig.isAutoUpdate());
+                .add("auto_update", packageMaterialConfig.isAutoUpdate())
+                .add("package_name", packageMaterialConfig.getPackageDefinition().getName())
+                .add("package_repo_name", packageMaterialConfig.getPackageDefinition().getRepository().getName());
     }
 }

--- a/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/representers/materials/PluggableScmMaterialRepresenter.java
+++ b/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/representers/materials/PluggableScmMaterialRepresenter.java
@@ -26,7 +26,8 @@ public class PluggableScmMaterialRepresenter implements MaterialRepresenter<Plug
     public Consumer<OutputWriter> toJSON(PluggableSCMMaterialConfig pluggableSCMMaterialConfig) {
         return jsonWriter -> {
             jsonWriter.add("ref", pluggableSCMMaterialConfig.getScmId())
-                    .add("auto_update", pluggableSCMMaterialConfig.isAutoUpdate());
+                    .add("auto_update", pluggableSCMMaterialConfig.isAutoUpdate())
+                    .add("scm_name", pluggableSCMMaterialConfig.getSCMConfig().getName());
         };
     }
 }

--- a/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/representers/materials/PackageMaterialRepresenterTest.groovy
+++ b/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/representers/materials/PackageMaterialRepresenterTest.groovy
@@ -15,13 +15,8 @@
  */
 package com.thoughtworks.go.apiv1.internalmaterials.representers.materials
 
-import com.thoughtworks.go.config.BasicCruiseConfig
-import com.thoughtworks.go.config.CaseInsensitiveString
-import com.thoughtworks.go.config.PipelineConfig
-import com.thoughtworks.go.config.PipelineConfigSaveValidationContext
-import com.thoughtworks.go.config.materials.MaterialConfigs
+
 import com.thoughtworks.go.config.materials.PackageMaterialConfig
-import com.thoughtworks.go.domain.packagerepository.PackageRepositoryMother
 import com.thoughtworks.go.helper.MaterialConfigsMother
 import org.junit.jupiter.api.Test
 
@@ -40,8 +35,10 @@ class PackageMaterialRepresenterTest {
       fingerprint: packageMaterialConfig.fingerprint,
       attributes :
         [
-          ref        : "p-id",
-          auto_update: true
+          ref              : "p-id",
+          auto_update      : true,
+          package_name     : "package-name",
+          package_repo_name: "repo-name"
         ]
     ])
   }

--- a/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/representers/materials/PluggableScmMaterialRepresenterTest.groovy
+++ b/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/representers/materials/PluggableScmMaterialRepresenterTest.groovy
@@ -34,7 +34,8 @@ class PluggableScmMaterialRepresenterTest {
       fingerprint: pluggableSCMMaterial.fingerprint,
       attributes : [
         ref        : "scm-id",
-        auto_update: true
+        auto_update: true,
+        scm_name   : "scm-scm-id"
       ]
     ])
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/materials_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/materials_spec.ts
@@ -16,18 +16,19 @@
 
 import {ApiResult, SuccessResponse} from "helpers/api_request_builder";
 import {SparkRoutes} from "helpers/spark_routes";
-import {Filter} from "models/maintenance_mode/material";
-import {MaterialAPIs, Materials, MaterialWithFingerprint, MaterialWithModification} from "../materials";
 import {
-  DependencyMaterialAttributes,
   GitMaterialAttributes,
   HgMaterialAttributes,
+  MaterialAPIs,
+  Materials,
+  MaterialWithFingerprint,
+  MaterialWithModification,
   P4MaterialAttributes,
   PackageMaterialAttributes,
   PluggableScmMaterialAttributes,
   SvnMaterialAttributes,
   TfsMaterialAttributes
-} from "../types";
+} from "../materials";
 
 describe('MaterialsAPISpec', () => {
   beforeEach(() => jasmine.Ajax.install());
@@ -155,14 +156,6 @@ describe('MaterialWithFingerPrintSpec', () => {
       expect(keys.length).toBe(3);
       expect(keys).toEqual(['URL', 'Domain', 'Project Path']);
     });
-
-    it('should return empty attributes for non-scm materials', () => {
-      const material = new MaterialWithFingerprint("dependency", "fingerprint", new DependencyMaterialAttributes("name", false, "some-url", "domain"));
-
-      const attrs = material.attributesAsMap();
-
-      expect(attrs.size).toBe(0);
-    });
   });
 });
 
@@ -174,19 +167,17 @@ describe('MaterialsWithModificationsSpec', () => {
     materials.push(new MaterialWithModification(new MaterialWithFingerprint("svn", "some", new SvnMaterialAttributes()), null));
     materials.push(new MaterialWithModification(new MaterialWithFingerprint("p4", "some", new P4MaterialAttributes()), null));
     materials.push(new MaterialWithModification(new MaterialWithFingerprint("tfs", "some", new TfsMaterialAttributes()), null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("dependency", "some", new DependencyMaterialAttributes()), null));
     materials.push(new MaterialWithModification(new MaterialWithFingerprint("package", "some", new PackageMaterialAttributes()), null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("plugin", "some", new PluggableScmMaterialAttributes(undefined, undefined, "", "", new Filter([]))), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("plugin", "some", new PluggableScmMaterialAttributes(undefined, undefined, "", "scm_name")), null));
 
     materials.sortOnType();
 
-    expect(materials[0].config.type()).toBe('dependency');
-    expect(materials[1].config.type()).toBe('git');
-    expect(materials[2].config.type()).toBe('hg');
-    expect(materials[3].config.type()).toBe('p4');
-    expect(materials[4].config.type()).toBe('package');
-    expect(materials[5].config.type()).toBe('plugin');
-    expect(materials[6].config.type()).toBe('svn');
-    expect(materials[7].config.type()).toBe('tfs');
+    expect(materials[0].config.type()).toBe('git');
+    expect(materials[1].config.type()).toBe('hg');
+    expect(materials[2].config.type()).toBe('p4');
+    expect(materials[3].config.type()).toBe('package');
+    expect(materials[4].config.type()).toBe('plugin');
+    expect(materials[5].config.type()).toBe('svn');
+    expect(materials[6].config.type()).toBe('tfs');
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
@@ -40,7 +40,7 @@ import urlParse from "url-parse";
 import {EncryptedValue, plainOrCipherValue} from "views/components/forms/encrypted_value";
 import {Filter} from "../maintenance_mode/material";
 
-const mapTypeToDisplayType: { [key: string]: string; } = {
+export const mapTypeToDisplayType: { [key: string]: string; } = {
   git:        "Git",
   svn:        "Subversion",
   hg:         "Mercurial",

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_widget.tsx
@@ -18,18 +18,13 @@ import {SparkRoutes} from "helpers/spark_routes";
 import {timeFormatter} from "helpers/time_formatter";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import m from "mithril";
-import Stream from "mithril/stream";
 import {MaterialModification} from "models/config_repos/types";
-import {MaterialWithFingerprint} from "models/materials/materials";
-import {Scms} from "models/materials/pluggable_scm";
-import {PackageMaterialAttributes, PluggableScmMaterialAttributes} from "models/materials/types";
-import {Packages} from "models/package_repositories/package_repositories";
+import {MaterialWithFingerprint, PackageMaterialAttributes, PluggableScmMaterialAttributes} from "models/materials/materials";
 import {CollapsiblePanel} from "views/components/collapsible_panel";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {KeyValuePair} from "views/components/key_value_pair";
 import {Link} from "views/components/link";
 import headerStyles from "views/pages/config_repos/index.scss";
-import {AdditionalInfoAttrs} from "../materials";
 import {MaterialHeaderWidget} from "./material_header_widget";
 import {MaterialUsageWidget} from "./material_usage_widget";
 import {MaterialVM} from "./models/material_view_model";
@@ -38,7 +33,8 @@ export interface MaterialAttrs {
   materialVM: MaterialVM;
 }
 
-interface MaterialWithInfoAttrs extends MaterialAttrs, AdditionalInfoAttrs {
+interface MaterialWithInfoAttrs extends MaterialAttrs {
+  shouldShowPackageOrScmLink: boolean;
 }
 
 export class MaterialWidget extends MithrilViewComponent<MaterialWithInfoAttrs> {
@@ -69,32 +65,30 @@ export class MaterialWidget extends MithrilViewComponent<MaterialWithInfoAttrs> 
         {modificationDetails}
       </div>
       <h3>Material Attributes</h3>
-      <KeyValuePair data-test-id={"material-attributes"} data={this.getMaterialData(material.config, vnode.attrs.packages, vnode.attrs.scms)}/>
+      <KeyValuePair data-test-id={"material-attributes"} data={this.getMaterialData(material.config, vnode.attrs.shouldShowPackageOrScmLink)}/>
     </CollapsiblePanel>;
   }
 
-  private getMaterialData(material: MaterialWithFingerprint, packages: Stream<Packages>, scms: Stream<Scms>): Map<string, m.Children> {
+  private getMaterialData(material: MaterialWithFingerprint, shouldShowPackageOrScmLink: boolean): Map<string, m.Children> {
     let map = new Map();
     if (material.type() === "package") {
       const pkgAttrs = material.attributes() as PackageMaterialAttributes;
-      const pkgInfo  = packages().find((pkg) => pkg.id() === pkgAttrs.ref());
 
-      const pkgName = pkgInfo === undefined
-        ? `No package found for '${pkgAttrs.ref()}'!`
-        : <Link href={SparkRoutes.packageRepositoriesSPA(pkgInfo.packageRepo().name(), pkgInfo.name())}>
-          {pkgInfo.name()}
-        </Link>;
+      const pkgName = shouldShowPackageOrScmLink
+        ? <Link href={SparkRoutes.packageRepositoriesSPA(pkgAttrs.packageRepoName(), pkgAttrs.packageName())}>
+          {pkgAttrs.packageName()}
+        </Link>
+        : pkgAttrs.packageName();
 
       map.set("Ref", pkgName);
     } else if (material.type() === "plugin") {
       const pluginAttrs = material.attributes() as PluggableScmMaterialAttributes;
-      const scmMaterial = scms().find((scm) => scm.id() === pluginAttrs.ref());
 
-      const value = scmMaterial === undefined
-        ? `No SCM found for '${pluginAttrs.ref()}'!`
-        : <Link href={SparkRoutes.pluggableScmSPA(scmMaterial.name())}>
-          {scmMaterial.name()}
-        </Link>;
+      const value = shouldShowPackageOrScmLink
+        ? <Link href={SparkRoutes.pluggableScmSPA(pluginAttrs.scmName())}>
+          {pluginAttrs.scmName()}
+        </Link>
+        : pluginAttrs.scmName();
 
       map.set("Ref", value);
     } else {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/materials_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/materials_widget.tsx
@@ -46,8 +46,8 @@ export class MaterialsWidget extends MithrilViewComponent<MaterialsAttrs> {
       </div>;
     }
     return <div data-test-id="materials-widget">
-      {vnode.attrs.materialVMs().map((materialVM) => <MaterialWidget materialVM={materialVM} scms={vnode.attrs.scms}
-                                                                     packages={vnode.attrs.packages}/>)}
+      {vnode.attrs.materialVMs().map((materialVM) => <MaterialWidget materialVM={materialVM}
+                                                                     shouldShowPackageOrScmLink={vnode.attrs.shouldShowPackageOrScmLink}/>)}
     </div>;
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/models/spec/material_view_model_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/models/spec/material_view_model_spec.ts
@@ -15,19 +15,19 @@
  */
 
 import {MaterialModification} from "models/config_repos/types";
-import {Filter} from "models/maintenance_mode/material";
-import {Materials, MaterialWithFingerprint, MaterialWithModification} from "models/materials/materials";
 import {
-  DependencyMaterialAttributes,
   GitMaterialAttributes,
   HgMaterialAttributes,
+  Materials,
+  MaterialWithFingerprint,
+  MaterialWithModification,
   P4MaterialAttributes,
   PackageMaterialAttributes,
   PluggableScmMaterialAttributes,
   SvnMaterialAttributes,
   TfsMaterialAttributes
-} from "models/materials/types";
-import {DummyCache} from "../../spec/material_usage_widget_spec";
+} from "models/materials/materials";
+import {DummyCache} from "views/pages/materials/spec/material_usage_widget_spec";
 import {MaterialVM, MaterialVMs} from "../material_view_model";
 
 describe('MaterialVMSpec', () => {
@@ -78,20 +78,18 @@ describe('MaterialsVMsSpec', () => {
     materials.push(new MaterialWithModification(new MaterialWithFingerprint("svn", "some", new SvnMaterialAttributes()), null));
     materials.push(new MaterialWithModification(new MaterialWithFingerprint("p4", "some", new P4MaterialAttributes()), null));
     materials.push(new MaterialWithModification(new MaterialWithFingerprint("tfs", "some", new TfsMaterialAttributes()), null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("dependency", "some", new DependencyMaterialAttributes()), null));
     materials.push(new MaterialWithModification(new MaterialWithFingerprint("package", "some", new PackageMaterialAttributes()), null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("plugin", "some", new PluggableScmMaterialAttributes(undefined, undefined, "", "", new Filter([]))), null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("plugin", "some", new PluggableScmMaterialAttributes(undefined, undefined, "", "scm-name")), null));
 
     const materialVMs = MaterialVMs.fromMaterials(materials);
     materialVMs.sortOnType();
 
-    expect(materialVMs[0].type()).toBe('dependency');
-    expect(materialVMs[1].type()).toBe('git');
-    expect(materialVMs[2].type()).toBe('hg');
-    expect(materialVMs[3].type()).toBe('p4');
-    expect(materialVMs[4].type()).toBe('package');
-    expect(materialVMs[5].type()).toBe('plugin');
-    expect(materialVMs[6].type()).toBe('svn');
-    expect(materialVMs[7].type()).toBe('tfs');
+    expect(materialVMs[0].type()).toBe('git');
+    expect(materialVMs[1].type()).toBe('hg');
+    expect(materialVMs[2].type()).toBe('p4');
+    expect(materialVMs[3].type()).toBe('package');
+    expect(materialVMs[4].type()).toBe('plugin');
+    expect(materialVMs[5].type()).toBe('svn');
+    expect(materialVMs[6].type()).toBe('tfs');
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_usage_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_usage_widget_spec.tsx
@@ -17,8 +17,7 @@
 import {asSelector} from "helpers/css_proxies";
 import m from "mithril";
 import {ObjectCache} from "models/base/cache";
-import {MaterialWithFingerprint, MaterialWithModification} from "models/materials/materials";
-import {GitMaterialAttributes} from "models/materials/types";
+import {GitMaterialAttributes, MaterialWithFingerprint, MaterialWithModification} from "models/materials/materials";
 import css from "views/pages/config_repos/defined_structs.scss";
 import {emptyTree,} from "views/pages/config_repos/spec/test_data";
 import {MaterialUsagesVM} from "views/pages/materials/models/material_usages_view_model";

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
@@ -16,7 +16,6 @@
 
 import {timeFormatter} from "helpers/time_formatter";
 import m from "mithril";
-import Stream from "mithril/stream";
 import {MaterialModification} from "models/config_repos/types";
 import {
   MaterialWithFingerprint,
@@ -24,10 +23,6 @@ import {
   PackageMaterialAttributes,
   PluggableScmMaterialAttributes
 } from "models/materials/materials";
-import {Scm, Scms} from "models/materials/pluggable_scm";
-import {Package, Packages} from "models/package_repositories/package_repositories";
-import {getPackage} from "models/package_repositories/spec/test_data";
-import {getPluggableScm} from "views/pages/pluggable_scms/spec/test_data";
 import {TestHelper} from "views/pages/spec/test_helper";
 import {MaterialWidget} from "../material_widget";
 import {MaterialVM} from "../models/material_view_model";
@@ -36,14 +31,10 @@ import {git} from "./materials_widget_spec";
 describe('MaterialWidgetSpec', () => {
   const helper = new TestHelper();
   let material: MaterialWithModification;
-  let packages: Packages;
-  let scms: Scms;
 
   afterEach((done) => helper.unmount(done));
   beforeEach(() => {
     material = new MaterialWithModification(MaterialWithFingerprint.fromJSON(git()), null);
-    packages = new Packages();
-    scms     = new Scms();
   });
 
   it('should display the header', () => {
@@ -64,10 +55,8 @@ describe('MaterialWidgetSpec', () => {
   });
 
   it('should render ref with link for plugin', () => {
-    const scm = Scm.fromJSON(getPluggableScm());
-    scms.push(scm);
     material.config
-      = new MaterialWithFingerprint("plugin", "fingerprint", new PluggableScmMaterialAttributes(undefined, true, scm.id(), "scm_name"));
+      = new MaterialWithFingerprint("plugin", "fingerprint", new PluggableScmMaterialAttributes(undefined, true, "scm-id", "scm_name"));
     mount();
 
     expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
@@ -76,15 +65,13 @@ describe('MaterialWidgetSpec', () => {
 
     expect(attrsElement).toBeInDOM();
     expect(helper.qa('li', attrsElement).length).toBe(1);
-    expect(helper.q('a', helper.byTestId('key-value-value-ref')).textContent).toBe('pluggable.scm.material.name');
-    expect(helper.q('a', helper.byTestId('key-value-value-ref'))).toHaveAttr('href', '/go/admin/scms#!pluggable.scm.material.name');
+    expect(helper.q('a', helper.byTestId('key-value-value-ref')).textContent).toBe('scm_name');
+    expect(helper.q('a', helper.byTestId('key-value-value-ref'))).toHaveAttr('href', '/go/admin/scms#!scm_name');
   });
 
   it('should render ref with link for package', () => {
-    const pkg = Package.fromJSON(getPackage());
-    packages.push(pkg);
     material.config
-      = new MaterialWithFingerprint("package", "fingerprint", new PackageMaterialAttributes(undefined, true, pkg.id(), "pkg-name", "pkg-repo-name"));
+      = new MaterialWithFingerprint("package", "fingerprint", new PackageMaterialAttributes(undefined, true, "pkg-id", "pkg-name", "pkg-repo-name"));
     mount();
 
     expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
@@ -124,12 +111,10 @@ describe('MaterialWidgetSpec', () => {
     expect(helper.q('span span', attrs[4])).toHaveAttr('title', '23 Dec, 2019 at 10:25:52 +00:00 Server Time');
   });
 
-  it('should display message if scm information is not present', () => {
-    const scm = Scm.fromJSON(getPluggableScm());
-    scms.push(scm);
+  it('should not add link if shouldShowPackageOrScmLink is false for scm', () => {
     material.config = new MaterialWithFingerprint("plugin", "fingerprint",
                                                   new PluggableScmMaterialAttributes(undefined, true, "some-id", "scm-name"));
-    mount();
+    mount(false);
 
     expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
 
@@ -137,14 +122,14 @@ describe('MaterialWidgetSpec', () => {
 
     expect(attrsElement).toBeInDOM();
     expect(helper.qa('li', attrsElement).length).toBe(1);
-    expect(helper.textByTestId('key-value-value-ref')).toBe("No SCM found for 'some-id'!");
+    expect(helper.textByTestId('key-value-value-ref')).toBe("scm-name");
+    expect(helper.q('a', helper.byTestId('key-value-value-ref'))).not.toBeInDOM();
   });
 
-  it('should display message if package information is not present', () => {
-    const pkg = Package.fromJSON(getPackage());
-    packages.push(pkg);
-    material.config = new MaterialWithFingerprint("package", "fingerprint", new PackageMaterialAttributes(undefined, true, "some-pkg-id"));
-    mount();
+  it('should not add link if shouldShowPackageOrScmLink is false for package', () => {
+    material.config = new MaterialWithFingerprint("package", "fingerprint",
+                                                  new PackageMaterialAttributes(undefined, true, "some-pkg-id", "pkg-name", "pkg-repo-name"));
+    mount(false);
 
     expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
 
@@ -152,10 +137,11 @@ describe('MaterialWidgetSpec', () => {
 
     expect(attrsElement).toBeInDOM();
     expect(helper.qa('li', attrsElement).length).toBe(1);
-    expect(helper.textByTestId('key-value-value-ref')).toBe("No package found for 'some-pkg-id'!");
+    expect(helper.textByTestId('key-value-value-ref')).toBe("pkg-name");
+    expect(helper.q('a', helper.byTestId('key-value-value-ref'))).not.toBeInDOM();
   });
 
-  function mount() {
-    helper.mount(() => <MaterialWidget materialVM={new MaterialVM(material)} packages={Stream(packages)} scms={Stream(scms)}/>);
+  function mount(shouldShowPackageOrScmLink: boolean = true) {
+    helper.mount(() => <MaterialWidget materialVM={new MaterialVM(material)} shouldShowPackageOrScmLink={shouldShowPackageOrScmLink}/>);
   }
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
@@ -18,14 +18,17 @@ import {timeFormatter} from "helpers/time_formatter";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {MaterialModification} from "models/config_repos/types";
-import {Filter} from "models/maintenance_mode/material";
-import {MaterialWithFingerprint, MaterialWithModification} from "models/materials/materials";
+import {
+  MaterialWithFingerprint,
+  MaterialWithModification,
+  PackageMaterialAttributes,
+  PluggableScmMaterialAttributes
+} from "models/materials/materials";
 import {Scm, Scms} from "models/materials/pluggable_scm";
-import {PackageMaterialAttributes, PluggableScmMaterialAttributes} from "models/materials/types";
 import {Package, Packages} from "models/package_repositories/package_repositories";
 import {getPackage} from "models/package_repositories/spec/test_data";
+import {getPluggableScm} from "views/pages/pluggable_scms/spec/test_data";
 import {TestHelper} from "views/pages/spec/test_helper";
-import {getPluggableScm} from "../../pluggable_scms/spec/test_data";
 import {MaterialWidget} from "../material_widget";
 import {MaterialVM} from "../models/material_view_model";
 import {git} from "./materials_widget_spec";
@@ -64,7 +67,7 @@ describe('MaterialWidgetSpec', () => {
     const scm = Scm.fromJSON(getPluggableScm());
     scms.push(scm);
     material.config
-      = new MaterialWithFingerprint("plugin", "fingerprint", new PluggableScmMaterialAttributes(undefined, true, scm.id(), "", new Filter([])));
+      = new MaterialWithFingerprint("plugin", "fingerprint", new PluggableScmMaterialAttributes(undefined, true, scm.id(), "scm_name"));
     mount();
 
     expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
@@ -81,7 +84,7 @@ describe('MaterialWidgetSpec', () => {
     const pkg = Package.fromJSON(getPackage());
     packages.push(pkg);
     material.config
-      = new MaterialWithFingerprint("package", "fingerprint", new PackageMaterialAttributes(undefined, true, pkg.id()));
+      = new MaterialWithFingerprint("package", "fingerprint", new PackageMaterialAttributes(undefined, true, pkg.id(), "pkg-name", "pkg-repo-name"));
     mount();
 
     expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");
@@ -125,7 +128,7 @@ describe('MaterialWidgetSpec', () => {
     const scm = Scm.fromJSON(getPluggableScm());
     scms.push(scm);
     material.config = new MaterialWithFingerprint("plugin", "fingerprint",
-                                                  new PluggableScmMaterialAttributes(undefined, true, "some-id", "", new Filter([])));
+                                                  new PluggableScmMaterialAttributes(undefined, true, "some-id", "scm-name"));
     mount();
 
     expect(helper.qa('h3')[1].textContent).toBe("Material Attributes");

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/materials_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/materials_widget_spec.tsx
@@ -17,8 +17,6 @@ import {docsUrl} from "gen/gocd_version";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {MaterialWithFingerprintJSON} from "models/materials/materials";
-import {Scms} from "models/materials/pluggable_scm";
-import {Packages} from "models/package_repositories/package_repositories";
 import {TestHelper} from "views/pages/spec/test_helper";
 import {MaterialsWidget} from "../materials_widget";
 import {MaterialVMs} from "../models/material_view_model";
@@ -47,7 +45,7 @@ describe('MaterialsWidgetSpec', () => {
   });
 
   function mount() {
-    helper.mount(() => <MaterialsWidget materialVMs={Stream(materialVMs)} packages={Stream(new Packages())} scms={Stream(new Scms())}/>);
+    helper.mount(() => <MaterialsWidget materialVMs={Stream(materialVMs)} shouldShowPackageOrScmLink={false}/>);
   }
 });
 


### PR DESCRIPTION
Issue: #8331

Description:
Currently the materials SPA makes a call to fetch all packages and scms available. But this API is available only to admins/group admins. This caused the page to not render.
Added the required info in the internal materials API and utilized the same.
