### PR TITLE
Allow group admin users to check connection for scm configs

### DIFF
--- a/api/api-internal-scms-v1/src/main/java/com/thoughtworks/go/apiv1/internalscms/InternalSCMsControllerV1.java
+++ b/api/api-internal-scms-v1/src/main/java/com/thoughtworks/go/apiv1/internalscms/InternalSCMsControllerV1.java
@@ -24,7 +24,6 @@ import com.thoughtworks.go.api.util.GsonTransformer;
 import com.thoughtworks.go.apiv1.internalscms.representers.SCMRepresenter;
 import com.thoughtworks.go.apiv1.internalscms.representers.VerifyConnectionResultRepresenter;
 import com.thoughtworks.go.domain.scm.SCM;
-import com.thoughtworks.go.plugin.api.response.Result;
 import com.thoughtworks.go.server.service.materials.PluggableScmService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.spark.Routes;
@@ -63,7 +62,7 @@ public class InternalSCMsControllerV1 extends ApiController implements SparkSpri
             before(Routes.SCM.VERIFY_CONNECTION, mimeType, this::setContentType);
             before(Routes.SCM.VERIFY_CONNECTION, mimeType, this.apiAuthenticationHelper::checkAdminUserOrGroupAdminUserAnd403);
 
-            post(Routes.Packages.VERIFY_CONNECTION, mimeType, this::verifyConnection);
+            post(Routes.SCM.VERIFY_CONNECTION, mimeType, this::verifyConnection);
         });
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
@@ -96,6 +96,7 @@ public class AuthorizeFilterChain extends FilterChainProxy {
                 .addAuthorityFilterChain("/api/admin/export/**", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/admin/encrypt", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/admin/scms/**", apiAccessDeniedHandler, ROLE_USER)
+                .addAuthorityFilterChain("/api/admin/internal/scms/**", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/admin/repositories/**", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/admin/packages/**", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/admin/plugin_info/**", apiAccessDeniedHandler, ROLE_USER)


### PR DESCRIPTION
Description:
 - Group Admin users can create/edit/delete SCM configs. They should be allowed to check connection as well.
