### PR TITLE
Move java dependency declarations to separate file and format for Dependabot

### DIFF
--- a/agent-bootstrapper/build.gradle
+++ b/agent-bootstrapper/build.gradle
@@ -20,19 +20,19 @@ description = 'GoCD Agent Bootstrapper'
 
 dependencies {
   implementation project(':agent-common')
-  implementation group: 'commons-codec', name: 'commons-codec', version: project.versions.commonsCodec
+  implementation project.deps.commonsCodec
 
-  testRuntimeOnly group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testRuntimeOnly group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: project.versions.bouncyCastle
+  testRuntimeOnly project.deps.bouncyCastle
+  testRuntimeOnly project.deps.bouncyCastlePkix
   testImplementation project(':test:test-utils')
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
+  testImplementation project.deps.mockito
+  testImplementation project.deps.hamcrestLibrary
   packagingOnly project(path: ':agent-launcher', configuration: 'fatJarConfig')
   extractedAtTopLevel project(':jar-class-loader')
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }
 
 jar {

--- a/agent-common/build.gradle
+++ b/agent-common/build.gradle
@@ -17,18 +17,18 @@
 description = 'GoCD Agent Common Utilities'
 
 dependencies {
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+  annotationProcessor project.deps.lombok
 
   api project(':base')
-  api group: 'com.beust', name: 'jcommander', version: project.versions.jcommander
+  api project.deps.jcommander
 
-  testRuntimeOnly group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testRuntimeOnly group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
+  testRuntimeOnly project.deps.bouncyCastle
+  testRuntimeOnly project.deps.bouncyCastlePkix
+  testImplementation project.deps.mockito
+  testImplementation project.deps.hamcrestLibrary
   testImplementation project(':test:test-utils')
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/agent-launcher/build.gradle
+++ b/agent-launcher/build.gradle
@@ -23,16 +23,16 @@ configurations {
 }
 
 dependencies {
-  packagingOnly group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  packagingOnly group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: project.versions.bouncyCastle
+  packagingOnly project.deps.bouncyCastle
+  packagingOnly project.deps.bouncyCastlePkix
 
   implementation project(':agent-common')
 
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
+  testImplementation project.deps.mockito
   testImplementation project(':test:test-utils')
 }
 

--- a/agent-process-launcher/build.gradle
+++ b/agent-process-launcher/build.gradle
@@ -18,13 +18,13 @@ description = 'GoCD Agent Process Launcher Classes'
 
 dependencies {
   implementation project(':agent-common')
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
+  testImplementation project.deps.mockito
+  testImplementation project.deps.hamcrestLibrary
   testImplementation project(':test:test-utils')
-  testRuntimeOnly group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testRuntimeOnly group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: project.versions.bouncyCastle
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testRuntimeOnly project.deps.bouncyCastle
+  testRuntimeOnly project.deps.bouncyCastlePkix
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -60,25 +60,25 @@ configurations {
 }
 
 dependencies {
-  packagingOnly group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  packagingOnly group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: project.versions.bouncyCastle
+  packagingOnly project.deps.bouncyCastle
+  packagingOnly project.deps.bouncyCastlePkix
 
   implementation project(':agent-common')
   implementation project(':common')
-  implementation group: 'javax.annotation', name: 'javax.annotation-api', version: project.versions.javaxAnnotation
-  implementation group: 'org.objenesis', name: 'objenesis', version: project.versions.objenesis
-  implementation group: 'org.apache.commons', name: 'commons-configuration2', version: project.versions.commonsConfiguration
-  implementation group: 'org.nanohttpd', name: 'nanohttpd', version: versions.nanohttpd
+  implementation project.deps.javaxAnnotation
+  implementation project.deps.objenesis
+  implementation project.deps.commonsConfiguration
+  implementation project.deps.nanohttpd
 
   testImplementation project(path: ':common', configuration: 'testOutput')
   testImplementation project(path: ':config:config-api', configuration: 'testOutput')
   testImplementation project(':test:test-utils')
 
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-migrationsupport', version: project.versions.junit5
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
+  testImplementation project.deps.junit5Migration
 
   extractedAtTopLevel project(':agent-process-launcher')
   extractedAtTopLevel project(':jar-class-loader')
@@ -142,7 +142,7 @@ task verifyJar(type: VerifyJarTask) {
       "commons-text-1.8.jar",
       "config-api-${project.version}.jar",
       "db-${project.version}.jar",
-      "dom4j-1.6.1.jar",
+      "dom4j-${project.versions.dom4j}.jar",
       "domain-${project.version}.jar",
       "error_prone_annotations-2.3.4.jar",
       "failureaccess-1.0.1.jar",
@@ -166,7 +166,7 @@ task verifyJar(type: VerifyJarTask) {
       "javax.activation-api-1.2.0.jar",
       "javax.annotation-api-${project.versions.javaxAnnotation}.jar",
       "javax.inject-1.jar",
-      "javax.servlet-api-3.1.0.jar",
+      "javax.servlet-api-${project.versions.servletApi}.jar",
       "jaxb-api-${project.versions.jaxb}.jar",
       "jaxb-runtime-${project.versions.jaxb}.jar",
       "jcl-over-slf4j-${project.versions.slf4j}.jar",
@@ -179,7 +179,7 @@ task verifyJar(type: VerifyJarTask) {
       "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
       "logback-classic-${project.versions.logback}.jar",
       "logback-core-${project.versions.logback}.jar",
-      "nanohttpd-2.3.1.jar",
+      "nanohttpd-${project.versions.nanohttpd}.jar",
       "objenesis-${project.versions.objenesis}.jar",
       "org.apache.felix.framework-${project.versions.felix}.jar",
       "plugin-metadata-store-${project.version}.jar",

--- a/api/api-abstract-material-test/build.gradle
+++ b/api/api-abstract-material-test/build.gradle
@@ -22,6 +22,6 @@ dependencies {
 
     testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+    testImplementation project.deps.junit5
+    testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-access-token-v1/build.gradle
+++ b/api/api-access-token-v1/build.gradle
@@ -22,6 +22,6 @@ dependencies {
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
   testImplementation project(path: ':server', configuration: 'sharedTestOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-admins-config-v2/build.gradle
+++ b/api/api-admins-config-v2/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-agent-job-history-v1/build.gradle
+++ b/api/api-agent-job-history-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-agents-v7/build.gradle
+++ b/api/api-agents-v7/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-api-info-v1/build.gradle
+++ b/api/api-api-info-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-api-info-v2/build.gradle
+++ b/api/api-api-info-v2/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-artifact-config-v1/build.gradle
+++ b/api/api-artifact-config-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-artifact-store-config-v1/build.gradle
+++ b/api/api-artifact-store-config-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-backup-config-v1/build.gradle
+++ b/api/api-backup-config-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-backups-v1/build.gradle
+++ b/api/api-backups-v1/build.gradle
@@ -21,7 +21,7 @@ dependencies {
   implementation project(':api:api-user-representers-v1')
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.bouncyCastle
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-backups-v2/build.gradle
+++ b/api/api-backups-v2/build.gradle
@@ -22,6 +22,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-base/build.gradle
+++ b/api/api-base/build.gradle
@@ -22,7 +22,7 @@ dependencies {
   testImplementation localGroovy()
   testImplementation project(path: ':server', configuration: 'testOutput')
   testImplementation project(path: ':spark:spark-base', configuration: 'testOutput')
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.bouncyCastle
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-build_cause-v1/build.gradle
+++ b/api/api-build_cause-v1/build.gradle
@@ -20,6 +20,6 @@ dependencies {
   implementation project(':api:api-base')
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-cctray/build.gradle
+++ b/api/api-cctray/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-cluster-profiles-v1/build.gradle
+++ b/api/api-cluster-profiles-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-compare-v2/build.gradle
+++ b/api/api-compare-v2/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-config-repo-operations-v1/build.gradle
+++ b/api/api-config-repo-operations-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-config-repos-v4/build.gradle
+++ b/api/api-config-repos-v4/build.gradle
@@ -22,6 +22,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-current-user-v1/build.gradle
+++ b/api/api-current-user-v1/build.gradle
@@ -21,7 +21,7 @@ dependencies {
   implementation project(':api:api-user-representers-v1')
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.bouncyCastle
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-dashboard-v3/build.gradle
+++ b/api/api-dashboard-v3/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation project(':api:api-base')
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.bouncyCastle
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-dashboard-v4/build.gradle
+++ b/api/api-dashboard-v4/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-default-job-timeout-v1/build.gradle
+++ b/api/api-default-job-timeout-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-dependency-material-autocomplete-v1/build.gradle
+++ b/api/api-dependency-material-autocomplete-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-elastic-profile-operation-v1/build.gradle
+++ b/api/api-elastic-profile-operation-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-elastic-profile-v2/build.gradle
+++ b/api/api-elastic-profile-v2/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-encryption-v1/build.gradle
+++ b/api/api-encryption-v1/build.gradle
@@ -18,11 +18,11 @@ apply plugin: 'groovy'
 
 dependencies {
   implementation project(':api:api-base')
-  implementation group: 'org.isomorphism', name: 'token-bucket', version: '1.7'
-  providedAtPackageTime group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
+  implementation project.deps.tokenBucket
+  providedAtPackageTime project.deps.bouncyCastle
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.bouncyCastle
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-environments-v3/build.gradle
+++ b/api/api-environments-v3/build.gradle
@@ -20,6 +20,6 @@ dependencies {
   implementation project(':api:api-base')
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-export-v1/build.gradle
+++ b/api/api-export-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-feature-toggles-v1/build.gradle
+++ b/api/api-feature-toggles-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-feeds-api-v1/build.gradle
+++ b/api/api-feeds-api-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-internal-dependency-pipelines-v1/build.gradle
+++ b/api/api-internal-dependency-pipelines-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-internal-environments-v1/build.gradle
+++ b/api/api-internal-environments-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-internal-material-test-v1/build.gradle
+++ b/api/api-internal-material-test-v1/build.gradle
@@ -23,6 +23,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-internal-materials-v1/build.gradle
+++ b/api/api-internal-materials-v1/build.gradle
@@ -19,9 +19,9 @@ apply plugin: 'groovy'
 dependencies {
   implementation project(':api:api-base')
 
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+  annotationProcessor project.deps.lombok
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-internal-pipeline-groups-v1/build.gradle
+++ b/api/api-internal-pipeline-groups-v1/build.gradle
@@ -19,9 +19,9 @@ apply plugin: 'groovy'
 dependencies {
   implementation project(':api:api-base')
 
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+  annotationProcessor project.deps.lombok
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-internal-pipeline-structure-v1/build.gradle
+++ b/api/api-internal-pipeline-structure-v1/build.gradle
@@ -19,9 +19,9 @@ apply plugin: 'groovy'
 dependencies {
   implementation project(':api:api-base')
 
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+  annotationProcessor project.deps.lombok
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-internal-resources-v1/build.gradle
+++ b/api/api-internal-resources-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-internal-scms-v1/build.gradle
+++ b/api/api-internal-scms-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-internal-secret-config-v1/build.gradle
+++ b/api/api-internal-secret-config-v1/build.gradle
@@ -18,9 +18,9 @@ apply plugin: 'groovy'
 
 dependencies {
   implementation project(':api:api-base')
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+  annotationProcessor project.deps.lombok
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-job-instance-v1/build.gradle
+++ b/api/api-job-instance-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-mail-server-v1/build.gradle
+++ b/api/api-mail-server-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-material-search-v1/build.gradle
+++ b/api/api-material-search-v1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation project(':api:api-base')
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.bouncyCastle
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-materials-v2/build.gradle
+++ b/api/api-materials-v2/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-notification-filter-v2/build.gradle
+++ b/api/api-notification-filter-v2/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-package-repository-v1/build.gradle
+++ b/api/api-package-repository-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-packages-v2/build.gradle
+++ b/api/api-packages-v2/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-permissions-v1/build.gradle
+++ b/api/api-permissions-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-pipeline-config-v11/build.gradle
+++ b/api/api-pipeline-config-v11/build.gradle
@@ -22,6 +22,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-pipeline-groups-v1/build.gradle
+++ b/api/api-pipeline-groups-v1/build.gradle
@@ -23,6 +23,6 @@ dependencies {
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
   testImplementation project(path: ':config:config-api', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-pipeline-instance-v1/build.gradle
+++ b/api/api-pipeline-instance-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-pipeline-operations-v1/build.gradle
+++ b/api/api-pipeline-operations-v1/build.gradle
@@ -21,11 +21,11 @@ dependencies {
   implementation project(':config:config-api')
   implementation project(':api:api-base')
 
-  providedAtPackageTime(group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle)
+  providedAtPackageTime(project.deps.bouncyCastle)
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
   testImplementation project(path: ':config:config-api', configuration: 'testOutput')
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.bouncyCastle
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-pipeline-selection-v1/build.gradle
+++ b/api/api-pipeline-selection-v1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation project(':api:api-base')
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.bouncyCastle
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-pipelines-as-code-internal-v1/build.gradle
+++ b/api/api-pipelines-as-code-internal-v1/build.gradle
@@ -22,6 +22,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-plugin-images/build.gradle
+++ b/api/api-plugin-images/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation project(':api:api-base')
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.bouncyCastle
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-plugin-infos-v7/build.gradle
+++ b/api/api-plugin-infos-v7/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-plugin-settings-v1/build.gradle
+++ b/api/api-plugin-settings-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-roles-config-v3/build.gradle
+++ b/api/api-roles-config-v3/build.gradle
@@ -18,9 +18,9 @@ apply plugin: 'groovy'
 
 dependencies {
   implementation project(':api:api-base')
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+  annotationProcessor project.deps.lombok
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-scms-v3/build.gradle
+++ b/api/api-scms-v3/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-scms-v4/build.gradle
+++ b/api/api-scms-v4/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-secret-configs-v2/build.gradle
+++ b/api/api-secret-configs-v2/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-secret-configs-v3/build.gradle
+++ b/api/api-secret-configs-v3/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-security-auth-config-v2/build.gradle
+++ b/api/api-security-auth-config-v2/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-server-health-messages-v1/build.gradle
+++ b/api/api-server-health-messages-v1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation project(':api:api-base')
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.bouncyCastle
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-server-health-v1/build.gradle
+++ b/api/api-server-health-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-server-maintenance-mode-v1/build.gradle
+++ b/api/api-server-maintenance-mode-v1/build.gradle
@@ -22,6 +22,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-server-site-urls-config-v1/build.gradle
+++ b/api/api-server-site-urls-config-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-shared-v1/build.gradle
+++ b/api/api-shared-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-shared-v10/build.gradle
+++ b/api/api-shared-v10/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-shared-v11/build.gradle
+++ b/api/api-shared-v11/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-shared-v9/build.gradle
+++ b/api/api-shared-v9/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-stage-instance-v2/build.gradle
+++ b/api/api-stage-instance-v2/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-stage-instance-v3/build.gradle
+++ b/api/api-stage-instance-v3/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-stage-operations-v2/build.gradle
+++ b/api/api-stage-operations-v2/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-support/build.gradle
+++ b/api/api-support/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-template-authorization-v1/build.gradle
+++ b/api/api-template-authorization-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-template-config-v7/build.gradle
+++ b/api/api-template-config-v7/build.gradle
@@ -23,8 +23,8 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
   testImplementation project(path: ':config:config-api', configuration: 'testOutput')
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
+  testImplementation project.deps.bouncyCastle
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-user-representers-v1/build.gradle
+++ b/api/api-user-representers-v1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation project(':api:api-base')
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.bouncyCastle
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-user-search-v1/build.gradle
+++ b/api/api-user-search-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-users-v3/build.gradle
+++ b/api/api-users-v3/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-version-infos-v1/build.gradle
+++ b/api/api-version-infos-v1/build.gradle
@@ -18,10 +18,10 @@ apply plugin: 'groovy'
 
 dependencies {
   implementation project(':api:api-base')
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+  annotationProcessor project.deps.lombok
   
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-version-v1/build.gradle
+++ b/api/api-version-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/api/api-webhook-v1/build.gradle
+++ b/api/api-webhook-v1/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 
   testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/app-server/build.gradle
+++ b/app-server/build.gradle
@@ -18,5 +18,5 @@ description = 'GoCD AppServer Module'
 
 dependencies {
   implementation project(':base')
-  implementation group: 'javax.servlet', name: 'javax.servlet-api', version: project.versions.servletApi
+  implementation project.deps.servletApi
 }

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -17,32 +17,32 @@
 description = 'GoCD Base'
 
 dependencies {
-  providedAtPackageTime group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  providedAtPackageTime group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: project.versions.bouncyCastle
+  providedAtPackageTime project.deps.bouncyCastle
+  providedAtPackageTime project.deps.bouncyCastlePkix
 
-  api(group: 'org.apache.ant', name: 'ant', version: project.versions.apacheAnt)  {
+  api(project.deps.apacheAnt)  {
     transitive = false
   }
-  api group: 'commons-io', name: 'commons-io', version: project.versions.commonsIO
-  api group: 'org.apache.commons', name: 'commons-lang3', version: project.versions.commonsLang3
-  api group: 'commons-codec', name: 'commons-codec', version: project.versions.commonsCodec
-  api(group: 'org.apache.httpcomponents', name: 'httpclient', version: project.versions.apacheHttpComponents) {
+  api project.deps.commonsIO
+  api project.deps.commonsLang3
+  api project.deps.commonsCodec
+  api(project.deps.apacheHttpComponents) {
     exclude(module: 'commons-codec')
     exclude(module: 'commons-logging')
   }
-  api group: 'joda-time', name: 'joda-time', version: project.versions.jodaTime
-  api group: 'org.slf4j', name: 'jcl-over-slf4j', version: project.versions.slf4j
-  api group: 'ch.qos.logback', name: 'logback-classic', version: project.versions.logback
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  testImplementation group: 'com.googlecode', name: 'junit-ext', version: '1.0'
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: project.versions.hamcrest
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-migrationsupport', version: project.versions.junit5
-  testImplementation group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
+  api project.deps.jodaTime
+  api project.deps.slf4jJcl
+  api project.deps.logback
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
+  testImplementation project.deps.junitExt
+  testImplementation project.deps.hamcrest
+  testImplementation project.deps.hamcrestLibrary
+  testImplementation project.deps.mockito
+  testImplementation project.deps.junit5Migration
+  testImplementation project.deps.assertJ
 }
 
 def generatedResourcesOutput = file("resources-generated")

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ buildscript {
   }
 }
 
+apply from: 'dependencies.gradle'
 apply plugin: 'base'
 apply plugin: 'com.github.jk1.dependency-license-report'
 apply plugin: 'org.owasp.dependencycheck'
@@ -162,91 +163,8 @@ project.ext.compilerOptions = [
   targetCompatibility: 11,
 ]
 
-rootProject.ext.versions = [
-  activeMQ              : '5.15.10',
-  apacheAnt             : '1.10.7',
-  apacheHttpComponents  : '4.5.6',
-  aspectj               : '1.9.5',
-  assertJ               : '3.12.2',
-  assertJ_DB            : '1.3.0',
-  bouncyCastle          : '1.67', // This version of BC is not compatible with the jruby-opensssl version, since we are not using jruby-opensssl going ahead with the upgrade.
-  bundler               : '2.1.1',
-  cglib                 : '3.3.0',
-  cloning               : '1.9.11',
-  commonsBeanutils      : '1.9.3',
-  commonsCodec          : '1.14',
-  commonsCollections    : '3.2.2',
-  commonsCollections4   : '4.4',
-  commonsConfiguration  : '2.6',
-  commonsDbcp           : '2.7.0',
-  commonsDigester       : '2.1',
-  commonsDigester3      : '3.2',
-  commonsFileUpload     : '1.4',
-  commonsIO             : '2.6',
-  commonsLang           : '2.6',
-  commonsLang3          : '3.9',
-  commonsPool           : '2.8.0',
-  dbunit                : '2.7.0',
-  ehcache               : '2.10.6',
-  felix                 : '5.6.10',
-  freemarker            : '2.3.29',
-  gson                  : '2.8.6',
-  guava                 : '29.0-jre',
-  h2                    : '1.4.200',
-  hamcrest              : '2.2',
-  hibernate             : '3.6.10.Final',
-  jackson               : '2.9.9',
-  javaAssist            : '3.12.1.GA',
-  javaxAnnotation       : '1.3.2',
-  jaxb                  : '2.3.1',
-  jaxen                 : '1.2.0',
-  jcommander            : '1.78',
-  jdom                  : '2.0.6',
-  jetBrainsAnnotations  : '19.0.0',
-  jetty                 : '9.4.27.v20200227',
-  jgit                  : '5.1.3.201810200350-r',
-  jodaTime              : '2.9.9', // joda-time version has to be compatible with the jruby version
-  jolt                  : '0.1.1',
-  jruby                 : '9.2.0.0',
-  jsonUnit              : '2.14.0',
-  jsoup                 : '1.13.1',
-  junit                 : '4.13',
-  junit5                : '5.6.0',
-  liquibase             : '3.9.0',
-  logback               : '1.2.3',
-  lombok                : '1.18.12',
-  mail                  : '1.6.1',
-  mockito               : '3.3.0',
-  mybatis               : '3.4.6',
-  mybatisSpring         : '1.3.2',
-  mysql                 : '8.0.19',
-  nanohttpd             : '2.3.1',
-  objenesis             : '2.6',
-  postgresql            : '42.2.10',
-  quartz                : '2.3.1',
-  rack                  : '1.1.21',
-  semanticVersion       : '2.1.0',
-  servletApi            : '3.1.0',
-  slf4j                 : '1.7.30',
-  spark                 : '2.7.2',
-  spring                : '4.3.29.RELEASE',
-  spring4jUnit5Extension: '1.5.0',
-  springSecurity        : '4.2.19.RELEASE',
-  systemRules           : '1.19.0',
-  tanuki                : '3.5.41',
-  testcontainersJdbc    : '1.14.3',
-  tini                  : '0.18.0',
-  tinybundles           : '3.0.0',
-  tokenBucket           : '1.7',
-  urlrewrite            : '3.2.0',
-  velocityToolsView     : '1.4',
-  xmlUnit               : '2.6.3',
-
-  seleniumDrivers       : [
-    chromedriver  : '86.0.4240.22',
-    geckodriver   : '0.27.0',
-  ],
-  adoptOpenjdk          : [
+project.ext.packaging = [
+  adoptOpenjdk: [
     featureVersion: 15,
     interimVersion: 0, // set to `null` for the first release
     updateVersion : 1, // set to `null` for the first release
@@ -716,10 +634,10 @@ subprojects {
       // replace log4j and commons-logging implementations with the slf4j apis that redirect logs to slf4j
       // see https://www.slf4j.org/legacy.html
       if (details.requested.name == 'log4j' && details.requested.group == 'log4j') {
-        details.useTarget group: 'org.slf4j', name: 'log4j-over-slf4j', version: project.versions.slf4j
+        details.useTarget project.deps.slf4jLog4j
       }
       if (details.requested.name == 'commons-logging' && details.requested.group == 'commons-logging') {
-        details.useTarget group: 'org.slf4j', name: 'jcl-over-slf4j', version: project.versions.slf4j
+        details.useTarget project.deps.slf4jJcl
       }
     }
   }
@@ -1106,8 +1024,8 @@ task newApi {
 
             testImplementation project(path: ':api:api-base', configuration: 'testOutput')
 
-            testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-            testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+            testImplementation project.deps.junit5
+            testRuntimeOnly project.deps.junit5Engine
           }
         """
       out.println(contents.stripIndent().trim())

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+apply from: '../dependencies.gradle'
 apply plugin: "groovy"
 
 repositories {
@@ -29,8 +30,8 @@ repositories {
 dependencies {
   implementation localGroovy()
   implementation gradleApi()
-  implementation group: 'commons-codec', name: 'commons-codec', version: '1.15'
-  implementation group: 'de.undercouch', name: 'gradle-download-task', version: '4.1.1'
-  implementation group: 'org.ysb33r.gradle', name: 'grolifant', version: '0.17.0'
-  implementation group: 'org.freemarker', name: 'freemarker', version: '2.3.28'
+  implementation project.deps.commonsCodec
+  implementation project.deps.gradleDownload
+  implementation project.deps.grolifant
+  implementation project.deps.freemarker
 }

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
@@ -44,10 +44,10 @@ trait DistroBehavior {
   List<String> getInstallJavaCommands(Project project) {
     def downloadUrl = AdoptOpenJDKUrlHelper.downloadURL(
       com.thoughtworks.go.build.OperatingSystem.linux,
-      project.versions.adoptOpenjdk.featureVersion,
-      project.versions.adoptOpenjdk.interimVersion,
-      project.versions.adoptOpenjdk.updateVersion,
-      project.versions.adoptOpenjdk.buildVersion)
+      project.packaging.adoptOpenjdk.featureVersion,
+      project.packaging.adoptOpenjdk.interimVersion,
+      project.packaging.adoptOpenjdk.updateVersion,
+      project.packaging.adoptOpenjdk.buildVersion)
 
     return [
       "curl --fail --location --silent --show-error '${downloadUrl}' --output /tmp/jre.tar.gz",

--- a/commandline/build.gradle
+++ b/commandline/build.gradle
@@ -20,16 +20,16 @@ dependencies {
   implementation project(':base')
   implementation project(':util')
   implementation project(':config:config-api')
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+  annotationProcessor project.deps.lombok
 
   testImplementation project(':test:test-utils')
-  testImplementation group: 'com.googlecode', name: 'junit-ext', version: '1.0'
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: project.versions.hamcrest
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-migrationsupport', version: project.versions.junit5
+  testImplementation project.deps.junitExt
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
+  testImplementation project.deps.hamcrest
+  testImplementation project.deps.hamcrestLibrary
+  testImplementation project.deps.mockito
+  testImplementation project.deps.junit5Migration
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -23,23 +23,23 @@ dependencies {
   api project(':util')
   api project(':domain')
   api project(':plugin-infra:go-plugin-access')
-  api group: 'dom4j', name: 'dom4j', version: '1.6.1'
-  api group: 'org.apache.httpcomponents', name: 'httpmime', version: project.versions.apacheHttpComponents
-  api group: 'org.apache.commons', name: 'commons-collections4', version: project.versions.commonsCollections4
-  api group: 'org.springframework', name: 'spring-tx', version: project.versions.spring
-  implementation group: 'joda-time', name: 'joda-time', version: project.versions.jodaTime
+  api project.deps.dom4j
+  api project.deps.apacheHttpMime
+  api project.deps.commonsCollections4
+  api project.deps.springTx
+  implementation project.deps.jodaTime
 
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: project.versions.bouncyCastle
+  testImplementation project.deps.bouncyCastle
+  testImplementation project.deps.bouncyCastlePkix
   testImplementation project(path: ':config:config-api', configuration: 'testOutput')
   testImplementation project(path: ':domain', configuration: 'testOutput')
-  testImplementation group: 'net.javacrumbs.json-unit', name: 'json-unit-fluent', version: project.versions.jsonUnit
+  testImplementation project.deps.jsonUnit
   testImplementation project(':test:test-utils')
-  testImplementation group: 'com.google.guava', name: 'guava', version: project.versions.guava
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: project.versions.junit5
+  testImplementation project.deps.guava
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
+  testImplementation project.deps.junit5Params
 }
 

--- a/config/config-api/build.gradle
+++ b/config/config-api/build.gradle
@@ -23,30 +23,30 @@ dependencies {
   implementation project(':plugin-infra:go-plugin-domain')
   implementation project(':plugin-infra:go-plugin-api')
   implementation project(':db')
-  api group: 'javax.annotation', name: 'javax.annotation-api', version: project.versions.javaxAnnotation
+  api project.deps.javaxAnnotation
 
-  implementation group: 'commons-codec', name: 'commons-codec', version: project.versions.commonsCodec
-  implementation group: 'org.apache.commons', name: 'commons-collections4', version: project.versions.commonsCollections4
-  api(group: 'org.quartz-scheduler', name: 'quartz', version: project.versions.quartz) {
+  implementation project.deps.commonsCodec
+  implementation project.deps.commonsCollections4
+  api(project.deps.quartz) {
     transitive = false
   }
-  api group: 'uk.com.robust-it', name: 'cloning', version: project.versions.cloning
-  api group: 'org.jdom', name: 'jdom2', version: project.versions.jdom
-  implementation group: 'org.slf4j', name: 'slf4j-api', version: project.versions.slf4j
-  implementation group: 'org.apache.felix', name: 'org.apache.felix.framework', version: project.versions.felix
-  api group: 'com.google.guava', name: 'guava', version: project.versions.guava
-  implementation group: 'joda-time', name: 'joda-time', version: project.versions.jodaTime
-  providedAtPackageTime group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+  api project.deps.cloning
+  api project.deps.jdom
+  implementation project.deps.slf4j
+  implementation project.deps.felix
+  api project.deps.guava
+  implementation project.deps.jodaTime
+  providedAtPackageTime project.deps.bouncyCastle
+  annotationProcessor project.deps.lombok
 
   testImplementation project(':test:test-utils')
-  testImplementation group: 'jaxen', name: 'jaxen', version: project.versions.jaxen
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-migrationsupport', version: project.versions.junit5
+  testImplementation project.deps.jaxen
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
+  testImplementation project.deps.mockito
+  testImplementation project.deps.hamcrestLibrary
+  testImplementation project.deps.junit5Params
+  testImplementation project.deps.junit5Migration
 }

--- a/config/config-server/build.gradle
+++ b/config/config-server/build.gradle
@@ -19,23 +19,23 @@ description = 'API to configure/access cruise-config.xml'
 dependencies {
   implementation project(':config:config-api')
   implementation project(':common')
-  implementation(group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: project.versions.jgit) {
+  implementation(project.deps.jgit) {
     exclude(group: 'org.apache.httpcomponents')
     exclude(module: 'jsch')
     exclude(module: 'jzlib')
   }
-  implementation group: 'org.slf4j', name: 'slf4j-api', version: project.versions.slf4j
-  implementation group: 'cglib', name: 'cglib', version: project.versions.cglib
-  providedAtPackageTime(group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle)
+  implementation project.deps.slf4j
+  implementation project.deps.cglib
+  providedAtPackageTime(project.deps.bouncyCastle)
   testImplementation project(path: ':config:config-api', configuration: 'testOutput')
   testImplementation project(':test:test-utils')
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-migrationsupport', version: project.versions.junit5
-  testImplementation group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
-  testImplementation group: 'org.xmlunit', name: 'xmlunit-assertj', version: project.versions.xmlUnit
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.junit5
+  testImplementation project.deps.junit5Migration
+  testImplementation project.deps.assertJ
+  testImplementation project.deps.xmlUnit
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testRuntimeOnly project.deps.junit5Engine
 
 }
 

--- a/db-support/db-migration/build.gradle
+++ b/db-support/db-migration/build.gradle
@@ -17,24 +17,24 @@
 apply plugin: 'java'
 
 dependencies {
-    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+    annotationProcessor project.deps.lombok
 
-    implementation group: 'org.apache.commons', name: 'commons-dbcp2', version: project.versions.commonsDbcp
-    implementation group: 'org.apache.commons', name: 'commons-lang3', version: project.versions.commonsLang3
-    implementation group: 'com.google.code.gson', name: 'gson', version: project.versions.gson
-    implementation group: 'org.springframework', name: 'spring-context', version: project.versions.spring
-    implementation group: 'javax.annotation', name: 'javax.annotation-api', version: project.versions.javaxAnnotation
+    implementation project.deps.commonsDbcp
+    implementation project.deps.commonsLang3
+    implementation project.deps.gson
+    implementation project.deps.springContext
+    implementation project.deps.javaxAnnotation
 
-    implementation group: 'org.liquibase', name: 'liquibase-core', version: project.versions.liquibase
-    implementation group: 'javax.xml.bind', name: 'jaxb-api', version: project.versions.jaxb
+    implementation project.deps.liquibase
+    implementation project.deps.jaxb
 
-    testImplementation group: 'org.testcontainers', name: 'jdbc', version: project.versions.testcontainersJdbc
+    testImplementation project.deps.testcontainersJdbc
 
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
-    testImplementation group: 'org.assertj', name: 'assertj-db', version: project.versions.assertJ_DB
+    testImplementation project.deps.assertJ
+    testImplementation project.deps.assertJ_DB
 
-    testImplementation group: 'com.h2database', name: 'h2', version: project.versions.h2
+    testImplementation project.deps.h2
 
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+    testImplementation project.deps.junit5
+    testRuntimeOnly project.deps.junit5Engine
 }

--- a/db-support/db-support-base/build.gradle
+++ b/db-support/db-support-base/build.gradle
@@ -15,18 +15,18 @@
  */
 
 dependencies {
-    implementation group: 'org.apache.commons', name: 'commons-dbcp2', version: project.versions.commonsDbcp
-    api group: 'org.apache.commons', name: 'commons-lang3', version: project.versions.commonsLang3
-    api group: 'org.zeroturnaround', name: 'zt-exec', version: '1.12'
-    api(group: 'org.apache.ant', name: 'ant', version: project.versions.apacheAnt) {
+    implementation project.deps.commonsDbcp
+    api project.deps.commonsLang3
+    api project.deps.ztExec
+    api(project.deps.apacheAnt) {
         transitive = false
     }
 
-    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+    annotationProcessor project.deps.lombok
 
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
+    testImplementation project.deps.assertJ
 
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+    testImplementation project.deps.junit5
+    testRuntimeOnly project.deps.junit5Engine
 }
 

--- a/db-support/db-support-h2/build.gradle
+++ b/db-support/db-support-h2/build.gradle
@@ -15,12 +15,12 @@
  */
 
 dependencies {
-    implementation group: 'com.h2database', name: 'h2', version: project.versions.h2
+    implementation project.deps.h2
     api project(':db-support:db-support-base')
 
     testImplementation project(path: ':db-support:db-migration', configuration: 'testOutput')
 
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+    testImplementation project.deps.assertJ
+    testImplementation project.deps.junit5
+    testRuntimeOnly project.deps.junit5Engine
 }

--- a/db-support/db-support-mysql/build.gradle
+++ b/db-support/db-support-mysql/build.gradle
@@ -15,18 +15,18 @@
  */
 
 dependencies {
-    implementation group: 'mysql', name: 'mysql-connector-java', version: project.versions.mysql
+    implementation project.deps.mysql
     api project(':db-support:db-support-base')
 
-    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+    annotationProcessor project.deps.lombok
 
     testImplementation project(path: ':db-support:db-migration', configuration: 'testOutput')
 
-    testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.14.3'
-    testImplementation group: 'org.testcontainers', name: 'testcontainers', version: '1.14.3'
-    testImplementation group: 'org.testcontainers', name: 'mysql', version: '1.14.3'
+    testImplementation project.deps.testcontainersJunit
+    testImplementation project.deps.testcontainers
+    testImplementation project.deps.testcontainersMysql
 
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+    testImplementation project.deps.assertJ
+    testImplementation project.deps.junit5
+    testRuntimeOnly project.deps.junit5Engine
 }

--- a/db-support/db-support-postgresql/build.gradle
+++ b/db-support/db-support-postgresql/build.gradle
@@ -15,18 +15,18 @@
  */
 
 dependencies {
-    implementation group: 'org.postgresql', name: 'postgresql', version: project.versions.postgresql
+    implementation project.deps.postgresql
     api project(':db-support:db-support-base')
 
-    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+    annotationProcessor project.deps.lombok
 
     testImplementation project(path: ':db-support:db-migration', configuration: 'testOutput')
 
-    testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.14.3'
-    testImplementation group: 'org.testcontainers', name: 'testcontainers', version: '1.14.3'
-    testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.14.3'
+    testImplementation project.deps.testcontainersJunit
+    testImplementation project.deps.testcontainers
+    testImplementation project.deps.testcontainersPostgresql
 
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+    testImplementation project.deps.assertJ
+    testImplementation project.deps.junit5
+    testRuntimeOnly project.deps.junit5Engine
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Parses a version from a dependency declaration string */
+static String versionOf(String dependencySpec) {
+  return dependencySpec.split(':').last()
+}
+
+final Map<String, String> libraries = [
+  // Dependabot will parse these dependencies.
+  // Keep all of these as uninterpolated string literals so that Dependabot can parse the versions and create PRs for
+  // upgrades.
+  //
+  // DO NOT interpolate version variables here because Dependabot is not smart enough to understand those. Dependabot's
+  // version parsing is simply regex matching and never actually evaluates a gradle script.
+  activeMQ            : 'org.apache.activemq:activemq-broker:5.15.10',
+  apacheAnt           : 'org.apache.ant:ant:1.10.7',
+  apacheHttpComponents: 'org.apache.httpcomponents:httpclient:4.5.6',
+  aspectj             : 'org.aspectj:aspectjrt:1.9.5',
+  assertJ             : 'org.assertj:assertj-core:3.12.2',
+  assertJ_DB          : 'org.assertj:assertj-db:1.3.0',
+  bouncyCastle        : 'org.bouncycastle:bcprov-jdk15on:1.67', // This version of BC is not compatible with the jruby-opensssl version, since we are not using jruby-opensssl going ahead with the upgrade.
+  bundler             : 'rubygems:bundler:2.1.1',
+  cglib               : 'cglib:cglib:3.3.0',
+  cloning             : 'uk.com.robust-it:cloning:1.9.11',
+  commonsCodec        : 'commons-codec:commons-codec:1.15',
+  commonsCollections  : 'commons-collections:commons-collections:3.2.2',
+  commonsCollections4 : 'org.apache.commons:commons-collections4:4.4',
+  commonsConfiguration: 'org.apache.commons:commons-configuration2:2.6',
+  commonsDbcp         : 'org.apache.commons:commons-dbcp2:2.7.0',
+  commonsDigester     : 'commons-digester:commons-digester:2.1',
+  commonsFileUpload   : 'commons-fileupload:commons-fileupload:1.4',
+  commonsIO           : 'commons-io:commons-io:2.6',
+  commonsLang         : 'commons-lang:commons-lang:2.6',
+  commonsLang3        : 'org.apache.commons:commons-lang3:3.9',
+  commonsPool         : 'org.apache.commons:commons-pool2:2.8.0',
+  dbunit              : 'org.dbunit:dbunit:2.7.0',
+  dom4j               : 'dom4j:dom4j:1.6.1',
+  ehcache             : 'net.sf.ehcache:ehcache:2.10.6',
+  felix               : 'org.apache.felix:org.apache.felix.framework:5.6.10',
+  freemarker          : 'org.freemarker:freemarker:2.3.29',
+  gradleDownload      : 'de.undercouch:gradle-download-task:4.1.1',
+  grolifant           : 'org.ysb33r.gradle:grolifant:0.17.0',
+  gson                : 'com.google.code.gson:gson:2.8.6',
+  guava               : 'com.google.guava:guava:29.0-jre',
+  h2                  : 'com.h2database:h2:1.4.200',
+  hamcrest            : 'org.hamcrest:hamcrest-core:2.2',
+  hibernate           : 'org.hibernate:hibernate-ehcache:3.6.10.Final',
+  httpClientMock      : 'com.github.paweladamski:HttpClientMock:1.0.4',
+  jackson             : 'com.fasterxml.jackson.core:jackson-core:2.9.9',
+  javaAssist          : 'javassist:javassist:3.12.1.GA',
+  javaxAnnotation     : 'javax.annotation:javax.annotation-api:1.3.2',
+  jaxb                : 'javax.xml.bind:jaxb-api:2.3.1',
+  jaxen               : 'jaxen:jaxen:1.2.0',
+  jcommander          : 'com.beust:jcommander:1.78',
+  jdom                : 'org.jdom:jdom2:2.0.6',
+  jetBrainsAnnotations: 'org.jetbrains:annotations:19.0.0',
+  jetty               : 'org.eclipse.jetty:jetty-server:9.4.27.v20200227',
+  jgit                : 'org.eclipse.jgit:org.eclipse.jgit:5.1.3.201810200350-r',
+  jodaTime            : 'joda-time:joda-time:2.9.9', // joda-time version has to be compatible with the jruby version
+  jolt                : 'com.bazaarvoice.jolt:jolt-core:0.1.1',
+  jruby               : 'org.jruby:jruby-complete:9.2.0.0',
+  jsonUnit            : 'net.javacrumbs.json-unit:json-unit-fluent:2.14.0',
+  jsontools           : 'com.sdicons.jsontools:jsontools-core:1.7',
+  jsoup               : 'org.jsoup:jsoup:1.13.1',
+  junit4              : 'junit:junit:4.13',
+  junit5              : 'org.junit.jupiter:junit-jupiter-api:5.6.0',
+  junitExt            : 'com.googlecode:junit-ext:1.0',
+  liquibase           : 'org.liquibase:liquibase-core:3.9.0',
+  logback             : 'ch.qos.logback:logback-classic:1.2.3',
+  lombok              : 'org.projectlombok:lombok:1.18.12',
+  mail                : 'com.sun.mail:mailapi:1.6.1',
+  mockito             : 'org.mockito:mockito-core:3.3.0',
+  mybatis             : 'org.mybatis:mybatis:3.4.6',
+  mybatisSpring       : 'org.mybatis:mybatis-spring:1.3.2',
+  mysql               : 'mysql:mysql-connector-java:8.0.19',
+  nanohttpd           : 'org.nanohttpd:nanohttpd:2.3.1',
+  objenesis           : 'org.objenesis:objenesis:2.6',
+  oscache             : 'opensymphony:oscache:2.4.1',
+  postgresql          : 'org.postgresql:postgresql:42.2.10',
+  quartz              : 'org.quartz-scheduler:quartz:2.3.1',
+  rack                : 'org.jruby.rack:jruby-rack:1.1.21',
+  semanticVersion     : 'de.skuzzle:semantic-version:2.1.0',
+  servletApi          : 'javax.servlet:javax.servlet-api:3.1.0',
+  slf4j               : 'org.slf4j:slf4j-api:1.7.30',
+  spark               : 'com.sparkjava:spark-core:2.7.2',
+  spring              : 'org.springframework:spring-core:4.3.29.RELEASE',
+  springSecurity      : 'org.springframework.security:spring-security-config:4.2.19.RELEASE',
+  springTestJunit5    : 'com.github.sbrannen:spring-test-junit5:1.5.0',
+  systemRules         : 'com.github.stefanbirkner:system-rules:1.19.0',
+  testcontainers      : 'org.testcontainers:testcontainers:1.14.3',
+  tfsSdk              : 'com.microsoft:tfs-sdk:14.118.0',
+  tinybundles         : 'org.ops4j.pax.tinybundles:tinybundles:3.0.0',
+  tokenBucket         : 'org.isomorphism:token-bucket:1.7',
+  urlrewrite          : 'org.tuckey:urlrewritefilter:3.2.0',
+  velocity            : 'org.apache.velocity:velocity:1.7',
+  xalan               : 'xalan:xalan:2.7.1',
+  xmlUnit             : 'org.xmlunit:xmlunit-assertj:2.6.3',
+  ztExec              : 'org.zeroturnaround:zt-exec:1.12',
+]
+
+// Export versions that are needed outside of this file (and elsewhere within)
+final Map<String, String> v = [
+  activeMQ            : versionOf(libraries.activeMQ),
+  apacheAnt           : versionOf(libraries.apacheAnt),
+  apacheHttpComponents: versionOf(libraries.apacheHttpComponents),
+  aspectj             : versionOf(libraries.aspectj),
+  bouncyCastle        : versionOf(libraries.bouncyCastle),
+  cglib               : versionOf(libraries.cglib),
+  cloning             : versionOf(libraries.cloning),
+  commonsCodec        : versionOf(libraries.commonsCodec),
+  commonsCollections  : versionOf(libraries.commonsCollections),
+  commonsCollections4 : versionOf(libraries.commonsCollections4),
+  commonsConfiguration: versionOf(libraries.commonsConfiguration),
+  commonsDbcp         : versionOf(libraries.commonsDbcp),
+  commonsDigester     : versionOf(libraries.commonsDigester),
+  commonsFileUpload   : versionOf(libraries.commonsFileUpload),
+  commonsIO           : versionOf(libraries.commonsIO),
+  commonsLang         : versionOf(libraries.commonsLang),
+  commonsLang3        : versionOf(libraries.commonsLang3),
+  commonsPool         : versionOf(libraries.commonsPool),
+  dom4j               : versionOf(libraries.dom4j),
+  ehcache             : versionOf(libraries.ehcache),
+  felix               : versionOf(libraries.felix),
+  freemarker          : versionOf(libraries.freemarker),
+  gson                : versionOf(libraries.gson),
+  guava               : versionOf(libraries.guava),
+  h2                  : versionOf(libraries.h2),
+  hamcrest            : versionOf(libraries.hamcrest),
+  hibernate           : versionOf(libraries.hibernate),
+  jackson             : versionOf(libraries.jackson),
+  javaAssist          : versionOf(libraries.javaAssist),
+  javaxAnnotation     : versionOf(libraries.javaxAnnotation),
+  jaxb                : versionOf(libraries.jaxb),
+  jaxen               : versionOf(libraries.jaxen),
+  jcommander          : versionOf(libraries.jcommander),
+  jdom                : versionOf(libraries.jdom),
+  jetty               : versionOf(libraries.jetty),
+  jgit                : versionOf(libraries.jgit),
+  jodaTime            : versionOf(libraries.jodaTime),
+  jolt                : versionOf(libraries.jolt),
+  jruby               : versionOf(libraries.jruby),
+  junit5              : versionOf(libraries.junit5),
+  liquibase           : versionOf(libraries.liquibase),
+  logback             : versionOf(libraries.logback),
+  mail                : versionOf(libraries.mail),
+  mybatis             : versionOf(libraries.mybatis),
+  mybatisSpring       : versionOf(libraries.mybatisSpring),
+  mysql               : versionOf(libraries.mysql),
+  nanohttpd           : versionOf(libraries.nanohttpd),
+  objenesis           : versionOf(libraries.objenesis),
+  oscache             : versionOf(libraries.oscache),
+  postgresql          : versionOf(libraries.postgresql),
+  quartz              : versionOf(libraries.quartz),
+  rack                : versionOf(libraries.rack),
+  semanticVersion     : versionOf(libraries.semanticVersion),
+  servletApi          : versionOf(libraries.servletApi),
+  slf4j               : versionOf(libraries.slf4j),
+  spark               : versionOf(libraries.spark),
+  spring              : versionOf(libraries.spring),
+  springSecurity      : versionOf(libraries.springSecurity),
+  testcontainers      : versionOf(libraries.testcontainers),
+  tfsSdk              : versionOf(libraries.tfsSdk),
+  tokenBucket         : versionOf(libraries.tokenBucket),
+  urlrewrite          : versionOf(libraries.urlrewrite),
+  velocity            : versionOf(libraries.velocity),
+  xmlUnit             : versionOf(libraries.xmlUnit),
+  ztExec              : versionOf(libraries.ztExec),
+
+  // misc
+  commonsBeanutils    : '1.9.3',
+  tanuki              : '3.5.41',
+  tini                : '0.18.0',
+  velocityToolsView   : '1.4',
+]
+
+// While Dependabot won't be able to parse these deps, these will get upgraded for free anyway since they share versions
+// with dependencies declared above that are parseable by Dependabot. This is just a workaround to be DRY while still
+// benefiting from Dependabot's automatic PR upgrades.
+final Map<String, String> related = [
+  apacheHttpMime          : "org.apache.httpcomponents:httpmime:${v.apacheHttpComponents}",
+  aspectjWeaver           : "org.aspectj:aspectjweaver:${v.aspectj}",
+  bouncyCastlePkix        : "org.bouncycastle:bcpkix-jdk15on:${v.bouncyCastle}",
+  hamcrestLibrary         : "org.hamcrest:hamcrest-library:${v.hamcrest}",
+  jacksonDatabind         : "com.fasterxml.jackson.core:jackson-databind:${v.jackson}",
+  jaxbRuntime             : "org.glassfish.jaxb:jaxb-runtime:${v.jaxb}",
+  jettyDeploy             : "org.eclipse.jetty:jetty-deploy:${v.jetty}",
+  jettyJmx                : "org.eclipse.jetty:jetty-jmx:${v.jetty}",
+  jettyPlus               : "org.eclipse.jetty:jetty-plus:${v.jetty}",
+  jettyServlet            : "org.eclipse.jetty:jetty-servlet:${v.jetty}",
+  jettyServlets           : "org.eclipse.jetty:jetty-servlets:${v.jetty}",
+  jettyUtil               : "org.eclipse.jetty:jetty-util:${v.jetty}",
+  jettyWebapp             : "org.eclipse.jetty:jetty-webapp:${v.jetty}",
+  jettyWebsocket          : "org.eclipse.jetty.websocket:websocket-server:${v.jetty}",
+  jgitServer              : "org.eclipse.jgit:org.eclipse.jgit.http.server:${v.jgit}",
+  joltJsonUtils           : "com.bazaarvoice.jolt:json-utils:${v.jolt}",
+  junit5Engine            : "org.junit.jupiter:junit-jupiter-engine:${v.junit5}",
+  junit5Migration         : "org.junit.jupiter:junit-jupiter-migrationsupport:${v.junit5}",
+  junit5Params            : "org.junit.jupiter:junit-jupiter-params:${v.junit5}",
+  junit5Vintage           : "org.junit.vintage:junit-vintage-engine:${v.junit5}",
+  mailSmtp                : "com.sun.mail:smtp:${v.mail}",
+  slf4jJcl                : "org.slf4j:jcl-over-slf4j:${v.slf4j}",
+  slf4jJul                : "org.slf4j:jul-to-slf4j:${v.slf4j}",
+  slf4jLog4j              : "org.slf4j:log4j-over-slf4j:${v.slf4j}",
+  springContext           : "org.springframework:spring-context:${v.spring}",
+  springContextSupport    : "org.springframework:spring-context-support:${v.spring}",
+  springOrm               : "org.springframework:spring-orm:${v.spring}",
+  springSecurityWeb       : "org.springframework.security:spring-security-web:${v.springSecurity}",
+  springTest              : "org.springframework:spring-test:${v.spring}",
+  springTx                : "org.springframework:spring-tx:${v.spring}",
+  springWeb               : "org.springframework:spring-web:${v.spring}",
+  springWebmvc            : "org.springframework:spring-webmvc:${v.spring}",
+  testcontainersJdbc      : "org.testcontainers:jdbc:${v.testcontainers}",
+  testcontainersJunit     : "org.testcontainers:junit-jupiter:${v.testcontainers}",
+  testcontainersMysql     : "org.testcontainers:mysql:${v.testcontainers}",
+  testcontainersPostgresql: "org.testcontainers:postgresql:${v.testcontainers}",
+  xmlUnitMatchers         : "org.xmlunit:xmlunit-matchers:${v.xmlUnit}",
+]
+
+ext {
+  //noinspection GroovyAssignabilityCheck
+  deps = libraries + related
+  //noinspection GroovyAssignabilityCheck
+  versions = v
+}

--- a/development-utility/development-server/build.gradle
+++ b/development-utility/development-server/build.gradle
@@ -26,25 +26,25 @@ dependencies {
   implementation project(':server')
   implementation project(':api').subprojects
   implementation project(':spark').subprojects
-  implementation group: 'org.eclipse.jetty', name: 'jetty-server', version: versions.jetty
-  implementation group: 'org.eclipse.jetty', name: 'jetty-plus', version: versions.jetty
-  implementation group: 'org.eclipse.jetty', name: 'jetty-jmx', version: versions.jetty
-  implementation group: 'org.eclipse.jetty', name: 'jetty-servlets', version: versions.jetty
-  implementation group: 'org.eclipse.jetty', name: 'jetty-util', version: versions.jetty
-  implementation group: 'org.eclipse.jetty', name: 'jetty-deploy', version: versions.jetty
-  implementation group: 'org.eclipse.jetty.websocket', name: 'websocket-server', version: versions.jetty
+  implementation project.deps.jetty
+  implementation project.deps.jettyPlus
+  implementation project.deps.jettyJmx
+  implementation project.deps.jettyServlets
+  implementation project.deps.jettyUtil
+  implementation project.deps.jettyDeploy
+  implementation project.deps.jettyWebsocket
 
-  implementation(group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.http.server', version: project.versions.jgit) {
+  implementation(project.deps.jgitServer) {
     exclude(module: 'jsch')
     exclude(module: 'jzlib')
   }
   implementation project(':jetty9')
-  implementation group: 'javax.servlet', name: 'javax.servlet-api', version: project.versions.servletApi
-  implementation group: 'org.jruby', name: 'jruby-complete', version: project.versions.jruby
-  implementation group: 'org.jruby.rack', name: 'jruby-rack', version: versions.rack
-  implementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  implementation group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: project.versions.bouncyCastle
-  implementation group: 'org.slf4j', name: 'slf4j-api', version: project.versions.slf4j
+  implementation project.deps.servletApi
+  implementation project.deps.jruby
+  implementation project.deps.rack
+  implementation project.deps.bouncyCastle
+  implementation project.deps.bouncyCastlePkix
+  implementation project.deps.slf4j
 
   copyOnly project(path: ':tw-go-plugins', configuration: 'pluginsZipConfig')
   copyOnly project(':plugin-infra:go-plugin-activator')

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -23,19 +23,19 @@ dependencies {
   implementation project(':config:config-api')
   implementation project(':commandline')
   implementation project(':plugin-infra:plugin-metadata-store')
-  implementation group: 'javax.annotation', name: 'javax.annotation-api', version: project.versions.javaxAnnotation
-  implementation group: 'org.apache.commons', name: 'commons-collections4', version: project.versions.commonsCollections4
-  implementation group: 'uk.com.robust-it', name: 'cloning', version: project.versions.cloning
-  implementation group: 'org.jdom', name: 'jdom2', version: project.versions.jdom
-  implementation group: 'joda-time', name: 'joda-time', version: project.versions.jodaTime
-  implementation group: 'org.springframework', name: 'spring-tx', version: project.versions.spring
-  api group: 'de.skuzzle', name: 'semantic-version', version: project.versions.semanticVersion
-  compileOnly group: 'org.jetbrains', name: 'annotations', version: project.versions.jetBrainsAnnotations
+  implementation project.deps.javaxAnnotation
+  implementation project.deps.commonsCollections4
+  implementation project.deps.cloning
+  implementation project.deps.jdom
+  implementation project.deps.jodaTime
+  implementation project.deps.springTx
+  api project.deps.semanticVersion
+  compileOnly project.deps.jetBrainsAnnotations
   testImplementation project(path: ':config:config-api', configuration: 'testOutput')
   testImplementation project(':test:test-utils')
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-migrationsupport', version: project.versions.junit5
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
+  testImplementation project.deps.junit5Migration
 }

--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -107,10 +107,10 @@ private File destFile(String url) {
 task downloadLinuxJreChecksum(type: DownloadFile) {
   def srcUrl = AdoptOpenJDKUrlHelper.sha256sumURL(
     com.thoughtworks.go.build.OperatingSystem.linux,
-    project.versions.adoptOpenjdk.featureVersion,
-    project.versions.adoptOpenjdk.interimVersion,
-    project.versions.adoptOpenjdk.updateVersion,
-    project.versions.adoptOpenjdk.buildVersion
+    project.packaging.adoptOpenjdk.featureVersion,
+    project.packaging.adoptOpenjdk.interimVersion,
+    project.packaging.adoptOpenjdk.updateVersion,
+    project.packaging.adoptOpenjdk.buildVersion
   )
   src srcUrl
   dest destFile(srcUrl)
@@ -121,10 +121,10 @@ task downloadLinuxJre(type: DownloadFile) {
   dependsOn downloadLinuxJreChecksum
   def srcUrl = AdoptOpenJDKUrlHelper.downloadURL(
     com.thoughtworks.go.build.OperatingSystem.linux,
-    project.versions.adoptOpenjdk.featureVersion,
-    project.versions.adoptOpenjdk.interimVersion,
-    project.versions.adoptOpenjdk.updateVersion,
-    project.versions.adoptOpenjdk.buildVersion
+    project.packaging.adoptOpenjdk.featureVersion,
+    project.packaging.adoptOpenjdk.interimVersion,
+    project.packaging.adoptOpenjdk.updateVersion,
+    project.packaging.adoptOpenjdk.buildVersion
   )
   src srcUrl
   dest destFile(srcUrl)

--- a/installers/osx.gradle
+++ b/installers/osx.gradle
@@ -26,10 +26,10 @@ private File destFile(String url) {
 task downloadOsxJreChecksum(type: DownloadFile) {
   def srcUrl = AdoptOpenJDKUrlHelper.sha256sumURL(
     com.thoughtworks.go.build.OperatingSystem.mac,
-    project.versions.adoptOpenjdk.featureVersion,
-    project.versions.adoptOpenjdk.interimVersion,
-    project.versions.adoptOpenjdk.updateVersion,
-    project.versions.adoptOpenjdk.buildVersion
+    project.packaging.adoptOpenjdk.featureVersion,
+    project.packaging.adoptOpenjdk.interimVersion,
+    project.packaging.adoptOpenjdk.updateVersion,
+    project.packaging.adoptOpenjdk.buildVersion
   )
   src srcUrl
   dest destFile(srcUrl)
@@ -39,10 +39,10 @@ task downloadOsxJre(type: DownloadFile) {
   dependsOn downloadOsxJreChecksum
   def srcUrl = AdoptOpenJDKUrlHelper.downloadURL(
     com.thoughtworks.go.build.OperatingSystem.mac,
-    project.versions.adoptOpenjdk.featureVersion,
-    project.versions.adoptOpenjdk.interimVersion,
-    project.versions.adoptOpenjdk.updateVersion,
-    project.versions.adoptOpenjdk.buildVersion
+    project.packaging.adoptOpenjdk.featureVersion,
+    project.packaging.adoptOpenjdk.interimVersion,
+    project.packaging.adoptOpenjdk.updateVersion,
+    project.packaging.adoptOpenjdk.buildVersion
   )
   src srcUrl
   dest destFile(srcUrl)

--- a/installers/windows.gradle
+++ b/installers/windows.gradle
@@ -28,10 +28,10 @@ private File destFile(String url) {
 task downloadWindowsJreChecksum(type: DownloadFile) {
   def srcUrl = AdoptOpenJDKUrlHelper.sha256sumURL(
     com.thoughtworks.go.build.OperatingSystem.windows,
-    project.versions.adoptOpenjdk.featureVersion,
-    project.versions.adoptOpenjdk.interimVersion,
-    project.versions.adoptOpenjdk.updateVersion,
-    project.versions.adoptOpenjdk.buildVersion
+    project.packaging.adoptOpenjdk.featureVersion,
+    project.packaging.adoptOpenjdk.interimVersion,
+    project.packaging.adoptOpenjdk.updateVersion,
+    project.packaging.adoptOpenjdk.buildVersion
   )
   src srcUrl
   dest destFile(srcUrl)
@@ -41,10 +41,10 @@ task downloadWindowsJre(type: DownloadFile) {
   dependsOn downloadWindowsJreChecksum
   def srcUrl = AdoptOpenJDKUrlHelper.downloadURL(
     com.thoughtworks.go.build.OperatingSystem.windows,
-    project.versions.adoptOpenjdk.featureVersion,
-    project.versions.adoptOpenjdk.interimVersion,
-    project.versions.adoptOpenjdk.updateVersion,
-    project.versions.adoptOpenjdk.buildVersion
+    project.packaging.adoptOpenjdk.featureVersion,
+    project.packaging.adoptOpenjdk.interimVersion,
+    project.packaging.adoptOpenjdk.updateVersion,
+    project.packaging.adoptOpenjdk.buildVersion
   )
   src srcUrl
   dest destFile(srcUrl)

--- a/jetty9/build.gradle
+++ b/jetty9/build.gradle
@@ -22,28 +22,28 @@ dependencies {
   implementation project(':config:config-server')
   implementation project(':common')
   implementation project(':rack_hack')
-  implementation group: 'org.apache.commons', name: 'commons-dbcp2', version: project.versions.commonsDbcp
-  implementation group: 'org.apache.commons', name: 'commons-pool2', version: project.versions.commonsPool
-  implementation group: 'org.slf4j', name: 'slf4j-api', version: project.versions.slf4j
+  implementation project.deps.commonsDbcp
+  implementation project.deps.commonsPool
+  implementation project.deps.slf4j
 
-  providedAtPackageTime group: 'org.eclipse.jetty', name: 'jetty-server', version: versions.jetty
-  providedAtPackageTime group: 'org.eclipse.jetty', name: 'jetty-plus', version: versions.jetty
-  providedAtPackageTime group: 'org.eclipse.jetty', name: 'jetty-jmx', version: versions.jetty
-  providedAtPackageTime group: 'org.eclipse.jetty', name: 'jetty-servlets', version: versions.jetty
-  providedAtPackageTime group: 'org.eclipse.jetty', name: 'jetty-util', version: versions.jetty
-  providedAtPackageTime group: 'org.eclipse.jetty', name: 'jetty-deploy', version: versions.jetty
-  providedAtPackageTime group: 'org.eclipse.jetty.websocket', name: 'websocket-server', version: versions.jetty
+  providedAtPackageTime project.deps.jetty
+  providedAtPackageTime project.deps.jettyPlus
+  providedAtPackageTime project.deps.jettyJmx
+  providedAtPackageTime project.deps.jettyServlets
+  providedAtPackageTime project.deps.jettyUtil
+  providedAtPackageTime project.deps.jettyDeploy
+  providedAtPackageTime project.deps.jettyWebsocket
 
   testImplementation project(':common')
   testImplementation project(':config:config-api')
   testImplementation project(':config:config-server')
   testImplementation project(':test:http-mocks')
   testImplementation project(':test:test-utils')
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: project.versions.junit5
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
+  testImplementation project.deps.hamcrestLibrary
+  testImplementation project.deps.junit5
+  testImplementation project.deps.junit5Params
+  testImplementation project.deps.mockito
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Engine
+  testRuntimeOnly project.deps.junit5Vintage
 }

--- a/plugin-infra/go-plugin-access/build.gradle
+++ b/plugin-infra/go-plugin-access/build.gradle
@@ -28,18 +28,18 @@ dependencies {
   implementation project(':domain')
   implementation project(':base')
   implementation project(':config:config-api')
-  api group: 'com.bazaarvoice.jolt', name: 'jolt-core', version: project.versions.jolt
-  api group: 'com.bazaarvoice.jolt', name: 'json-utils', version: project.versions.jolt
-  api group: 'org.apache.commons', name: 'commons-collections4', version: project.versions.commonsCollections4
-  implementation group: 'com.google.code.gson', name: 'gson', version: project.versions.gson
-  implementation group: 'org.springframework', name: 'spring-context', version: project.versions.spring
+  api project.deps.jolt
+  api project.deps.joltJsonUtils
+  api project.deps.commonsCollections4
+  implementation project.deps.gson
+  implementation project.deps.springContext
   testImplementation localGroovy()
-  testImplementation group: 'net.javacrumbs.json-unit', name: 'json-unit-fluent', version: project.versions.jsonUnit
+  testImplementation project.deps.jsonUnit
   testImplementation project(':test:test-utils')
   testImplementation project(path: ':domain', configuration: 'testOutput')
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  testImplementation group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
+  testImplementation project.deps.assertJ
 }

--- a/plugin-infra/go-plugin-activator/build.gradle
+++ b/plugin-infra/go-plugin-activator/build.gradle
@@ -18,13 +18,13 @@ description = 'Bootloader for GoCD Plugins'
 
 dependencies {
   implementation project(':plugin-infra:go-plugin-api')
-  api group: 'org.apache.felix', name: 'org.apache.felix.framework', version: project.versions.felix
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: project.versions.hamcrest
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
+  api project.deps.felix
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
+  testImplementation project.deps.hamcrest
+  testImplementation project.deps.hamcrestLibrary
+  testImplementation project.deps.mockito
 
 }

--- a/plugin-infra/go-plugin-api/build.gradle
+++ b/plugin-infra/go-plugin-api/build.gradle
@@ -20,13 +20,13 @@ description = 'Interfaces necessary for GoCD to access plugins'
 
 dependencies {
   api project(':plugin-infra:go-plugin-api-internal')
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: project.versions.hamcrest
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
+  testImplementation project.deps.hamcrest
+  testImplementation project.deps.hamcrestLibrary
+  testImplementation project.deps.mockito
   testImplementation project(':test:test-utils')
 }
 

--- a/plugin-infra/go-plugin-config-repo/build.gradle
+++ b/plugin-infra/go-plugin-config-repo/build.gradle
@@ -20,12 +20,12 @@ dependencies {
   implementation project(':base')
   implementation project(':config:config-api')
   implementation project(':domain')
-  implementation group: 'com.google.code.gson', name: 'gson', version: project.versions.gson
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: project.versions.hamcrest
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
+  implementation project.deps.gson
+  annotationProcessor project.deps.lombok
+  testCompileOnly project.deps.junit4
+  testImplementation project.deps.hamcrest
+  testImplementation project.deps.hamcrestLibrary
+  testImplementation project.deps.mockito
   testImplementation project(':test:test-utils')
 }
 

--- a/plugin-infra/go-plugin-domain/build.gradle
+++ b/plugin-infra/go-plugin-domain/build.gradle
@@ -17,17 +17,17 @@
 description = 'GoCD Plugins Domain'
 
 dependencies {
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+  annotationProcessor project.deps.lombok
 
   implementation project(':plugin-infra:go-plugin-api')
-  implementation group: 'commons-io', name: 'commons-io', version: project.versions.commonsIO
-  implementation group: 'org.apache.commons', name: 'commons-lang3', version: project.versions.commonsLang3
-  testImplementation group: 'net.javacrumbs.json-unit', name: 'json-unit-fluent', version: project.versions.jsonUnit
+  implementation project.deps.commonsIO
+  implementation project.deps.commonsLang3
+  testImplementation project.deps.jsonUnit
   testImplementation project(':test:test-utils')
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
+  testImplementation project.deps.mockito
+  testImplementation project.deps.hamcrestLibrary
 }

--- a/plugin-infra/go-plugin-infra/build.gradle
+++ b/plugin-infra/go-plugin-infra/build.gradle
@@ -25,19 +25,19 @@ dependencies {
   implementation project(':util')
   implementation project(':plugin-infra:go-plugin-api')
   implementation project(':plugin-infra:go-plugin-activator')
-  implementation group: 'org.apache.commons', name: 'commons-collections4', version: project.versions.commonsCollections4
-  api group: 'javax.xml.bind', name: 'jaxb-api', version: project.versions.jaxb
-  api group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: project.versions.jaxb
+  implementation project.deps.commonsCollections4
+  api project.deps.jaxb
+  api project.deps.jaxbRuntime
 
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+  annotationProcessor project.deps.lombok
 
-  testImplementation group: 'com.github.sbrannen', name: 'spring-test-junit5', version: project.versions.spring4jUnit5Extension
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
+  testImplementation project.deps.springTestJunit5
+  testImplementation project.deps.mockito
   testImplementation project(':test:test-utils')
-  testImplementation group: 'org.ops4j.pax.tinybundles', name: 'tinybundles', version: '3.0.0'
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.tinybundles
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Engine
 }
 
 clean {

--- a/plugin-infra/plugin-metadata-store/build.gradle
+++ b/plugin-infra/plugin-metadata-store/build.gradle
@@ -17,13 +17,13 @@
 description = 'Metadata store for GoCD Plugins'
 
 dependencies {
-  implementation group: 'org.apache.commons', name: 'commons-lang3', version: project.versions.commonsLang3
+  implementation project.deps.commonsLang3
   implementation project(':plugin-infra:go-plugin-api')
   implementation project(':plugin-infra:go-plugin-domain')
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
+  testImplementation project.deps.mockito
   testImplementation project(':test:test-utils')
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/rack_hack/build.gradle
+++ b/rack_hack/build.gradle
@@ -17,11 +17,11 @@
 description = 'GoCD Rack Delegator'
 dependencies {
   implementation project(':app-server')
-  providedAtPackageTime(group: 'javax.servlet', name: 'javax.servlet-api', version: project.versions.servletApi)
+  providedAtPackageTime(project.deps.servletApi)
   testImplementation project(':test:test-utils')
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.mockito
+  testImplementation project.deps.junit5
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/server-launcher/build.gradle
+++ b/server-launcher/build.gradle
@@ -55,19 +55,19 @@ dependencies {
   packagingInLibDir(project(path: ':plugin-infra:go-plugin-activator')) {
     transitive = false
   }
-  packagingInLibDir group: 'javax.servlet', name: 'javax.servlet-api', version: project.versions.servletApi
-  packagingInLibDir group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  packagingInLibDir group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: project.versions.bouncyCastle
-  packagingInLibDir group: 'commons-io', name: 'commons-io', version: project.versions.commonsIO
-  packagingInLibDir group: 'org.apache.commons', name: 'commons-lang3', version: project.versions.commonsLang3
-  packagingInLibDir group: 'joda-time', name: 'joda-time', version: project.versions.jodaTime
+  packagingInLibDir project.deps.servletApi
+  packagingInLibDir project.deps.bouncyCastle
+  packagingInLibDir project.deps.bouncyCastlePkix
+  packagingInLibDir project.deps.commonsIO
+  packagingInLibDir project.deps.commonsLang3
+  packagingInLibDir project.deps.jodaTime
 
   // Not needed for compilation, but we want to centralize all logging using logback
-  packagingInLibDir group: 'org.slf4j', name: 'slf4j-api', version: project.versions.slf4j
-  packagingInLibDir group: 'org.slf4j', name: 'log4j-over-slf4j', version: project.versions.slf4j
-  packagingInLibDir group: 'org.slf4j', name: 'jcl-over-slf4j', version: project.versions.slf4j
-  packagingInLibDir group: 'org.slf4j', name: 'jul-to-slf4j', version: project.versions.slf4j
-  packagingInLibDir group: 'ch.qos.logback', name: 'logback-classic', version: project.versions.logback
+  packagingInLibDir project.deps.slf4j
+  packagingInLibDir project.deps.slf4jLog4j
+  packagingInLibDir project.deps.slf4jJcl
+  packagingInLibDir project.deps.slf4jJul
+  packagingInLibDir project.deps.logback
 
   pluginsZip project(path: ':tw-go-plugins', configuration: 'pluginsZipConfig')
 
@@ -202,23 +202,23 @@ task verifyFatJar(type: VerifyJarTask) {
       "commons-io-${project.versions.commonsIO}.jar",
       "commons-lang3-${project.versions.commonsLang3}.jar",
       "go-plugin-activator.jar",
-      "javax.servlet-api-3.1.0.jar",
+      "javax.servlet-api-${project.versions.servletApi}.jar",
       "jcl-over-slf4j-${project.versions.slf4j}.jar",
-      "jetty-client-${versions.jetty}.jar",
-      "jetty-continuation-${versions.jetty}.jar",
-      "jetty-deploy-${versions.jetty}.jar",
-      "jetty-http-${versions.jetty}.jar",
-      "jetty-io-${versions.jetty}.jar",
-      "jetty-jmx-${versions.jetty}.jar",
-      "jetty-jndi-${versions.jetty}.jar",
-      "jetty-plus-${versions.jetty}.jar",
-      "jetty-security-${versions.jetty}.jar",
-      "jetty-server-${versions.jetty}.jar",
-      "jetty-servlet-${versions.jetty}.jar",
-      "jetty-servlets-${versions.jetty}.jar",
-      "jetty-util-${versions.jetty}.jar",
-      "jetty-webapp-${versions.jetty}.jar",
-      "jetty-xml-${versions.jetty}.jar",
+      "jetty-client-${project.versions.jetty}.jar",
+      "jetty-continuation-${project.versions.jetty}.jar",
+      "jetty-deploy-${project.versions.jetty}.jar",
+      "jetty-http-${project.versions.jetty}.jar",
+      "jetty-io-${project.versions.jetty}.jar",
+      "jetty-jmx-${project.versions.jetty}.jar",
+      "jetty-jndi-${project.versions.jetty}.jar",
+      "jetty-plus-${project.versions.jetty}.jar",
+      "jetty-security-${project.versions.jetty}.jar",
+      "jetty-server-${project.versions.jetty}.jar",
+      "jetty-servlet-${project.versions.jetty}.jar",
+      "jetty-servlets-${project.versions.jetty}.jar",
+      "jetty-util-${project.versions.jetty}.jar",
+      "jetty-webapp-${project.versions.jetty}.jar",
+      "jetty-xml-${project.versions.jetty}.jar",
       "joda-time-${project.versions.jodaTime}.jar",
       "jul-to-slf4j-${project.versions.slf4j}.jar",
       "log4j-over-slf4j-${project.versions.slf4j}.jar",
@@ -227,11 +227,11 @@ task verifyFatJar(type: VerifyJarTask) {
       "server-launcher-${project.version}-main.jar",
       "slf4j-api-${project.versions.slf4j}.jar",
       "tfs-impl-14.jar",
-      "websocket-api-${versions.jetty}.jar",
-      "websocket-client-${versions.jetty}.jar",
-      "websocket-common-${versions.jetty}.jar",
-      "websocket-server-${versions.jetty}.jar",
-      "websocket-servlet-${versions.jetty}.jar",
+      "websocket-api-${project.versions.jetty}.jar",
+      "websocket-client-${project.versions.jetty}.jar",
+      "websocket-common-${project.versions.jetty}.jar",
+      "websocket-server-${project.versions.jetty}.jar",
+      "websocket-servlet-${project.versions.jetty}.jar",
     ]
   ]
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -36,8 +36,8 @@ buildscript {
   }
 
   dependencies {
-    classpath group: 'org.jruby', name: 'jruby-complete', version: project.versions.jruby
-    classpath group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: project.versions.jgit
+    classpath project.deps.jruby
+    classpath project.deps.jgit
   }
 }
 apply plugin: 'com.github.jruby-gradle.core'
@@ -222,8 +222,8 @@ props.putAll(project.hasProperty('testSystemProperties') ? project.testSystemPro
 project.ext.testSystemProperties = props
 
 dependencies {
-  jrubyGems group: 'rubygems', name: 'bundler', version: project.versions.bundler
-  compileOnly group: 'org.jetbrains', name: 'annotations', version: project.versions.jetBrainsAnnotations
+  jrubyGems project.deps.bundler
+  compileOnly project.deps.jetBrainsAnnotations
 
   apiBase project(':api:api-base')
   allApis project(':api').subprojects
@@ -240,68 +240,68 @@ dependencies {
   implementation project(':db-support:db-support-mysql')
 
   packagingOnly project(':base')
-  packagingOnly group: 'javax.servlet', name: 'javax.servlet-api', version: project.versions.servletApi
+  packagingOnly project.deps.servletApi
 
   copyOnly project(path: ':tfs-impl:tfs-impl-14', configuration: 'fatJarConfig')
   copyOnly project(path: ':agent', configuration: 'fatJarConfig')
   copyOnly project(path: ':agent-launcher', configuration: 'fatJarConfig')
   copyOnlyTestData project(':test:test-agent')
 
-  implementation group: 'org.apache.commons', name: 'commons-dbcp2', version: project.versions.commonsDbcp
-  api(group: 'org.hibernate', name: 'hibernate-ehcache', version: project.versions.hibernate) {
+  implementation project.deps.commonsDbcp
+  api(project.deps.hibernate) {
     exclude(module: 'ehcache-core')
     exclude(module: 'commons-collections')
   }
 
-  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: project.versions.commonsFileUpload
+  implementation project.deps.commonsFileUpload
 
-  implementation group: 'javassist', name: 'javassist', version: project.versions.javaAssist
-  implementation group: 'org.mybatis', name: 'mybatis', version: project.versions.mybatis
-  implementation group: 'org.mybatis', name: 'mybatis-spring', version: project.versions.mybatisSpring
-  implementation group: 'net.sf.ehcache', name: 'ehcache', version: project.versions.ehcache
-  implementation(group: 'opensymphony', name: 'oscache', version: '2.4.1') {
+  implementation project.deps.javaAssist
+  implementation project.deps.mybatis
+  implementation project.deps.mybatisSpring
+  implementation project.deps.ehcache
+  implementation(project.deps.oscache) {
     exclude(module: 'jms')
     exclude(module: 'servlet-api')
   }
 
-  implementation group: 'org.apache.activemq', name: 'activemq-broker', version: project.versions.activeMQ
+  implementation project.deps.activeMQ
 
-  implementation group: 'org.jruby', name: 'jruby-complete', version: project.versions.jruby
-  implementation group: 'org.jruby.rack', name: 'jruby-rack', version: versions.rack
+  implementation project.deps.jruby
+  implementation project.deps.rack
 
-  implementation group: 'org.springframework', name: 'spring-orm', version: project.versions.spring
-  api group: 'org.springframework', name: 'spring-web', version: project.versions.spring
-  api group: 'org.springframework', name: 'spring-context-support', version: project.versions.spring
-  api(group: 'org.springframework.security', name: 'spring-security-web', version: project.versions.springSecurity) {
+  implementation project.deps.springOrm
+  api project.deps.springWeb
+  api project.deps.springContextSupport
+  api(project.deps.springSecurityWeb) {
     exclude(group: 'org.springframework')
   }
-  implementation(group: 'org.springframework.security', name: 'spring-security-config', version: project.versions.springSecurity)
-  implementation group: 'org.aspectj', name: 'aspectjrt', version: project.versions.aspectj
-  implementation group: 'org.aspectj', name: 'aspectjweaver', version: project.versions.aspectj
-  implementation group: 'org.tuckey', name: 'urlrewritefilter', version: project.versions.urlrewrite
-  implementation(group: 'org.apache.velocity', name: 'velocity', version: '1.7') {
+  implementation(project.deps.springSecurity)
+  implementation project.deps.aspectj
+  implementation project.deps.aspectjWeaver
+  implementation project.deps.urlrewrite
+  implementation(project.deps.velocity) {
     exclude(module: 'commons-lang')
     exclude(module: 'commons-collections')
   }
   implementation files("vendor/velocity-tools-view-${project.versions.velocityToolsView}.jar")
   // old digester version required by velocity-tools-view
-  implementation group: 'commons-digester', name: 'commons-digester', version: project.versions.commonsDigester
+  implementation project.deps.commonsDigester
 
   // this is needed by velocity tools view
-  implementation group: 'commons-lang', name: 'commons-lang', version: project.versions.commonsLang
-  implementation group: 'commons-collections', name: 'commons-collections', version: project.versions.commonsCollections
-  implementation group: 'com.google.guava', name: 'guava', version: project.versions.guava
-  implementation group: 'com.sun.mail', name: 'mailapi', version: project.versions.mail
-  implementation group: 'com.sun.mail', name: 'smtp', version: project.versions.mail
-  implementation group: 'org.objenesis', name: 'objenesis', version: project.versions.objenesis
+  implementation project.deps.commonsLang
+  implementation project.deps.commonsCollections
+  implementation project.deps.guava
+  implementation project.deps.mail
+  implementation project.deps.mailSmtp
+  implementation project.deps.objenesis
 
   // needed by jdom2 for some XPATH stuff
-  implementation(group: 'jaxen', name: 'jaxen', version: project.versions.jaxen) {
+  implementation(project.deps.jaxen) {
     exclude(module: 'xom')
     exclude(module: 'jdom')
   }
-  implementation group: 'org.slf4j', name: 'slf4j-api', version: project.versions.slf4j
-  implementation(group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.http.server', version: project.versions.jgit) {
+  implementation project.deps.slf4j
+  implementation(project.deps.jgitServer) {
     exclude(module: 'jsch')
     exclude(module: 'jzlib')
   }
@@ -310,13 +310,13 @@ dependencies {
     // these artifacts from packaging; this happens in the `war` task when excluding `doNotPackage` configurations
     transitive = false
   }
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
-  providedAtPackageTime group: 'ch.qos.logback', name: 'logback-classic', version: project.versions.logback
-  providedAtPackageTime group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  providedAtPackageTime group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: project.versions.bouncyCastle
-  providedAtPackageTime group: 'org.eclipse.jetty.websocket', name: 'websocket-server', version: versions.jetty
+  annotationProcessor project.deps.lombok
+  providedAtPackageTime project.deps.logback
+  providedAtPackageTime project.deps.bouncyCastle
+  providedAtPackageTime project.deps.bouncyCastlePkix
+  providedAtPackageTime project.deps.jettyWebsocket
 
-  testImplementation(group: 'org.dbunit', name: 'dbunit', version: project.versions.dbunit) {
+  testImplementation(project.deps.dbunit) {
     exclude(group: 'postgresql')
   }
   testImplementation project(path: ':common', configuration: 'testOutput')
@@ -324,23 +324,23 @@ dependencies {
   testImplementation project(path: ':config:config-api', configuration: 'testOutput')
   testImplementation project(path: ':test:test-utils')
   testImplementation project(':jetty9')
-  testImplementation group: 'net.javacrumbs.json-unit', name: 'json-unit-fluent', version: project.versions.jsonUnit
-  testImplementation group: 'org.jsoup', name: 'jsoup', version: project.versions.jsoup
-  testImplementation group: 'org.xmlunit', name: 'xmlunit-matchers', version: project.versions.xmlUnit
-  testImplementation group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
-  testImplementation group: 'org.xmlunit', name: 'xmlunit-assertj', version: project.versions.xmlUnit
+  testImplementation project.deps.jsonUnit
+  testImplementation project.deps.jsoup
+  testImplementation project.deps.xmlUnitMatchers
+  testImplementation project.deps.assertJ
+  testImplementation project.deps.xmlUnit
 
   testImplementation project(':test:http-mocks')
 
-  testImplementation group: 'com.github.paweladamski', name: 'HttpClientMock', version: '1.0.4'
+  testImplementation project.deps.httpClientMock
 
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-migrationsupport', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  integrationTestImplementation group: 'com.github.sbrannen', name: 'spring-test-junit5', version: project.versions.spring4jUnit5Extension
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5Params
+  testImplementation project.deps.junit5Migration
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
+  integrationTestImplementation project.deps.springTestJunit5
 }
 
 jar {
@@ -826,7 +826,7 @@ task verifyWar(type: VerifyJarTask) {
         "db-support-h2-${project.version}.jar",
         "db-support-mysql-${project.version}.jar",
         "db-support-postgresql-${project.version}.jar",
-        "dom4j-1.6.1.jar",
+        "dom4j-${project.versions.dom4j}.jar",
         "domain-${project.version}.jar",
         "ehcache-${project.versions.ehcache}.jar",
         "error_prone_annotations-2.3.4.jar",
@@ -861,7 +861,7 @@ task verifyWar(type: VerifyJarTask) {
         "javax.activation-api-1.2.0.jar",
         "javax.annotation-api-${project.versions.javaxAnnotation}.jar",
         "javax.inject-1.jar",
-        "javax.servlet-api-3.1.0.jar",
+        "javax.servlet-api-${project.versions.servletApi}.jar",
         "jaxb-api-${project.versions.jaxb}.jar",
         "jaxb-runtime-${project.versions.jaxb}.jar",
         "jaxen-${project.versions.jaxen}.jar",
@@ -870,7 +870,7 @@ task verifyWar(type: VerifyJarTask) {
         "joda-time-${project.versions.jodaTime}.jar",
         "jolt-core-${project.versions.jolt}.jar",
         "jruby-complete-${project.versions.jruby}.jar",
-        "jruby-rack-${versions.rack}.jar",
+        "jruby-rack-${project.versions.rack}.jar",
         "json-utils-${project.versions.jolt}.jar",
         "jsr305-3.0.2.jar",
         "jta-1.1.jar",
@@ -884,7 +884,7 @@ task verifyWar(type: VerifyJarTask) {
         "org.apache.felix.framework-${project.versions.felix}.jar",
         "org.eclipse.jgit-${project.versions.jgit}.jar",
         "org.eclipse.jgit.http.server-${project.versions.jgit}.jar",
-        "oscache-2.4.1.jar",
+        "oscache-${project.versions.oscache}.jar",
         "plugin-metadata-store-${project.version}.jar",
         "postgresql-${project.versions.postgresql}.jar",
         "protobuf-java-3.6.1.jar",
@@ -913,9 +913,9 @@ task verifyWar(type: VerifyJarTask) {
         "txw2-${project.versions.jaxb}.jar",
         "urlrewritefilter-${project.versions.urlrewrite}.jar",
         "util-${project.version}.jar",
-        "velocity-1.7.jar",
+        "velocity-${project.versions.velocity}.jar",
         "velocity-tools-view-${project.versions.velocityToolsView}.jar",
-        "zt-exec-1.12.jar",
+        "zt-exec-${project.versions.ztExec}.jar",
       ])
   ]
 }

--- a/server/jasmine.gradle
+++ b/server/jasmine.gradle
@@ -1,5 +1,5 @@
-import com.thoughtworks.go.build.ExecuteUnderRailsTask
 import com.thoughtworks.go.build.DownloaderTask
+import com.thoughtworks.go.build.ExecuteUnderRailsTask
 import org.gradle.internal.os.OperatingSystem
 
 import java.util.regex.Pattern
@@ -20,7 +20,12 @@ import java.util.regex.Pattern
  * limitations under the License.
  */
 
-org.gradle.internal.os.OperatingSystem currentOS = org.gradle.internal.os.OperatingSystem.current()
+OperatingSystem currentOS = OperatingSystem.current()
+
+final Map<String, String> seleniumDrivers = [
+  chromedriver: '86.0.4240.22',
+  geckodriver : '0.27.0',
+]
 
 def execute = { String path, String... argv ->
   ByteArrayOutputStream stdout = new ByteArrayOutputStream()
@@ -92,20 +97,19 @@ def driverImpl = { ->
   }
 }
 
-
 task downloadGeckoDriver(type: DownloaderTask) { thisTask ->
   executable = 'geckodriver'
   packageName = 'geckodriver'
-  packageVersion = project.versions.seleniumDrivers.geckodriver
+  packageVersion = seleniumDrivers.geckodriver
 
   String osURIPart;
   String archiveExtension  = currentOS.isWindows() ? 'zip' : 'tar.gz';
 
   switch (currentOS) {
-    case org.gradle.internal.os.OperatingSystem.MacOs:
+    case OperatingSystem.MacOs:
       osURIPart = 'macos';
       break
-    case org.gradle.internal.os.OperatingSystem.Windows:
+    case OperatingSystem.Windows:
       osURIPart = 'win64'
       break
     default:
@@ -118,15 +122,15 @@ task downloadGeckoDriver(type: DownloaderTask) { thisTask ->
 task downloadChromeDriver(type: DownloaderTask) { thisTask ->
   executable = 'chromedriver'
   packageName = 'chromedriver'
-  packageVersion = project.versions.seleniumDrivers.chromedriver
+  packageVersion = seleniumDrivers.chromedriver
 
   String osURIPart;
 
   switch (currentOS) {
-    case org.gradle.internal.os.OperatingSystem.MacOs:
+    case OperatingSystem.MacOs:
       osURIPart = 'mac64';
       break
-    case org.gradle.internal.os.OperatingSystem.Windows:
+    case OperatingSystem.Windows:
       osURIPart = 'win32'
       break
     default:

--- a/spark/spark-base/build.gradle
+++ b/spark/spark-base/build.gradle
@@ -20,24 +20,24 @@ dependencies {
   api project(':common')
   api project(':server')
 
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: project.versions.jackson
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: project.versions.jackson
-  implementation group: 'org.springframework', name: 'spring-web', version: project.versions.spring
+  implementation project.deps.jackson
+  implementation project.deps.jacksonDatabind
+  implementation project.deps.springWeb
 
-  api(group: 'com.sparkjava', name: 'spark-core', version: project.versions.spark) {
+  api(project.deps.spark) {
     transitive = false
   }
 
   testImplementation localGroovy()
   testImplementation project(path: ':jetty9', configuration: 'testOutput')
 
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.bouncyCastle
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
-  testImplementation group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
-  testImplementation group: 'net.javacrumbs.json-unit', name: 'json-unit-fluent', version: project.versions.jsonUnit
-  testImplementation group: 'org.springframework', name: 'spring-test', version: project.versions.spring
+  testImplementation project.deps.mockito
+  testImplementation project.deps.assertJ
+  testImplementation project.deps.jsonUnit
+  testImplementation project.deps.springTest
   testImplementation project(':test:http-mocks')
 }

--- a/spark/spark-spa/build.gradle
+++ b/spark/spark-spa/build.gradle
@@ -18,12 +18,12 @@ apply plugin: 'groovy'
 dependencies {
   implementation project(':spark:spark-base')
 
-  implementation group: 'org.freemarker', name: 'freemarker', version: project.versions.freemarker
+  implementation project.deps.freemarker
 
-  testCompileOnly group: 'net.sf.ehcache', name: 'ehcache', version: project.versions.ehcache
+  testCompileOnly project.deps.ehcache
   testImplementation project(path: ':spark:spark-base', configuration: 'testOutput')
-  testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle
-  testImplementation group: 'org.jsoup', name: 'jsoup', version: project.versions.jsoup
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testImplementation project.deps.bouncyCastle
+  testImplementation project.deps.jsoup
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
 }

--- a/test/http-mocks/build.gradle
+++ b/test/http-mocks/build.gradle
@@ -15,13 +15,13 @@
  */
 
 dependencies {
-  implementation group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
-  implementation group: 'junit', name: 'junit', version: project.versions.junit
-  implementation group: 'org.apache.commons', name: 'commons-lang3', version: project.versions.commonsLang3
-  implementation group: 'javax.servlet', name: 'javax.servlet-api', version: project.versions.servletApi
-  implementation group: 'com.google.code.gson', name: 'gson', version: project.versions.gson
-  implementation group: 'org.apache.httpcomponents', name: 'httpmime', version: project.versions.apacheHttpComponents
-  implementation group: 'org.springframework', name: 'spring-core', version: project.versions.spring
-  implementation group: 'org.springframework', name: 'spring-web', version: project.versions.spring
-  implementation group: 'net.javacrumbs.json-unit', name: 'json-unit-fluent', version: project.versions.jsonUnit
+  implementation project.deps.assertJ
+  implementation project.deps.junit4
+  implementation project.deps.commonsLang3
+  implementation project.deps.servletApi
+  implementation project.deps.gson
+  implementation project.deps.apacheHttpMime
+  implementation project.deps.spring
+  implementation project.deps.springWeb
+  implementation project.deps.jsonUnit
 }

--- a/test/test-utils/build.gradle
+++ b/test/test-utils/build.gradle
@@ -25,27 +25,27 @@ configurations {
 dependencies {
   implementation project(':base')
   api project(':util')
-  api group: 'com.sdicons.jsontools', name: 'jsontools-core', version: '1.7'
-  api group: 'org.springframework', name: 'spring-test', version: project.versions.spring
-  implementation group: 'org.eclipse.jetty', name: 'jetty-server', version: versions.jetty
-  implementation group: 'org.eclipse.jetty', name: 'jetty-plus', version: versions.jetty
-  implementation group: 'org.eclipse.jetty', name: 'jetty-jmx', version: versions.jetty
-  implementation group: 'org.eclipse.jetty', name: 'jetty-util', version: versions.jetty
-  implementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version: versions.jetty
-  api group: 'org.eclipse.jetty', name: 'jetty-webapp', version: versions.jetty
-  implementation group: 'com.sun.mail', name: 'mailapi', version: versions.mail
-  api group: 'com.github.stefanbirkner', name: 'system-rules', version: project.versions.systemRules
+  api project.deps.jsontools
+  api project.deps.springTest
+  implementation project.deps.jetty
+  implementation project.deps.jettyPlus
+  implementation project.deps.jettyJmx
+  implementation project.deps.jettyUtil
+  implementation project.deps.jettyServlet
+  api project.deps.jettyWebapp
+  implementation project.deps.mail
+  api project.deps.systemRules
 
-  api group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
-  compileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  runtimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  api group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  runtimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  api group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: project.versions.junit5
+  api project.deps.assertJ
+  compileOnly project.deps.junit4
+  runtimeOnly project.deps.junit5Vintage
+  api project.deps.junit5
+  runtimeOnly project.deps.junit5Engine
+  api project.deps.junit5Params
 
-  api group: 'com.googlecode', name: 'junit-ext', version: '1.0'
-  api group: 'org.hamcrest', name: 'hamcrest-core', version: project.versions.hamcrest
-  api group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
+  api project.deps.junitExt
+  api project.deps.hamcrest
+  api project.deps.hamcrestLibrary
 
   copyOnly project(path: ':agent-launcher', configuration: 'fatJarConfig')
   copyOnly project(path: ':test:test-agent')

--- a/tfs-impl/tfs-impl-14/build.gradle
+++ b/tfs-impl/tfs-impl-14/build.gradle
@@ -20,16 +20,16 @@ description = 'GoCD TFS SDK wrapper v14'
 
 dependencies {
   implementation project(':common')
-  implementation group: 'com.microsoft', name: 'tfs-sdk', version: '14.118.0'
+  implementation project.deps.tfsSdk
   // not an implementation dependency, but some classloader hell
-  implementation(group: 'xalan', name: 'xalan', version: '2.7.1')
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: project.versions.hamcrest
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
-  testImplementation group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
+  implementation project.deps.xalan
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
+  testImplementation project.deps.hamcrest
+  testImplementation project.deps.mockito
+  testImplementation project.deps.assertJ
 }
 
 jar {
@@ -58,7 +58,7 @@ task verifyJar(type: VerifyJarTask) {
   expectedJars = [
       "lib": [
           "tfs-impl-14-${project.version}-classes.jar",
-          "tfs-sdk-14.118.0.jar",
+          "tfs-sdk-${project.versions.tfsSdk}.jar",
       ]
   ]
 }

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -18,17 +18,17 @@ description = 'GoCD Utils'
 
 dependencies {
   implementation project(':base')
-  api group: 'org.springframework', name: 'spring-context', version: project.versions.spring
-  api group: 'org.springframework', name: 'spring-webmvc', version: project.versions.spring
-  api group: 'javax.servlet', name: 'javax.servlet-api', version: project.versions.servletApi
-  api group: 'com.google.code.gson', name: 'gson', version: project.versions.gson
-  implementation group: 'uk.com.robust-it', name: 'cloning', version: project.versions.cloning
-  testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
-  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: project.versions.junit5
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: project.versions.hamcrest
-  testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
-  testImplementation group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
+  api project.deps.springContext
+  api project.deps.springWebmvc
+  api project.deps.servletApi
+  api project.deps.gson
+  implementation project.deps.cloning
+  testCompileOnly project.deps.junit4
+  testRuntimeOnly project.deps.junit5Vintage
+  testImplementation project.deps.junit5
+  testRuntimeOnly project.deps.junit5Engine
+  testImplementation project.deps.junit5Params
+  testImplementation project.deps.hamcrest
+  testImplementation project.deps.hamcrestLibrary
+  testImplementation project.deps.assertJ
 }


### PR DESCRIPTION
Fixes #8232

Most of our dependencies have been declared in the following format:

```groovy
implementation group: 'mygroup', name: 'mylib', version: project.versions.mylib
```

Currently, Dependabot is not able to parse most of our java dependencies because it isn't able to dereference variables or interpolate strings. This is because Dependabot's `gradle` engine does not actually evaluate Gradle scripts; it uses a simple regex to extract information.

So, this PR creates a `dependencies.gradle` file to hold all the dependency declarations. Dependabot will examine any gradle script with the work `dependencies` in it, in addition to `build.gradle`.

The formatting in this file is particular. Instead of using a groovy map to declare dependencies, we use the maven-like string declarations, e.g. `groupId:artifiactId:versionString`. Dependabot can more reliably extract this info as compared to the map format. Using a map (i.e., `[group: 'foo', name: 'bar', version: '1.0.0']`) might fail because the regex does not match the necessary square brackets needed by groovy's map declaration when used out of context from a gradle dependency configuration statement.

In other words, dependabot can match this:

```groovy
implementation group: 'foo', name: 'bar', version: '1.0.0
```

And this:

```groovy
implementation(group: 'foo', name: 'bar', version: '1.0.0) {
  // some closure body
}
```
**But NOT this**:

```groovy
project.ext.libraries = [
  foo: [group: 'foo', name: 'bar', version: '1.0.0],
  ...
]
```

So it _must_ be in this form instead:

```groovy
project.ext.libraries = [
  foo: 'foo:bar:1.0.0',
  ...
]
```

Version strings must be plaintext string literals instead of interpolated variables because of the reasons mentioned before. Related libraries that share versions with other dependencies are defined in a separate section in the file. See inline comments for explanations.

## Note to reviewers

This PR is built atop of #8557, so it only makes sense to review this after the other PR has been merged.