### PR TITLE
Stage overview fixes (#8438)

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/models/dashboard_view_model.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/models/dashboard_view_model.js
@@ -153,7 +153,9 @@ export function DashboardViewModel(dashboard) {
       hide: () => {
         if(self.stageOverview.model()) {
           self.stageOverview.model().stopRepeater();
+          self.stageOverview.model(undefined);
         }
+
         stageOverviewPipelineName = undefined;
         stageOverviewPipelineCounter = undefined;
         stageOverviewStageName = undefined;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.tsx
@@ -103,6 +103,7 @@ export class StageOverview extends MithrilComponent<Attrs, {}> {
 
     if (!vnode.attrs.stageOverviewVM()) {
       return <div data-test-id="stage-overview-container-spinner" class={`${styles.stageOverviewContainer} ${status}`}>
+        <div className={`${status} ${styles.stageOverviewStatus}`}/>
         <Spinner/>
       </div>;
     }


### PR DESCRIPTION
Issue: #8438

Description:

* Do not show stale stage overview.
  When clicking on a new stage overview, for a short duration,
  the stage overview information from the previous stage was shown.
  This was due to not clearing older stage overview model on close.

* Show stage status bar even when stage overview is loading.