### PR TITLE
Allow users to see older stage runs from stage overview.

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
@@ -91,7 +91,7 @@ $building: #ffc11b;
   .stage-name-container {
     i {
       font-size:   17px;
-      margin:      11px 10px 0 10px;
+      margin:      17px 10px 0 10px;
       font-weight: 400;
 
       &:before {
@@ -140,6 +140,16 @@ $building: #ffc11b;
 
   .rerun-wrapper {
     left: 34px;
+  }
+
+  .stage-counter-dropdown-wrapper {
+    select {
+      padding-right: 0;
+    }
+
+    i {
+      margin-top: 6px;
+    }
   }
 }
 
@@ -270,7 +280,7 @@ $building: #ffc11b;
 
   i {
     font-size:   17px;
-    margin:      13px 10px 0 10px;
+    margin:      17px 10px 0 10px;
     font-weight: 400;
     color:       $gray;
   }
@@ -282,11 +292,30 @@ $building: #ffc11b;
 }
 
 .stage-name {
-  margin-top:  -4px;
+  margin-top:  3px;
   font-size:   17px;
   font-weight: 600;
   max-width:   200px;
   word-break:  break-all;
+}
+
+.stage-counter-dropdown-wrapper {
+  display: flex;
+
+  select {
+    width:         55px !important; //sass-lint:disable-line no-important
+    padding-right: 25px;
+    height:        30px;
+    line-height:   30px;
+    margin-top:    3px;
+    margin-bottom: -30px;
+  }
+
+  i {
+    margin-top:  5px;
+    margin-left: 3px;
+    height:      24px;
+  }
 }
 
 .stage-trigger-and-timing-container {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss.d.ts
@@ -48,6 +48,7 @@ export const sourceRoot: string;
 export const sources: string;
 export const sourcesContent: string;
 export const spin: string;
+export const stageCounterDropdownWrapper: string;
 export const stageDetailsPageLink: string;
 export const stageHeaderContainer: string;
 export const stageName: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.tsx
@@ -25,6 +25,10 @@ import {StageOverviewViewModel} from "./models/stage_overview_view_model";
 import {StageState} from "./models/types";
 import {StageHeaderWidget} from "./stage_overview_header";
 
+interface State {
+  userSelectedStageCounter: Stream<number | string>;
+}
+
 export interface Attrs {
   pipelineName: string;
   pipelineCounter: string | number;
@@ -39,8 +43,12 @@ export interface Attrs {
   stageOverviewVM: Stream<StageOverviewViewModel | undefined>;
 }
 
-export class StageOverview extends MithrilComponent<Attrs, {}> {
-  oncreate(vnode: m.Vnode<Attrs, {}>) {
+export class StageOverview extends MithrilComponent<Attrs, State> {
+  oninit(vnode: m.Vnode<Attrs, State>) {
+    vnode.state.userSelectedStageCounter = Stream<string | number>(vnode.attrs.stageCounter);
+  }
+
+  oncreate(vnode: m.Vnode<Attrs, State>) {
     // @ts-ignore
     vnode.dom.onclick = (e: any) => {
       e.stopPropagation();
@@ -135,7 +143,7 @@ export class StageOverview extends MithrilComponent<Attrs, {}> {
     vnode.dom.style.left = `${leftAlign}px`;
   }
 
-  view(vnode: m.Vnode<Attrs, {}>): m.Children | void | null {
+  view(vnode: m.Vnode<Attrs, State>): m.Children | void | null {
     // @ts-ignore
     const status = styles[`${vnode.attrs.stageInstanceFromDashboard.status.toLowerCase()}-stage`];
 
@@ -151,16 +159,19 @@ export class StageOverview extends MithrilComponent<Attrs, {}> {
       <div class={`${status} ${styles.stageOverviewStatus}`}/>
       <StageHeaderWidget stageName={vnode.attrs.stageName}
                          stageCounter={vnode.attrs.stageCounter}
+                         userSelectedStageCounter={vnode.state.userSelectedStageCounter}
                          pipelineName={vnode.attrs.pipelineName}
                          pipelineCounter={vnode.attrs.pipelineCounter}
                          templateName={vnode.attrs.templateName}
                          stageInstanceFromDashboard={vnode.attrs.stageInstanceFromDashboard}
                          inProgressStageFromPipeline={inProgressStageFromPipeline}
+                         stageOverviewVM={vnode.attrs.stageOverviewVM as Stream<StageOverviewViewModel>}
                          flashMessage={vnode.attrs.stageOverviewVM()!.flashMessage}
                          canAdminister={vnode.attrs.canAdminister}
                          stageInstance={vnode.attrs.stageOverviewVM()!.stageInstance}/>
       <JobCountAndRerunWidget stageName={vnode.attrs.stageName}
                               stageCounter={vnode.attrs.stageCounter}
+                              userSelectedStageCounter={vnode.state.userSelectedStageCounter}
                               pipelineName={vnode.attrs.pipelineName}
                               pipelineCounter={vnode.attrs.pipelineCounter}
                               flashMessage={vnode.attrs.stageOverviewVM()!.flashMessage}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/job_count_and_rerun_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/job_count_and_rerun_widget.tsx
@@ -31,11 +31,12 @@ export interface Attrs {
   flashMessage: FlashMessageModelWithTimeout;
   jobsVM: Stream<JobsViewModel>;
   inProgressStageFromPipeline: Stream<any | undefined>;
+  userSelectedStageCounter: Stream<string | number>;
 }
 
 export interface State {
-  rerunFailed: (attrs: Attrs) => void;
-  rerunSelected: (attrs: Attrs) => void;
+  rerunFailed: (vnode: m.Vnode<Attrs, State>) => void;
+  rerunSelected: (vnode: m.Vnode<Attrs, State>) => void;
 }
 
 export class JobCountAndRerunWidget extends MithrilComponent<Attrs, State> {
@@ -44,18 +45,19 @@ export class JobCountAndRerunWidget extends MithrilComponent<Attrs, State> {
       return (result: any) => {
         result.do((successResponse: any) => {
           attrs.flashMessage.setMessage(MessageType.success, JSON.parse(successResponse.body).message);
+          vnode.attrs.userSelectedStageCounter(`${(+vnode.attrs.stageCounter) + 1}`);
         }, (errorResponse: ErrorResponse) => {
           attrs.flashMessage.setMessage(MessageType.alert, JSON.parse(errorResponse.body!).message);
         });
       };
     }
 
-    vnode.state.rerunFailed = (attrs: Attrs) => {
-      attrs.jobsVM().rerunFailedJobs(attrs.pipelineName, attrs.pipelineCounter, attrs.stageName, attrs.stageCounter).then(getResultHandler(attrs));
+    vnode.state.rerunFailed = (vnode: m.Vnode<Attrs, State>) => {
+      vnode.attrs.jobsVM().rerunFailedJobs(vnode.attrs.pipelineName, vnode.attrs.pipelineCounter, vnode.attrs.stageName, vnode.attrs.userSelectedStageCounter()).then(getResultHandler(vnode.attrs));
     };
 
-    vnode.state.rerunSelected = (attrs: Attrs) => {
-      attrs.jobsVM().rerunSelectedJobs(attrs.pipelineName, attrs.pipelineCounter, attrs.stageName, attrs.stageCounter).then(getResultHandler(attrs));
+    vnode.state.rerunSelected = (vnode: m.Vnode<Attrs, State>) => {
+      vnode.attrs.jobsVM().rerunSelectedJobs(vnode.attrs.pipelineName, vnode.attrs.pipelineCounter, vnode.attrs.stageName, vnode.attrs.userSelectedStageCounter()).then(getResultHandler(vnode.attrs));
     };
   }
 
@@ -93,9 +95,9 @@ export class JobCountAndRerunWidget extends MithrilComponent<Attrs, State> {
       <div class={styles.jobRerunContainer} data-test-id="job-rerun-container">
         <ButtonGroup>
           <Secondary title={rerunFailedTitle} disabled={disableRerunFailed} small={true}
-                     onclick={vnode.state.rerunFailed.bind(vnode.state, vnode.attrs)}>Rerun Failed</Secondary>
+                     onclick={vnode.state.rerunFailed.bind(vnode.state, vnode)}>Rerun Failed</Secondary>
           <Secondary title={rerunSelectedTitle} disabled={disableRerunSelected} small={true}
-                     onclick={vnode.state.rerunSelected.bind(vnode.state, vnode.attrs)}>Rerun Selected</Secondary>
+                     onclick={vnode.state.rerunSelected.bind(vnode.state, vnode)}>Rerun Selected</Secondary>
         </ButtonGroup>
       </div>
       <div class={styles.jobCountContainer} data-test-id="job-cont-container">

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/models/stage_instance.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/models/stage_instance.ts
@@ -72,6 +72,10 @@ export class StageInstance {
     return this.json.result === Result[Result.Cancelled];
   }
 
+  result(): any {
+    return this.json.result;
+  }
+
   isCompleted(): boolean {
     return !this.isStageInProgress();
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/index_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/index_spec.tsx
@@ -29,7 +29,7 @@ describe("Stage Overview Widget", () => {
   const pipelineName = "build-linux";
   const pipelineCounter = 123456789;
   const stageName = "build-and-run-jasmine-specs";
-  const stageCounter = 97654321;
+  const stageCounter = 1;
 
   afterEach(() => {
     helper.unmount();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/job_count_and_rerun_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/job_count_and_rerun_widget_spec.tsx
@@ -139,6 +139,7 @@ describe("Job Count And Rerun Widget", () => {
                                      pipelineCounter={1}
                                      stageName="up42_stage"
                                      stageCounter={1}
+                                     userSelectedStageCounter={Stream<string | number>(1)}
                                      flashMessage={new FlashMessageModelWithTimeout()}
                                      jobsVM={Stream(jobs)} inProgressStageFromPipeline={Stream()}/>;
     });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/stage_overview_header_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/stage_overview_header_spec.tsx
@@ -16,9 +16,11 @@
 
 import m from "mithril";
 import Stream from "mithril/stream";
+import {Agents} from "../../../../models/agents/agents";
 import {FlashMessageModelWithTimeout, MessageType} from "../../../components/flash_message";
 import {TestHelper} from "../../../pages/spec/test_helper";
 import {StageInstance} from "../models/stage_instance";
+import {StageOverviewViewModel} from "../models/stage_overview_view_model";
 import {Result} from "../models/types";
 import {StageHeaderWidget} from "../stage_overview_header";
 import {TestData} from "./test_data";
@@ -29,11 +31,12 @@ describe('Stage Overview Header', () => {
   const pipelineName = "up42";
   const pipelineCounter = 20;
   const stageName = "up42_stage";
-  const stageCounter = 1;
+  let stageCounter: number;
 
   let stageInstance: StageInstance, flashMessage: FlashMessageModelWithTimeout;
 
   beforeEach(() => {
+    stageCounter = 1;
     flashMessage = new FlashMessageModelWithTimeout();
     stageInstance = new StageInstance(TestData.stageInstanceJSON());
     mount();
@@ -58,6 +61,29 @@ describe('Stage Overview Header', () => {
   it('should render stage instance', () => {
     expect(helper.byTestId('stage-instance-container')).toContainText('Instance');
     expect(helper.byTestId('stage-instance-container')).toContainText('1');
+  });
+
+  it('should render stage counter as plain text when stage counter is 1', () => {
+    expect(helper.byTestId('stage-counter')).toBeInDOM();
+    expect(helper.byTestId('stage-counter-dropdown')).not.toBeInDOM();
+
+    expect(helper.byTestId('stage-counter')).toContainText('1');
+  });
+
+  it('should render stage counter as dropdown when stage counter greater than 1', () => {
+    helper.unmount();
+    stageCounter = 2;
+    mount();
+
+    expect(helper.byTestId('stage-counter')).not.toBeInDOM();
+    expect(helper.byTestId('stage-counter-dropdown')).toBeInDOM();
+
+    expect((helper.q('select') as HTMLSelectElement).value).toBe("2");
+
+    const options = helper.qa('option');
+
+    expect((options[0] as HTMLOptionElement).value).toBe("1");
+    expect((options[1] as HTMLOptionElement).value).toBe("2");
   });
 
   it('should render stage operations container', () => {
@@ -172,7 +198,9 @@ describe('Stage Overview Header', () => {
                                 templateName={templateName}
                                 stageName={stageName}
                                 stageCounter={stageCounter}
+                                userSelectedStageCounter={Stream<number | string>(stageCounter)}
                                 flashMessage={flashMessage}
+                                stageOverviewVM={Stream(new StageOverviewViewModel(pipelineName, pipelineCounter, stageName, stageCounter, stageInstance, new Agents()))}
                                 stageInstance={Stream(stageInstance)}/>;
     });
   }


### PR DESCRIPTION
* Show stage counter as plain text when counter is 1.
* Show stage counter as a dropdown when counter is greater than 1.
* Show spinner next to dropdown when new stage overview is loading.
* Change the stage status from dashboard as well based on the
  selected stage counter's stage status.
* Stop the older poller and poll for new stage overview.
* Fix stylings for the stage counter dropdown on the pipeline
  activity page.
* When an older stage overview is selected and few jobs from
  the older stage are rerun, rerun jobs from the selected stage
  counter instead of running always from latest.

![Screen Shot 2020-09-21 at 8 43 20 AM](https://user-images.githubusercontent.com/15275847/93730508-97707180-fbe6-11ea-97e3-d21baaf6c00a.png)
![Screen Shot 2020-09-21 at 8 43 28 AM](https://user-images.githubusercontent.com/15275847/93730511-9a6b6200-fbe6-11ea-907e-d4beb8374435.png)
