### PR TITLE
Fix job rerun icon positioning on stage overview

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
@@ -139,8 +139,7 @@ $building: #ffc11b;
   }
 
   .rerun-wrapper {
-    margin-top:  20px;
-    margin-left: 17px;
+    left: 36px;
   }
 }
 
@@ -351,12 +350,14 @@ $building: #ffc11b;
 }
 
 .rerun-wrapper {
-  position:    absolute;
   transform:   rotate(150deg);
-  margin-top:  10px;
-  margin-left: 10px;
   font-weight: 900;
   font-size:   14px;
+  position:    relative;
+  left:        38px;
+  top:         29px;
+  width:       0;
+  height:      0;
   color:       $dark-gray;
 
   i {


### PR DESCRIPTION
BUG:
	Due to absolute positioning of the rerun icon, icons are rendered outside of the stage overview and are rendered at the fixed position even when scrolling.

![Screen Shot 2020-09-10 at 3 43 56 PM](https://user-images.githubusercontent.com/15275847/92716885-0b0bb680-f37d-11ea-89ac-048ede037902.png)
![Screen Shot 2020-09-10 at 3 44 05 PM](https://user-images.githubusercontent.com/15275847/92716902-0fd06a80-f37d-11ea-9062-4d47269c0476.png)


FIX:
	Use relative positioning. Align rerun icon on the job state icon using transform and left positioning.
