### PR TITLE
Truncate material name if too long

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss
@@ -66,6 +66,12 @@ $button_color: #2d6ca2;
   }
 }
 
+.truncate {
+  overflow:      hidden;
+  text-overflow: ellipsis;
+  white-space:   nowrap;
+}
+
 .modification-modal {
   background-color: $primary-bg;
   // fill the whole modal

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss.d.ts
@@ -23,6 +23,7 @@ export const searchBoxWrapper: string;
 export const spinnerWrapper: string;
 export const subversion: string;
 export const tfs: string;
+export const truncate: string;
 export const unknown: string;
 export const usages: string;
 export const user: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_header_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_header_widget.tsx
@@ -36,7 +36,10 @@ export class MaterialHeaderWidget extends MithrilViewComponent<MaterialAttrs> {
     return [
       MaterialHeaderWidget.getIcon(material),
       <div className={headerStyles.headerTitle}>
-        <h4 data-test-id="material-type" className={headerStyles.headerTitleText}>{material.config.displayName()}</h4>
+        <h4 data-test-id="material-type" className={classnames(headerStyles.headerTitleText, styles.truncate)}
+            title={material.config.displayName()}>
+          {material.config.displayName()}
+        </h4>
         <span data-test-id="material-display-name" className={headerStyles.headerTitleUrl}>{material.config.attributesAsString()}</span>
       </div>,
       <div data-test-id="latest-mod-in-header">

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/modal.tsx
@@ -98,7 +98,7 @@ export class ShowModificationsModal extends Modal {
               <div class={styles.username} data-test-id="mod-modified-time">{details.get("Modified Time")}</div>
             </div>
             <div class={styles.commentWrapper} data-test-id="mod-comment">
-              <EllipseText text={details.get("Comment")}/>
+              <CommentRenderer text={details.get("Comment")}/>
             </div>
             <div class={styles.rev} data-test-id="mod-rev">{details.get("Revision")}</div>
           </div>;
@@ -251,12 +251,11 @@ interface EllipseState {
   setExpandedTo: (state: boolean, e: MouseEvent) => void;
 }
 
-class EllipseText extends MithrilComponent<EllipseAttrs, EllipseState> {
-  private static MIN_CHAR_COUNT = 80;
+class CommentRenderer extends MithrilComponent<EllipseAttrs, EllipseState> {
+  private static MIN_CHAR_COUNT = 73;
 
   oninit(vnode: m.Vnode<EllipseAttrs, EllipseState>): any {
-    vnode.state.expanded = Stream();
-    vnode.state.expanded(false);
+    vnode.state.expanded = Stream<boolean>(false);
 
     vnode.state.setExpandedTo = (state: boolean) => {
       vnode.state.expanded(state);
@@ -270,8 +269,8 @@ class EllipseText extends MithrilComponent<EllipseAttrs, EllipseState> {
     }
     return <span class={classnames(styles.ellipseWrapper, styles.comment)}
                  data-test-id="ellipsized-content">
-      {vnode.state.expanded() ? vnode.attrs.text : EllipseText.getEllipsizedString(vnode, charactersToShow)}
-      {vnode.state.expanded() ? EllipseText.element(vnode, "less", false) : EllipseText.element(vnode, "more", true)}
+      {vnode.state.expanded() ? vnode.attrs.text : CommentRenderer.getEllipsizedString(vnode, charactersToShow)}
+      {vnode.state.expanded() ? CommentRenderer.element(vnode, "less", false) : CommentRenderer.element(vnode, "more", true)}
       </span>;
   }
 
@@ -285,10 +284,12 @@ class EllipseText extends MithrilComponent<EllipseAttrs, EllipseState> {
   }
 
   private getCharCountToShow(vnode: m.Vnode<EllipseAttrs, EllipseState>) {
-    return (vnode.attrs.text.includes('\n') ? vnode.attrs.text.indexOf('\n') : EllipseText.MIN_CHAR_COUNT);
+    return (vnode.attrs.text.includes('\n')
+      ? Math.min(vnode.attrs.text.indexOf('\n'), CommentRenderer.MIN_CHAR_COUNT)
+      : CommentRenderer.MIN_CHAR_COUNT);
   }
 
   private shouldRenderWithoutEllipse(vnode: m.Vnode<EllipseAttrs, EllipseState>) {
-    return vnode.attrs.text.length <= EllipseText.MIN_CHAR_COUNT && !vnode.attrs.text.includes('\n');
+    return vnode.attrs.text.length <= CommentRenderer.MIN_CHAR_COUNT && !vnode.attrs.text.includes('\n');
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/modal_spec.tsx
@@ -160,7 +160,7 @@ describe('ShowModificationsModalSpec', () => {
     materialMods.push(new MaterialModification("GoCD Test User <devnull@example.com>", null, "b9b4f4b758e91117d70121a365ba0f8e37f89a9d", "A very long comment to be shown as part of the panel body which should be trimmed and rest part should not be shown by default. ", "2019-12-23T10:25:52Z"));
     mount();
 
-    expect(helper.textByTestId('mod-comment')).toBe('A very long comment to be shown as part of the panel body which should be trimme...more');
+    expect(helper.textByTestId('mod-comment')).toBe('A very long comment to be shown as part of the panel body which should be...more');
     helper.clickByTestId("ellipse-action-more");
 
     expect(helper.textByTestId('mod-comment')).toBe('A very long comment to be shown as part of the panel body which should be trimmed and rest part should not be shown by default. less');
@@ -174,6 +174,16 @@ describe('ShowModificationsModalSpec', () => {
     helper.clickByTestId("ellipse-action-more");
 
     expect(helper.textByTestId('mod-comment')).toBe('A very long comment to be shown as part of the panel body.\n Which should be trimmed and rest part should not be shown by default.less');
+  });
+
+  it('should truncate the first line in modification comment if it exceeds the limit', () => {
+    materialMods.push(new MaterialModification("GoCD Test User <devnull@example.com>", null, "b9b4f4b758e91117d70121a365ba0f8e37f89a9d", "A very long comment to be shown as part of the panel body which should be trimmed.\n Rest part should not be shown by default.", "2019-12-23T10:25:52Z"));
+    mount();
+
+    expect(helper.textByTestId('mod-comment')).toBe('A very long comment to be shown as part of the panel body which should be...more');
+    helper.clickByTestId("ellipse-action-more");
+
+    expect(helper.textByTestId('mod-comment')).toBe('A very long comment to be shown as part of the panel body which should be trimmed.\n Rest part should not be shown by default.less');
   });
 });
 


### PR DESCRIPTION
Issue: #8483 

Description:
 - truncate material name if too long
 - truncate the comment on modifications modal to 72 or less chars. Should render the first line as is or truncated based on length.



