### PR TITLE
Exponential backoff material update in case of failures

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/Clock.java
+++ b/base/src/main/java/com/thoughtworks/go/util/Clock.java
@@ -19,6 +19,7 @@ import com.thoughtworks.go.utils.Timeout;
 import org.joda.time.DateTime;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Date;
 
 public interface Clock {
@@ -27,6 +28,8 @@ public interface Clock {
     DateTime currentDateTime();
 
     Timestamp currentTimestamp();
+
+    LocalDateTime currentLocalDateTime();
 
     long currentTimeMillis();
 

--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.*;
 
+import static java.lang.Double.parseDouble;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class SystemEnvironment implements Serializable, ConfigDirProvider {
@@ -202,6 +203,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<Boolean> HSTS_HEADER_INCLUDE_SUBDOMAINS = new GoBooleanSystemProperty("gocd.hsts.header.include.subdomains", false);
     public static GoSystemProperty<Boolean> HSTS_HEADER_PRELOAD = new GoBooleanSystemProperty("gocd.hsts.header.preload", false);
     public static GoSystemProperty<Long> EPHEMERAL_AUTO_REGISTER_KEY_EXPIRY = new GoLongSystemProperty("gocd.ephemeral.auto.register.key.expiry.millis", 30 * 60 *1000L);
+    public static GoSystemProperty<Double> MDU_EXPONENTIAL_BACKOFF_MULTIPLIER = new GoDoubleSystemProperty("gocd.mdu.exponential.backoff.multiplier", 1.5);
 
     private final static Map<String, String> GIT_ALLOW_PROTOCOL;
 
@@ -793,6 +795,9 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
         return EPHEMERAL_AUTO_REGISTER_KEY_EXPIRY.getValue();
     }
 
+    public double getMDUExponentialBackOffMultiplier() {
+        return MDU_EXPONENTIAL_BACKOFF_MULTIPLIER.getValue();
+    }
 
     public static abstract class GoSystemProperty<T> {
         private String propertyName;
@@ -840,6 +845,21 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
             try {
                 return Long.parseLong(propertyValueFromSystem);
             } catch (NumberFormatException e) {
+                return defaultValue;
+            }
+        }
+    }
+
+    private static class GoDoubleSystemProperty extends GoSystemProperty<Double> {
+        public GoDoubleSystemProperty(String propertyName, Double defaultValue) {
+            super(propertyName, defaultValue);
+        }
+
+        @Override
+        protected Double convertValue(String propertyValueFromSystem, Double defaultValue) {
+            try {
+                return parseDouble(propertyValueFromSystem);
+            } catch (Exception e) {
                 return defaultValue;
             }
         }

--- a/base/src/main/java/com/thoughtworks/go/util/SystemTimeClock.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemTimeClock.java
@@ -20,7 +20,10 @@ import org.joda.time.DateTime;
 
 import java.io.Serializable;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Date;
+
+import static java.time.LocalDateTime.now;
 
 public class SystemTimeClock implements Clock, Serializable {
     @Override
@@ -36,6 +39,11 @@ public class SystemTimeClock implements Clock, Serializable {
     @Override
     public Timestamp currentTimestamp() {
         return new Timestamp(currentTimeMillis());
+    }
+
+    @Override
+    public LocalDateTime currentLocalDateTime() {
+        return now();
     }
 
     @Override

--- a/base/src/main/java/com/thoughtworks/go/util/TestingClock.java
+++ b/base/src/main/java/com/thoughtworks/go/util/TestingClock.java
@@ -19,10 +19,14 @@ import com.thoughtworks.go.utils.Timeout;
 import org.joda.time.DateTime;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+
+import static java.time.Instant.ofEpochMilli;
+import static java.time.ZoneId.systemDefault;
 
 public class TestingClock implements Clock {
     private Date currentTime;
@@ -49,6 +53,11 @@ public class TestingClock implements Clock {
     @Override
     public Timestamp currentTimestamp() {
         return new Timestamp(currentTimeMillis());
+    }
+
+    @Override
+    public LocalDateTime currentLocalDateTime() {
+        return LocalDateTime.ofInstant(ofEpochMilli(currentTimeMillis()), systemDefault());
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/materials/BackOffResult.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/BackOffResult.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.materials;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class BackOffResult {
+    boolean backOff;
+    private LocalDateTime lastFailureTime;
+    private LocalDateTime failureStartTime;
+    private LocalDateTime nextRetryAttempt;
+
+    public static BackOffResult PERMIT = new BackOffResult(false, null, null, null);
+    public static BackOffResult DENY = new BackOffResult(true, null, null, null);
+
+    public BackOffResult(boolean backOff, LocalDateTime failureStartTime, LocalDateTime lastFailureTime,
+                         LocalDateTime nextRetryAttempt) {
+        this.backOff = backOff;
+        this.lastFailureTime = lastFailureTime;
+        this.failureStartTime = failureStartTime;
+        this.nextRetryAttempt = nextRetryAttempt;
+    }
+
+    public boolean shouldBackOff() {
+        return backOff;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/materials/ExponentialBackOff.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/ExponentialBackOff.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.materials;
+
+import com.thoughtworks.go.util.SystemTimeClock;
+
+import java.time.LocalDateTime;
+
+import static java.lang.Math.round;
+import static java.time.temporal.ChronoUnit.MILLIS;
+
+public class ExponentialBackOff {
+    private LocalDateTime lastFailureTime;
+    private LocalDateTime failureStartTime;
+    private long retryInterval;
+    private final long DEFAULT_INITIAL_INTERVAL_IN_MILLIS = 5 * 60 * 1000;
+    private final long MAX_RETRY_INTERVAL_IN_MILLIS = 60 * 60 * 1000;
+    double multiplier;
+    private SystemTimeClock clock;
+
+    public ExponentialBackOff(double multiplier) {
+        this(multiplier, new SystemTimeClock());
+    }
+
+    protected ExponentialBackOff(double multiplier, SystemTimeClock clock) {
+        this.clock = clock;
+        this.retryInterval = DEFAULT_INITIAL_INTERVAL_IN_MILLIS;
+        this.lastFailureTime = this.failureStartTime = now();
+        this.multiplier = multiplier;
+    }
+
+    public BackOffResult backOffResult() {
+        boolean backOff = lastFailureTime
+                .plus(this.retryInterval, MILLIS)
+                .isAfter(now());
+
+        return new BackOffResult(backOff, failureStartTime, lastFailureTime,
+                lastFailureTime.plus(this.retryInterval, MILLIS));
+    }
+
+    public void failedAgain() {
+        LocalDateTime now = now();
+        this.retryInterval = retryInterval(now);
+        this.lastFailureTime = now;
+    }
+
+    private long retryInterval(LocalDateTime now) {
+        long timeBetweenFailures = lastFailureTime.until(now, MILLIS);
+        long retryInterval = round(timeBetweenFailures * multiplier);
+
+        return retryInterval > MAX_RETRY_INTERVAL_IN_MILLIS
+                ? MAX_RETRY_INTERVAL_IN_MILLIS
+                : retryInterval;
+    }
+
+    private LocalDateTime now() {
+        return clock.currentLocalDateTime();
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/materials/ExponentialBackoffService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/ExponentialBackoffService.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.materials;
+
+import com.thoughtworks.go.domain.materials.Material;
+import com.thoughtworks.go.server.messaging.GoMessageListener;
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@Service
+public class ExponentialBackoffService implements GoMessageListener<MaterialUpdateCompletedMessage>  {
+    private final SystemEnvironment systemEnvironment;
+    private ConcurrentMap<Material, ExponentialBackOff> materials = new ConcurrentHashMap<>();
+
+    @Autowired
+    public ExponentialBackoffService(MaterialUpdateCompletedTopic completed, SystemEnvironment systemEnvironment) {
+        this.systemEnvironment = systemEnvironment;
+        completed.addListener(this);
+    }
+
+    public BackOffResult shouldBackOff(Material material) {
+        ExponentialBackOff exponentialBackOff = materials.get(material);
+
+        if (exponentialBackOff == null) {
+            return BackOffResult.PERMIT;
+        }
+
+        return exponentialBackOff.backOffResult();
+    }
+
+    @Override
+    public void onMessage(MaterialUpdateCompletedMessage message) {
+        if (message instanceof MaterialUpdateFailedMessage) {
+            ExponentialBackOff backOff = materials.get(message.getMaterial());
+
+            if (null == backOff) {
+                materials.put(message.getMaterial(), new ExponentialBackOff(systemEnvironment.getMDUExponentialBackOffMultiplier()));
+            } else {
+                backOff.failedAgain();
+            }
+        } else {
+            materials.remove(message.getMaterial());
+        }
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdater.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdater.java
@@ -124,7 +124,7 @@ public class MaterialDatabaseUpdater {
             String finalMessage = message + affectedPipelinesMessage;
             String errorDescription = e.getMessage() == null ? "Unknown error" : escapeHtml4(e.getMessage());
             healthService.update(ServerHealthState.errorWithHtml(finalMessage, errorDescription, HealthStateType.general(scope)));
-            LOGGER.warn("[Material Update] {}", message, e);
+            LOGGER.debug("[Material Update] {}", message, e);
             throw e;
         }
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/ExponentialBackOffTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/ExponentialBackOffTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.materials;
+
+import com.thoughtworks.go.util.SystemTimeClock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+
+import static java.time.Clock.fixed;
+import static java.time.LocalDateTime.now;
+import static java.time.ZoneId.systemDefault;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ExponentialBackOffTest {
+
+    private SystemTimeClock systemTimeClock;
+
+    @BeforeEach
+    void setUp() {
+        systemTimeClock = mock(SystemTimeClock.class);
+    }
+
+    @Nested
+    class shouldBackOff {
+        @Test
+        void shouldBackOffIfCurrentTimeIsBefore_DefaultRetryInterval() {
+            ExponentialBackOff backOff = new ExponentialBackOff(0);
+
+            assertThat(backOff.backOffResult().shouldBackOff()).isTrue();
+        }
+
+        @Test
+        void shouldBackOffIfCurrentTimeIsBefore_LastFailureTime_Plus_RetryInterval() {
+            Clock tenSecondsFromNow = fixed(Instant.now().plusSeconds(10), systemDefault());
+            when(systemTimeClock.currentLocalDateTime())
+                    .thenReturn(now())
+                    .thenReturn(now(tenSecondsFromNow));
+
+            ExponentialBackOff backOff = new ExponentialBackOff(1.5, systemTimeClock);
+
+            backOff.failedAgain();
+
+            assertThat(backOff.backOffResult().shouldBackOff()).isTrue();
+        }
+
+        @Test
+        void shouldNotBackOffIfCurrentTimeIsAfter_LastFailureTime_Plus_RetryInterval() {
+            Clock fiveSecondsAgo = fixed(Instant.now().minusSeconds(5), systemDefault());
+            when(systemTimeClock.currentLocalDateTime())
+                    .thenReturn(now())
+                    .thenReturn(now(fiveSecondsAgo));
+
+            ExponentialBackOff backOff = new ExponentialBackOff(0.5, systemTimeClock);
+
+            backOff.failedAgain();
+
+            assertThat(backOff.backOffResult().shouldBackOff()).isFalse();
+        }
+
+        @Test
+        void backOffShouldLimitToMaxRetryInterval() {
+            Clock oneHourFromNow = fixed(Instant.now().plusSeconds(61 * 60 * 1000), systemDefault());
+            Clock oneHourTwoMinutesFromNow = fixed(Instant.now().plusSeconds(62 * 60 * 1000), systemDefault());
+            when(systemTimeClock.currentLocalDateTime())
+                    .thenReturn(now())
+                    .thenReturn(now(oneHourFromNow))
+                    .thenReturn(now(oneHourTwoMinutesFromNow));
+
+            ExponentialBackOff backOff = new ExponentialBackOff(2, systemTimeClock);
+
+            backOff.failedAgain();
+
+            assertThat(backOff.backOffResult().shouldBackOff()).isFalse();
+        }
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/ExponentialBackoffServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/ExponentialBackoffServiceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.materials;
+
+import com.thoughtworks.go.config.materials.git.GitMaterial;
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+
+public class ExponentialBackoffServiceTest {
+
+    private MaterialUpdateCompletedTopic materialUpdateCompletedTopic;
+    private ExponentialBackoffService exponentialBackoffService;
+
+    @BeforeEach
+    void setUp() {
+        materialUpdateCompletedTopic = mock(MaterialUpdateCompletedTopic.class);
+        exponentialBackoffService = new ExponentialBackoffService(materialUpdateCompletedTopic, new SystemEnvironment());
+    }
+
+    @Test
+    void shouldBeMaterialUpdateCompleteMessageListener() {
+        MaterialUpdateCompletedTopic completedTopic = mock(MaterialUpdateCompletedTopic.class);
+
+        new ExponentialBackoffService(completedTopic, new SystemEnvironment());
+
+        verify(completedTopic).addListener(any(ExponentialBackoffService.class));
+    }
+
+    @Nested
+    class shouldBackoff {
+        @Test
+        void shouldBackoffUpdatesForMaterialWithMDUFailures() {
+            GitMaterial material = new GitMaterial("http://github.com/example.git", "master");
+            MaterialUpdateFailedMessage failedMessage = new MaterialUpdateFailedMessage(material, 1L, new RuntimeException());
+
+            exponentialBackoffService.onMessage(failedMessage);
+
+            assertThat(exponentialBackoffService.shouldBackOff(material).shouldBackOff()).isTrue();
+        }
+
+        @Test
+        void shouldNotBackOffUpdatesForMaterialWithoutMDUFailures() {
+            assertThat(exponentialBackoffService.shouldBackOff(new GitMaterial("http://github.com/ex.git")).shouldBackOff()).isFalse();
+        }
+
+        @Test
+        void shouldEnsurePreviouslyFailedMaterialsAreNotBackedOffAfterSuccessfulMDU() {
+            GitMaterial material = new GitMaterial("http://github.com/example.git", "master");
+            MaterialUpdateFailedMessage failedMessage = new MaterialUpdateFailedMessage(material, 1L, new RuntimeException());
+
+            exponentialBackoffService.onMessage(failedMessage);
+
+            assertThat(exponentialBackoffService.shouldBackOff(material).shouldBackOff()).isTrue();
+
+            exponentialBackoffService.onMessage(new MaterialUpdateSuccessfulMessage(material, 2L));
+
+            assertThat(exponentialBackoffService.shouldBackOff(material).shouldBackOff()).isFalse();
+        }
+    }
+}

--- a/server/src/test-integration/java/com/thoughtworks/go/server/materials/MaterialUpdateServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/materials/MaterialUpdateServiceIntegrationTest.java
@@ -64,7 +64,7 @@ public class MaterialUpdateServiceIntegrationTest {
 
         MaterialUpdateService materialUpdateService = new MaterialUpdateService(null,null, mock(MaterialUpdateCompletedTopic.class),
                 mock(GoConfigWatchList.class),mock(GoConfigService.class),
-                systemEnvironment, serverHealthService, null, mock(MDUPerformanceLogger.class), materialConfigConverter, null, maintenanceModeService, null);
+                systemEnvironment, serverHealthService, null, mock(MDUPerformanceLogger.class), materialConfigConverter, null, maintenanceModeService, null, null);
 
         materialUpdateService.onConfigChange(configWithMaterial(goodMaterial));
 
@@ -80,7 +80,7 @@ public class MaterialUpdateServiceIntegrationTest {
 
         MaterialUpdateService materialUpdateService = new MaterialUpdateService(null,null, mock(MaterialUpdateCompletedTopic.class),
                 mock(GoConfigWatchList.class),mock(GoConfigService.class),
-                systemEnvironment, serverHealthService, null, mock(MDUPerformanceLogger.class), materialConfigConverter, null, maintenanceModeService, null);
+                systemEnvironment, serverHealthService, null, mock(MDUPerformanceLogger.class), materialConfigConverter, null, maintenanceModeService, null, null);
 
         materialUpdateService.onConfigChange(configWithMaterial(material));
 


### PR DESCRIPTION
* In cases where material update fails continuously, exponentially backoff subsequent updates to reduce unnecessary retries and errors in logs.
* Only material updates through the timer are checked for previous failures and backed-off exponentially.
* The exponential backoff logic ensures a delay between MDU for failing updates. The calculation for the delay is **(time_ between_2_subsequent_failures * MULTIPLIER)**. The MULTIPLIER is defaulted to 1.5, which can be changed by the GoCD System property `gocd.mdu.exponential.backoff.multiplier`
* The backoff logic does not consider any max retires, just that the delay interval increases exponentially.
* A successful MDU would ensure subsequent MDU for the material are not backed-off.
* To force an MDU, material update can be triggered using the manual pipeline trigger or the trigger through the new Materials page.
* Material Update through webhooks do not backoff.
 


