### PR TITLE
Plugin and Package materials are updated on changes to global SCM or …

### DIFF
--- a/config/config-api/src/test/java/com/thoughtworks/go/domain/scm/SCMMother.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/domain/scm/SCMMother.java
@@ -15,8 +15,7 @@
  */
 package com.thoughtworks.go.domain.scm;
 
-import com.thoughtworks.go.domain.config.Configuration;
-import com.thoughtworks.go.domain.config.PluginConfiguration;
+import com.thoughtworks.go.domain.config.*;
 
 public class SCMMother {
     public static SCM create(String id) {
@@ -31,5 +30,17 @@ public class SCMMother {
         scm.setPluginConfiguration(new PluginConfiguration(pluginId, pluginVersion));
         scm.setConfiguration(configuration);
         return scm;
+    }
+
+    public static SCM create(String scmId, String... properties) {
+        SCM scmConfig = create(scmId);
+        Configuration configuration = new Configuration();
+        for (String property : properties) {
+            ConfigurationProperty configurationProperty = new ConfigurationProperty(new ConfigurationKey(property), new ConfigurationValue(property + "-value"));
+            configuration.add(configurationProperty);
+        }
+        scmConfig.setConfiguration(configuration);
+
+        return scmConfig;
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/helper/MaterialConfigsMother.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/helper/MaterialConfigsMother.java
@@ -282,14 +282,11 @@ public class MaterialConfigsMother {
     }
 
     public static PluggableSCMMaterialConfig pluggableSCMMaterialConfigWithConfigProperties(String... properties) {
-        SCM scmConfig = SCMMother.create("scm-id");
-        Configuration configuration = new Configuration();
-        for (String property : properties) {
-            ConfigurationProperty configurationProperty = new ConfigurationProperty(new ConfigurationKey(property), new ConfigurationValue(property + "-value"));
-            configuration.add(configurationProperty);
-        }
-        scmConfig.setConfiguration(configuration);
-        return new PluggableSCMMaterialConfig(null, scmConfig, "des-folder", null, false);
+        return new PluggableSCMMaterialConfig(null, SCMMother.create("scm-id", properties), "des-folder", null, false);
+    }
+
+    public static PluggableSCMMaterialConfig pluggableSCMMaterialConfig(String scmId, String... properties) {
+        return new PluggableSCMMaterialConfig(null, SCMMother.create(scmId, properties), "des-folder", null, false);
     }
 
     public static PluggableSCMMaterialConfig pluggableSCMMaterialConfig(String scmId, String destinationFolder, Filter filter) {

--- a/server/src/main/java/com/thoughtworks/go/server/materials/SCMMaterialSource.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/SCMMaterialSource.java
@@ -15,11 +15,13 @@
  */
 package com.thoughtworks.go.server.materials;
 
-import com.thoughtworks.go.config.CruiseConfig;
-import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.domain.materials.Material;
+import com.thoughtworks.go.domain.packagerepository.PackageDefinition;
+import com.thoughtworks.go.domain.packagerepository.PackageRepository;
+import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.listener.ConfigChangedListener;
 import com.thoughtworks.go.listener.EntityConfigChangedListener;
 import com.thoughtworks.go.server.service.GoConfigService;
@@ -31,9 +33,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -63,7 +63,12 @@ public class SCMMaterialSource extends EntityConfigChangedListener<ConfigRepoCon
 
     public void initialize() {
         goConfigService.register(this);
-        goConfigService.register(pipelineConfigChangedListener());
+        goConfigService.register(new InternalConfigChangeListener() {
+            @Override
+            public void onEntityConfigChange(Object entity) {
+                updateSchedulableMaterials(true);
+            }
+        });
         materialUpdateService.registerMaterialSources(this);
         materialUpdateService.registerMaterialUpdateCompleteListener(this);
     }
@@ -132,6 +137,20 @@ public class SCMMaterialSource extends EntityConfigChangedListener<ConfigRepoCon
     private void updateSchedulableMaterials(boolean forceLoad) {
         if (forceLoad || schedulableMaterials == null) {
             schedulableMaterials = materialConfigConverter.toMaterials(goConfigService.getSchedulableSCMMaterials());
+        }
+    }
+
+    private abstract class InternalConfigChangeListener extends EntityConfigChangedListener<Object> {
+        private final List<Class<?>> securityConfigClasses = Arrays.asList(
+                PipelineConfig.class,
+                PackageDefinition.class,
+                PackageRepository.class,
+                SCM.class
+        );
+
+        @Override
+        public boolean shouldCareAbout(Object entity) {
+            return securityConfigClasses.stream().anyMatch(aClass -> aClass.isAssignableFrom(entity.getClass()));
         }
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/materials/PluggableSCMMaterialPoller.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/materials/PluggableSCMMaterialPoller.java
@@ -15,7 +15,6 @@
  */
 package com.thoughtworks.go.server.service.materials;
 
-import com.thoughtworks.go.config.SecretParams;
 import com.thoughtworks.go.config.materials.PluggableSCMMaterial;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
 import com.thoughtworks.go.domain.MaterialInstance;

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/SCMMaterialSourceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/SCMMaterialSourceTest.java
@@ -17,11 +17,18 @@ package com.thoughtworks.go.server.materials;
 
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.config.materials.git.GitMaterial;
+import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.domain.materials.Material;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
+import com.thoughtworks.go.domain.packagerepository.PackageDefinition;
+import com.thoughtworks.go.domain.packagerepository.PackageRepository;
+import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.helper.MaterialsMother;
+import com.thoughtworks.go.listener.ConfigChangedListener;
 import com.thoughtworks.go.listener.EntityConfigChangedListener;
+import com.thoughtworks.go.listener.SecurityConfigChangeListener;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.MaterialConfigConverter;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
@@ -31,12 +38,12 @@ import org.joda.time.DateTimeUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -70,10 +77,10 @@ public class SCMMaterialSourceTest {
 
     @Test
     public void shouldListAllSchedulableSCMMaterials_schedulableMaterials() {
-        Set<MaterialConfig> schedulableMaterialConfigs = new HashSet<>(Collections.singleton(svnMaterial.config()));
+        Set<MaterialConfig> schedulableMaterialConfigs = new HashSet<>(singleton(svnMaterial.config()));
 
         when(goConfigService.getSchedulableSCMMaterials()).thenReturn(schedulableMaterialConfigs);
-        when(materialConfigConverter.toMaterials(schedulableMaterialConfigs)).thenReturn(new HashSet<>(Collections.singleton(svnMaterial)));
+        when(materialConfigConverter.toMaterials(schedulableMaterialConfigs)).thenReturn(new HashSet<>(singleton(svnMaterial)));
 
         Set<Material> materials = source.materialsForUpdate();
 
@@ -104,15 +111,116 @@ public class SCMMaterialSourceTest {
 
     @Test
     public void shouldListenToConfigChange() {
-        EntityConfigChangedListener entityConfigChangedListener = mock(EntityConfigChangedListener.class);
         source = spy(source);
-
-        when(source.pipelineConfigChangedListener()).thenReturn(entityConfigChangedListener);
 
         source.initialize();
 
         verify(goConfigService).register(source);
-        verify(goConfigService).register(entityConfigChangedListener);
+    }
+
+    @Test
+    public void shouldRefreshMaterialCacheOnPipelineConfigChange() {
+        GitMaterialConfig gitMaterial = new GitMaterialConfig();
+        gitMaterial.setUrl("http://github.com/gocd/gocd");
+        ArgumentCaptor<EntityConfigChangedListener> captor = ArgumentCaptor.forClass(EntityConfigChangedListener.class);
+
+        doNothing().when(goConfigService).register(captor.capture());
+        when(goConfigService.getSchedulableSCMMaterials())
+                .thenReturn(emptySet())
+                .thenReturn(singleton(gitMaterial));
+
+        source = new SCMMaterialSource(goConfigService, systemEnvironment, new MaterialConfigConverter(), materialUpdateService);
+        source.initialize();
+
+        EntityConfigChangedListener entityConfigChangedListener = captor.getAllValues().get(1);
+
+        assertTrue(entityConfigChangedListener.shouldCareAbout(new PipelineConfig()));
+        assertThat(source.materialsForUpdate().size(), is(0));
+
+        entityConfigChangedListener.onEntityConfigChange(new PipelineConfig());
+
+        Set<Material> materials = source.materialsForUpdate();
+        assertThat(materials.size(), is(1));
+        assertThat(materials.iterator().next().getFingerprint(), is(gitMaterial.getFingerprint()));
+    }
+
+    @Test
+    public void shouldRefreshMaterialCacheOnPackageDefinitionChange() {
+        GitMaterialConfig gitMaterial = new GitMaterialConfig();
+        gitMaterial.setUrl("http://github.com/gocd/gocd");
+        ArgumentCaptor<EntityConfigChangedListener> captor = ArgumentCaptor.forClass(EntityConfigChangedListener.class);
+
+        doNothing().when(goConfigService).register(captor.capture());
+        when(goConfigService.getSchedulableSCMMaterials())
+                .thenReturn(emptySet())
+                .thenReturn(singleton(gitMaterial));
+
+
+        source = new SCMMaterialSource(goConfigService, systemEnvironment, new MaterialConfigConverter(), materialUpdateService);
+        source.initialize();
+
+        EntityConfigChangedListener entityConfigChangedListener = captor.getAllValues().get(1);
+
+        assertTrue(entityConfigChangedListener.shouldCareAbout(new PackageDefinition()));
+        assertThat(source.materialsForUpdate().size(), is(0));
+
+        entityConfigChangedListener.onEntityConfigChange(new PackageDefinition());
+
+        Set<Material> materials = source.materialsForUpdate();
+        assertThat(materials.size(), is(1));
+        assertThat(materials.iterator().next().getFingerprint(), is(gitMaterial.getFingerprint()));
+    }
+
+    @Test
+    public void shouldRefreshMaterialCacheOnPackageRepositoryChange() {
+        GitMaterialConfig gitMaterial = new GitMaterialConfig();
+        gitMaterial.setUrl("http://github.com/gocd/gocd");
+        ArgumentCaptor<EntityConfigChangedListener> captor = ArgumentCaptor.forClass(EntityConfigChangedListener.class);
+
+        doNothing().when(goConfigService).register(captor.capture());
+        when(goConfigService.getSchedulableSCMMaterials())
+                .thenReturn(emptySet())
+                .thenReturn(singleton(gitMaterial));
+
+        source = new SCMMaterialSource(goConfigService, systemEnvironment, new MaterialConfigConverter(), materialUpdateService);
+        source.initialize();
+
+        EntityConfigChangedListener entityConfigChangedListener = captor.getAllValues().get(1);
+
+        assertTrue(entityConfigChangedListener.shouldCareAbout(new PackageRepository()));
+        assertThat(source.materialsForUpdate().size(), is(0));
+
+        entityConfigChangedListener.onEntityConfigChange(new PackageRepository());
+
+        Set<Material> materials = source.materialsForUpdate();
+        assertThat(materials.size(), is(1));
+        assertThat(materials.iterator().next().getFingerprint(), is(gitMaterial.getFingerprint()));
+    }
+
+    @Test
+    public void shouldRefreshMaterialCacheOnSCMChange() {
+        GitMaterialConfig gitMaterial = new GitMaterialConfig();
+        gitMaterial.setUrl("http://github.com/gocd/gocd");
+        ArgumentCaptor<EntityConfigChangedListener> captor = ArgumentCaptor.forClass(EntityConfigChangedListener.class);
+
+        doNothing().when(goConfigService).register(captor.capture());
+        when(goConfigService.getSchedulableSCMMaterials())
+                .thenReturn(emptySet())
+                .thenReturn(singleton(gitMaterial));
+
+        source = new SCMMaterialSource(goConfigService, systemEnvironment, new MaterialConfigConverter(), materialUpdateService);
+        source.initialize();
+
+        EntityConfigChangedListener entityConfigChangedListener = captor.getAllValues().get(1);
+
+        assertTrue(entityConfigChangedListener.shouldCareAbout(new SCM()));
+        assertThat(source.materialsForUpdate().size(), is(0));
+
+        entityConfigChangedListener.onEntityConfigChange(new SCM());
+
+        Set<Material> materials = source.materialsForUpdate();
+        assertThat(materials.size(), is(1));
+        assertThat(materials.iterator().next().getFingerprint(), is(gitMaterial.getFingerprint()));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
@@ -17,12 +17,19 @@ package com.thoughtworks.go.server.service;
 
 import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.materials.MaterialConfigs;
+import com.thoughtworks.go.config.materials.PackageMaterialConfig;
+import com.thoughtworks.go.config.materials.PluggableSCMMaterialConfig;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
 import com.thoughtworks.go.config.pluggabletask.PluggableTask;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
+import com.thoughtworks.go.domain.config.Configuration;
+import com.thoughtworks.go.domain.config.ConfigurationProperty;
+import com.thoughtworks.go.domain.packagerepository.*;
+import com.thoughtworks.go.domain.scm.SCM;
+import com.thoughtworks.go.domain.scm.SCMMother;
 import com.thoughtworks.go.helper.JobConfigMother;
-import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.presentation.CanDeleteResult;
 import com.thoughtworks.go.server.service.tasks.PluggableTaskService;
@@ -35,8 +42,10 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.thoughtworks.go.helper.EnvironmentConfigMother.environment;
-import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
+import static com.thoughtworks.go.helper.MaterialConfigsMother.*;
 import static com.thoughtworks.go.helper.PipelineConfigMother.createGroup;
+import static com.thoughtworks.go.helper.PipelineConfigMother.pipelineConfig;
+import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
@@ -56,7 +65,7 @@ public class PipelineConfigServiceTest {
         downstream(configs);
         cruiseConfig = new BasicCruiseConfig(configs);
         cruiseConfig.addEnvironment(environment("foo", "in_env"));
-        PipelineConfig remotePipeline = PipelineConfigMother.pipelineConfig("remote");
+        PipelineConfig remotePipeline = pipelineConfig("remote");
         remotePipeline.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(git("url"), "plugin", "id"), "1234"));
         cruiseConfig.addPipeline("group", remotePipeline);
 
@@ -91,7 +100,7 @@ public class PipelineConfigServiceTest {
     }
 
     private void downstream(PipelineConfigs configs) {
-        PipelineConfig down = PipelineConfigMother.pipelineConfig("down");
+        PipelineConfig down = pipelineConfig("down");
         down.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("pipeline"), new CaseInsensitiveString("mingle")));
         configs.add(down);
     }
@@ -107,7 +116,7 @@ public class PipelineConfigServiceTest {
         job1.addTask(xUnit);
         job2.addTask(docker);
 
-        PipelineConfig pipeline = PipelineConfigMother.pipelineConfig("P1", new StageConfig(new CaseInsensitiveString("S1"), new JobConfigs(job1)),
+        PipelineConfig pipeline = pipelineConfig("P1", new StageConfig(new CaseInsensitiveString("S1"), new JobConfigs(job1)),
                 new StageConfig(new CaseInsensitiveString("S2"), new JobConfigs(job2)));
 
         pipelineConfigService.updatePipelineConfig(null, pipeline, "group", null, null);
@@ -127,7 +136,7 @@ public class PipelineConfigServiceTest {
         job1.addTask(xUnit);
         job2.addTask(docker);
 
-        PipelineConfig pipeline = PipelineConfigMother.pipelineConfig("P1", new StageConfig(new CaseInsensitiveString("S1"), new JobConfigs(job1)),
+        PipelineConfig pipeline = pipelineConfig("P1", new StageConfig(new CaseInsensitiveString("S1"), new JobConfigs(job1)),
                 new StageConfig(new CaseInsensitiveString("S2"), new JobConfigs(job2)));
 
         pipelineConfigService.createPipelineConfig(null, pipeline, null, null);
@@ -145,7 +154,7 @@ public class PipelineConfigServiceTest {
     public void pipelineCountShouldIncludeConfigRepoPipelinesAsWell() {
         CruiseConfig mergedCruiseConfig = new Cloner().deepClone(cruiseConfig);
         ReflectionUtil.setField(mergedCruiseConfig, "allPipelineConfigs", null);
-        mergedCruiseConfig.addPipeline("default", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
+        mergedCruiseConfig.addPipeline("default", pipelineConfig(UUID.randomUUID().toString()));
         when(goConfigService.cruiseConfig()).thenReturn(mergedCruiseConfig);
         when(goConfigService.getConfigForEditing()).thenReturn(cruiseConfig);
         when(goConfigService.getAllPipelineConfigs()).thenReturn(mergedCruiseConfig.getAllPipelineConfigs());
@@ -157,9 +166,9 @@ public class PipelineConfigServiceTest {
     public void shouldGetAllViewableMergePipelineConfigs() throws Exception {
         CruiseConfig mergedCruiseConfig = new Cloner().deepClone(cruiseConfig);
         ReflectionUtil.setField(mergedCruiseConfig, "allPipelineConfigs", null);
-        mergedCruiseConfig.addPipeline("group1", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
-        mergedCruiseConfig.addPipeline("group2", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
-        mergedCruiseConfig.addPipeline("group3", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
+        mergedCruiseConfig.addPipeline("group1", pipelineConfig(UUID.randomUUID().toString()));
+        mergedCruiseConfig.addPipeline("group2", pipelineConfig(UUID.randomUUID().toString()));
+        mergedCruiseConfig.addPipeline("group3", pipelineConfig(UUID.randomUUID().toString()));
 
         when(goConfigService.getMergedConfigForEditing()).thenReturn(mergedCruiseConfig);
         when(goConfigService.getAllPipelineConfigs()).thenReturn(mergedCruiseConfig.getAllPipelineConfigs());
@@ -182,8 +191,8 @@ public class PipelineConfigServiceTest {
     public void shouldGetAllViewableGroups() throws Exception {
         CruiseConfig cruiseConfig = new Cloner().deepClone(this.cruiseConfig);
         ReflectionUtil.setField(cruiseConfig, "allPipelineConfigs", null);
-        cruiseConfig.addPipeline("group1", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
-        cruiseConfig.addPipeline("group2", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
+        cruiseConfig.addPipeline("group1", pipelineConfig(UUID.randomUUID().toString()));
+        cruiseConfig.addPipeline("group2", pipelineConfig(UUID.randomUUID().toString()));
 
         when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
         when(goConfigService.getAllPipelineConfigs()).thenReturn(cruiseConfig.getAllPipelineConfigs());
@@ -197,5 +206,81 @@ public class PipelineConfigServiceTest {
 
         assertThat(pipelineConfigs.size(), is(1));
         assertThat(pipelineConfigs.get(0).getGroup(), is("group1"));
+    }
+
+    @Test
+    public void onSCMConfigChange_shouldUpdateAllPipelinesWithReferenceToTheSCM() {
+        PluggableSCMMaterialConfig pluggableMaterial1 = pluggableSCMMaterialConfig("scm-id1", "key1", "key2");
+        PluggableSCMMaterialConfig pluggableMaterial2 = pluggableSCMMaterialConfig("scm-id2", "key1", "key2");
+
+        PipelineConfig pipelineConfig1 = pipelineConfig("pipe1", new MaterialConfigs(git("http://localhost"), pluggableMaterial1));
+        PipelineConfig pipelineConfig2 = pipelineConfig("pipe2", new MaterialConfigs(pluggableMaterial1));
+        PipelineConfig pipelineConfig3 = pipelineConfig("pipe3", new MaterialConfigs(pluggableMaterial2));
+
+        when(goConfigService.getAllPipelineConfigs()).thenReturn(asList(pipelineConfig1, pipelineConfig2, pipelineConfig3));
+
+        SCM updatedSCM = SCMMother.create("scm-id1", "key3");
+        pipelineConfigService.scmConfigChangeListener().onEntityConfigChange(updatedSCM);
+
+        assertThat(pipelineConfig1.materialConfigs().getSCMMaterial().getSCMConfig(), is(updatedSCM));
+        assertThat(pipelineConfig2.materialConfigs().getSCMMaterial().getSCMConfig(), is(updatedSCM));
+        assertThat(pipelineConfig3.materialConfigs().getSCMMaterial().getSCMConfig(), is(SCMMother.create("scm-id2", "key1", "key2")));
+    }
+
+    @Test
+    public void onPackageDefinitionChange_shouldUpdateAllPipelinesWithReferenceToThePackage() {
+        ConfigurationProperty property1 = ConfigurationPropertyMother.create("key1", "value1");
+        ConfigurationProperty property2 = ConfigurationPropertyMother.create("key2", "value2");
+        ConfigurationProperty property3 = ConfigurationPropertyMother.create("key3", "value3");
+
+        PackageDefinition packageDefinition1 = PackageDefinitionMother.create("pack-id-1", "pack-1", new Configuration(property1, property2), null);
+        PackageDefinition packageDefinition2 = PackageDefinitionMother.create("pack-id-1", "pack-1", new Configuration(property3), null);
+
+        PackageMaterialConfig material1 = new PackageMaterialConfig(new CaseInsensitiveString("material1"), "pack-id-1", packageDefinition1);
+        PackageMaterialConfig material2 = new PackageMaterialConfig(new CaseInsensitiveString("material2"), "pack-id-2", packageDefinition2);
+
+        PipelineConfig pipelineConfig1 = pipelineConfig("pipe1", new MaterialConfigs(git("http://localhost"), material1));
+        PipelineConfig pipelineConfig2 = pipelineConfig("pipe2", new MaterialConfigs(material1));
+        PipelineConfig pipelineConfig3 = pipelineConfig("pipe3", new MaterialConfigs(material2));
+
+        when(goConfigService.getAllPipelineConfigs()).thenReturn(asList(pipelineConfig1, pipelineConfig2, pipelineConfig3));
+
+        PackageDefinition updatedPackage = PackageDefinitionMother.create("pack-id-1", "pack-1", new Configuration(property2), null);
+
+        pipelineConfigService.packageChangeListener().onEntityConfigChange(updatedPackage);
+
+        assertThat(pipelineConfig1.materialConfigs().getPackageMaterial().getPackageDefinition(), is(updatedPackage));
+        assertThat(pipelineConfig2.materialConfigs().getPackageMaterial().getPackageDefinition(), is(updatedPackage));
+        assertThat(pipelineConfig3.materialConfigs().getPackageMaterial().getPackageDefinition(), is(packageDefinition2));
+    }
+
+    @Test
+    public void onPackageRepositoryChange_shouldUpdateAllPipelinesWithReferenceToThePackage() {
+        ConfigurationProperty property1 = ConfigurationPropertyMother.create("key1", "value1");
+        ConfigurationProperty property2 = ConfigurationPropertyMother.create("key2", "value2");
+        ConfigurationProperty property3 = ConfigurationPropertyMother.create("key3", "value3");
+
+        PackageRepository packageRepository1 = PackageRepositoryMother.create("repo-1", "repo-1", "plugin1", "0.1", new Configuration(property1, property2));
+        PackageRepository packageRepository2 = PackageRepositoryMother.create("repo-2", "repo-2", "plugin1", "0.1", new Configuration(property3));
+
+        PackageDefinition packageDefinition1 = PackageDefinitionMother.create("pack-id-1", "pack-1", new Configuration(), packageRepository1);
+        PackageDefinition packageDefinition2 = PackageDefinitionMother.create("pack-id-1", "pack-1", new Configuration(), packageRepository2);
+
+        PackageMaterialConfig material1 = new PackageMaterialConfig(new CaseInsensitiveString("material1"), "pack-id-1", packageDefinition1);
+        PackageMaterialConfig material2 = new PackageMaterialConfig(new CaseInsensitiveString("material2"), "pack-id-2", packageDefinition2);
+
+        PipelineConfig pipelineConfig1 = pipelineConfig("pipe1", new MaterialConfigs(git("http://localhost"), material1));
+        PipelineConfig pipelineConfig2 = pipelineConfig("pipe2", new MaterialConfigs(material1));
+        PipelineConfig pipelineConfig3 = pipelineConfig("pipe3", new MaterialConfigs(material2));
+
+        when(goConfigService.getAllPipelineConfigs()).thenReturn(asList(pipelineConfig1, pipelineConfig2, pipelineConfig3));
+
+        PackageRepository updatedPackageRepository = PackageRepositoryMother.create("repo-1", "repo-1", "plugin1", "0.1", new Configuration(property2));
+
+        pipelineConfigService.packageRespositoryChangeListener().onEntityConfigChange(updatedPackageRepository);
+
+        assertThat(pipelineConfig1.materialConfigs().getPackageMaterial().getPackageDefinition().getRepository(), is(updatedPackageRepository));
+        assertThat(pipelineConfig2.materialConfigs().getPackageMaterial().getPackageDefinition().getRepository(), is(updatedPackageRepository));
+        assertThat(pipelineConfig3.materialConfigs().getPackageMaterial().getPackageDefinition().getRepository(), is(packageRepository2));
     }
 }


### PR DESCRIPTION
…Package #8542

* PluggableSCM or Package materials in pipeline refer to the global
  copy. In case of changes to the configuration of the global copy the
  same was not updated on the PipelineConfig materials. This commit
  ensures the materials in PipelineConfig are updated.
* SCMMaterialSource refreshes the material cache on changes to SCM
  or Package/Repository.

Issue: #8542


