### PR TITLE
Revert "Plugin and Package materials are updated on changes to global SCM or …"

### DIFF
--- a/config/config-api/src/test/java/com/thoughtworks/go/domain/scm/SCMMother.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/domain/scm/SCMMother.java
@@ -15,7 +15,8 @@
  */
 package com.thoughtworks.go.domain.scm;
 
-import com.thoughtworks.go.domain.config.*;
+import com.thoughtworks.go.domain.config.Configuration;
+import com.thoughtworks.go.domain.config.PluginConfiguration;
 
 public class SCMMother {
     public static SCM create(String id) {
@@ -30,17 +31,5 @@ public class SCMMother {
         scm.setPluginConfiguration(new PluginConfiguration(pluginId, pluginVersion));
         scm.setConfiguration(configuration);
         return scm;
-    }
-
-    public static SCM create(String scmId, String... properties) {
-        SCM scmConfig = create(scmId);
-        Configuration configuration = new Configuration();
-        for (String property : properties) {
-            ConfigurationProperty configurationProperty = new ConfigurationProperty(new ConfigurationKey(property), new ConfigurationValue(property + "-value"));
-            configuration.add(configurationProperty);
-        }
-        scmConfig.setConfiguration(configuration);
-
-        return scmConfig;
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/helper/MaterialConfigsMother.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/helper/MaterialConfigsMother.java
@@ -282,11 +282,14 @@ public class MaterialConfigsMother {
     }
 
     public static PluggableSCMMaterialConfig pluggableSCMMaterialConfigWithConfigProperties(String... properties) {
-        return new PluggableSCMMaterialConfig(null, SCMMother.create("scm-id", properties), "des-folder", null, false);
-    }
-
-    public static PluggableSCMMaterialConfig pluggableSCMMaterialConfig(String scmId, String... properties) {
-        return new PluggableSCMMaterialConfig(null, SCMMother.create(scmId, properties), "des-folder", null, false);
+        SCM scmConfig = SCMMother.create("scm-id");
+        Configuration configuration = new Configuration();
+        for (String property : properties) {
+            ConfigurationProperty configurationProperty = new ConfigurationProperty(new ConfigurationKey(property), new ConfigurationValue(property + "-value"));
+            configuration.add(configurationProperty);
+        }
+        scmConfig.setConfiguration(configuration);
+        return new PluggableSCMMaterialConfig(null, scmConfig, "des-folder", null, false);
     }
 
     public static PluggableSCMMaterialConfig pluggableSCMMaterialConfig(String scmId, String destinationFolder, Filter filter) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineConfigService.java
@@ -19,17 +19,11 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.exceptions.GoConfigInvalidException;
-import com.thoughtworks.go.config.materials.PackageMaterialConfig;
-import com.thoughtworks.go.config.materials.PluggableSCMMaterialConfig;
 import com.thoughtworks.go.config.pluggabletask.PluggableTask;
 import com.thoughtworks.go.config.remote.ConfigOrigin;
 import com.thoughtworks.go.config.update.*;
 import com.thoughtworks.go.domain.PipelineGroups;
 import com.thoughtworks.go.domain.Task;
-import com.thoughtworks.go.domain.packagerepository.PackageDefinition;
-import com.thoughtworks.go.domain.packagerepository.PackageRepository;
-import com.thoughtworks.go.domain.scm.SCM;
-import com.thoughtworks.go.listener.EntityConfigChangedListener;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.presentation.CanDeleteResult;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
@@ -72,9 +66,6 @@ public class PipelineConfigService {
         this.pluggableTaskService = pluggableTaskService;
         this.entityHashingService = entityHashingService;
         this.externalArtifactsService = externalArtifactsService;
-        goConfigService.register(scmConfigChangeListener());
-        goConfigService.register(packageChangeListener());
-        goConfigService.register(packageRespositoryChangeListener());
     }
 
     public Map<CaseInsensitiveString, CanDeleteResult> canDeletePipelines() {
@@ -256,52 +247,4 @@ public class PipelineConfigService {
         goConfigService.updateConfig(new ExtractTemplateFromPipelineEntityConfigUpdateCommand(securityService, pipelineName, templateName, currentUser), currentUser);
     }
 
-    protected EntityConfigChangedListener<PackageDefinition> packageChangeListener() {
-        return new EntityConfigChangedListener<>() {
-            @Override
-            public void onEntityConfigChange(PackageDefinition packageDefinition) {
-                goConfigService.getAllPipelineConfigs().forEach(pipeline -> pipeline.materialConfigs().forEach(material -> {
-                    if (material instanceof PackageMaterialConfig) {
-                        PackageMaterialConfig packageMaterial = (PackageMaterialConfig) material;
-                        if (packageMaterial.getPackageId().equalsIgnoreCase(packageDefinition.getId())) {
-                            packageMaterial.setPackageDefinition(packageDefinition);
-                        }
-                    }
-                }));
-            }
-        };
-    }
-
-    protected EntityConfigChangedListener<PackageRepository> packageRespositoryChangeListener() {
-        return new EntityConfigChangedListener<>() {
-            @Override
-            public void onEntityConfigChange(PackageRepository packageRepository) {
-                goConfigService.getAllPipelineConfigs().forEach(pipeline -> pipeline.materialConfigs().forEach(material -> {
-                    if (material instanceof PackageMaterialConfig) {
-                        PackageMaterialConfig packageMaterial = (PackageMaterialConfig) material;
-                        if (packageMaterial.getPackageDefinition().getRepository().getId().equalsIgnoreCase(packageRepository.getId())) {
-                            PackageDefinition packageDefinition = packageMaterial.getPackageDefinition();
-                            packageDefinition.setRepository(packageRepository);
-                        }
-                    }
-                }));
-            }
-        };
-    }
-
-    protected EntityConfigChangedListener<SCM> scmConfigChangeListener() {
-        return new EntityConfigChangedListener<>() {
-            @Override
-            public void onEntityConfigChange(SCM scm) {
-                goConfigService.getAllPipelineConfigs().forEach(pipeline -> pipeline.materialConfigs().forEach(material -> {
-                    if (material instanceof PluggableSCMMaterialConfig) {
-                        PluggableSCMMaterialConfig pluggableMaterial = (PluggableSCMMaterialConfig) material;
-                        if (pluggableMaterial.getScmId().equalsIgnoreCase(scm.getId())) {
-                            pluggableMaterial.setSCMConfig(scm);
-                        }
-                    }
-                }));
-            }
-        };
-    }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/materials/PluggableSCMMaterialPoller.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/materials/PluggableSCMMaterialPoller.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.server.service.materials;
 
+import com.thoughtworks.go.config.SecretParams;
 import com.thoughtworks.go.config.materials.PluggableSCMMaterial;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
 import com.thoughtworks.go.domain.MaterialInstance;

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
@@ -17,19 +17,12 @@ package com.thoughtworks.go.server.service;
 
 import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.*;
-import com.thoughtworks.go.config.materials.MaterialConfigs;
-import com.thoughtworks.go.config.materials.PackageMaterialConfig;
-import com.thoughtworks.go.config.materials.PluggableSCMMaterialConfig;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
 import com.thoughtworks.go.config.pluggabletask.PluggableTask;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
-import com.thoughtworks.go.domain.config.Configuration;
-import com.thoughtworks.go.domain.config.ConfigurationProperty;
-import com.thoughtworks.go.domain.packagerepository.*;
-import com.thoughtworks.go.domain.scm.SCM;
-import com.thoughtworks.go.domain.scm.SCMMother;
 import com.thoughtworks.go.helper.JobConfigMother;
+import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.presentation.CanDeleteResult;
 import com.thoughtworks.go.server.service.tasks.PluggableTaskService;
@@ -42,10 +35,8 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.thoughtworks.go.helper.EnvironmentConfigMother.environment;
-import static com.thoughtworks.go.helper.MaterialConfigsMother.*;
+import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
 import static com.thoughtworks.go.helper.PipelineConfigMother.createGroup;
-import static com.thoughtworks.go.helper.PipelineConfigMother.pipelineConfig;
-import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
@@ -65,7 +56,7 @@ public class PipelineConfigServiceTest {
         downstream(configs);
         cruiseConfig = new BasicCruiseConfig(configs);
         cruiseConfig.addEnvironment(environment("foo", "in_env"));
-        PipelineConfig remotePipeline = pipelineConfig("remote");
+        PipelineConfig remotePipeline = PipelineConfigMother.pipelineConfig("remote");
         remotePipeline.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(git("url"), "plugin", "id"), "1234"));
         cruiseConfig.addPipeline("group", remotePipeline);
 
@@ -100,7 +91,7 @@ public class PipelineConfigServiceTest {
     }
 
     private void downstream(PipelineConfigs configs) {
-        PipelineConfig down = pipelineConfig("down");
+        PipelineConfig down = PipelineConfigMother.pipelineConfig("down");
         down.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("pipeline"), new CaseInsensitiveString("mingle")));
         configs.add(down);
     }
@@ -116,7 +107,7 @@ public class PipelineConfigServiceTest {
         job1.addTask(xUnit);
         job2.addTask(docker);
 
-        PipelineConfig pipeline = pipelineConfig("P1", new StageConfig(new CaseInsensitiveString("S1"), new JobConfigs(job1)),
+        PipelineConfig pipeline = PipelineConfigMother.pipelineConfig("P1", new StageConfig(new CaseInsensitiveString("S1"), new JobConfigs(job1)),
                 new StageConfig(new CaseInsensitiveString("S2"), new JobConfigs(job2)));
 
         pipelineConfigService.updatePipelineConfig(null, pipeline, "group", null, null);
@@ -136,7 +127,7 @@ public class PipelineConfigServiceTest {
         job1.addTask(xUnit);
         job2.addTask(docker);
 
-        PipelineConfig pipeline = pipelineConfig("P1", new StageConfig(new CaseInsensitiveString("S1"), new JobConfigs(job1)),
+        PipelineConfig pipeline = PipelineConfigMother.pipelineConfig("P1", new StageConfig(new CaseInsensitiveString("S1"), new JobConfigs(job1)),
                 new StageConfig(new CaseInsensitiveString("S2"), new JobConfigs(job2)));
 
         pipelineConfigService.createPipelineConfig(null, pipeline, null, null);
@@ -154,7 +145,7 @@ public class PipelineConfigServiceTest {
     public void pipelineCountShouldIncludeConfigRepoPipelinesAsWell() {
         CruiseConfig mergedCruiseConfig = new Cloner().deepClone(cruiseConfig);
         ReflectionUtil.setField(mergedCruiseConfig, "allPipelineConfigs", null);
-        mergedCruiseConfig.addPipeline("default", pipelineConfig(UUID.randomUUID().toString()));
+        mergedCruiseConfig.addPipeline("default", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
         when(goConfigService.cruiseConfig()).thenReturn(mergedCruiseConfig);
         when(goConfigService.getConfigForEditing()).thenReturn(cruiseConfig);
         when(goConfigService.getAllPipelineConfigs()).thenReturn(mergedCruiseConfig.getAllPipelineConfigs());
@@ -166,9 +157,9 @@ public class PipelineConfigServiceTest {
     public void shouldGetAllViewableMergePipelineConfigs() throws Exception {
         CruiseConfig mergedCruiseConfig = new Cloner().deepClone(cruiseConfig);
         ReflectionUtil.setField(mergedCruiseConfig, "allPipelineConfigs", null);
-        mergedCruiseConfig.addPipeline("group1", pipelineConfig(UUID.randomUUID().toString()));
-        mergedCruiseConfig.addPipeline("group2", pipelineConfig(UUID.randomUUID().toString()));
-        mergedCruiseConfig.addPipeline("group3", pipelineConfig(UUID.randomUUID().toString()));
+        mergedCruiseConfig.addPipeline("group1", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
+        mergedCruiseConfig.addPipeline("group2", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
+        mergedCruiseConfig.addPipeline("group3", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
 
         when(goConfigService.getMergedConfigForEditing()).thenReturn(mergedCruiseConfig);
         when(goConfigService.getAllPipelineConfigs()).thenReturn(mergedCruiseConfig.getAllPipelineConfigs());
@@ -191,8 +182,8 @@ public class PipelineConfigServiceTest {
     public void shouldGetAllViewableGroups() throws Exception {
         CruiseConfig cruiseConfig = new Cloner().deepClone(this.cruiseConfig);
         ReflectionUtil.setField(cruiseConfig, "allPipelineConfigs", null);
-        cruiseConfig.addPipeline("group1", pipelineConfig(UUID.randomUUID().toString()));
-        cruiseConfig.addPipeline("group2", pipelineConfig(UUID.randomUUID().toString()));
+        cruiseConfig.addPipeline("group1", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
+        cruiseConfig.addPipeline("group2", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
 
         when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
         when(goConfigService.getAllPipelineConfigs()).thenReturn(cruiseConfig.getAllPipelineConfigs());
@@ -206,81 +197,5 @@ public class PipelineConfigServiceTest {
 
         assertThat(pipelineConfigs.size(), is(1));
         assertThat(pipelineConfigs.get(0).getGroup(), is("group1"));
-    }
-
-    @Test
-    public void onSCMConfigChange_shouldUpdateAllPipelinesWithReferenceToTheSCM() {
-        PluggableSCMMaterialConfig pluggableMaterial1 = pluggableSCMMaterialConfig("scm-id1", "key1", "key2");
-        PluggableSCMMaterialConfig pluggableMaterial2 = pluggableSCMMaterialConfig("scm-id2", "key1", "key2");
-
-        PipelineConfig pipelineConfig1 = pipelineConfig("pipe1", new MaterialConfigs(git("http://localhost"), pluggableMaterial1));
-        PipelineConfig pipelineConfig2 = pipelineConfig("pipe2", new MaterialConfigs(pluggableMaterial1));
-        PipelineConfig pipelineConfig3 = pipelineConfig("pipe3", new MaterialConfigs(pluggableMaterial2));
-
-        when(goConfigService.getAllPipelineConfigs()).thenReturn(asList(pipelineConfig1, pipelineConfig2, pipelineConfig3));
-
-        SCM updatedSCM = SCMMother.create("scm-id1", "key3");
-        pipelineConfigService.scmConfigChangeListener().onEntityConfigChange(updatedSCM);
-
-        assertThat(pipelineConfig1.materialConfigs().getSCMMaterial().getSCMConfig(), is(updatedSCM));
-        assertThat(pipelineConfig2.materialConfigs().getSCMMaterial().getSCMConfig(), is(updatedSCM));
-        assertThat(pipelineConfig3.materialConfigs().getSCMMaterial().getSCMConfig(), is(SCMMother.create("scm-id2", "key1", "key2")));
-    }
-
-    @Test
-    public void onPackageDefinitionChange_shouldUpdateAllPipelinesWithReferenceToThePackage() {
-        ConfigurationProperty property1 = ConfigurationPropertyMother.create("key1", "value1");
-        ConfigurationProperty property2 = ConfigurationPropertyMother.create("key2", "value2");
-        ConfigurationProperty property3 = ConfigurationPropertyMother.create("key3", "value3");
-
-        PackageDefinition packageDefinition1 = PackageDefinitionMother.create("pack-id-1", "pack-1", new Configuration(property1, property2), null);
-        PackageDefinition packageDefinition2 = PackageDefinitionMother.create("pack-id-1", "pack-1", new Configuration(property3), null);
-
-        PackageMaterialConfig material1 = new PackageMaterialConfig(new CaseInsensitiveString("material1"), "pack-id-1", packageDefinition1);
-        PackageMaterialConfig material2 = new PackageMaterialConfig(new CaseInsensitiveString("material2"), "pack-id-2", packageDefinition2);
-
-        PipelineConfig pipelineConfig1 = pipelineConfig("pipe1", new MaterialConfigs(git("http://localhost"), material1));
-        PipelineConfig pipelineConfig2 = pipelineConfig("pipe2", new MaterialConfigs(material1));
-        PipelineConfig pipelineConfig3 = pipelineConfig("pipe3", new MaterialConfigs(material2));
-
-        when(goConfigService.getAllPipelineConfigs()).thenReturn(asList(pipelineConfig1, pipelineConfig2, pipelineConfig3));
-
-        PackageDefinition updatedPackage = PackageDefinitionMother.create("pack-id-1", "pack-1", new Configuration(property2), null);
-
-        pipelineConfigService.packageChangeListener().onEntityConfigChange(updatedPackage);
-
-        assertThat(pipelineConfig1.materialConfigs().getPackageMaterial().getPackageDefinition(), is(updatedPackage));
-        assertThat(pipelineConfig2.materialConfigs().getPackageMaterial().getPackageDefinition(), is(updatedPackage));
-        assertThat(pipelineConfig3.materialConfigs().getPackageMaterial().getPackageDefinition(), is(packageDefinition2));
-    }
-
-    @Test
-    public void onPackageRepositoryChange_shouldUpdateAllPipelinesWithReferenceToThePackage() {
-        ConfigurationProperty property1 = ConfigurationPropertyMother.create("key1", "value1");
-        ConfigurationProperty property2 = ConfigurationPropertyMother.create("key2", "value2");
-        ConfigurationProperty property3 = ConfigurationPropertyMother.create("key3", "value3");
-
-        PackageRepository packageRepository1 = PackageRepositoryMother.create("repo-1", "repo-1", "plugin1", "0.1", new Configuration(property1, property2));
-        PackageRepository packageRepository2 = PackageRepositoryMother.create("repo-2", "repo-2", "plugin1", "0.1", new Configuration(property3));
-
-        PackageDefinition packageDefinition1 = PackageDefinitionMother.create("pack-id-1", "pack-1", new Configuration(), packageRepository1);
-        PackageDefinition packageDefinition2 = PackageDefinitionMother.create("pack-id-1", "pack-1", new Configuration(), packageRepository2);
-
-        PackageMaterialConfig material1 = new PackageMaterialConfig(new CaseInsensitiveString("material1"), "pack-id-1", packageDefinition1);
-        PackageMaterialConfig material2 = new PackageMaterialConfig(new CaseInsensitiveString("material2"), "pack-id-2", packageDefinition2);
-
-        PipelineConfig pipelineConfig1 = pipelineConfig("pipe1", new MaterialConfigs(git("http://localhost"), material1));
-        PipelineConfig pipelineConfig2 = pipelineConfig("pipe2", new MaterialConfigs(material1));
-        PipelineConfig pipelineConfig3 = pipelineConfig("pipe3", new MaterialConfigs(material2));
-
-        when(goConfigService.getAllPipelineConfigs()).thenReturn(asList(pipelineConfig1, pipelineConfig2, pipelineConfig3));
-
-        PackageRepository updatedPackageRepository = PackageRepositoryMother.create("repo-1", "repo-1", "plugin1", "0.1", new Configuration(property2));
-
-        pipelineConfigService.packageRespositoryChangeListener().onEntityConfigChange(updatedPackageRepository);
-
-        assertThat(pipelineConfig1.materialConfigs().getPackageMaterial().getPackageDefinition().getRepository(), is(updatedPackageRepository));
-        assertThat(pipelineConfig2.materialConfigs().getPackageMaterial().getPackageDefinition().getRepository(), is(updatedPackageRepository));
-        assertThat(pipelineConfig3.materialConfigs().getPackageMaterial().getPackageDefinition().getRepository(), is(packageRepository2));
     }
 }


### PR DESCRIPTION
Reverts gocd/gocd#8563

The PipelineConfig is cached in multiple places, updating the SCM and Package for a pipleine in just PipelineConfigService leads to some unintended side effects, Refer - https://github.com/gocd/gocd/issues/8542#issuecomment-695925251

Reverting this commit for now, needs a thorough look before we try to fix it again.