### PR TITLE
Backing up wrapper config dir is optional now #8525

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/backup/BackupStatusUpdater.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/backup/BackupStatusUpdater.java
@@ -41,9 +41,9 @@ public class BackupStatusUpdater implements BackupUpdateListener {
     }
 
     @Override
-    public void completed() {
+    public void completed(String message) {
         serverBackup.markCompleted();
-        serverBackup.setMessage("Backup was generated successfully.");
+        serverBackup.setMessage(message);
         this.serverBackupRepository.update(serverBackup);
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/backup/BackupUpdateListener.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/backup/BackupUpdateListener.java
@@ -22,5 +22,5 @@ public interface BackupUpdateListener {
 
     void error(String message);
 
-    void completed();
+    void completed(String message);
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/backup/progress_indicator.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/backup/progress_indicator.tsx
@@ -64,7 +64,7 @@ export class ProgressIndicator extends MithrilViewComponent<Attrs> {
                       status={this.getStatus(BackupProgressStatus.POST_BACKUP_SCRIPT_START, currentStatus, status)}>
             Executing Post Backup Script</BackupStep>
         </ul>
-        {this.backupComplete(status)}
+        {this.backupComplete(status, vnode.attrs.message)}
       </div>
     );
   }
@@ -90,9 +90,9 @@ export class ProgressIndicator extends MithrilViewComponent<Attrs> {
     }
   }
 
-  private backupComplete(backupStatus: BackupStatus) {
+  private backupComplete(backupStatus: BackupStatus, message: string) {
     if (backupStatus === BackupStatus.COMPLETED) {
-      return <p class={styles.backupMessage}>Backup Completed</p>;
+      return <p class={styles.backupMessage}>{message}</p>;
     }
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/backup/spec/progress_indicator_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/backup/spec/progress_indicator_spec.tsx
@@ -51,7 +51,7 @@ describe("Backup Progress Indicator Widget", () => {
   });
 
   it("should render status after backup is complete", () => {
-    mount(BackupStatus.COMPLETED, "", BackupProgressStatus.POST_BACKUP_SCRIPT_COMPLETE);
+    mount(BackupStatus.COMPLETED, "Backup Completed", BackupProgressStatus.POST_BACKUP_SCRIPT_COMPLETE);
 
     for (let key = BackupProgressStatus.CREATING_DIR; key < BackupProgressStatus.POST_BACKUP_SCRIPT_COMPLETE; key++) {
       expect(helper.byTestId(`step-${key}`)).toHaveClass(styles.backedUp);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/backup/BackupStatusUpdaterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/backup/BackupStatusUpdaterTest.java
@@ -69,7 +69,7 @@ public class BackupStatusUpdaterTest {
         ServerBackup serverBackup = new ServerBackup("path", new Date(), "admin", "a message");
         BackupStatusUpdater backupStatusUpdater = new BackupStatusUpdater(serverBackup, serverBackupRepository);
 
-        backupStatusUpdater.completed();
+        backupStatusUpdater.completed("Backup was generated successfully.");
 
         verify(serverBackupRepository).update(serverBackup);
         assertThat(serverBackup.getMessage()).isEqualTo("Backup was generated successfully.");


### PR DESCRIPTION
* As part of backing up the wrapper config folder, the
  folder location is determined using the env variable
  WRAPPER_CONF_DIR which is set by Tanuki wrapper during startup.
  Starting the GoCD server not as a service would not set the
  env variable and would hence fail the backup. Hence making
  it optional.

Issue: #8525


