### PR TITLE
Fixes w.r.t. secrets support for package and plugin materials

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/config/materials/scm/PluggableSCMMaterialTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/scm/PluggableSCMMaterialTest.java
@@ -498,12 +498,13 @@ class PluggableSCMMaterialTest {
     @Test
     void shouldUpdateMaterialFromMaterialConfig() {
         PluggableSCMMaterial material = MaterialsMother.pluggableSCMMaterial();
-        PluggableSCMMaterialConfig materialConfig = MaterialConfigsMother.pluggableSCMMaterialConfig();
+        PluggableSCMMaterialConfig materialConfig = MaterialConfigsMother.pluggableSCMMaterialConfig("some-scm-name");
         Configuration configuration = new Configuration(new ConfigurationProperty(new ConfigurationKey("new_key"), new ConfigurationValue("new_value")));
         materialConfig.getSCMConfig().setConfiguration(configuration);
 
         material.updateFromConfig(materialConfig);
-        assertThat(material.getScmConfig().getConfiguration().equals(materialConfig.getSCMConfig().getConfiguration())).isTrue();
+        assertThat(material.getScmConfig().getConfiguration()).isEqualTo(materialConfig.getSCMConfig().getConfiguration());
+        assertThat(material.getScmConfig().getName()).isEqualTo(materialConfig.getSCMConfig().getName());
     }
 
     private PluggableSCMMaterial createPluggableSCMMaterialWithSecureConfiguration() {

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/PackageMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/PackageMaterial.java
@@ -252,6 +252,7 @@ public class PackageMaterial extends AbstractMaterial implements SecretParamAwar
     public void updateFromConfig(MaterialConfig materialConfig) {
         super.updateFromConfig(materialConfig);
         this.getPackageDefinition().setConfiguration(((PackageMaterialConfig) materialConfig).getPackageDefinition().getConfiguration());
+        this.getPackageDefinition().getRepository().setName(((PackageMaterialConfig) materialConfig).getPackageDefinition().getRepository().getName());
         this.getPackageDefinition().getRepository().setConfiguration(((PackageMaterialConfig) materialConfig).getPackageDefinition().getRepository().getConfiguration());
     }
 

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/PluggableSCMMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/PluggableSCMMaterial.java
@@ -315,6 +315,7 @@ public class PluggableSCMMaterial extends AbstractMaterial implements SecretPara
     @Override
     public void updateFromConfig(MaterialConfig materialConfig) {
         super.updateFromConfig(materialConfig);
+        this.getScmConfig().setName(((PluggableSCMMaterialConfig) materialConfig).getSCMConfig().getName());
         this.getScmConfig().setConfiguration(((PluggableSCMMaterialConfig) materialConfig).getSCMConfig().getConfiguration());
     }
 

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/PackageMaterialTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/PackageMaterialTest.java
@@ -27,6 +27,7 @@ import com.thoughtworks.go.domain.materials.Modifications;
 import com.thoughtworks.go.domain.materials.packagematerial.PackageMaterialInstance;
 import com.thoughtworks.go.domain.materials.packagematerial.PackageMaterialRevision;
 import com.thoughtworks.go.domain.packagerepository.*;
+import com.thoughtworks.go.helper.MaterialConfigsMother;
 import com.thoughtworks.go.helper.MaterialsMother;
 import com.thoughtworks.go.plugin.access.packagematerial.PackageConfigurations;
 import com.thoughtworks.go.plugin.access.packagematerial.PackageMetadataStore;
@@ -513,5 +514,18 @@ class PackageMaterialTest {
         assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_K2")).isEqualTo("some-resolved-password");
         assertThat(environmentVariableContext.getPropertyForDisplay("GO_PACKAGE_TW_DEV_GO_AGENT_K2")).isEqualTo(MASK_VALUE);
         assertThat(environmentVariableContext.getProperty("GO_PACKAGE_TW_DEV_GO_AGENT_LABEL")).isEqualTo("revision-123");
+    }
+
+    @Test
+    void shouldUpdateMaterialFromMaterialConfig() {
+        PackageMaterial material = MaterialsMother.packageMaterial();
+        PackageMaterialConfig materialConfig = MaterialConfigsMother.packageMaterialConfig("pkg-repo-name", "pkg-name");
+        Configuration configuration = new Configuration(new ConfigurationProperty(new ConfigurationKey("new_key"), new ConfigurationValue("new_value")));
+        materialConfig.getPackageDefinition().setConfiguration(configuration);
+
+        material.updateFromConfig(materialConfig);
+        assertThat(material.getPackageDefinition().getConfiguration()).isEqualTo(materialConfig.getPackageDefinition().getConfiguration());
+        assertThat(material.getPackageDefinition().getRepository().getConfiguration()).isEqualTo(materialConfig.getPackageDefinition().getRepository().getConfiguration());
+        assertThat(material.getPackageDefinition().getRepository().getName()).isEqualTo(materialConfig.getPackageDefinition().getRepository().getName());
     }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/secret_configs.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/secret_configs.tsx
@@ -18,6 +18,8 @@ import {ErrorResponse, SuccessResponse} from "helpers/api_request_builder";
 import m from "mithril";
 import Stream from "mithril/stream";
 import {EnvironmentCRUD} from "models/environments/environment_crud";
+import {PluggableScmCRUD} from "models/materials/pluggable_scm_crud";
+import {PackageRepositoriesCRUD} from "models/package_repositories/package_repositories_crud";
 import {PipelineGroupCRUD} from "models/pipeline_configs/pipeline_groups_cache";
 import {Rules} from "models/rules/rules";
 import {SecretConfig, SecretConfigs} from "models/secret_configs/secret_configs";
@@ -30,18 +32,8 @@ import {FlashMessage, MessageType} from "views/components/flash_message";
 import {HeaderPanel} from "views/components/header_panel";
 import {DeleteConfirmModal} from "views/components/modal/delete_confirm_modal";
 import {Page, PageState} from "views/pages/page";
-import {
-  AddOperation,
-  CloneOperation,
-  DeleteOperation,
-  EditOperation,
-  RequiresPluginInfos, SaveOperation
-} from "views/pages/page_operations";
-import {
-  CloneSecretConfigModal,
-  CreateSecretConfigModal,
-  EditSecretConfigModal
-} from "views/pages/secret_configs/modals";
+import {AddOperation, CloneOperation, DeleteOperation, EditOperation, RequiresPluginInfos, SaveOperation} from "views/pages/page_operations";
+import {CloneSecretConfigModal, CreateSecretConfigModal, EditSecretConfigModal} from "views/pages/secret_configs/modals";
 import {SecretConfigsWidget} from "views/pages/secret_configs/secret_configs_widget";
 
 interface State extends RequiresPluginInfos, AddOperation<SecretConfig>, EditOperation<SecretConfig>, CloneOperation<SecretConfig>, DeleteOperation<SecretConfig>, SaveOperation {
@@ -135,7 +127,7 @@ export class SecretConfigsPage extends Page<null, State> {
   }
 
   fetchData(vnode: m.Vnode<null, State>): Promise<any> {
-    return Promise.all([PluginInfoCRUD.all({type: ExtensionTypeString.SECRETS}), SecretConfigsCRUD.all(), PipelineGroupCRUD.all(), EnvironmentCRUD.all()])
+    return Promise.all([PluginInfoCRUD.all({type: ExtensionTypeString.SECRETS}), SecretConfigsCRUD.all(), PipelineGroupCRUD.all(), EnvironmentCRUD.all(), PluggableScmCRUD.all(), PackageRepositoriesCRUD.all()])
                   .then((results) => {
                     results[0].do((successResponse) => {
                       vnode.state.pluginInfos = Stream(successResponse.body);
@@ -155,6 +147,16 @@ export class SecretConfigsPage extends Page<null, State> {
                     results[3].do((successResponse) => {
                       vnode.state.resourceAutocompleteHelper()
                            .set("environment", ["*"].concat(successResponse.body.map((env) => env.name())));
+                    }, () => this.setErrorState());
+
+                    results[4].do((successResponse) => {
+                      vnode.state.resourceAutocompleteHelper()
+                           .set("pluggable_scm", ["*"].concat(successResponse.body.map((scm) => scm.name())));
+                    }, () => this.setErrorState());
+
+                    results[5].do((successResponse) => {
+                      vnode.state.resourceAutocompleteHelper()
+                           .set("package_repository", ["*"].concat(successResponse.body.map((pkgRepo) => pkgRepo.name())));
                     }, () => this.setErrorState());
                   });
   }


### PR DESCRIPTION
Description:
 - provide auto_complete support on secrets spa
 - Update package repository name in the package material while building work to be executed
 - Same with plugin materials - update pluggable scm name

