### PR TITLE
Show relative job progress bar width (#8438)

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
@@ -354,7 +354,6 @@ $building: #ffc11b;
 
 .progress-bar-container {
   height:        11px;
-  width:         240px;
   display:       flex;
   border:        0.5px solid $border-color;
   border-radius: 3px;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/models/job_duration_stratergy_helper.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/models/job_duration_stratergy_helper.ts
@@ -28,6 +28,7 @@ export interface JobDuration {
   buildTimePercentage: number;
   uploadingArtifactTimePercentage: number;
   unknownTimePercentage: number;
+  totalTime: any;
 
   waitTimeForDisplay: string;
   preparingTimeForDisplay: string;
@@ -137,7 +138,8 @@ export class JobDurationStrategyHelper {
       totalTimeForDisplay,
 
       startTimeForDisplay,
-      endTimeForDisplay
+      endTimeForDisplay,
+      totalTime
     };
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/job_progress_bar_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/job_progress_bar_widget_spec.tsx
@@ -19,6 +19,7 @@ import Stream from "mithril/stream";
 import {TestHelper} from "../../../pages/spec/test_helper";
 import styles from "../index.scss";
 import {JobProgressBarWidget} from "../job_progress_bar_widget";
+import {JobDurationStrategyHelper} from "../models/job_duration_stratergy_helper";
 import {JobJSON} from "../models/types";
 import {TestData} from "./test_data";
 
@@ -166,7 +167,10 @@ describe("Job Progress Bar Widget", () => {
 
   function mount(job: JobJSON) {
     helper.mount(() => {
-      return <JobProgressBarWidget job={job} lastPassedStageInstance={Stream()}/>;
+      return <JobProgressBarWidget job={job}
+                                   jobDuration={JobDurationStrategyHelper.getDuration(job, undefined)}
+                                   longestTotalTime={1000000000}
+                                   lastPassedStageInstance={Stream()}/>;
     });
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/models/job_duration_stratergy_helper_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/models/job_duration_stratergy_helper_spec.ts
@@ -52,6 +52,8 @@ describe("Job Duration Strategy Helper", () => {
 
         totalTimeForDisplay: "unknown",
 
+        totalTime: moment.utc(moment.unix(currentTime.getTime() / 1000).diff(moment.unix(scheduledTime / 1000))),
+
         endTimeForDisplay:   "unknown",
         startTimeForDisplay: timeFormatter.format(moment.unix(scheduledTime / 1000))
       });
@@ -89,6 +91,8 @@ describe("Job Duration Strategy Helper", () => {
         uploadingArtifactTimeForDisplay: "00s",
 
         totalTimeForDisplay: "unknown",
+
+        totalTime: moment.utc(moment.unix(currentTime.getTime() / 1000).diff(moment.unix(scheduledTime / 1000))),
 
         endTimeForDisplay:   "unknown",
         startTimeForDisplay: timeFormatter.format(moment.unix(scheduledTime / 1000))
@@ -132,6 +136,8 @@ describe("Job Duration Strategy Helper", () => {
         uploadingArtifactTimeForDisplay: "00s",
 
         totalTimeForDisplay: "unknown",
+
+        totalTime: moment.utc(moment.unix(currentTime.getTime() / 1000).diff(moment.unix(scheduledTime / 1000))),
 
         endTimeForDisplay:   "unknown",
         startTimeForDisplay: timeFormatter.format(moment.unix(scheduledTime / 1000))
@@ -180,6 +186,8 @@ describe("Job Duration Strategy Helper", () => {
         uploadingArtifactTimeForDisplay: "00s",
 
         totalTimeForDisplay: "unknown",
+
+        totalTime: moment.utc(moment.unix(currentTime.getTime() / 1000).diff(moment.unix(scheduledTime / 1000))),
 
         endTimeForDisplay:   "unknown",
         startTimeForDisplay: timeFormatter.format(moment.unix(scheduledTime / 1000))
@@ -233,6 +241,8 @@ describe("Job Duration Strategy Helper", () => {
         uploadingArtifactTimeForDisplay: "02m 00s",
 
         totalTimeForDisplay: "unknown",
+
+        totalTime: moment.utc(moment.unix(currentTime.getTime() / 1000).diff(moment.unix(scheduledTime / 1000))),
 
         endTimeForDisplay:   "unknown",
         startTimeForDisplay: timeFormatter.format(moment.unix(scheduledTime / 1000))
@@ -291,6 +301,8 @@ describe("Job Duration Strategy Helper", () => {
 
         totalTimeForDisplay: "10m 00s",
 
+        totalTime: moment.utc(moment.unix(currentTime.getTime() / 1000).diff(moment.unix(scheduledTime / 1000))),
+
         endTimeForDisplay:   timeFormatter.format(moment.unix(currentTime.getTime() / 1000)),
         startTimeForDisplay: timeFormatter.format(moment.unix(scheduledTime / 1000))
       });
@@ -325,6 +337,8 @@ describe("Job Duration Strategy Helper", () => {
         uploadingArtifactTimeForDisplay: "00s",
 
         totalTimeForDisplay: "unknown",
+
+        totalTime: moment.utc(moment.unix(currentTime.getTime() / 1000).diff(moment.unix((currentTime.getTime() - (1000 * 60 * 10)) / 1000))),
 
         endTimeForDisplay:   "unknown",
         startTimeForDisplay: timeFormatter.format(moment.unix(scheduledTime / 1000))


### PR DESCRIPTION
Issue: #8438

Description:

* Show all the job progress bar relative to the longest running job.
* Always show tooltip at the center of the job.


![Screen Shot 2020-08-11 at 4 00 57 PM](https://user-images.githubusercontent.com/15275847/89890039-48e7b480-dbf0-11ea-90c6-124b052c5aad.png)


