### PR TITLE
Updated yaml plugin to 0.13.0

### DIFF
--- a/Dojofile
+++ b/Dojofile
@@ -1,2 +1,2 @@
 # For building GoCD in docker see https://github.com/kudulab/docker-gocd-dojo
-DOJO_DOCKER_IMAGE=kudulab/gocd-dojo:2.1.0
+DOJO_DOCKER_IMAGE=kudulab/gocd-dojo:2.2.0

--- a/tw-go-plugins/build.gradle
+++ b/tw-go-plugins/build.gradle
@@ -48,9 +48,9 @@ def dependencies = [
   new GithubArtifact(
     user: 'tomzo',
     repo: 'gocd-yaml-config-plugin',
-    tagName: '0.12.0',
-    asset: 'yaml-config-plugin-0.12.0.jar',
-    checksum: '9eeeec3f90adf8c6e96a72e879558e699da4558960d21ad4ab17a3e3b9a2ec62'
+    tagName: '0.13.0',
+    asset: 'yaml-config-plugin-0.13.0.jar',
+    checksum: 'be113ca18b8fefdb20b04cd59ec9b56c4e877c0f2b017207690c1c32efd6d772'
   ),
   new GithubArtifact(
     user: 'tomzo',


### PR DESCRIPTION
Issue: #8266

Description:
Updates YAML plugin to 0.13.0 - which now supports format_version: 10.

What I tested:
Built GoCD from this branch.
Started a dev server.
Added a config repo with format_version:9 and some whitelist/blacklist uses in it
Renamed whitelist/blacklist to includes/ignore
Switched format version to 10

Commit history for the test: https://github.com/tomzo/gocd-yaml-config-example/commits/f10

Basically, a graceful way of upgrading and migrating the keywords will be possible now.

