### PR TITLE
Added support for invertFilter for ConfigRepoMaterial type #3962

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -52,6 +52,8 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
 /**
  * Helper to transform config repo classes to config-api classes
  */
@@ -321,21 +323,19 @@ public class ConfigConverter {
         } else if (crMaterial instanceof CRConfigMaterial) {
             CRConfigMaterial crConfigMaterial = (CRConfigMaterial) crMaterial;
             MaterialConfig repoMaterial = cloner.deepClone(context.configMaterial());
-            if (StringUtils.isNotEmpty(crConfigMaterial.getName()))
+            if (isNotEmpty(crConfigMaterial.getName()))
                 repoMaterial.setName(new CaseInsensitiveString(crConfigMaterial.getName()));
-            if (StringUtils.isNotEmpty(crConfigMaterial.getDestination()))
+            if (isNotEmpty(crConfigMaterial.getDestination()))
                 setDestination(repoMaterial, crConfigMaterial.getDestination());
             if (crConfigMaterial.getFilter() != null && !crConfigMaterial.getFilter().isEmpty()) {
                 if (repoMaterial instanceof ScmMaterialConfig) {
                     ScmMaterialConfig scmMaterialConfig = (ScmMaterialConfig) repoMaterial;
                     scmMaterialConfig.setFilter(toFilter(crConfigMaterial.getFilter().getList()));
                     scmMaterialConfig.setInvertFilter(crConfigMaterial.getFilter().isIncluded());
-                } else //must be a pluggable SCM
-                {
+                } else { //must be a pluggable SCM
                     PluggableSCMMaterialConfig pluggableSCMMaterial = (PluggableSCMMaterialConfig) repoMaterial;
                     pluggableSCMMaterial.setFilter(toFilter(crConfigMaterial.getFilter().getList()));
-                    if (crConfigMaterial.getFilter().isIncluded())
-                        throw new ConfigConvertionException("Pluggable SCMs do not support includes");
+                    pluggableSCMMaterial.setInvertFilter(crConfigMaterial.getFilter().isIncluded());
                 }
             }
             return repoMaterial;

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -606,22 +606,21 @@ class ConfigConverterTest {
     }
 
     @Test
-    void shouldFailToConvertConfigMaterialWhenPluggableScmMaterialWithWhitelist() {
+    void shouldConvertConfigMaterialWhenPluggableScmMaterialWithWhitelist() {
         SCM myscm = new SCM("scmid", new PluginConfiguration(), new Configuration());
         SCMs scms = new SCMs(myscm);
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         cruiseConfig.setSCMs(scms);
+        PluggableSCMMaterialConfig configRepoMaterial = new PluggableSCMMaterialConfig(new CaseInsensitiveString("scmid"), myscm, null, null, true);
+
         when(cachedGoConfig.currentConfig()).thenReturn(cruiseConfig);
-        PluggableSCMMaterialConfig configRepoMaterial = new PluggableSCMMaterialConfig(new CaseInsensitiveString("scmid"), myscm, null, null, false);
         when(context.configMaterial()).thenReturn(configRepoMaterial);
+
         CRConfigMaterial crConfigMaterial = new CRConfigMaterial("example", "dest1", new CRFilter(filter, true));
 
-        try {
-            configConverter.toMaterialConfig(crConfigMaterial, context);
-            fail("should have thrown");
-        } catch (ConfigConvertionException ex) {
-            assertThat(ex.getMessage()).isEqualTo("Pluggable SCMs do not support includes");
-        }
+        MaterialConfig pluggableMaterial = configConverter.toMaterialConfig(crConfigMaterial, context);
+
+        assertTrue(pluggableMaterial.isInvertFilter());
     }
 
     @Test


### PR DESCRIPTION
* Adding support for invertFilter for pluggable scm materials passed as
  of  type ConfigRepo from plugin. Refer: https://github.com/tomzo/gocd-yaml-config-plugin/#configrepo

Issue: #3962


