### PR TITLE
Showcase building job before passed jobs on the stage overview

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/models/jobs_view_model.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/models/jobs_view_model.ts
@@ -160,8 +160,8 @@ export class JobsViewModel {
       const priority = [
         Result[Result.Failed],
         Result[Result.Cancelled],
-        Result[Result.Passed],
-        Result[Result.Unknown]
+        Result[Result.Unknown],
+        Result[Result.Passed]
       ];
 
       const firstPriority = priority.indexOf(first.result as string);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/models/jobs_view_model_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/models/jobs_view_model_spec.ts
@@ -36,7 +36,7 @@ describe('Jobs View Model', () => {
 
   it('should provide sorted list of jobs by job state in descending order', () => {
     const sortedJobNames: string[] = jobsVM.getJobs().map((j) => j.name);
-    const expected: string[] = ['another-failed-job', 'failed-job', 'cancelled-job', 'passing-job', 'running-job', 'waiting-job'];
+    const expected: string[] = ['another-failed-job', 'failed-job', 'cancelled-job', 'running-job', 'waiting-job', 'passing-job'];
 
     expect(sortedJobNames).toEqual(expected);
   });


### PR DESCRIPTION
Issue: https://github.com/gocd/gocd/pull/8461#issuecomment-676978270

Description:
In case of re-run of failed jobs, the current running jobs should be shown upfront before the passed ones.

