### PR TITLE
Start GoCD Server in maintenance mode. (#5787)

### DIFF
--- a/api/api-server-maintenance-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/servermaintenancemode/representers/MaintenanceModeInfoRepresenterTest.groovy
+++ b/api/api-server-maintenance-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/servermaintenancemode/representers/MaintenanceModeInfoRepresenterTest.groovy
@@ -19,6 +19,7 @@ import com.thoughtworks.go.helper.JobInstanceMother
 import com.thoughtworks.go.helper.MaterialsMother
 import com.thoughtworks.go.server.domain.ServerMaintenanceMode
 import com.thoughtworks.go.server.service.MaintenanceModeService
+import com.thoughtworks.go.util.SystemEnvironment
 import com.thoughtworks.go.util.TimeProvider
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -42,9 +43,12 @@ class MaintenanceModeInfoRepresenterTest {
   @Mock
   TimeProvider timeProvider
 
+  @Mock
+  SystemEnvironment systemEnvironment
+
   @Test
   void "should represent maintenance mode info"() {
-    def maintenanceModeService = new MaintenanceModeService(timeProvider)
+    def maintenanceModeService = new MaintenanceModeService(timeProvider, systemEnvironment)
 
     def gitMaterial = MaterialsMother.gitMaterial("foo/bar")
     def hgMaterial = MaterialsMother.hgMaterial()
@@ -168,7 +172,7 @@ class MaintenanceModeInfoRepresenterTest {
 
   @Test
   void 'should not add attributes if server is not in maintenance mode'() {
-    def maintenanceModeService = new MaintenanceModeService(timeProvider)
+    def maintenanceModeService = new MaintenanceModeService(timeProvider, systemEnvironment)
 
     def actualJson = toObjectString({
       MaintenanceModeInfoRepresenter.toJSON(it, maintenanceModeService.get(), false, null, null, null)

--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -205,6 +205,8 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<Long> EPHEMERAL_AUTO_REGISTER_KEY_EXPIRY = new GoLongSystemProperty("gocd.ephemeral.auto.register.key.expiry.millis", 30 * 60 *1000L);
     public static GoSystemProperty<Double> MDU_EXPONENTIAL_BACKOFF_MULTIPLIER = new GoDoubleSystemProperty("gocd.mdu.exponential.backoff.multiplier", 1.5);
 
+    public static GoSystemProperty<Boolean> START_IN_MAINTENANCE_MODE = new GoBooleanSystemProperty("gocd.server.start.in.maintenance.mode", false);
+
     private final static Map<String, String> GIT_ALLOW_PROTOCOL;
 
     static {
@@ -797,6 +799,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public double getMDUExponentialBackOffMultiplier() {
         return MDU_EXPONENTIAL_BACKOFF_MULTIPLIER.getValue();
+    }
+
+    public boolean shouldStartServerInMaintenanceMode() {
+        return START_IN_MAINTENANCE_MODE.getValue();
     }
 
     public static abstract class GoSystemProperty<T> {

--- a/server/src/main/java/com/thoughtworks/go/server/service/MaintenanceModeService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/MaintenanceModeService.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.server.service;
 import com.google.gson.internal.bind.util.ISO8601Utils;
 import com.thoughtworks.go.domain.materials.Material;
 import com.thoughtworks.go.server.domain.ServerMaintenanceMode;
+import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TimeProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,9 +39,13 @@ public class MaintenanceModeService {
     private TimeProvider timeProvider;
 
     @Autowired
-    public MaintenanceModeService(TimeProvider timeProvider) {
+    public MaintenanceModeService(TimeProvider timeProvider, SystemEnvironment systemEnvironment) {
         this.timeProvider = timeProvider;
-        this.serverMaintenanceMode = new ServerMaintenanceMode();
+        if (systemEnvironment.shouldStartServerInMaintenanceMode()) {
+            this.serverMaintenanceMode = new ServerMaintenanceMode(true, "GoCD", timeProvider.currentTime());
+        } else {
+            this.serverMaintenanceMode = new ServerMaintenanceMode();
+        }
     }
 
     public ServerMaintenanceMode get() {

--- a/server/src/main/resources/server_in_maintenance_mode.html
+++ b/server/src/main/resources/server_in_maintenance_mode.html
@@ -80,7 +80,7 @@
     <div class="header clear_float">
       <a href="#" id="application_logo">&nbsp;</a>
       <div class="message">
-        <span id="message_text">%updatedBy% turned on maintenance mode at %updatedOn%.</span>
+        <span id="message_text"/>
         &nbsp;
         <a target="_blank" href="%docsBaseUrl%/advanced_usage/maintenance_mode.html">Learn more..</a>
       </div>
@@ -91,6 +91,9 @@
 <script type="application/javascript">
   (function () {
     var message = "%updatedBy% turned on maintenance mode at " + new Date("%updatedOn%").toString();
+    if("%updatedBy%" === 'GoCD') {
+      message = "GoCD Server is started in maintenance mode at " + new Date("%updatedOn%").toString();
+    }
     document.getElementById("message_text").innerText = message;
   })();
 </script>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/maintenance_mode_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/maintenance_mode_widget.tsx
@@ -19,8 +19,8 @@ import m from "mithril";
 import {MaintenanceModeInfo, RunningSystem, StageLocator} from "models/maintenance_mode/types";
 import {Link} from "views/components/link";
 import {SwitchBtn} from "views/components/switch";
-import {TooltipSize} from "views/components/tooltip";
 import * as Tooltip from "views/components/tooltip";
+import {TooltipSize} from "views/components/tooltip";
 import {DisabledSubsystemsWidget} from "views/pages/maintenance_mode/disabled_susbsystems_widget";
 import {JobInfoWidget} from "views/pages/maintenance_mode/running_jobs_widget.tsx";
 import {MDUInfoWidget} from "views/pages/maintenance_mode/running_mdus_widget";
@@ -54,7 +54,11 @@ export class MaintenanceModeWidget extends MithrilViewComponent<Attrs> {
 
     let updatedByMessage = "GoCD server maintenance mode is disabled by default.";
     if (maintenanceModeInfo.metdata.updatedBy !== null) {
-      updatedByMessage = `${maintenanceModeInfo.metdata.updatedBy} changed the maintenance mode state on ${maintenanceModeInfo.metdata.updatedOn}.`;
+      if (maintenanceModeInfo.metdata.updatedBy === "GoCD") {
+        updatedByMessage = `GoCD Server is started in maintenance mode at ${maintenanceModeInfo.metdata.updatedOn}.`;
+      } else {
+        updatedByMessage = `${maintenanceModeInfo.metdata.updatedBy} changed the maintenance mode state on ${maintenanceModeInfo.metdata.updatedOn}.`;
+      }
     }
 
     return (

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/spec/maintenance_mode_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/spec/maintenance_mode_widget_spec.tsx
@@ -19,16 +19,19 @@ import m from "mithril";
 import {MaintenanceModeWidget} from "views/pages/maintenance_mode/maintenance_mode_widget";
 import {TestData} from "views/pages/maintenance_mode/spec/test_data";
 import {TestHelper} from "views/pages/spec/test_helper";
+import {MaintenanceModeInfo} from "../../../../models/maintenance_mode/types";
 
 describe("Maintenance Mode Widget", () => {
   const toggleMaintenanceMode = jasmine.createSpy("onToggle");
-  const onCancelStage         = jasmine.createSpy("onCancelStage");
-  const helper                = new TestHelper();
+  const onCancelStage = jasmine.createSpy("onCancelStage");
+  const helper = new TestHelper();
 
+  let info: MaintenanceModeInfo;
   beforeEach(() => {
+    info = TestData.info();
     helper.mount(() => <MaintenanceModeWidget toggleMaintenanceMode={toggleMaintenanceMode}
                                               onCancelStage={onCancelStage}
-                                              maintenanceModeInfo={TestData.info()}/>);
+                                              maintenanceModeInfo={info}/>);
   });
 
   afterEach(helper.unmount.bind(helper));
@@ -47,8 +50,17 @@ describe("Maintenance Mode Widget", () => {
   });
 
   it("should provide the maintenance mode updated information", () => {
-    const updatedOn             = timeFormatter.format(TestData.UPDATED_ON);
+    const updatedOn = timeFormatter.format(TestData.UPDATED_ON);
     const expectedUpdatedByInfo = `${TestData.info().metdata.updatedBy} changed the maintenance mode state on ${updatedOn}.`;
+    expect(helper.textByTestId("maintenance-mode-updated-by-info")).toContain(expectedUpdatedByInfo);
+  });
+
+  it("should provide the maintenance mode updated information when GoCD Server is started in maintenance mode", () => {
+    info.metdata.updatedBy = "GoCD";
+    helper.redraw();
+
+    const updatedOn = timeFormatter.format(TestData.UPDATED_ON);
+    const expectedUpdatedByInfo = `GoCD Server is started in maintenance mode at ${updatedOn}.`;
     expect(helper.textByTestId("maintenance-mode-updated-by-info")).toContain(expectedUpdatedByInfo);
   });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.tsx
@@ -66,7 +66,12 @@ export class SiteFooter extends MithrilViewComponent<Attrs> {
   private static maintenanceModeOrLegacyBrowserBanner(vnode: m.Vnode<Attrs>) {
     if (vnode.attrs.isServerInMaintenanceMode) {
       const updatedOnLocalTime = TimeFormatter.format(vnode.attrs.maintenanceModeUpdatedOn);
-      const updatedByMessage   = `${vnode.attrs.maintenanceModeUpdatedBy} turned on maintenance mode at ${updatedOnLocalTime}.`;
+
+      let updatedByMessage   = `${vnode.attrs.maintenanceModeUpdatedBy} turned on maintenance mode at ${updatedOnLocalTime}.`;
+      if(vnode.attrs.maintenanceModeUpdatedBy === "GoCD") {
+        updatedByMessage   = `GoCD Server is started in maintenance mode at ${updatedOnLocalTime}.`;
+      }
+
       return (<div data-test-id="maintenance-mode-banner" class={styles.footerWarningBanner}>
         {updatedByMessage}
         &nbsp;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/spec/site_footer_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/spec/site_footer_spec.tsx
@@ -64,6 +64,26 @@ describe("SiteFooter", () => {
     expect(helper.root).not.toContainText("unsupported browser");
   });
 
+  it("should render maintenance mode banner when GoCD Server is started in maintenance mode", () => {
+    const attrs = {
+      copyrightYear: "2000",
+      formattedVersion: "x.y.z-1234-sha",
+      fullVersion: "x.y.z-1234",
+      goVersion: "x.y.z",
+      isServerInMaintenanceMode: true,
+      isSupportedBrowser: true,
+      maintenanceModeUpdatedOn: "2019-06-18T14:30:15Z",
+      maintenanceModeUpdatedBy: "GoCD"
+    };
+    mount(attrs);
+
+    expect(helper.byTestId("maintenance-mode-banner")).toBeInDOM();
+    const expectedMsg = `GoCD Server is started in maintenance mode at ${timeFormatter.format(attrs.maintenanceModeUpdatedOn)}`;
+    expect(helper.textByTestId("maintenance-mode-banner")).toContain(expectedMsg);
+    expect(helper.root).toContainText("maintenance");
+    expect(helper.root).not.toContainText("unsupported browser");
+  });
+
   it("should render old browser message on IE11", () => {
     const attrs = {
       copyrightYear: "2000",

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/MaintenanceModeServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/MaintenanceModeServiceTest.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.server.service;
 import com.thoughtworks.go.config.materials.svn.SvnMaterial;
 import com.thoughtworks.go.helper.MaterialsMother;
 import com.thoughtworks.go.server.domain.ServerMaintenanceMode;
+import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TimeProvider;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -32,16 +33,28 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 public class MaintenanceModeServiceTest {
     private TimeProvider timeProvider;
     private MaintenanceModeService maintenanceModeService;
+    private SystemEnvironment systemEnvironment;
 
     @BeforeEach
     void setUp() {
+        System.setProperty(SystemEnvironment.START_IN_MAINTENANCE_MODE.propertyName(), "false");
         timeProvider = new TimeProvider();
-        maintenanceModeService = new MaintenanceModeService(timeProvider);
+        systemEnvironment = new SystemEnvironment();
+        maintenanceModeService = new MaintenanceModeService(timeProvider, systemEnvironment);
     }
 
     @Test
     void shouldSetMaintenanceModeServiceToFalseOnStartup() {
         assertThat(maintenanceModeService.isMaintenanceMode()).isFalse();
+    }
+
+    @Test
+    void shouldSetMaintenanceModeServiceToTrueWhenServerIsStartedInMaintenanceMode() {
+        System.setProperty(SystemEnvironment.START_IN_MAINTENANCE_MODE.propertyName(), "true");
+        maintenanceModeService = new MaintenanceModeService(timeProvider, systemEnvironment);
+
+        assertThat(maintenanceModeService.isMaintenanceMode()).isTrue();
+        assertThat(maintenanceModeService.updatedBy()).isEqualTo("GoCD");
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/TimerSchedulerQuartzIntegrationTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/TimerSchedulerQuartzIntegrationTest.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.server.domain.ServerMaintenanceMode;
 import com.thoughtworks.go.server.scheduling.BuildCauseProducerService;
 import com.thoughtworks.go.server.service.result.ServerHealthStateOperationResult;
 import com.thoughtworks.go.util.SystemEnvironment;
+import com.thoughtworks.go.util.TestingClock;
 import com.thoughtworks.go.util.TimeProvider;
 import org.junit.After;
 import org.junit.Before;
@@ -45,10 +46,10 @@ public class TimerSchedulerQuartzIntegrationTest {
 
     @Before
     public void setUp() throws Exception {
-        maintenanceModeService = new MaintenanceModeService(new TimeProvider());
+        systemEnvironment = new SystemEnvironment();
+        maintenanceModeService = new MaintenanceModeService(new TimeProvider(), systemEnvironment);
         quartzSchedulerFactory = new StdSchedulerFactory();
         scheduler = quartzSchedulerFactory.getScheduler();
-        systemEnvironment = new SystemEnvironment();
         scheduler.start();
     }
 

--- a/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
+++ b/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
@@ -116,7 +116,7 @@ public class GoConfigFileHelper {
         SystemEnvironment systemEnvironment = new SystemEnvironment();
         try {
 
-            MaintenanceModeService maintenanceModeService = new MaintenanceModeService(new TimeProvider());
+            MaintenanceModeService maintenanceModeService = new MaintenanceModeService(new TimeProvider(), systemEnvironment);
             ServerHealthService serverHealthService = new ServerHealthService();
             ConfigRepository configRepository = new ConfigRepository(systemEnvironment);
             configRepository.initialize();


### PR DESCRIPTION
* Introduce 'gocd.server.start.in.maintenance.mode' system property
  to specify starting GoCD Server in maintenance mode.

* Update maintenance mode message when server is started in maintenance
  mode on:
	- maintenance mode spa.
	- global page footer.
	- maintenance mode banner at server_in_maintenance_mode.html


