### PR TITLE
Remove the `branch_support` toggle. This enables new API versions.

### DIFF
--- a/api/api-config-repos-v4/src/main/java/com/thoughtworks/go/apiv4/configrepos/ConfigReposControllerV4.java
+++ b/api/api-config-repos-v4/src/main/java/com/thoughtworks/go/apiv4/configrepos/ConfigReposControllerV4.java
@@ -55,7 +55,6 @@ import static com.thoughtworks.go.util.CachedDigestUtils.sha512_256Hex;
 import static java.util.stream.Collectors.toCollection;
 import static spark.Spark.*;
 
-@ToggleRegisterLatest(controllerPath = Routes.ConfigRepos.BASE, apiVersion = ApiVersion.v4, as = "branch_support")
 @Component
 public class ConfigReposControllerV4 extends ApiController implements SparkSpringController, CrudController<ConfigRepoConfig> {
     private final ApiAuthenticationHelper authHelper;

--- a/api/api-config-repos-v4/src/main/java/com/thoughtworks/go/apiv4/configrepos/ConfigReposInternalControllerV4.java
+++ b/api/api-config-repos-v4/src/main/java/com/thoughtworks/go/apiv4/configrepos/ConfigReposInternalControllerV4.java
@@ -47,7 +47,6 @@ import static com.thoughtworks.go.util.CachedDigestUtils.sha512_256Hex;
 import static java.util.stream.Collectors.toList;
 import static spark.Spark.*;
 
-@ToggleRegisterLatest(controllerPath = ConfigRepos.INTERNAL_BASE, apiVersion = ApiVersion.v4, as = "branch_support")
 @Component
 public class ConfigReposInternalControllerV4 extends AbstractMaterialTestController implements SparkSpringController {
 

--- a/api/api-plugin-infos-v7/src/main/java/com/thoughtworks/go/apiv7/plugininfos/PluginInfosControllerV7.java
+++ b/api/api-plugin-infos-v7/src/main/java/com/thoughtworks/go/apiv7/plugininfos/PluginInfosControllerV7.java
@@ -46,7 +46,6 @@ import static com.thoughtworks.go.api.util.HaltApiMessages.notFoundMessage;
 import static java.util.stream.Collectors.toList;
 import static spark.Spark.*;
 
-@ToggleRegisterLatest(controllerPath = Routes.PluginInfoAPI.BASE, apiVersion = ApiVersion.v7, as = "branch_support")
 @Component
 public class PluginInfosControllerV7 extends ApiController implements SparkSpringController {
 

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -17,10 +17,6 @@
       "value": false
     },
     {
-      "key": "branch_support",
-      "value": false
-    },
-    {
       "key": "use_rails_template_authorization_page",
       "description": "Use rails based templates authorization page in the UI. Default is false.",
       "value": false


### PR DESCRIPTION
This allows the groovy plugin to use PR support in its full capacity.

See #6123