### PR TITLE
Solve issue around missing SCMs coming from config repo

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -25,6 +25,7 @@ import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
 import com.thoughtworks.go.config.materials.tfs.TfsMaterialConfig;
 import com.thoughtworks.go.config.pluggabletask.PluggableTask;
 import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.domain.KillAllChildProcessTask;
 import com.thoughtworks.go.domain.NullTask;
 import com.thoughtworks.go.domain.RunIfConfigs;
@@ -316,7 +317,7 @@ public class ConfigConverter {
             return toScmMaterialConfig(crScmMaterial);
         } else if (crMaterial instanceof CRPluggableScmMaterial) {
             CRPluggableScmMaterial crPluggableScmMaterial = (CRPluggableScmMaterial) crMaterial;
-            return toPluggableScmMaterialConfig(crPluggableScmMaterial);
+            return toPluggableScmMaterialConfig(crPluggableScmMaterial, context);
         } else if (crMaterial instanceof CRPackageMaterial) {
             CRPackageMaterial crPackageMaterial = (CRPackageMaterial) crMaterial;
             return toPackageMaterial(crPackageMaterial);
@@ -366,7 +367,7 @@ public class ConfigConverter {
         return packageRepositoryHaving.findPackage(packageId);
     }
 
-    private PluggableSCMMaterialConfig toPluggableScmMaterialConfig(CRPluggableScmMaterial crPluggableScmMaterial) {
+    private PluggableSCMMaterialConfig toPluggableScmMaterialConfig(CRPluggableScmMaterial crPluggableScmMaterial, PartialConfigLoadContext context) {
         String id = crPluggableScmMaterial.getScmId();
         CRPluginConfiguration pluginConfig = crPluggableScmMaterial.getPluginConfiguration();
         SCM scmConfig;
@@ -386,6 +387,12 @@ public class ConfigConverter {
                 }
             } else {
                 scmConfig = getSCMs().findDuplicate(scmConfig);
+                if (scmConfig.getOrigin() instanceof RepoConfigOrigin) {
+                    RepoConfigOrigin origin = (RepoConfigOrigin) scmConfig.getOrigin();
+                    if (origin.getMaterial().equals(context.configMaterial())) {
+                        newSCMs.add(scmConfig);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Issue: https://github.com/gocd/gocd/issues/8546#issuecomment-691819884

Description:
During conversion of configs from config repo to one stored by GoCD, we check if the said scm is already present or not. If former, we set the same as material config and ignore the one defined.
The search for presence was on all the configs including the ones present in the partials.
 - On the first parse, the SCM would not be found - hence the same would be added to the partial. On save, this will get integrated with all the scms.
 - However on the next parse it would be found - hence the same will not be added to the partial. On save, this will get integrated with the ones defined in the scm, deleting the older partial - effectively removing the scm

Fix: if the scm is already present - check the origin. If the origin is the current config repo - add it to the partial



