### PR TITLE
Upgrade Typescript to 4.0.2

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -129,7 +129,7 @@
     "ts-loader": "^8.0.3",
     "ts-node": "^9.0.0",
     "tslint": "^6.1.3",
-    "typescript": "^3.9.7",
+    "typescript": "4.0.2",
     "unused-webpack-plugin": "^2.4.0",
     "upath": "^1.2.0",
     "url-loader": "^4.1.0",

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/agents/spec/agent_vm_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/agents/spec/agent_vm_spec.ts
@@ -194,6 +194,7 @@ describe("AgentVM", () => {
 
     it("should filter skip agent if property is not defined", () => {
       const agentOneJson = AgentsTestData.withHostname("Hostname-AAA");
+      // @ts-ignore
       delete agentOneJson.hostname;
 
       const agentOne       = Agent.fromJSON(agentOneJson),

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/artifact_stores/spec/artifact_stores_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/artifact_stores/spec/artifact_stores_spec.ts
@@ -47,6 +47,7 @@ describe("ArtifactStoreModal", () => {
 
   it("should validate presence of plugin id", () => {
     const dockerJSON = ArtifactStoreTestData.dockerArtifactStore();
+    // @ts-ignore
     delete dockerJSON.plugin_id;
     const artifactStores = ArtifactStores.fromJSON(ArtifactStoreTestData.artifactStoreList(dockerJSON));
 
@@ -59,6 +60,7 @@ describe("ArtifactStoreModal", () => {
 
   it("should validate presence of id", () => {
     const dockerJSON = ArtifactStoreTestData.dockerArtifactStore();
+    // @ts-ignore
     delete dockerJSON.id;
     const artifactStores = ArtifactStores.fromJSON(ArtifactStoreTestData.artifactStoreList(dockerJSON));
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/auth_configs/spec/auth_configs_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/auth_configs/spec/auth_configs_spec.ts
@@ -43,6 +43,7 @@ describe("AuthorizationConfigurationModel", () => {
 
   it("should validate presence of plugin id", () => {
     const ldapAuthConfigJSON = TestData.ldapAuthConfig();
+    // @ts-ignore
     delete ldapAuthConfigJSON.plugin_id;
     const authConfigs = AuthConfigs.fromJSON(TestData.authConfigList(ldapAuthConfigJSON));
 
@@ -55,6 +56,7 @@ describe("AuthorizationConfigurationModel", () => {
 
   it("should validate presence of id", () => {
     const ldapAuthConfigJSON = TestData.ldapAuthConfig();
+    // @ts-ignore
     delete ldapAuthConfigJSON.id;
     const authConfigs = AuthConfigs.fromJSON(TestData.authConfigList(ldapAuthConfigJSON));
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/maintenance_mode/spec/material_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/maintenance_mode/spec/material_spec.ts
@@ -79,6 +79,7 @@ describe("Material specs", () => {
     const materialJSON   = TestData.git();
     const attributesJSON = materialJSON.attributes as ScmAttributesJSON;
 
+    // @ts-ignore
     delete attributesJSON.url;
     const material = Material.fromJSON(materialJSON);
 
@@ -92,6 +93,7 @@ describe("Material specs", () => {
       const materialJSON   = TestData.p4();
       const attributesJSON = materialJSON.attributes as P4MaterialAttributesJSON;
 
+      // @ts-ignore
       delete attributesJSON.view;
       const material = Material.fromJSON(materialJSON);
 
@@ -104,6 +106,7 @@ describe("Material specs", () => {
       const materialJSON   = TestData.p4();
       const attributesJSON = materialJSON.attributes as P4MaterialAttributesJSON;
 
+      // @ts-ignore
       delete attributesJSON.port;
       const material = Material.fromJSON(materialJSON);
 
@@ -118,6 +121,7 @@ describe("Material specs", () => {
       const materialJSON   = TestData.tfs();
       const attributesJSON = materialJSON.attributes as TfsMaterialAttributesJSON;
 
+      // @ts-ignore
       delete attributesJSON.project_path;
       const material = Material.fromJSON(materialJSON);
 
@@ -130,6 +134,7 @@ describe("Material specs", () => {
       const materialJSON   = TestData.tfs();
       const attributesJSON = materialJSON.attributes as TfsMaterialAttributesJSON;
 
+      // @ts-ignore
       delete attributesJSON.username;
       const material = Material.fromJSON(materialJSON);
 
@@ -142,6 +147,7 @@ describe("Material specs", () => {
       const materialJSON   = TestData.tfs();
       const attributesJSON = materialJSON.attributes as TfsMaterialAttributesJSON;
 
+      // @ts-ignore
       delete attributesJSON.password;
       const material = Material.fromJSON(materialJSON);
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/spec/environment_agents_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/spec/environment_agents_spec.ts
@@ -34,6 +34,7 @@ describe("Environments Model - Agents", () => {
 
   it("should return empty list if input is undefined", () => {
     const env = data.environment_json();
+    // @ts-ignore
     delete env.agents;
     const agents = Agents.fromJSON(env.agents);
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/spec/environments_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/new-environments/spec/environments_spec.ts
@@ -206,6 +206,7 @@ describe("Environments Model - Environments", () => {
 
   it("should set origins as GoCD origin if not exist", () => {
     const env = data.environment_json();
+    // @ts-ignore
     delete env.origins;
     const envWithOrigin = EnvironmentWithOrigin.fromJSON(env);
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/package_repositories/spec/package_repositories_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/package_repositories/spec/package_repositories_spec.ts
@@ -22,6 +22,7 @@ describe('PackageRepositoriesModelSpec', () => {
   describe('PackageModelSpec', () => {
     it("should validate presence of repo id", () => {
       const packageJSON = getPackage();
+      // @ts-ignore
       delete packageJSON.package_repo.id;
       const pkg = Package.fromJSON(packageJSON);
 
@@ -34,6 +35,7 @@ describe('PackageRepositoriesModelSpec', () => {
 
     it("should validate presence of name", () => {
       const packageJSON = getPackage();
+      // @ts-ignore
       delete packageJSON.name;
       const pkg = Package.fromJSON(packageJSON);
 
@@ -78,6 +80,7 @@ describe('PackageRepositoriesModelSpec', () => {
 
   it("should validate presence of plugin id", () => {
     const packageRepositoryJSON = getPackageRepository();
+    // @ts-ignore
     delete packageRepositoryJSON.plugin_metadata.id;
     const packageRepository = PackageRepository.fromJSON(packageRepositoryJSON);
 
@@ -90,6 +93,7 @@ describe('PackageRepositoriesModelSpec', () => {
 
   it("should validate presence of name", () => {
     const packageRepositoryJSON = getPackageRepository();
+    // @ts-ignore
     delete packageRepositoryJSON.name;
     const packageRepository = PackageRepository.fromJSON(packageRepositoryJSON);
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/roles/spec/roles_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/roles/spec/roles_spec.ts
@@ -52,6 +52,7 @@ describe("RoleModel", () => {
 
   it("should validate the presence of name", () => {
     const goCDRoleJSON = RolesTestData.GoCDRoleJSON();
+    // @ts-ignore
     delete goCDRoleJSON.name;
     const goCDRole = Role.fromJSON(goCDRoleJSON);
 
@@ -102,9 +103,13 @@ describe("RoleModel", () => {
 
   it('should validate policy for presence of permissions', () => {
     const goCDRoleJSON = RolesTestData.GoCDRoleJSON();
+    // @ts-ignore
     delete goCDRoleJSON.policy[0].permission;
+    // @ts-ignore
     delete goCDRoleJSON.policy[0].action;
+    // @ts-ignore
     delete goCDRoleJSON.policy[0].type;
+    // @ts-ignore
     delete goCDRoleJSON.policy[0].resource;
     const goCDRole = Role.fromJSON(goCDRoleJSON) as GoCDRole;
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/rules/specs/rules_type_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/rules/specs/rules_type_spec.ts
@@ -34,6 +34,7 @@ describe("RulesModelSpec", () => {
 
     it("should validate directive", () => {
       const ruleJSON = ruleTestData();
+      // @ts-ignore
       delete ruleJSON.directive;
 
       const rule = Rule.fromJSON(ruleJSON);
@@ -46,6 +47,7 @@ describe("RulesModelSpec", () => {
 
     it("should validate action", () => {
       const ruleJSON = ruleTestData();
+      // @ts-ignore
       delete ruleJSON.action;
 
       const rule = Rule.fromJSON(ruleJSON);
@@ -58,6 +60,7 @@ describe("RulesModelSpec", () => {
 
     it("should validate type", () => {
       const ruleJSON = ruleTestData();
+      // @ts-ignore
       delete ruleJSON.type;
 
       const rule = Rule.fromJSON(ruleJSON);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/secret_configs/spec/secret_configs_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/secret_configs/spec/secret_configs_spec.ts
@@ -55,6 +55,7 @@ describe("SecretConfigsModelSpec", () => {
   describe("Validate", () => {
     it("should validate presence of id", () => {
       const secretConfigJson = secretConfigTestData();
+      // @ts-ignore
       delete secretConfigJson.id;
       const secretConfig = SecretConfig.fromJSON(secretConfigJson);
       secretConfig.isValid();
@@ -78,6 +79,7 @@ describe("SecretConfigsModelSpec", () => {
 
     it("should validate presence of plugin id", () => {
       const secretConfigJson = secretConfigTestData();
+      // @ts-ignore
       delete secretConfigJson.plugin_id;
       const secretConfig = SecretConfig.fromJSON(secretConfigJson);
       secretConfig.isValid();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/forms/live_validating_input.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/forms/live_validating_input.tsx
@@ -20,7 +20,7 @@ import m from "mithril";
 import {TextField, TextFieldAttrs} from "views/components/forms/input_fields";
 
 export interface LiveInputAttrs extends TextFieldAttrs {
-  validator: (value: string) => string | undefined;
+  validator?: (value: string) => string | undefined;
 }
 
 interface State {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/code_scroller.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/code_scroller.tsx
@@ -63,6 +63,7 @@ export class CodeScroller extends MithrilComponent<{}, State> {
         innerCodePane.style.maxHeight = (availHeight - offset - paddingTop - paddingBottom) + "px";
       } else {
         spacer.style.height = "0";
+        // @ts-ignore
         delete innerCodePane.style.maxHeight;
       }
     });
@@ -78,6 +79,7 @@ export class CodeScroller extends MithrilComponent<{}, State> {
     vnode.state.teardown = () => {
       pane.removeChild(spacer);
       observer.disconnect();
+      // @ts-ignore
       delete innerCodePane.style.maxHeight;
     };
 

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -7943,10 +7943,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.7:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 ua-parser-js@0.7.21:
   version "0.7.21"


### PR DESCRIPTION
Description:

* Typescript 4 added a rule for 'Operands for delete must be optional'
  Where if a property of an object is deleted (using delete) at a
  later point in time, such property must be defined optional (?), as
  such property value will be undefined after delete.

* In GoCD, the delete property is used only in tests to verify not
  specifying a property throws validation errors, ignore such validation
  errors.

Reference:
https://devblogs.microsoft.com/typescript/announcing-typescript-4-0-beta/#operands-for-delete-must-be-optional

