### PR TITLE
Fix the order of the yes and no button as well as the style

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/server-configuration/confirm_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/server-configuration/confirm_modal.tsx
@@ -44,9 +44,9 @@ export class ConfirmModal extends Modal {
 
   buttons(): m.ChildArray {
     return [
-      <Danger ajaxOperationMonitor={this.operationState} data-test-id='button-no-cancel' onclick={this.close.bind(this)}
-      >No</Danger>,
-      <Cancel data-test-id='button-cancel' onclick={this.oncancel} ajaxOperationMonitor={this.operationState}>Yes</Cancel>
+      <Danger data-test-id='button-cancel' onclick={this.oncancel} ajaxOperationMonitor={this.operationState}>Yes</Danger>,
+      <Cancel ajaxOperationMonitor={this.operationState} data-test-id='button-no-cancel' onclick={this.close.bind(this)}
+      >No</Cancel>
     ];
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/server-configuration/spec/confirm_modal_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/server-configuration/spec/confirm_modal_spec.tsx
@@ -40,7 +40,7 @@ describe("ConfirmModal", () => {
 
   it("should render", () => {
     expect(modal).toContainTitle("Some modal title");
-    expect(modal).toContainButtons(["Yes", "No"]);
+    expect(modal).toContainButtons(["No", "Yes"]);
     expect(modal).toContainBody("Do you want to cancel?");
   });
 


### PR DESCRIPTION
Description:
The confirm delete on the preferences page had the major button as `No`. Updated the styles

Before:
<img width="893" alt="Screen Shot 2020-10-05 at 3 33 23 PM" src="https://user-images.githubusercontent.com/41165891/95070140-49e71f00-0725-11eb-97e9-ca419b75d91a.png">

Now:
<img width="640" alt="Screen Shot 2020-10-05 at 4 12 21 PM" src="https://user-images.githubusercontent.com/41165891/95070324-93d00500-0725-11eb-8124-8f98dc80366b.png">

