### PR TITLE
[Stage Overview] Fix in progress stage name on disabled rerun icon on stage activity page.

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/pipeline_run_info_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/pipeline_run_info_widget.tsx
@@ -132,6 +132,9 @@ export class PipelineRunWidget extends MithrilViewComponent<PipelineRunAttrs> {
             // @ts-ignore
             stage.canOperate = vnode.attrs.canOperatePipeline;
 
+            //@ts-ignore
+            pipelineRunInfo.stages().forEach((s: Stage) => s.name = s.stageName());
+
             optionalStageOverview = <StageOverview pipelineName={stage.pipelineName()}
                                                    isDisplayedOnPipelineActivityPage={true}
                                                    canAdminister={vnode.attrs.canAdministerPipeline}


### PR DESCRIPTION
* Stage overview expects the stage name to be present on 'name' field,
  whereas, it was passed as 'stageName()' from the pipeline activity page.

* Add another field 'name' on the stage model before passing the model
  to the stage overview.

#### Before
![Screen Shot 2020-09-21 at 8 51 17 AM](https://user-images.githubusercontent.com/15275847/93730901-6002c480-fbe8-11ea-9a3a-be228d08ec51.png)

#### After
![Screen Shot 2020-09-21 at 8 50 27 AM](https://user-images.githubusercontent.com/15275847/93730904-62fdb500-fbe8-11ea-97eb-eae099f0f842.png)


