### PR TITLE
[Stage Overview] Fix job tooltip invalid state transition state (#8467)

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/job_progress_bar_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/job_progress_bar_widget.tsx
@@ -102,10 +102,10 @@ export class JobProgressBarWidget extends MithrilComponent<Attrs> {
         {
           Object.keys(stateTransitionItems).map((key, index) => {
             const value = (stateTransitionItems as any)[key];
-            const isUnknownProperty = isUnknown(value, isJobInProgress);
+            const isUnknownProperty = isUnknown(key, isJobInProgress, vnode.attrs.job);
             const valueForDisplay = isUnknownProperty ? "unknown" : value;
             const isLastItem = Object.keys(stateTransitionItems).length - 1 === index;
-            const isNextUnknownProperty = isLastItem ? isJobInProgress : isUnknown((stateTransitionItems as any)[Object.keys(stateTransitionItems)[index + 1]], isJobInProgress);
+            const isNextUnknownProperty = isLastItem ? isJobInProgress : isUnknown(Object.keys(stateTransitionItems)[index + 1], isJobInProgress, vnode.attrs.job);
 
             let stateTransitionLine: m.Child;
             if (!isLastItem) {
@@ -121,7 +121,7 @@ export class JobProgressBarWidget extends MithrilComponent<Attrs> {
 
             return [
               <div class={`${styles.tooltipKeyValuePair} ${styles.stateTransitionItem}`}>
-                <span className={transitionCircleClass}/>
+                <span data-test-id="transition-circle" className={transitionCircleClass}/>
                 <div className={styles.tooltipKey}>{key} :</div>
                 <div className={classnames({[styles.unknownProperty]: isUnknownProperty})}>{valueForDisplay}</div>
               </div>,
@@ -132,7 +132,7 @@ export class JobProgressBarWidget extends MithrilComponent<Attrs> {
         {
           Object.keys(tooltipItems).map(key => {
             const value = (tooltipItems as any)[key];
-            const isUnknownProperty = isUnknown(value, isJobInProgress);
+            const isUnknownProperty = isUnknown(key, isJobInProgress, vnode.attrs.job);
             const valueForDisplay = isUnknownProperty ? "unknown" : value;
             return (
               <div class={`${styles.tooltipKeyValuePair} ${styles.tooltipItem}`}>
@@ -147,6 +147,16 @@ export class JobProgressBarWidget extends MithrilComponent<Attrs> {
   }
 }
 
-function isUnknown(val: string, isJobInProgress: boolean) {
-  return isJobInProgress && (val.toLowerCase() === "00s" || val.toLowerCase() === "unknown");
+function isUnknown(key: string, isJobInProgress: boolean, job: JobJSON) {
+  const originalKeyMapping = {
+    'Waiting':             'Scheduled',
+    'Preparing':           'Preparing',
+    'Building':            'Building',
+    'Uploading Artifacts': 'Completing',
+    'Total Time':          'Completed',
+    'Scheduled At':        'Scheduled',
+    'Completed At':        'Completed',
+  } as any;
+
+  return isJobInProgress && !job.job_state_transitions.find(t => t.state === originalKeyMapping[key]);
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/job_progress_bar_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/job_progress_bar_widget_spec.tsx
@@ -163,6 +163,46 @@ describe("Job Progress Bar Widget", () => {
       expect(tooltip).toContainText("Completed At");
       expect(tooltip).toContainText(TestData.unixTime((json.job_state_transitions[5].state_change_time as number) / 1000));
     });
+
+    it('should not render state as unknown when it is completed in 0 seconds', () => {
+      helper.unmount();
+      mount(TestData.jobWithNoPreparingTime());
+
+      const progressBar = helper.byTestId('progress-bar-container-div');
+      const tooltip = helper.byTestId('progress-bar-tooltip');
+      progressBar.dispatchEvent(new MouseEvent('mouseover'));
+
+      expect(tooltip).toContainText("Building");
+      expect(tooltip).toContainText("00s");
+
+      const transitionCircles = helper.qa('[data-test-id="transition-circle"]');
+      expect(transitionCircles[1]).toHaveClass(styles.preparing);
+      expect(transitionCircles[1]).toHaveClass(styles.completed);
+    });
+
+    it('should render transition circle as completed when the state is completed in 0 seconds', () => {
+      helper.unmount();
+      mount(TestData.jobWithNoPreparingTime());
+
+      const progressBar = helper.byTestId('progress-bar-container-div');
+      progressBar.dispatchEvent(new MouseEvent('mouseover'));
+
+      const transitionCircles = helper.qa('[data-test-id="transition-circle"]');
+      expect(transitionCircles[1]).toHaveClass(styles.preparing);
+      expect(transitionCircles[1]).toHaveClass(styles.completed);
+    });
+
+    it('should render scheduled transition circle as in progress when preparing takes 0 seconds to complete', () => {
+      helper.unmount();
+      mount(TestData.jobWithNoPreparingTime());
+
+      const progressBar = helper.byTestId('progress-bar-container-div');
+      progressBar.dispatchEvent(new MouseEvent('mouseover'));
+
+      const transitionCircles = helper.qa('[data-test-id="transition-circle"]');
+      expect(transitionCircles[0]).toHaveClass(styles.waiting);
+      expect(transitionCircles[0]).toHaveClass(styles.completed);
+    });
   });
 
   function mount(job: JobJSON) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/test_data.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/test_data.ts
@@ -241,4 +241,37 @@ export class TestData {
       }]
     }];
   }
+
+  static jobWithNoPreparingTime(): JobJSON {
+    return {
+        name:                  "waiting-job",
+        state:                 "Building",
+        result:                "Unknown",
+        scheduled_date:        1597384671236,
+        rerun:                 false,
+        original_job_id:       null,
+        agent_uuid:            null,
+        // @ts-ignore
+        pipeline_name:         null,
+        pipeline_counter:      null,
+        stage_name:            null,
+        stage_counter:         null,
+        job_state_transitions: [{
+          state:             "Scheduled",
+          state_change_time: 1597384671236
+        }, {
+          state:             "Assigned",
+          state_change_time: 1597384799431
+        }, {
+          state:             "Preparing",
+          state_change_time: 1597384809477
+        }, {
+          state:             "Building",
+          state_change_time: 1597384809477
+        }, {
+          state:             "Completing",
+          state_change_time: 1597384812057
+        }]
+      };
+  }
 }


### PR DESCRIPTION
Issue: #8467

Description:

* Remove '00s' seconds check for considering a job state as unknown.
* Check if job state transition json contains a particular state
  to consider the state as unknown.