### PR TITLE
Delete plugin settings on a successful migration of the plugin settings to cluster profile. (#8643)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/dao/PluginDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/PluginDao.java
@@ -27,4 +27,6 @@ public interface PluginDao {
     List<Plugin> getAllPlugins();
 
     void deleteAllPlugins();
+
+    void deletePluginIfExists(String pluginId);
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/ElasticAgentInformationMigratorImpl.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ElasticAgentInformationMigratorImpl.java
@@ -19,12 +19,15 @@ import com.thoughtworks.go.config.UpdateConfigCommand;
 import com.thoughtworks.go.config.update.ReplaceElasticAgentInformationCommand;
 import com.thoughtworks.go.domain.Plugin;
 import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
+import com.thoughtworks.go.plugin.access.elastic.v4.ElasticAgentExtensionV4;
 import com.thoughtworks.go.plugin.infra.ElasticAgentInformationMigrator;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.PluginPostLoadHook;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 import com.thoughtworks.go.server.dao.PluginSqlMapDao;
 import com.thoughtworks.go.util.json.JsonHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -43,6 +46,8 @@ public class ElasticAgentInformationMigratorImpl implements ElasticAgentInformat
     private PluginManager pluginManager;
     private GoConfigService goConfigService;
     private PluginSqlMapDao pluginSqlMapDao;
+
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticAgentInformationMigratorImpl.class);
 
     @Autowired
     public ElasticAgentInformationMigratorImpl(PluginSqlMapDao pluginSqlMapDao, ClusterProfilesService clusterProfilesService, ElasticProfileService elasticProfileService, ElasticAgentExtension elasticAgentExtension, PluginManager pluginManager, GoConfigService goConfigService) {
@@ -68,12 +73,29 @@ public class ElasticAgentInformationMigratorImpl implements ElasticAgentInformat
             return true;
         }
 
+        LOG.debug("Migrating elastic agent information for {} plugin", pluginId);
         Plugin plugin = pluginSqlMapDao.findPlugin(pluginId);
         String pluginConfiguration = plugin.getConfiguration();
         HashMap<String, String> pluginSettings = (pluginConfiguration == null) ? new HashMap<>() : JsonHelper.fromJson(pluginConfiguration, HashMap.class);
         ReplaceElasticAgentInformationCommand command = new ReplaceElasticAgentInformationCommand(clusterProfilesService, elasticProfileService, elasticAgentExtension, pluginDescriptor, pluginSettings);
 
-        return update(command, pluginDescriptor);
+        boolean updated = update(command, pluginDescriptor);
+
+        if (updated) {
+            LOG.debug("Done Migrating elastic agent information for {} plugin", pluginId);
+
+            // all the plugins implementing elastic agent extension v5, does not use plugin settings and hence delete them after successful migration
+            if (!pluginManager.resolveExtensionVersion(pluginId, ELASTIC_AGENT_EXTENSION, ElasticAgentExtension.SUPPORTED_VERSIONS).equals(ElasticAgentExtensionV4.VERSION)) {
+                LOG.debug("Deleting stale plugin settings for {} plugin, after successful plugin config migration", pluginId);
+                pluginSqlMapDao.deletePluginIfExists(pluginId);
+            } else {
+                LOG.debug("Skip deleting plugin settings for {} plugin, as the plugin implements elastic agent v4 extension which uses plugin settings", pluginId);
+            }
+        } else {
+            LOG.debug("Failed migrating elastic agent information for {} plugin", pluginId);
+        }
+
+        return updated;
     }
 
     private boolean update(UpdateConfigCommand command, GoPluginDescriptor pluginDescriptor) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/PluginSqlMapDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/PluginSqlMapDaoIntegrationTest.java
@@ -117,6 +117,37 @@ public class PluginSqlMapDaoIntegrationTest {
     }
 
     @Test
+    public void shouldDoNothingWhenAPluginToDeleteDoesNotExists() {
+        String pluginId = "my.fancy.plugin.id";
+
+        assertThat(goCache.get(pluginSqlMapDao.cacheKeyForPluginSettings(pluginId)), is(nullValue()));
+        assertThat(pluginSqlMapDao.getAllPlugins().size(), is(0));
+
+        pluginSqlMapDao.deletePluginIfExists(pluginId);
+
+        assertThat(goCache.get(pluginSqlMapDao.cacheKeyForPluginSettings(pluginId)), is(nullValue()));
+        assertThat(pluginSqlMapDao.getAllPlugins().size(), is(0));
+    }
+
+    @Test
+    public void shouldDeleteAPlugin() {
+        String pluginId = "my.fancy.plugin.id";
+
+        Plugin plugin = savePlugin(pluginId);
+
+        Plugin pluginInDB = pluginSqlMapDao.findPlugin(pluginId);
+        assertThat(pluginInDB, is(plugin));
+
+        assertThat(goCache.get(pluginSqlMapDao.cacheKeyForPluginSettings(pluginId)), is(plugin));
+        assertThat(pluginSqlMapDao.getAllPlugins().size(), is(1));
+
+        pluginSqlMapDao.deletePluginIfExists(pluginId);
+
+        assertThat(goCache.get(pluginSqlMapDao.cacheKeyForPluginSettings(pluginId)), is(nullValue()));
+        assertThat(pluginSqlMapDao.getAllPlugins().size(), is(0));
+    }
+
+    @Test
     public void shouldDeleteAllPlugins() {
         savePlugin("plugin-id-1");
         savePlugin("plugin-id-2");


### PR DESCRIPTION
Issue: #8643

Description:

* Do not delete the plugin settings when the migrate-config call fails.
* Do not delete the plugin settings when the elastic agent plugin implements
  elastic agent extension v4, which relies on plugin settings.
* Delete the plugin settings when the plugin successfully migrates the
  plugin settings to cluster profile and the plugin implements elastic
  agent extension v5 or above, which does not rely on plugin settings.


