### PR TITLE
Upgrade chromedriver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -245,7 +245,7 @@ rootProject.ext.versions = [
   xmlUnit               : '2.6.3',
 
   seleniumDrivers       : [
-    chromedriver  : '83.0.4103.39',
+    chromedriver  : '86.0.4240.22',
     geckodriver   : '0.21.0',
     iedriverserver: '3.14.0'
   ],


### PR DESCRIPTION
Description:

Old jasmine specs fail with the error `Selenium::WebDriver::Error::SessionNotCreatedError: session not created: This version of ChromeDriver only supports Chrome version 83`.

Upgrade chromedriver to the latest.

