### PR TITLE
Add plugin icon for materials SPA

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/vsm_renderer.js
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/vsm_renderer.js
@@ -258,13 +258,18 @@ Graph_Renderer = function (container) {
         });
     }
 
+    function isNodeTypeScm() {
+        return ['git', 'mercurial', 'subversion', 'perforce', 'tfs', 'package'].indexOf(nodeClassName) === -1;
+    }
+
     function renderScmEntity(node) {
         var gui = '', node_name = '';
         var modification = firstModification(node);
 
         if (modification) {
             nodeClassName = node.node_type.toLowerCase();
-            gui += '<div class= "material_revisions ' + nodeClassName + '"></div>'
+            var pluginClassName = isNodeTypeScm() ? "scm " : "";
+            gui += '<div class= "material_revisions ' + pluginClassName + nodeClassName + '"></div>'
             if (node.node_type == 'PACKAGE' && typeof(node.material_names) !== "undefined") {
                 node_name = node.material_names.join();
             } else {

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/_module.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/_module.scss
@@ -2802,6 +2802,10 @@ li.task_property {
     background-position: 10px -332px;
 }
 
+.material_revisions.scm {
+    background:      image_url('andare/icon-plugin-default.png') no-repeat center;
+    background-size: 42px;
+}
 
 .material_names {
     padding: 3px;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.scss
@@ -199,6 +199,10 @@ $btn-group-border-radius: $global-border-radius;
   @include icon-before($type: $fa-var-file-text-o);
 }
 
+.list {
+  @include icon-before($type: $fa-var-list);
+}
+
 .icon-group {
   border:        1px solid $border-color;
   border-radius: $btn-group-border-radius;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.scss.d.ts
@@ -20,6 +20,7 @@ export const enabled: string;
 export const forward: string;
 export const iconGroup: string;
 export const infoCircle: string;
+export const list: string;
 export const lock: string;
 export const minus: string;
 export const plus: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
@@ -263,6 +263,12 @@ export class ConsoleLog extends Icon {
   }
 }
 
+export class List extends Icon {
+  constructor() {
+    super(styles.list, "List");
+  }
+}
+
 export class IconGroup extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs>) {
     return (

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
@@ -207,6 +207,7 @@ export class KitchenSink extends MithrilComponent<null, any> {
             <Icons.Lock onclick={() => alert("You pressed lock button!")}/>
             <Icons.Close onclick={() => alert("You pressed close button!")}/>
             <Icons.QuestionMark onclick={() => alert("You pressed question button!")}/>
+            <Icons.List onclick={() => alert("You pressed list button!")}/>
           </IconGroup>
         </p>
         <p>
@@ -219,6 +220,7 @@ export class KitchenSink extends MithrilComponent<null, any> {
             <Icons.Lock disabled={true}/>
             <Icons.Close disabled={true}/>
             <Icons.QuestionMark disabled={true}/>
+            <Icons.List disabled={true}/>
           </IconGroup>
         </p>
         <hr/>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss
@@ -55,6 +55,11 @@ $button_color: #2d6ca2;
     background-position: 0 -332px;
   }
 
+  &.plugin {
+    background:      transparent url("../../../../app/assets/images/andare/icon-plugin-default.png") no-repeat;
+    background-size: 45px;
+  }
+
   &.unknown {
     @include icon-before($type: $fa-var-question, $color: $icon-light-color, $size: 35px, $margin: 0);
     background: $white;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss.d.ts
@@ -12,6 +12,7 @@ export const package: string;
 export const pagination: string;
 export const paginationLink: string;
 export const perforce: string;
+export const plugin: string;
 export const searchBoxWrapper: string;
 export const subversion: string;
 export const tfs: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_header_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_header_widget.tsx
@@ -66,6 +66,9 @@ export class MaterialHeaderWidget extends MithrilViewComponent<MaterialAttrs> {
       case "package":
         style = styles.package;
         break;
+      case "plugin":
+        style = styles.plugin;
+        break;
     }
     return <div data-test-id="material-icon" className={classnames(styles.material, style)}/>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_widget.tsx
@@ -23,7 +23,7 @@ import {MaterialModification} from "models/config_repos/types";
 import {MaterialWithFingerprint, PackageMaterialAttributes, PluggableScmMaterialAttributes} from "models/materials/materials";
 import {CollapsiblePanel} from "views/components/collapsible_panel";
 import {FlashMessage, MessageType} from "views/components/flash_message";
-import {Analytics, Edit, IconGroup} from "views/components/icons";
+import {Edit, IconGroup, List} from "views/components/icons";
 import {KeyValuePair} from "views/components/key_value_pair";
 import {Link} from "views/components/link";
 import headerStyles from "views/pages/config_repos/index.scss";
@@ -71,8 +71,8 @@ export class MaterialWidget extends MithrilViewComponent<MaterialWithInfoAttrs> 
     }
     const actionButtons = <IconGroup>
       {maybeEditButton}
-      <Analytics data-test-id={"show-modifications-material"} title={"Show Modifications"}
-                 onclick={vnode.attrs.showModifications.bind(this, config)}/>
+      <List data-test-id={"show-modifications-material"} title={"Show Modifications"}
+            onclick={vnode.attrs.showModifications.bind(this, config)}/>
     </IconGroup>;
 
     return <CollapsiblePanel header={<MaterialHeaderWidget {...vnode.attrs} />}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_header_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_header_widget_spec.tsx
@@ -73,7 +73,7 @@ describe('MaterialHeaderWidgetSpec', () => {
   [
     {type: "p4", classname: styles.perforce, attrs: new P4MaterialAttributes()},
     {type: "package", classname: styles.package, attrs: new PackageMaterialAttributes()},
-    {type: "plugin", classname: styles.unknown, attrs: new PluggableScmMaterialAttributes(undefined, true, "", "")}
+    {type: "plugin", classname: styles.plugin, attrs: new PluggableScmMaterialAttributes(undefined, true, "", "")}
   ].forEach((parameter) => {
     it(`should display icon for ${parameter.type} `, () => {
       material.config.attributes(parameter.attrs);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
@@ -58,7 +58,7 @@ describe('MaterialWidgetSpec', () => {
     expect(helper.qa('li', attrsElement).length).toBe(2);
   });
 
-  it('should render ref with link for plugin', () => {
+  it('should render ref with link and edit material icon for plugin', () => {
     material.config
       = new MaterialWithFingerprint("plugin", "fingerprint", new PluggableScmMaterialAttributes(undefined, true, "scm-id", "scm_name"));
     mount();
@@ -74,7 +74,7 @@ describe('MaterialWidgetSpec', () => {
     expect(helper.q('a', helper.byTestId('key-value-value-ref'))).toHaveAttr('href', '/go/admin/scms#!scm_name');
   });
 
-  it('should render ref with link for package', () => {
+  it('should render ref with link and edit material icon for package', () => {
     material.config
       = new MaterialWithFingerprint("package", "fingerprint", new PackageMaterialAttributes(undefined, true, "pkg-id", "pkg-name", "pkg-repo-name"));
     mount();


### PR DESCRIPTION
Issue: #8331

Description:
Changes:
  - Add an icon for plugin materials on Materials SPA
  - Use the list icon instead of Analytics one for modifications button
  - Use the same icon for plugin materials for VSM page as well

