### PR TITLE
Do not fail while performing config save when last known config repo partial has structural errors (#8463)

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Argument.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Argument.java
@@ -17,9 +17,11 @@ package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.domain.ConfigErrors;
 
+import static com.thoughtworks.go.config.ExecTask.ARG_LIST_STRING;
+
 @ConfigTag(value = "arg", label = "arg")
 public class Argument implements Validatable{
-    @ConfigValue @ValidationErrorKey(value = ExecTask.ARG_LIST_STRING) private String value;
+    @ConfigValue @ValidationErrorKey(value = ARG_LIST_STRING) private String value;
     private final ConfigErrors configErrors = new ConfigErrors();
 
     public Argument() {
@@ -64,6 +66,9 @@ public class Argument implements Validatable{
 
     @Override
     public void validate(ValidationContext validationContext) {
+        if (null == value) {
+            configErrors.add("arg", "Invalid argument, cannot be null.");
+        }
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/ExecTask.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/ExecTask.java
@@ -163,6 +163,7 @@ public class ExecTask extends AbstractTask implements CommandTask {
         }
 
         for (Argument argument : getArgList()) {
+            argument.validate(ctx);
             if (!argument.errors().isEmpty()) {
                 errors.add(ARG_LIST_STRING, argument.errors().asString());
             }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/ExecTaskTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/ExecTaskTest.java
@@ -61,13 +61,14 @@ public class ExecTaskTest {
     }
 
     @Test
-    public void shouldAddErrorsOfEachArgumentToTheParent() {
-        Argument argument = new Argument("invalid-argument");
-        argument.addError(ExecTask.ARG_LIST_STRING, "Invalid argument");
-        ExecTask execTask = new ExecTask("echo", new Arguments(argument), null);
+    public void shouldValidateEachArgumentAndAddErrorsToTask() {
+        ExecTask execTask = new ExecTask("echo", new Arguments(new Argument(null)), null);
+
         execTask.validate(ConfigSaveValidationContext.forChain(new BasicCruiseConfig()));
-        assertThat(execTask.errors().on(ExecTask.ARG_LIST_STRING), is("Invalid argument"));
+
+        assertThat(execTask.errors().on(ExecTask.ARG_LIST_STRING), is("Invalid argument, cannot be null."));
     }
+
 
     @Test
     public void shouldBeValid() throws Exception {

--- a/server/src/main/java/com/thoughtworks/go/config/PartialConfigHelper.java
+++ b/server/src/main/java/com/thoughtworks/go/config/PartialConfigHelper.java
@@ -99,6 +99,15 @@ public class PartialConfigHelper {
     }
 
     private String hash(PartialConfig partial) {
-        return hashes.digestPartial(partial);
+        // hashes.digestPartial method is responsible to serialize domain config entity into xml and then compute hex
+        // in case of a deserialization bug, a plugin may return an invalid config which might fail during serializing into xml
+        // hence, in case of a serialization error, return null has hash
+        //
+        // it is safe to return null on a structurally invalid config, as once a the config is fixed, a hash will be computed.
+        try {
+            return hashes.digestPartial(partial);
+        } catch (Exception e) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Issue: #8463

Description:

* Add a safety check around config partial hash generation.
  The hash generation function serializes config entity into xml and then
  computes hex. There is a possibility of plugin providing a structurally
  invalid config which can fail during serializing into xml. Hence,
  add a try/catch safety net to avoid failures while serializing.

