### PR TITLE
Fix the check connection button text on pluggable scm modal

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/pluggable_scm.ts
@@ -17,7 +17,7 @@
 import Stream from "mithril/stream";
 import {Errors, ErrorsJSON} from "models/mixins/errors";
 import {ValidatableMixin} from "models/mixins/new_validatable_mixin";
-import {Origin, OriginJSON} from "models/origin";
+import {Origin, OriginJSON, OriginType} from "models/origin";
 import {Configurations, PropertyJSON} from "models/shared/configuration";
 
 export interface ScmsJSON {
@@ -32,7 +32,7 @@ export interface ScmJSON {
   id: string;
   name: string;
   auto_update: boolean;
-  origin: OriginJSON;
+  origin?: OriginJSON;
   plugin_metadata: PluginMetadataJSON;
   configuration: PropertyJSON[];
   errors?: ErrorsJSON;
@@ -97,7 +97,8 @@ export class Scm extends ValidatableMixin {
   }
 
   static fromJSON(data: ScmJSON): Scm {
-    const scm = new Scm(data.id, data.name, data.auto_update, Origin.fromJSON(data.origin), PluginMetadata.fromJSON(data.plugin_metadata), Configurations.fromJSON(data.configuration));
+    const origin = data.origin ? Origin.fromJSON(data.origin) : new Origin(OriginType.GoCD);
+    const scm    = new Scm(data.id, data.name, data.auto_update, origin, PluginMetadata.fromJSON(data.plugin_metadata), Configurations.fromJSON(data.configuration));
     scm.errors(new Errors(data.errors));
     return scm;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/modals.tsx
@@ -33,13 +33,14 @@ import styles from "./index.scss";
 import {PluggableScmModalBody} from "./pluggable_scm_modal_body";
 
 abstract class PluggableScmModal extends EntityModal<Scm> {
+  private static readonly TEST_CONNECTION_TEXT = "Check Connection";
+  protected message: FlashMessageModel         = new FlashMessageModel();
   protected readonly originalEntityId: string;
   protected readonly originalEntityName: string;
-  protected message: FlashMessageModel = new FlashMessageModel();
   private readonly disableId: boolean;
-  private readonly disablePluginId: boolean;
 
-  private testConnectionButtonText: string = "Check Connection";
+  private readonly disablePluginId: boolean;
+  private testConnectionButtonText: string = PluggableScmModal.TEST_CONNECTION_TEXT;
   private testConnectionButtonIcon: string | undefined;
 
   constructor(entity: Scm,
@@ -143,7 +144,7 @@ abstract class PluggableScmModal extends EntityModal<Scm> {
                                }
                              });
                            })
-                           .finally(() => this.testConnectionButtonText = "Test Connection");
+                           .finally(() => this.testConnectionButtonText = PluggableScmModal.TEST_CONNECTION_TEXT);
   }
 
   private testConnectionInProgress() {


### PR DESCRIPTION
Description:
Reset the check connection button text when the check connection calls completes to the original value





