### PR TITLE
Synchronise token verification

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/AgentAuthenticationFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/AgentAuthenticationFilter.java
@@ -22,7 +22,6 @@ import com.thoughtworks.go.server.security.GoAuthority;
 import com.thoughtworks.go.server.security.userdetail.GoUserPrinciple;
 import com.thoughtworks.go.server.service.AgentService;
 import com.thoughtworks.go.server.service.GoConfigService;
-import com.thoughtworks.go.server.service.support.toggle.Toggles;
 import com.thoughtworks.go.util.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,30 +87,10 @@ public class AgentAuthenticationFilter extends OncePerRequestFilter {
         if (isAuthenticated(agentToken, authenticationToken)) {
             LOGGER.debug("Agent is already authenticated");
         } else {
-            try {
-                String hmac = hmacOf(uuid);
-                if (!hmac.equals(token)) {
-                    LOGGER.debug("Denying access, agent with uuid '{}' submitted bad token.", uuid);
-                    if (Toggles.isToggleOn(Toggles.LOG_AGENT_TOKEN)) {
-                        LOGGER.info("[Debug Issue #8427] Agent token and generated hmac does not match,\n " +
-                                "UUID from Agent: '{}'\n" +
-                                "Token from agent: '{}'\n" +
-                                "Generated hmac: '{}'\n" +
-                                "Token generation key used: '{}'\n", uuid, token, hmac, goConfigService.serverConfig().getTokenGenerationKey());
-                    }
-
-                    response.setStatus(403);
-                    return;
-                }
-            } catch (Exception e) {
-                if (Toggles.isToggleOn(Toggles.LOG_AGENT_TOKEN)) {
-                    LOGGER.error("[Debug Issue #8427] Error while generating hmac or comparing with given token,\n" +
-                            "UUID from Agent: '{}'\n" +
-                            "Token from agent: '{}'\n" +
-                            "Token generation key used: '{}'\n", uuid, token, goConfigService.serverConfig().getTokenGenerationKey(), e);
-                }
-
-                throw e;
+            if (!hmacOf(uuid).equals(token)) {
+                LOGGER.debug("Denying access, agent with uuid '{}' submitted bad token.", uuid);
+                response.setStatus(403);
+                return;
             }
 
             GoUserPrinciple agentUser = new GoUserPrinciple("_go_agent_" + uuid, "", GoAuthority.ROLE_AGENT.asAuthority());

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/AgentAuthenticationFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/AgentAuthenticationFilter.java
@@ -103,7 +103,9 @@ public class AgentAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    String hmacOf(String string) {
+    /*Fixes:#8427 HMAC generation is not thread safe, if multiple agents try to authenticate at the same time the hmac
+    generated using the Agent UUID would not match the actual token.*/
+    synchronized String hmacOf(String string) {
         return encodeBase64String(hmac().doFinal(string.getBytes()));
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -22,7 +22,6 @@ public class Toggles {
     public static String USE_RAILS_TEMPLATE_AUTHORIZATION_PAGE = "use_rails_template_authorization_page";
     public static String USE_RAILS_VERSION_INFOS_API = "use_rails_version_infos_api";
     public static String SHOW_MATERIALS_SPA = "show_materials_spa";
-    public static String LOG_AGENT_TOKEN = "log_agent_token";
 
     private static FeatureToggleService service;
 

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -34,11 +34,6 @@
       "key": "show_materials_spa",
       "description": "Show materials spa in menu as well allow users to visit it. Default is false.",
       "value": false
-    },
-    {
-      "key": "log_agent_token",
-      "description": "Temporary toggle to log agent token, debugging issue #8427",
-      "value": false
     }
   ]
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filters/AgentAuthenticationFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filters/AgentAuthenticationFilterTest.java
@@ -28,18 +28,14 @@ import com.thoughtworks.go.server.security.GoAuthority;
 import com.thoughtworks.go.server.security.userdetail.GoUserPrinciple;
 import com.thoughtworks.go.server.service.AgentService;
 import com.thoughtworks.go.server.service.GoConfigService;
-import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
-import com.thoughtworks.go.server.service.support.toggle.Toggles;
 import com.thoughtworks.go.util.TestingClock;
 import org.junit.Rule;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.Mock;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -49,7 +45,6 @@ import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 @EnableRuleMigrationSupport
 public class AgentAuthenticationFilterTest {
@@ -59,24 +54,14 @@ public class AgentAuthenticationFilterTest {
     @Rule
     public final ClearSingleton clearSingleton = new ClearSingleton();
 
-    @Mock
-    private FeatureToggleService featureToggleService;
-
     private final MockHttpServletResponse response = new MockHttpServletResponse();
     private final FilterChain filterChain = mock(FilterChain.class);
     private final TestingClock clock = new TestingClock();
 
     @BeforeEach
     void setUp() throws IOException {
-        initMocks(this);
         temporaryFolder = new TemporaryFolder(tempDir);
         temporaryFolder.create();
-        Toggles.initializeWith(featureToggleService);
-    }
-
-    @AfterEach
-    void tearDown() {
-        Toggles.deinitialize();
     }
 
     @Nested


### PR DESCRIPTION
* HMAC generation is not thread safe, if multiple agents try to authenticate at the same time the hmac
   generated using the Agent UUID would not match the actual token.
