### PR TITLE
Add button to trigger material update

### DIFF
--- a/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/models/MaterialInfo.java
+++ b/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/models/MaterialInfo.java
@@ -28,11 +28,7 @@ import java.sql.Timestamp;
 @EqualsAndHashCode
 public class MaterialInfo {
     private Modification modification;
+    private boolean hasOperatePermission;
     private boolean isUpdateInProgress;
     private Timestamp updateStartTime;
-
-    public MaterialInfo(Modification modification, boolean isUpdateInProgress) {
-        this.modification = modification;
-        this.isUpdateInProgress = isUpdateInProgress;
-    }
 }

--- a/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/models/MaterialInfo.java
+++ b/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/models/MaterialInfo.java
@@ -21,10 +21,18 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.sql.Timestamp;
+
 @Getter
 @AllArgsConstructor
 @EqualsAndHashCode
 public class MaterialInfo {
     private Modification modification;
     private boolean isUpdateInProgress;
+    private Timestamp updateStartTime;
+
+    public MaterialInfo(Modification modification, boolean isUpdateInProgress) {
+        this.modification = modification;
+        this.isUpdateInProgress = isUpdateInProgress;
+    }
 }

--- a/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/representers/MaterialWithModificationsRepresenter.java
+++ b/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/representers/MaterialWithModificationsRepresenter.java
@@ -37,7 +37,8 @@ public class MaterialWithModificationsRepresenter {
         outputWriter.addChildList("materials", materialWriter -> {
             modificationsMap.forEach((config, info) -> materialWriter.addChild(childWriter -> {
                 childWriter.addChild("config", MaterialsRepresenter.toJSON(config))
-                        .add("material_update_in_progress", info.isUpdateInProgress());
+                        .add("material_update_in_progress", info.isUpdateInProgress())
+                        .addIfNotNull("material_update_start_time", info.getUpdateStartTime());
                 if (info.getModification() == null) {
                     childWriter.renderNull("modification");
                 } else {

--- a/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/representers/MaterialWithModificationsRepresenter.java
+++ b/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/representers/MaterialWithModificationsRepresenter.java
@@ -35,8 +35,9 @@ public class MaterialWithModificationsRepresenter {
             return;
         }
         outputWriter.addChildList("materials", materialWriter -> {
-            modificationsMap.forEach((config, info) -> materialWriter.addChild(childWriter -> {
-                childWriter.addChild("config", MaterialsRepresenter.toJSON(config))
+            modificationsMap.forEach((material, info) -> materialWriter.addChild(childWriter -> {
+                childWriter.addChild("config", MaterialsRepresenter.toJSON(material))
+                        .add("can_trigger_update", info.isHasOperatePermission())
                         .add("material_update_in_progress", info.isUpdateInProgress())
                         .addIfNotNull("material_update_start_time", info.getUpdateStartTime());
                 if (info.getModification() == null) {

--- a/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/representers/MaterialWithModificationsRepresenterTest.groovy
+++ b/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/representers/MaterialWithModificationsRepresenterTest.groovy
@@ -54,7 +54,8 @@ class MaterialWithModificationsRepresenterTest {
     def map = new HashMap();
     def git = MaterialConfigsMother.git("http://example.com", "main")
     def modification = ModificationsMother.withModifiedFileWhoseNameLengthIsOneK()
-    map.put(git, new MaterialInfo(modification, true))
+    def timestamp = new Date().toTimestamp()
+    map.put(git, new MaterialInfo(modification, true, timestamp))
 
     def actualJson = toObjectString({ MaterialWithModificationsRepresenter.toJSON(it, map) })
 
@@ -71,6 +72,7 @@ class MaterialWithModificationsRepresenterTest {
         [
           "config"                     : toObject(MaterialsRepresenter.toJSON(git)),
           "material_update_in_progress": true,
+          "material_update_start_time" : jsonDate(timestamp),
           "modification"               : [
             "username"     : "lgao",
             "email_address": "foo@bar.com",
@@ -87,6 +89,37 @@ class MaterialWithModificationsRepresenterTest {
 
   @Test
   void 'should render modification as null'() {
+    def map = new HashMap();
+    def git = MaterialConfigsMother.git("http://example.com", "main")
+    def timestamp = new Date().toTimestamp()
+    map.put(git, new MaterialInfo(null, true, timestamp))
+
+    def actualJson = toObjectString({ MaterialWithModificationsRepresenter.toJSON(it, map) })
+
+    def expectedJson = [
+      _links   : [
+        self: [
+          href: "http://test.host/go/api/internal/materials"
+        ],
+        doc : [
+          href: apiDocsUrl("#materials")
+        ]
+      ],
+      materials: [
+        [
+          "config"                     : toObject(MaterialsRepresenter.toJSON(git)),
+          "material_update_in_progress": true,
+          "material_update_start_time" : jsonDate(timestamp),
+          "modification"               : null
+        ]
+      ]
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should not render material update start time if null'() {
     def map = new HashMap();
     def git = MaterialConfigsMother.git("http://example.com", "main")
     map.put(git, new MaterialInfo(null, false))
@@ -110,7 +143,5 @@ class MaterialWithModificationsRepresenterTest {
         ]
       ]
     ]
-
-    assertThatJson(actualJson).isEqualTo(expectedJson)
   }
 }

--- a/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/representers/MaterialWithModificationsRepresenterTest.groovy
+++ b/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/representers/MaterialWithModificationsRepresenterTest.groovy
@@ -55,7 +55,7 @@ class MaterialWithModificationsRepresenterTest {
     def git = MaterialConfigsMother.git("http://example.com", "main")
     def modification = ModificationsMother.withModifiedFileWhoseNameLengthIsOneK()
     def timestamp = new Date().toTimestamp()
-    map.put(git, new MaterialInfo(modification, true, timestamp))
+    map.put(git, new MaterialInfo(modification, true, true, timestamp))
 
     def actualJson = toObjectString({ MaterialWithModificationsRepresenter.toJSON(it, map) })
 
@@ -71,6 +71,7 @@ class MaterialWithModificationsRepresenterTest {
       materials: [
         [
           "config"                     : toObject(MaterialsRepresenter.toJSON(git)),
+          "can_trigger_update"         : true,
           "material_update_in_progress": true,
           "material_update_start_time" : jsonDate(timestamp),
           "modification"               : [
@@ -92,7 +93,7 @@ class MaterialWithModificationsRepresenterTest {
     def map = new HashMap();
     def git = MaterialConfigsMother.git("http://example.com", "main")
     def timestamp = new Date().toTimestamp()
-    map.put(git, new MaterialInfo(null, true, timestamp))
+    map.put(git, new MaterialInfo(null, false, true, timestamp))
 
     def actualJson = toObjectString({ MaterialWithModificationsRepresenter.toJSON(it, map) })
 
@@ -108,6 +109,7 @@ class MaterialWithModificationsRepresenterTest {
       materials: [
         [
           "config"                     : toObject(MaterialsRepresenter.toJSON(git)),
+          "can_trigger_update"         : false,
           "material_update_in_progress": true,
           "material_update_start_time" : jsonDate(timestamp),
           "modification"               : null
@@ -122,7 +124,7 @@ class MaterialWithModificationsRepresenterTest {
   void 'should not render material update start time if null'() {
     def map = new HashMap();
     def git = MaterialConfigsMother.git("http://example.com", "main")
-    map.put(git, new MaterialInfo(null, false))
+    map.put(git, new MaterialInfo(null, false, false, null))
 
     def actualJson = toObjectString({ MaterialWithModificationsRepresenter.toJSON(it, map) })
 
@@ -138,6 +140,7 @@ class MaterialWithModificationsRepresenterTest {
       materials: [
         [
           "config"                     : toObject(MaterialsRepresenter.toJSON(git)),
+          "can_trigger_update"         : true,
           "material_update_in_progress": false,
           "modification"               : null
         ]

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -632,6 +632,10 @@ export class SparkRoutes {
     return `/go/api/internal/materials/${fingerprint}/usages`;
   }
 
+  static getMaterialTriggerPath(fingerprint: string) {
+    return `/go/api/internal/materials/${fingerprint}/trigger_update`;
+  }
+
   static materialsVsmLink(fingerprint: string, revision: string) {
     return `/go/materials/value_stream_map/${fingerprint}/${revision}`;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/materials.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/materials.ts
@@ -84,6 +84,7 @@ export interface MaterialWithFingerprintJSON {
 
 interface MaterialWithModificationJSON {
   config: MaterialWithFingerprintJSON;
+  can_trigger_update: boolean;
   material_update_in_progress: boolean;
   material_update_start_time?: string;
   modification: MaterialModificationJSON;
@@ -370,12 +371,14 @@ export class MaterialWithFingerprint {
 
 export class MaterialWithModification {
   config: MaterialWithFingerprint;
+  canTriggerUpdate: boolean;
   materialUpdateInProgress: boolean;
   materialUpdateStartTime: stringOrUndefined;
   modification: MaterialModification | null;
 
-  constructor(config: MaterialWithFingerprint, materialUpdateInProgress: boolean, materialUpdateStartTime: stringOrUndefined, modification: MaterialModification | null) {
+  constructor(config: MaterialWithFingerprint, canTriggerUpdate: boolean = false, materialUpdateInProgress: boolean = false, materialUpdateStartTime?: stringOrUndefined, modification: MaterialModification | null = null) {
     this.config                   = config;
+    this.canTriggerUpdate         = canTriggerUpdate;
     this.materialUpdateInProgress = materialUpdateInProgress;
     this.materialUpdateStartTime  = materialUpdateStartTime;
     this.modification             = modification;
@@ -383,7 +386,8 @@ export class MaterialWithModification {
 
   static fromJSON(data: MaterialWithModificationJSON): MaterialWithModification {
     const mod = data.modification === null ? null : MaterialModification.fromJSON(data.modification);
-    return new MaterialWithModification(MaterialWithFingerprint.fromJSON(data.config), data.material_update_in_progress, data.material_update_start_time, mod);
+    return new MaterialWithModification(MaterialWithFingerprint.fromJSON(data.config), data.can_trigger_update
+      , data.material_update_in_progress, data.material_update_start_time, mod);
   }
 
   matches(query: string) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/materials.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/materials.ts
@@ -85,6 +85,7 @@ export interface MaterialWithFingerprintJSON {
 interface MaterialWithModificationJSON {
   config: MaterialWithFingerprintJSON;
   material_update_in_progress: boolean;
+  material_update_start_time?: string;
   modification: MaterialModificationJSON;
 }
 
@@ -370,17 +371,19 @@ export class MaterialWithFingerprint {
 export class MaterialWithModification {
   config: MaterialWithFingerprint;
   materialUpdateInProgress: boolean;
+  materialUpdateStartTime: stringOrUndefined;
   modification: MaterialModification | null;
 
-  constructor(config: MaterialWithFingerprint, materialUpdateInProgress: boolean, modification: MaterialModification | null) {
+  constructor(config: MaterialWithFingerprint, materialUpdateInProgress: boolean, materialUpdateStartTime: stringOrUndefined, modification: MaterialModification | null) {
     this.config                   = config;
     this.materialUpdateInProgress = materialUpdateInProgress;
+    this.materialUpdateStartTime  = materialUpdateStartTime;
     this.modification             = modification;
   }
 
   static fromJSON(data: MaterialWithModificationJSON): MaterialWithModification {
     const mod = data.modification === null ? null : MaterialModification.fromJSON(data.modification);
-    return new MaterialWithModification(MaterialWithFingerprint.fromJSON(data.config), data.material_update_in_progress, mod);
+    return new MaterialWithModification(MaterialWithFingerprint.fromJSON(data.config), data.material_update_in_progress, data.material_update_start_time, mod);
   }
 
   matches(query: string) {
@@ -479,6 +482,10 @@ export class MaterialAPIs {
                               const parse = JSON.parse(body) as MaterialUsagesJSON;
                               return MaterialUsages.fromJSON(parse);
                             }));
+  }
+
+  static triggerUpdate(fingerprint: string) {
+    return ApiRequestBuilder.POST(SparkRoutes.getMaterialTriggerPath(fingerprint), this.API_VERSION_HEADER);
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/materials_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/materials_spec.ts
@@ -39,7 +39,9 @@ describe('MaterialsAPISpec', () => {
       expect(material.config.fingerprint()).toBe('4879d548d34a4f3ba7ed4a532bc1b02');
 
       expect(material.config.attributes()).toBeInstanceOf(GitMaterialAttributes);
+      expect(material.canTriggerUpdate).toBe(true);
       expect(material.materialUpdateInProgress).toBe(true);
+      expect(material.materialUpdateStartTime).toBeUndefined();
 
       expect(material.modification).not.toBeNull();
       expect(material.modification!.modifiedTime).toBe("2019-12-23T10:25:52Z");
@@ -154,6 +156,7 @@ describe('MaterialsAPISpec', () => {
             shallow_clone:    false
           }
         },
+        can_trigger_update:          true,
         material_update_in_progress: true,
         modification:                {
           username:      "GoCD test user",
@@ -373,13 +376,13 @@ describe('MaterialWithFingerPrintSpec', () => {
 describe('MaterialsSpec', () => {
   it('should sort based on type', () => {
     const materials = new Materials();
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("git", "some", new GitMaterialAttributes()), false, undefined, null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("hg", "some", new HgMaterialAttributes()), false, undefined, null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("svn", "some", new SvnMaterialAttributes()), false, undefined, null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("p4", "some", new P4MaterialAttributes()), false, undefined, null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("tfs", "some", new TfsMaterialAttributes()), false, undefined, null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("package", "some", new PackageMaterialAttributes()), false, undefined, null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("plugin", "some", new PluggableScmMaterialAttributes(undefined, undefined, "", "scm_name")), false, undefined, null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("git", "some", new GitMaterialAttributes())));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("hg", "some", new HgMaterialAttributes())));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("svn", "some", new SvnMaterialAttributes())));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("p4", "some", new P4MaterialAttributes())));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("tfs", "some", new TfsMaterialAttributes())));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("package", "some", new PackageMaterialAttributes())));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("plugin", "some", new PluggableScmMaterialAttributes(undefined, undefined, "", "scm_name"))));
 
     materials.sortOnType();
 
@@ -396,7 +399,7 @@ describe('MaterialsSpec', () => {
 describe('MaterialsWithModificationSpec', () => {
   it('should return true if search string matches name, type or display url of the config', () => {
     const material = new MaterialWithFingerprint("git", "fingerprint", new GitMaterialAttributes("some-name", false, "http://svn.com/gocd/gocd", "master"));
-    const withMod  = new MaterialWithModification(material, false, undefined, null);
+    const withMod  = new MaterialWithModification(material);
 
     expect(withMod.matches("git")).toBeTrue();
     expect(withMod.matches("name")).toBeTrue();
@@ -407,7 +410,7 @@ describe('MaterialsWithModificationSpec', () => {
 
   it('should return true if search string matches username, revision or comment for the latest modification', () => {
     const material = new MaterialWithFingerprint("git", "fingerprint", new GitMaterialAttributes("", false, "some-url", "master"));
-    const withMod  = new MaterialWithModification(material, true, undefined, new MaterialModification("username", "email_address", "some-revision", "a very very long comment with abc", ""));
+    const withMod  = new MaterialWithModification(material, true, true, undefined, new MaterialModification("username", "email_address", "some-revision", "a very very long comment with abc", ""));
 
     expect(withMod.matches("revision")).toBeTrue();
     expect(withMod.matches("comment")).toBeTrue();
@@ -418,7 +421,7 @@ describe('MaterialsWithModificationSpec', () => {
 
   it('should return type as config.type', () => {
     const material = new MaterialWithFingerprint("git", "fingerprint", new GitMaterialAttributes("some-name", false, "http://svn.com/gocd/gocd", "master"));
-    const withMod  = new MaterialWithModification(material, true, undefined, null);
+    const withMod  = new MaterialWithModification(material);
 
     expect(withMod.type()).toBe(material.type());
   });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/materials_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/materials_spec.ts
@@ -124,6 +124,18 @@ describe('MaterialsAPISpec', () => {
     expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
   });
 
+  it("should make a trigger update request", () => {
+    const api = SparkRoutes.getMaterialTriggerPath("fingerprint");
+    jasmine.Ajax.stubRequest(api).andReturn(triggerUpdateResponse());
+
+    MaterialAPIs.triggerUpdate("fingerprint");
+
+    const request = jasmine.Ajax.requests.mostRecent();
+    expect(request.url).toEqual(api);
+    expect(request.method).toEqual("POST");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
+  });
+
   function materialsResponse() {
     const data = {
       materials: [{
@@ -195,6 +207,17 @@ describe('MaterialsAPISpec', () => {
         "Content-Type": "application/vnd.go.cd.v1+json; charset=utf-8",
       },
       responseText:    JSON.stringify(data)
+    };
+  }
+
+  function triggerUpdateResponse() {
+    return {
+      status:          200,
+      responseHeaders: {
+        "Content-Type": "application/vnd.go.cd.v1+json; charset=utf-8",
+        "ETag":         "some-etag"
+      },
+      responseText:    JSON.stringify({message: "OK"})
     };
   }
 });
@@ -350,13 +373,13 @@ describe('MaterialWithFingerPrintSpec', () => {
 describe('MaterialsSpec', () => {
   it('should sort based on type', () => {
     const materials = new Materials();
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("git", "some", new GitMaterialAttributes()), false, null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("hg", "some", new HgMaterialAttributes()), false, null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("svn", "some", new SvnMaterialAttributes()), false, null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("p4", "some", new P4MaterialAttributes()), false, null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("tfs", "some", new TfsMaterialAttributes()), false, null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("package", "some", new PackageMaterialAttributes()), false, null));
-    materials.push(new MaterialWithModification(new MaterialWithFingerprint("plugin", "some", new PluggableScmMaterialAttributes(undefined, undefined, "", "scm_name")), false, null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("git", "some", new GitMaterialAttributes()), false, undefined, null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("hg", "some", new HgMaterialAttributes()), false, undefined, null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("svn", "some", new SvnMaterialAttributes()), false, undefined, null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("p4", "some", new P4MaterialAttributes()), false, undefined, null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("tfs", "some", new TfsMaterialAttributes()), false, undefined, null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("package", "some", new PackageMaterialAttributes()), false, undefined, null));
+    materials.push(new MaterialWithModification(new MaterialWithFingerprint("plugin", "some", new PluggableScmMaterialAttributes(undefined, undefined, "", "scm_name")), false, undefined, null));
 
     materials.sortOnType();
 
@@ -373,7 +396,7 @@ describe('MaterialsSpec', () => {
 describe('MaterialsWithModificationSpec', () => {
   it('should return true if search string matches name, type or display url of the config', () => {
     const material = new MaterialWithFingerprint("git", "fingerprint", new GitMaterialAttributes("some-name", false, "http://svn.com/gocd/gocd", "master"));
-    const withMod  = new MaterialWithModification(material, false, null);
+    const withMod  = new MaterialWithModification(material, false, undefined, null);
 
     expect(withMod.matches("git")).toBeTrue();
     expect(withMod.matches("name")).toBeTrue();
@@ -384,7 +407,7 @@ describe('MaterialsWithModificationSpec', () => {
 
   it('should return true if search string matches username, revision or comment for the latest modification', () => {
     const material = new MaterialWithFingerprint("git", "fingerprint", new GitMaterialAttributes("", false, "some-url", "master"));
-    const withMod  = new MaterialWithModification(material, true, new MaterialModification("username", "email_address", "some-revision", "a very very long comment with abc", ""));
+    const withMod  = new MaterialWithModification(material, true, undefined, new MaterialModification("username", "email_address", "some-revision", "a very very long comment with abc", ""));
 
     expect(withMod.matches("revision")).toBeTrue();
     expect(withMod.matches("comment")).toBeTrue();
@@ -395,7 +418,7 @@ describe('MaterialsWithModificationSpec', () => {
 
   it('should return type as config.type', () => {
     const material = new MaterialWithFingerprint("git", "fingerprint", new GitMaterialAttributes("some-name", false, "http://svn.com/gocd/gocd", "master"));
-    const withMod  = new MaterialWithModification(material, true, null);
+    const withMod  = new MaterialWithModification(material, true, undefined, null);
 
     expect(withMod.type()).toBe(material.type());
   });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials.tsx
@@ -30,6 +30,7 @@ import configRepoStyles from "./config_repos/index.scss";
 import {ShowModificationsModal, ShowUsagesModal} from "./materials/modal";
 
 export interface AdditionalInfoAttrs {
+  triggerUpdate: (material: MaterialWithFingerprint, e: MouseEvent) => void;
   onEdit: (material: MaterialWithFingerprint, e: MouseEvent) => void;
   showUsages: (material: MaterialWithFingerprint, e: MouseEvent) => void;
   showModifications: (material: MaterialWithFingerprint, e: MouseEvent) => void;
@@ -52,6 +53,19 @@ export class MaterialsPage extends Page<null, State> {
 
     vnode.state.materials  = Stream();
     vnode.state.searchText = Stream();
+
+    vnode.state.triggerUpdate = (material: MaterialWithFingerprint, e: MouseEvent) => {
+      e.stopPropagation();
+      MaterialAPIs.triggerUpdate(material.fingerprint())
+                  .then((result) => {
+                    result.do(() => {
+                      this.flashMessage.success(`An update was scheduled for '${material.displayName()}' material.`);
+                      this.fetchData(vnode);
+                    }, (err) => {
+                      this.flashMessage.alert(`Unable to schedule an update for '${material.displayName()}' material. ${err.message}`);
+                    });
+                  });
+    };
 
     vnode.state.onEdit = (material: MaterialWithFingerprint, e: MouseEvent) => {
       e.stopPropagation();
@@ -106,8 +120,8 @@ export class MaterialsPage extends Page<null, State> {
       <FlashMessage key={this.flashMessage.type} type={this.flashMessage.type} message={this.flashMessage.message}/>
       , <MaterialsWidget key={filteredMaterials().length} materials={filteredMaterials}
                          shouldShowPackageOrScmLink={Page.isUserAnAdmin() || Page.isUserAGroupAdmin()}
-                         onEdit={vnode.state.onEdit} showModifications={vnode.state.showModifications}
-                         showUsages={vnode.state.showUsages}/>
+                         triggerUpdate={vnode.state.triggerUpdate} onEdit={vnode.state.onEdit}
+                         showModifications={vnode.state.showModifications} showUsages={vnode.state.showUsages}/>
     ];
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_widget.tsx
@@ -22,7 +22,7 @@ import {MaterialModification} from "models/config_repos/types";
 import {MaterialWithFingerprint, MaterialWithModification, PackageMaterialAttributes, PluggableScmMaterialAttributes} from "models/materials/materials";
 import {CollapsiblePanel} from "views/components/collapsible_panel";
 import {FlashMessage, MessageType} from "views/components/flash_message";
-import {Edit, IconGroup, List, Usage} from "views/components/icons";
+import {Edit, IconGroup, List, Refresh, Usage} from "views/components/icons";
 import {KeyValuePair} from "views/components/key_value_pair";
 import {Link} from "views/components/link";
 import headerStyles from "views/pages/config_repos/index.scss";
@@ -69,7 +69,12 @@ export class MaterialWidget extends MithrilViewComponent<MaterialWithInfoAttrs> 
                               onclick={vnode.attrs.onEdit.bind(this, config)}/>;
     }
 
+    const refreshTitle  = material.materialUpdateInProgress
+      ? `Update in progress since ${timeFormatter.format(material.materialUpdateStartTime)}`
+      : "Trigger Update";
     const actionButtons = <IconGroup>
+      <Refresh data-test-id={"trigger-update"} title={refreshTitle}
+               disabled={material.materialUpdateInProgress} onclick={vnode.attrs.triggerUpdate.bind(this, config)}/>
       {maybeEditButton}
       <Usage data-test-id={"show-usages"} title={"Show Usages"} onclick={vnode.attrs.showUsages.bind(this, config)}/>
       <List data-test-id={"show-modifications-material"} title={"Show Modifications"}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_widget.tsx
@@ -69,12 +69,9 @@ export class MaterialWidget extends MithrilViewComponent<MaterialWithInfoAttrs> 
                               onclick={vnode.attrs.onEdit.bind(this, config)}/>;
     }
 
-    const refreshTitle  = material.materialUpdateInProgress
-      ? `Update in progress since ${timeFormatter.format(material.materialUpdateStartTime)}`
-      : "Trigger Update";
     const actionButtons = <IconGroup>
-      <Refresh data-test-id={"trigger-update"} title={refreshTitle}
-               disabled={material.materialUpdateInProgress} onclick={vnode.attrs.triggerUpdate.bind(this, config)}/>
+      <Refresh data-test-id={"trigger-update"} title={this.getTriggerUpdateTitle(material)}
+               disabled={!material.canTriggerUpdate || material.materialUpdateInProgress} onclick={vnode.attrs.triggerUpdate.bind(this, config)}/>
       {maybeEditButton}
       <Usage data-test-id={"show-usages"} title={"Show Usages"} onclick={vnode.attrs.showUsages.bind(this, config)}/>
       <List data-test-id={"show-modifications-material"} title={"Show Modifications"}
@@ -94,6 +91,14 @@ export class MaterialWidget extends MithrilViewComponent<MaterialWithInfoAttrs> 
       <h3>Material Attributes</h3>
       <KeyValuePair data-test-id={"material-attributes"} data={this.getMaterialData(material.config, vnode.attrs.shouldShowPackageOrScmLink)}/>
     </CollapsiblePanel>;
+  }
+
+  private getTriggerUpdateTitle(material: MaterialWithModification) {
+    return material.canTriggerUpdate
+      ? material.materialUpdateInProgress
+        ? `Update in progress since ${timeFormatter.format(material.materialUpdateStartTime)}`
+        : "Trigger Update"
+      : "You do not have permission to trigger an update for this material";
   }
 
   private getMaterialData(material: MaterialWithFingerprint, shouldShowPackageOrScmLink: boolean): Map<string, m.Children> {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/materials_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/materials_widget.tsx
@@ -48,7 +48,8 @@ export class MaterialsWidget extends MithrilViewComponent<MaterialsAttrs> {
     return <div data-test-id="materials-widget">
       {vnode.attrs.materials().map((material) => <MaterialWidget material={material}
                                                                  shouldShowPackageOrScmLink={vnode.attrs.shouldShowPackageOrScmLink}
-                                                                 onEdit={vnode.attrs.onEdit} showModifications={vnode.attrs.showModifications}
+                                                                 triggerUpdate={vnode.attrs.triggerUpdate} onEdit={vnode.attrs.onEdit}
+                                                                 showModifications={vnode.attrs.showModifications}
                                                                  showUsages={vnode.attrs.showUsages}/>)}
     </div>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_header_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_header_widget_spec.tsx
@@ -30,7 +30,7 @@ describe('MaterialHeaderWidgetSpec', () => {
 
   afterEach((done) => helper.unmount(done));
   beforeEach(() => {
-    material = new MaterialWithModification(MaterialWithFingerprint.fromJSON(git()), false, null);
+    material = new MaterialWithModification(MaterialWithFingerprint.fromJSON(git()), false, undefined, null);
   });
 
   it('should display the name of the material with attributes', () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
@@ -33,13 +33,15 @@ describe('MaterialWidgetSpec', () => {
 
   afterEach((done) => helper.unmount(done));
   beforeEach(() => {
-    material = new MaterialWithModification(MaterialWithFingerprint.fromJSON(git()), true, "2019-12-23T10:15:52Z", null);
+    material = new MaterialWithModification(MaterialWithFingerprint.fromJSON(git()), true, true, "2019-12-23T10:15:52Z");
   });
 
   it('should display the header and action buttons', () => {
     mount();
 
     expect(helper.byTestId("material-icon")).toBeInDOM();
+    expect(helper.byTestId("trigger-update")).toBeInDOM();
+    expect(helper.byTestId("show-usages")).toBeInDOM();
     expect(helper.byTestId("show-modifications-material")).toBeInDOM();
   });
 
@@ -164,12 +166,23 @@ describe('MaterialWidgetSpec', () => {
     expect(helper.q('a', helper.byTestId('key-value-value-ref'))).not.toBeInDOM();
   });
 
-  it('should display inprogress bar if material update is in progress', () => {
+  it('should display inprogress bar if material update is in progress and disable the trigger button', () => {
     material.materialUpdateInProgress = true;
     mount();
 
     expect(helper.byTestId("material-update-in-progress")).toBeInDOM();
     expect(helper.byTestId("material-update-in-progress")).toHaveClass(headerStyles.configRepoUpdateInProgress);
+
+    expect(helper.byTestId("trigger-update")).toBeDisabled();
+    expect(helper.byTestId("trigger-update")).toHaveAttr('title', `Update in progress since ${timeFormatter.format(material.materialUpdateStartTime)}`);
+  });
+
+  it('should disable trigger button when canTriggerValue is false', () => {
+    material.canTriggerUpdate = false;
+    mount();
+
+    expect(helper.byTestId("trigger-update")).toBeDisabled();
+    expect(helper.byTestId("trigger-update")).toHaveAttr('title', 'You do not have permission to trigger an update for this material');
   });
 
   function mount(shouldShowPackageOrScmLink: boolean = true) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
@@ -24,15 +24,16 @@ import {MaterialWidget} from "../material_widget";
 import {git} from "./materials_widget_spec";
 
 describe('MaterialWidgetSpec', () => {
-  const helper        = new TestHelper();
-  const showModSpy    = jasmine.createSpy("showModifications");
-  const onEditSpy     = jasmine.createSpy("onEdit");
-  const showUsagesSpy = jasmine.createSpy("showUsages");
+  const helper           = new TestHelper();
+  const showModSpy       = jasmine.createSpy("showModifications");
+  const triggerUpdateSpy = jasmine.createSpy("triggerUpdate");
+  const onEditSpy        = jasmine.createSpy("onEdit");
+  const showUsagesSpy    = jasmine.createSpy("showUsages");
   let material: MaterialWithModification;
 
   afterEach((done) => helper.unmount(done));
   beforeEach(() => {
-    material = new MaterialWithModification(MaterialWithFingerprint.fromJSON(git()), true, null);
+    material = new MaterialWithModification(MaterialWithFingerprint.fromJSON(git()), true, "2019-12-23T10:15:52Z", null);
   });
 
   it('should display the header and action buttons', () => {
@@ -173,6 +174,7 @@ describe('MaterialWidgetSpec', () => {
 
   function mount(shouldShowPackageOrScmLink: boolean = true) {
     helper.mount(() => <MaterialWidget material={material} shouldShowPackageOrScmLink={shouldShowPackageOrScmLink}
-                                       onEdit={onEditSpy} showModifications={showModSpy} showUsages={showUsagesSpy}/>);
+                                       triggerUpdate={triggerUpdateSpy} onEdit={onEditSpy} showModifications={showModSpy}
+                                       showUsages={showUsagesSpy}/>);
   }
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/materials_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/materials_widget_spec.tsx
@@ -45,8 +45,8 @@ describe('MaterialsWidgetSpec', () => {
 
   function mount() {
     helper.mount(() => <MaterialsWidget materials={Stream(materials)} shouldShowPackageOrScmLink={false}
-                                        onEdit={jasmine.createSpy("onEdit")} showModifications={jasmine.createSpy("showModifications")}
-                                        showUsages={jasmine.createSpy("showUsages")}/>);
+                                        triggerUpdate={jasmine.createSpy("triggerUpdate")} onEdit={jasmine.createSpy("onEdit")}
+                                        showModifications={jasmine.createSpy("showModifications")} showUsages={jasmine.createSpy("showUsages")}/>);
   }
 });
 

--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -37,8 +37,8 @@
 
   <rule>
     <name>Internal Materials URL for usages</name>
-    <from>^/api/internal/materials/([^/]+)/usages(/?)$</from>
-    <to last="true">/spark/api/internal/materials/${escape:$1}/usages</to>
+    <from>^/api/internal/materials/([^/]+)/(usages|trigger_update)(/?)$</from>
+    <to last="true">/spark/api/internal/materials/${escape:$1}/${escape:$2}</to>
   </rule>
 
   <rule>

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -917,6 +917,7 @@ public class Routes {
     public static class InternalMaterialConfig {
         public static final String INTERNAL_BASE = "/api/internal/materials";
         public static final String USAGES = "/:fingerprint/usages";
+        public static final String TRIGGER_UPDATE = "/:fingerprint/trigger_update";
 
         public static final String INTERNAL_BASE_MODIFICATIONS = "/api/internal/materials/:fingerprint/modifications";
 


### PR DESCRIPTION
Issue: #8331

Description:
Add a trigger material update button for the materials
 - will be disabled if the user does not have operate permissions for any group
 - will be disabled if a material update is currently in progress. On hover- the update start time will be shown

Preview:

<img width="1647" alt="Screen Shot 2020-09-01 at 2 33 42 PM" src="https://user-images.githubusercontent.com/41165891/91830278-347f6080-ec60-11ea-8b21-261d95fc82c1.png">

 - message shown on successful trigger
    <img width="1674" alt="Screen Shot 2020-09-01 at 2 33 50 PM" src="https://user-images.githubusercontent.com/41165891/91830283-35b08d80-ec60-11ea-9826-444d9ace3ccf.png">
