### PR TITLE
Fix issues related materials spa

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials.tsx
@@ -89,15 +89,7 @@ export class MaterialsPage extends Page<null, State> {
 
     vnode.state.showUsages = (material: MaterialWithFingerprint, e: MouseEvent) => {
       e.stopPropagation();
-      MaterialAPIs.usages(material.fingerprint())
-                  .then((result) => {
-                    result.do(
-                      (successResponse) => {
-                        new ShowUsagesModal(material, successResponse.body).render();
-                      },
-                      this.onOperationError(vnode)
-                    );
-                  });
+      new ShowUsagesModal(material).render();
     };
 
     vnode.state.showModifications = (material: MaterialWithFingerprint, e: MouseEvent) => {
@@ -154,12 +146,6 @@ export class MaterialsPage extends Page<null, State> {
       buttons.push(searchBox);
     }
     return <HeaderPanel title={this.pageName()} buttons={buttons} help={this.helpText()}/>;
-  }
-
-  private onOperationError(vnode: m.Vnode<null, State>): (errorResponse: ErrorResponse) => void {
-    return (errorResponse: ErrorResponse) => {
-      this.flashMessage.alert(JSON.parse(errorResponse.body!).message);
-    };
   }
 
   private refreshMaterials(vnode: m.Vnode<null, State>) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss
@@ -180,13 +180,6 @@ $button_color: #2d6ca2;
   float:         left;
 }
 
-.username {
-  width:         100%;
-  overflow:      hidden;
-  text-overflow: ellipsis;
-  white-space:   nowrap;
-}
-
 .comment {
   white-space: pre-wrap;
   max-height:  160px;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss.d.ts
@@ -33,6 +33,5 @@ export const truncate: string;
 export const unknown: string;
 export const usages: string;
 export const user: string;
-export const username: string;
 export const version: string;
 export const warnings: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_widget.tsx
@@ -70,12 +70,15 @@ export class MaterialWidget extends MithrilViewComponent<MaterialWithInfoAttrs> 
                               onclick={vnode.attrs.onEdit.bind(this, config)}/>;
     }
 
-    const actionButtons = <IconGroup>
+    const modificationIconTitle = material.modification === null
+      ? "No modifications to show"
+      : "Show Modifications";
+    const actionButtons         = <IconGroup>
       <Refresh data-test-id={"trigger-update"} title={this.getTriggerUpdateTitle(material)}
                disabled={!material.canTriggerUpdate || material.materialUpdateInProgress} onclick={vnode.attrs.triggerUpdate.bind(this, material)}/>
       {maybeEditButton}
       <Usage data-test-id={"show-usages"} title={"Show Usages"} onclick={vnode.attrs.showUsages.bind(this, config)}/>
-      <List data-test-id={"show-modifications-material"} title={"Show Modifications"}
+      <List data-test-id={"show-modifications-material"} title={modificationIconTitle} disabled={material.modification === null}
             onclick={vnode.attrs.showModifications.bind(this, config)}/>
     </IconGroup>;
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/material_widget.tsx
@@ -72,7 +72,7 @@ export class MaterialWidget extends MithrilViewComponent<MaterialWithInfoAttrs> 
 
     const actionButtons = <IconGroup>
       <Refresh data-test-id={"trigger-update"} title={this.getTriggerUpdateTitle(material)}
-               disabled={!material.canTriggerUpdate || material.materialUpdateInProgress} onclick={vnode.attrs.triggerUpdate.bind(this, config)}/>
+               disabled={!material.canTriggerUpdate || material.materialUpdateInProgress} onclick={vnode.attrs.triggerUpdate.bind(this, material)}/>
       {maybeEditButton}
       <Usage data-test-id={"show-usages"} title={"Show Usages"} onclick={vnode.attrs.showUsages.bind(this, config)}/>
       <List data-test-id={"show-modifications-material"} title={"Show Modifications"}
@@ -101,7 +101,9 @@ export class MaterialWidget extends MithrilViewComponent<MaterialWithInfoAttrs> 
   private getTriggerUpdateTitle(material: MaterialWithModification): string {
     return material.canTriggerUpdate
       ? material.materialUpdateInProgress
-        ? `Update in progress since ${timeFormatter.format(material.materialUpdateStartTime)}`
+        ? material.materialUpdateStartTime
+          ? `Update in progress since ${timeFormatter.format(material.materialUpdateStartTime)}`
+          : "Update in progress"
         : "Trigger Update"
       : "You do not have permission to trigger an update for this material";
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/modal.tsx
@@ -94,10 +94,11 @@ export class ShowModificationsModal extends Modal {
         {this.modifications().map((mod, index) => {
           const details = MaterialWidget.showModificationDetails(mod);
           ShowModificationsModal.updateWithVsmLink(details, mod, this.material.fingerprint());
+          const username = details.get("Username");
           return <div data-test-id={`mod-${index}`} class={styles.modification}>
             <div class={styles.user}>
-              <div class={styles.username} data-test-id="mod-username">{details.get("Username")}</div>
-              <div class={styles.username} data-test-id="mod-modified-time">{details.get("Modified Time")}</div>
+              <div className={styles.truncate} data-test-id="mod-username" title={username}>{username}</div>
+              <div className={styles.truncate} data-test-id="mod-modified-time">{details.get("Modified Time")}</div>
             </div>
             <div class={styles.commentWrapper} data-test-id="mod-comment">
               <CommentRenderer text={details.get("Comment")}/>
@@ -116,9 +117,10 @@ export class ShowModificationsModal extends Modal {
   }
 
   private static updateWithVsmLink(details: Map<string, m.Children>, mod: MaterialModification, fingerprint: string) {
-    const vsmLink = <Link dataTestId={"vsm-link"} href={SparkRoutes.materialsVsmLink(fingerprint, mod.revision)}
-                          title={"Value Stream Map"}>VSM</Link>;
-    details.set("Revision", <div><span class={styles.revision}>{details.get("Revision")} </span>| {vsmLink}</div>);
+    const vsmLink  = <Link dataTestId={"vsm-link"} href={SparkRoutes.materialsVsmLink(fingerprint, mod.revision)}
+                           title={"Value Stream Map"}>VSM</Link>;
+    const revision = details.get("Revision");
+    details.set("Revision", <div><span class={styles.revision} title={revision}>{revision} </span>| {vsmLink}</div>);
   }
 
   private onPageChange(link: string) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/modal.tsx
@@ -58,7 +58,7 @@ export class ShowModificationsModal extends Modal {
     </div>;
     const header    = <HeaderPanel title={title} buttons={searchBox}/>;
 
-    if (this.errorMessage()) {
+    if (!_.isEmpty(this.errorMessage())) {
       return <div data-test-id="modifications-modal" class={styles.modificationModal}>
         {header}
         <div className={styles.modificationWrapper}>
@@ -125,22 +125,27 @@ export class ShowModificationsModal extends Modal {
     this.fetchModifications(link);
   }
 
-  private onPatternChange() {
+  private onPatternChange(e: InputEvent) {
+    // @ts-ignore
+    this.searchQuery(e.target!.value);  // this needs to be done as the oninput method is called before the property stream gets updated
     _.throttle(() => this.fetchModifications(), 500, {trailing: true})();
   }
 
   private fetchModifications(link?: string) {
-    this.operationInProgress(true);
-    this.service.fetchHistory(this.material.fingerprint(), this.searchQuery(), link,
-                              (mods) => {
-                                this.modifications(mods);
-                                this.operationInProgress(false);
-                                this.focusOnSearchBox();
-                              },
-                              (errMsg) => {
-                                this.errorMessage(errMsg);
-                                this.operationInProgress(false);
-                              });
+    if (this.operationInProgress() !== true) {
+      this.operationInProgress(true);
+      this.errorMessage("");
+      this.service.fetchHistory(this.material.fingerprint(), this.searchQuery(), link,
+                                (mods) => {
+                                  this.modifications(mods);
+                                  this.operationInProgress(false);
+                                  this.focusOnSearchBox();
+                                },
+                                (errMsg) => {
+                                  this.errorMessage(errMsg);
+                                  this.operationInProgress(false);
+                                });
+    }
 
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/modal.tsx
@@ -61,7 +61,9 @@ export class ShowModificationsModal extends Modal {
     if (this.errorMessage()) {
       return <div data-test-id="modifications-modal" class={styles.modificationModal}>
         {header}
-        <FlashMessage type={MessageType.alert} message={this.errorMessage()}/>
+        <div className={styles.modificationWrapper}>
+          <FlashMessage type={MessageType.alert} message={this.errorMessage()}/>
+        </div>
       </div>;
     }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
@@ -34,7 +34,7 @@ describe('MaterialWidgetSpec', () => {
 
   afterEach((done) => helper.unmount(done));
   beforeEach(() => {
-    material = new MaterialWithModification(MaterialWithFingerprint.fromJSON(git()), true, true, "2019-12-23T10:15:52Z");
+    material = new MaterialWithModification(MaterialWithFingerprint.fromJSON(git()), true, false, "2019-12-23T10:15:52Z");
   });
 
   it('should display the header and action buttons', () => {
@@ -195,6 +195,24 @@ describe('MaterialWidgetSpec', () => {
     expect(helper.byTestId('message-0', helper.byTestId('warnings'))).toBeInDOM();
     expect(helper.byTestId('errors')).toBeInDOM();
     expect(helper.byTestId('message-0', helper.byTestId('errors'))).toBeInDOM();
+  });
+
+  it('should not show material mdu start time if undefined', () => {
+    material.materialUpdateInProgress = true;
+    material.materialUpdateStartTime  = undefined;
+    mount();
+
+    expect(helper.byTestId("trigger-update")).toBeDisabled();
+    expect(helper.byTestId("trigger-update")).toHaveAttr('title', 'Update in progress');
+  });
+
+  it('should send a callback to trigger update method', () => {
+    mount();
+
+    helper.clickByTestId("trigger-update");
+
+    expect(triggerUpdateSpy).toHaveBeenCalled();
+    expect(triggerUpdateSpy).toHaveBeenCalledWith(material, jasmine.any(MouseEvent));
   });
 
   function mount(shouldShowPackageOrScmLink: boolean = true) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/spec/material_widget_spec.tsx
@@ -117,8 +117,22 @@ describe('MaterialWidgetSpec', () => {
     expect(helper.q('span span', attrs[4])).toHaveAttr('title', '23 Dec, 2019 at 10:25:52 +00:00 Server Time');
   });
 
-  it('should send a callback to showModifications method', () => {
+  it('should disable modifications icon when modification is null', () => {
     mount();
+
+    expect(helper.byTestId("show-modifications-material")).toBeInDOM();
+    expect(helper.byTestId("show-modifications-material")).toBeDisabled();
+    expect(helper.byTestId("show-modifications-material")).toHaveAttr('title', 'No modifications to show');
+  });
+
+  it('should send a callback to showModifications method', () => {
+    material.modification
+      = new MaterialModification("GoCD Test User <devnull@example.com>", null, "b9b4f4b758e91117d70121a365ba0f8e37f89a9d", "Initial commit", "2019-12-23T10:25:52Z");
+    mount();
+
+    expect(helper.byTestId("show-modifications-material")).toBeInDOM();
+    expect(helper.byTestId("show-modifications-material")).not.toBeDisabled();
+    expect(helper.byTestId("show-modifications-material")).toHaveAttr('title', 'Show Modifications');
 
     helper.clickByTestId("show-modifications-material");
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/modals.tsx
@@ -60,9 +60,8 @@ abstract class PluggableScmModal extends EntityModal<Scm> {
       this.errorMessage(JSON.parse(errorResponse.body).message);
     } else if (errorResponse.data) {
       this.entity(Scm.fromJSON(errorResponse.data));
-    } else {
-      this.errorMessage(errorResponse.message);
     }
+    this.errorMessage(errorResponse.message);
   }
 
   buttons(): any[] {


### PR DESCRIPTION
Description:

 - Do not re-fetch data on triggering update for a material
    - set `materialUpdateInProgress` to true - disables the trigger button and shows the progress bar
    - do not render date in the onHover text
 - Render usages modal nd make the API call for fetching usages
 - Show error messages on modifications modal completely - update the position based on the height of the header
 - Clearing search result would now render the modifications
     - earlier the `oninput` method was called before the stream was updated
    - now setting the stream value to the `targetElement.value` makes sure that the api call takes in the latest value
 - Showing complete username and revision in hover text on modifications modal
 - Disable modifications icon when `material.modification` is null as this would mean there are no modifications to render