### PR TITLE
Stage overview fixes

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -598,14 +598,14 @@ body {
     text-align:  center;
 
     &.passed {
-      @include icon-before($passed-icon, 12px, 3px);
+      @include icon-before($passed-icon, 12px, 0);
 
       background: $passed;
       color:      #fff;
     }
 
     &.failed {
-      @include icon-before($failed-icon, 12px, 3px);
+      @include icon-before($failed-icon, 12px, 0);
 
       background: $failed;
       color:      #fff;
@@ -631,7 +631,7 @@ body {
     }
 
     &.cancelled {
-      @include icon-before($cancelled-icon, 12px, 3px);
+      @include icon-before($cancelled-icon, 12px, 0);
 
       background: $building;
       color:      $dark-gray;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.scss
@@ -195,6 +195,10 @@ $btn-group-border-radius: $global-border-radius;
   @include icon-before($type: $fa-var-ban);
 }
 
+.console-log {
+  @include icon-before($type: $fa-var-file-text-o);
+}
+
 .icon-group {
   border:        1px solid $border-color;
   border-radius: $btn-group-border-radius;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.scss.d.ts
@@ -12,6 +12,7 @@ export const chevronRightRound: string;
 export const clone: string;
 export const close: string;
 export const comment: string;
+export const consoleLog: string;
 export const disabled: string;
 export const download: string;
 export const edit: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
@@ -257,6 +257,12 @@ export class CancelStage extends Icon {
   }
 }
 
+export class ConsoleLog extends Icon {
+  constructor() {
+    super(styles.consoleLog, "Console Log");
+  }
+}
+
 export class IconGroup extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs>) {
     return (

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
@@ -287,7 +287,7 @@ $building: #ffc11b;
 }
 
 .table-body {
-  max-height: 318px;
+  max-height: 243px;
   overflow-x: hidden;
   overflow-y: scroll;
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
@@ -244,7 +244,7 @@ $building: #ffc11b;
   }
 
   .name-cell {
-    width:         120px;
+    width:         165px;
     display:       flex;
     overflow:      hidden;
     text-overflow: ellipsis;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
@@ -385,7 +385,7 @@ $building: #ffc11b;
   border-radius: 6px;
   position:      absolute;
   z-index:       map_get($zindex, tooltip);
-  background:    rgb(243, 243, 243, 0.85); //sass-lint:disable-line no-color-literals
+  background:    rgb(243, 243, 243, 0.95); //sass-lint:disable-line no-color-literals
   border:        1px solid $tooltip-border-color;
 
   :before {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
@@ -245,7 +245,7 @@ $building: #ffc11b;
   }
 
   .name-cell {
-    width:         120px;
+    width:         171px;
     display:       flex;
     overflow:      hidden;
     text-overflow: ellipsis;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
@@ -245,11 +245,19 @@ $building: #ffc11b;
   }
 
   .name-cell {
-    min-width:     90px;
-    max-width:     165px;
+    width:         120px;
     display:       flex;
     overflow:      hidden;
     text-overflow: ellipsis;
+
+    i {
+      color:       $link-color;
+      margin-left: 2px;
+
+      &:hover {
+        font-size: 14px;
+      }
+    }
   }
 
   .state-cell {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
@@ -218,7 +218,7 @@ $building: #ffc11b;
 }
 
 .unknown {
-  min-width: 18px;
+  min-width:  18px;
   background: transparent url('../../../../app/assets/images/building.gif') repeat-x;
 }
 
@@ -245,7 +245,8 @@ $building: #ffc11b;
   }
 
   .name-cell {
-    width:         165px;
+    min-width:     90px;
+    max-width:     165px;
     display:       flex;
     overflow:      hidden;
     text-overflow: ellipsis;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
@@ -281,7 +281,7 @@ $building: #ffc11b;
   border-radius: 5px 5px 0 0;
 
   .name-cell {
-    padding-left: 50px;
+    padding-left: 30px;
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
@@ -218,6 +218,7 @@ $building: #ffc11b;
 }
 
 .unknown {
+  min-width: 18px;
   background: transparent url('../../../../app/assets/images/building.gif') repeat-x;
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
@@ -278,6 +278,7 @@ $building: #ffc11b;
     margin-right:  10px;
     overflow:      hidden;
     text-overflow: ellipsis;
+    white-space:   nowrap;
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.tsx
@@ -104,7 +104,7 @@ export class StageOverview extends MithrilComponent<Attrs, {}> {
       </div>;
     }
 
-    const inProgressStageFromPipeline = Stream(vnode.attrs.stages.find((s) => !s.isCompleted()));
+    const inProgressStageFromPipeline = Stream(vnode.attrs.stages.find((s) => s.isBuilding()));
 
     return <div data-test-id="stage-overview-container" class={styles.stageOverviewContainer}>
       <StageHeaderWidget stageName={vnode.attrs.stageName}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/job_progress_bar_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/job_progress_bar_widget.tsx
@@ -36,6 +36,14 @@ export class JobProgressBarWidget extends MithrilComponent<Attrs> {
     vnode.dom.children[0].onmouseover = () => {
       // @ts-ignore
       vnode.dom.children[1].style.visibility = 'visible';
+
+      // stage overview job table body is a scrollable div and the tooltips are rendered absolute WRT to the job progress bar.
+      // when the table body is scrolled, the tooltip is not re-positioned to considered the scrolled div.
+      // find the amount of pixels the body is scrolled and reposition the tooltip considering scrolled offset.
+      // 8 px is the default margin top required for the tooltip caret.
+      const scrolledTop = document.getElementById("scrollable-jobs-table-body")!.scrollTop;
+      // @ts-ignore
+      vnode.dom.children[1].style.marginTop = (8 - scrolledTop) + 'px';
     };
 
     // @ts-ignore

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/job_progress_bar_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/job_progress_bar_widget.tsx
@@ -41,7 +41,7 @@ export class JobProgressBarWidget extends MithrilComponent<Attrs> {
       // when the table body is scrolled, the tooltip is not re-positioned to considered the scrolled div.
       // find the amount of pixels the body is scrolled and reposition the tooltip considering scrolled offset.
       // 8 px is the default margin top required for the tooltip caret.
-      const scrolledTop = document.getElementById("scrollable-jobs-table-body")!.scrollTop;
+      const scrolledTop = document.getElementById("scrollable-jobs-table-body")?.scrollTop || 0;
       // @ts-ignore
       vnode.dom.children[1].style.marginTop = (8 - scrolledTop) + 'px';
     };

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/job_state_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/job_state_widget.tsx
@@ -31,15 +31,15 @@ export class JobStateWidget extends MithrilComponent<Attrs, State> {
     vnode.state.getState = (job: JobJSON) => {
       switch (job.state) {
         case "Scheduled":
-          return "waiting for an agent";
+          return "Waiting for an agent";
         case "Assigned":
-          return "agent assigned";
+          return "Agent assigned";
         case "Preparing":
-          return "checking out materials";
+          return "Checking out materials";
         case "Building":
-          return "building";
+          return "Building";
         case "Completing":
-          return "uploading artifacts";
+          return "Uploading artifacts";
         case"Completed":
           return `${job.result}`;
       }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/jobs_list_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/jobs_list_widget.tsx
@@ -85,7 +85,7 @@ export class JobsListWidget extends MithrilComponent<Attrs, State> {
         <div class={styles.durationCell} data-test-id="duration-header">Duration</div>
         <div class={styles.agentCell} data-test-id="agent-header">Agent</div>
       </div>
-      <div class={styles.tableBody} data-test-id="table-body">
+      <div id="scrollable-jobs-table-body" class={styles.tableBody} data-test-id="table-body">
         {vnode.attrs.jobsVM().getJobs().map(job => {
           const checkboxStream = vnode.attrs.jobsVM().checkedState.get(job.name)!;
           return vnode.state.getTableRowForJob(job, vnode.attrs.lastPassedStageInstance, vnode.attrs.agents, checkboxStream);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/jobs_list_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/jobs_list_widget.tsx
@@ -20,7 +20,6 @@ import * as Icons from "views/components/icons";
 import {MithrilComponent} from "../../../jsx/mithril-component";
 import {Agents} from "../../../models/agents/agents";
 import {CheckboxField} from "../../components/forms/input_fields";
-import {Link} from "../../components/link";
 import * as styles from "./index.scss";
 import {JobAgentWidget} from "./job_agent_widget";
 import {JobProgressBarWidget} from "./job_progress_bar_widget";

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/jobs_list_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/jobs_list_widget.tsx
@@ -16,16 +16,16 @@
 
 import m from "mithril";
 import Stream from "mithril/stream";
+import * as Icons from "views/components/icons";
 import {MithrilComponent} from "../../../jsx/mithril-component";
-import {CheckboxField} from "../../components/forms/input_fields";
-import * as styles from "./index.scss";
-import {JobsViewModel} from "./models/jobs_view_model";
-
 import {Agents} from "../../../models/agents/agents";
+import {CheckboxField} from "../../components/forms/input_fields";
 import {Link} from "../../components/link";
+import * as styles from "./index.scss";
 import {JobAgentWidget} from "./job_agent_widget";
 import {JobProgressBarWidget} from "./job_progress_bar_widget";
 import {JobStateWidget} from "./job_state_widget";
+import {JobsViewModel} from "./models/jobs_view_model";
 import {JobDurationStrategyHelper} from "./models/job_duration_stratergy_helper";
 import {StageInstance} from "./models/stage_instance";
 import {JobJSON} from "./models/types";
@@ -55,9 +55,8 @@ export class JobsListWidget extends MithrilComponent<Attrs, State> {
         </div>
         <div class={styles.nameCell} data-test-id={`job-name-for-${job.name}`}>
           <div className={`${(styles as any)[job.result.toString().toLowerCase() as string]} ${styles.jobResult}`}/>
-          <div className={styles.jobName}>
-            <Link title={job.name} href={jobDetailsPageLink} target={"_blank"}>{job.name}</Link>
-          </div>
+          <span title={job.name} className={styles.jobName}>{job.name}</span>
+          <Icons.ConsoleLog onclick={() => window.open(jobDetailsPageLink)} target={"_blank"} iconOnly={true}/>
         </div>
         <div class={styles.stateCell} data-test-id={`state-for-${job.name}`}>
           <JobStateWidget job={job}/>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/jobs_list_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/jobs_list_widget.tsx
@@ -79,7 +79,7 @@ export class JobsListWidget extends MithrilComponent<Attrs, State> {
     return <div data-test-id="jobs-list-widget" class={styles.jobListContainer}>
       <div class={styles.tableHeader} data-test-id="table-header">
         <div class={styles.checkboxCell} data-test-id="checkbox-header"/>
-        <div class={styles.nameCell} data-test-id="job-name-header">Name</div>
+        <div class={styles.nameCell} data-test-id="job-name-header">Job Name</div>
         <div class={styles.stateCell} data-test-id="state-header">State</div>
         <div class={styles.statusCell} data-test-id="status-header">Status</div>
         <div class={styles.durationCell} data-test-id="duration-header">Duration</div>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/models/stage_overview_view_model.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/models/stage_overview_view_model.ts
@@ -27,7 +27,7 @@ import {StageInstance} from "./stage_instance";
 import {Result, StageInstanceJSON, StageState} from "./types";
 
 export class StageOverviewViewModel {
-  private static POLLING_INTERVAL_IN_SECONDS = 5;
+  private static POLLING_INTERVAL_IN_SECONDS = 10;
   private static STAGES_API_VERSION_HEADER = ApiVersion.latest;
   readonly stageInstance: Stream<StageInstance>;
   readonly jobsVM: Stream<JobsViewModel>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/job_state_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/job_state_widget_spec.tsx
@@ -28,27 +28,27 @@ describe("Job State Widget", () => {
 
   it("should render scheduled job state", () => {
     mount("Scheduled");
-    expect(helper.root).toContainText('waiting for an agent');
+    expect(helper.root).toContainText('Waiting for an agent');
   });
 
   it("should render assigned job state", () => {
     mount("Assigned");
-    expect(helper.root).toContainText('agent assigned');
+    expect(helper.root).toContainText('Agent assigned');
   });
 
   it("should render preparing job state", () => {
     mount("Preparing");
-    expect(helper.root).toContainText('checking out materials');
+    expect(helper.root).toContainText('Checking out materials');
   });
 
   it("should render building job state", () => {
     mount("Building");
-    expect(helper.root).toContainText('building');
+    expect(helper.root).toContainText('Building');
   });
 
   it("should render completing job state", () => {
     mount("Completing");
-    expect(helper.root).toContainText('uploading artifacts');
+    expect(helper.root).toContainText('Uploading artifacts');
   });
 
   it("should render completed passed job state", () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/stage_overview_header_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/stage_overview_header_spec.tsx
@@ -89,6 +89,11 @@ describe('Stage Overview Header', () => {
     expect(helper.byTestId('stage-trigger-and-timing-container')).toContainText(stageInstance.triggeredOn());
   });
 
+  it('should render triggered on server time information on hover', () => {
+    expect(helper.byTestId('stage-trigger-and-timing-container')).toBeInDOM();
+    expect(helper.q('span', helper.byTestId('triggered-on-container')).title).toBe(stageInstance.triggeredOnServerTime());
+  });
+
   it('should render stage duration', () => {
     expect(helper.byTestId('stage-trigger-and-timing-container')).toContainText('Duration');
     expect(helper.byTestId('stage-trigger-and-timing-container')).toContainText('01h 40m 50s');
@@ -108,12 +113,23 @@ describe('Stage Overview Header', () => {
     expect(helper.byTestId('cancelled-on-container')).toContainText(stageInstance.cancelledOn());
   });
 
+  it('should render cancelled on server time information on hover', () => {
+    helper.unmount();
+    const json = TestData.stageInstanceJSON();
+    json.result = Result[Result.Cancelled];
+    json.cancelled_by = 'admin';
+    stageInstance = new StageInstance(json);
+    mount();
+
+    expect(helper.q('span', helper.byTestId('cancelled-on-container')).title).toBe(stageInstance.cancelledOnServerTime());
+  });
+
   it('should render link to stage details page', () => {
     const expectedLink = `/go/pipelines/up42/20/up42_stage/1`;
     const link = helper.q('a');
 
     expect(helper.byTestId('stage-details-page-link')).toBeInDOM();
-    expect(link).toContainText('Go to Stage Details Page >>');
+    expect(link).toContainText('Go to Stage Details Page');
     expect((link as any).href.indexOf(expectedLink)).not.toBe(-1);
   });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/stage_overview_header.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/stage_overview_header.tsx
@@ -134,9 +134,7 @@ export class StageHeaderWidget extends MithrilComponent<StageHeaderAttrs, StageH
         </div>
         <div data-test-id="stage-details-page-link" class={styles.stageDetailsPageLink}>
           {dummyContainer}
-          <Link href={stageDetailsPageLink} target={"_blank"}>
-            {`Go to Stage Details Page >>`}
-          </Link>
+          <Link href={stageDetailsPageLink} externalLinkIcon={true} target={"_blank"}>Go to Stage Details Page</Link>
         </div>
       </div>
     </div>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/stage_overview_header.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/stage_overview_header.tsx
@@ -55,7 +55,7 @@ export class StageHeaderWidget extends MithrilComponent<StageHeaderAttrs, StageH
           Cancelled by <span className={styles.triggeredByAndOn}>{vnode.attrs.stageInstance().cancelledBy()}</span>
         </div>
         <div data-test-id="cancelled-on-container" className={styles.triggeredByContainer}>
-          on <span className={styles.triggeredByAndOn}>{vnode.attrs.stageInstance().cancelledOn()}</span> Local Time
+          on <span title={vnode.attrs.stageInstance().cancelledOnServerTime()} className={styles.triggeredByAndOn}>{vnode.attrs.stageInstance().cancelledOn()}</span> Local Time
         </div>
       </div>);
 
@@ -127,7 +127,7 @@ export class StageHeaderWidget extends MithrilComponent<StageHeaderAttrs, StageH
             Triggered by <span class={styles.triggeredByAndOn}>{vnode.attrs.stageInstance().triggeredBy()}</span>
           </div>
           <div data-test-id="triggered-on-container" className={styles.triggeredByContainer}>
-            on <span className={styles.triggeredByAndOn}>{vnode.attrs.stageInstance().triggeredOn()}</span> Local Time
+            on <span title={vnode.attrs.stageInstance().triggeredOnServerTime()} className={styles.triggeredByAndOn}>{vnode.attrs.stageInstance().triggeredOn()}</span> Local Time
             <span className={styles.durationSeparator}>|</span>
             Duration: <span className={styles.triggeredByAndOn}>{vnode.attrs.stageInstance().stageDuration()}</span>
           </div>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/stage_overview_header.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/stage_overview_header.tsx
@@ -184,6 +184,7 @@ class StageTriggerOrCancelButtonWidget extends MithrilComponent<StageTriggerOrCa
 
       return <div data-test-id="rerun-stage">
         <Icons.Repeat iconOnly={true} disabled={disabled}
+                      title="Rerun stage"
                       onmouseover={() => vnode.state.isTriggerHover(true)}
                       onmouseout={() => vnode.state.isTriggerHover(false)}
                       onclick={() => {vnode.attrs.stageInstance().runStage().then(vnode.state.getResultHandler(vnode.attrs));}}/>
@@ -194,6 +195,7 @@ class StageTriggerOrCancelButtonWidget extends MithrilComponent<StageTriggerOrCa
     const disabledMessage = `You dont have permissions to cancel the stage.`;
     return <div data-test-id="cancel-stage">
       <Icons.CancelStage iconOnly={true} disabled={disabled}
+                         title="Cancel stage"
                          onmouseover={() => vnode.state.isTriggerHover(true)}
                          onmouseout={() => vnode.state.isTriggerHover(false)}
                          onclick={() => {vnode.attrs.stageInstance().cancelStage().then(vnode.state.getResultHandler(vnode.attrs));}}/>


### PR DESCRIPTION
Issue: #8438

Description:

* Show ellipsis on agent name when the hostname contains a hypen
* Fix rerun failed/cancelled and rerun stage button disabled bug
* Fix job name width to account for job console log icon
* Add a console log icon to go to job console log page
* Add console log icon
* Show server time on hover of stage triggered on and cancelled on timings
* Increase polling interval
* Decrease tooltip opacity to make tooltip text more readable
* Decrease the height of the table body to show there are more items in the scroll window
* Use min/max width instead of just width for job name
* Change table header from 'name' to 'job name'
* Use external link icon for stage details page link
* Add stage operations btn title - Cancel/Rerun Stage
* Capitalize job state
* Fix job state shrink issue when job name is too long
* Increase width of job name
* Fix stage status icon
* Fix tooltip positioning issue when jobs are scrolled.
