### PR TITLE
Update webhook endpoints to support `SCM_NAME`

### DIFF
--- a/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/PushWebhookControllerV1.java
+++ b/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/PushWebhookControllerV1.java
@@ -79,20 +79,20 @@ public class PushWebhookControllerV1 extends ApiController implements SparkSprin
             return renderMessage(response, HttpStatus.ACCEPTED.value(), PING_RESPONSE);
         }
 
-        return notify(response, push.webhookUrls(), push.getPayload());
+        return notify(response, push.webhookUrls(), push.getPayload(), push.getScmNames());
     }
 
     protected String bitbucketCloud(Request request, Response response) {
         BitBucketCloudPushRequest push = new BitBucketCloudPushRequest(request);
         push.validate(serverConfigService.getWebhookSecret());
-        return notify(response, push.webhookUrls(), push.getPayload());
+        return notify(response, push.webhookUrls(), push.getPayload(), push.getScmNames());
     }
 
     protected String gitlab(Request request, Response response) {
         GitLabPushRequest push = new GitLabPushRequest(request);
         push.validate(serverConfigService.getWebhookSecret());
 
-        return notify(response, push.webhookUrls(), push.getPayload());
+        return notify(response, push.webhookUrls(), push.getPayload(), push.getScmNames());
     }
 
     protected String github(Request request, Response response) {
@@ -103,13 +103,13 @@ public class PushWebhookControllerV1 extends ApiController implements SparkSprin
             return renderMessage(response, HttpStatus.ACCEPTED.value(), PING_RESPONSE);
         }
 
-        return notify(response, push.webhookUrls(), push.getPayload());
+        return notify(response, push.webhookUrls(), push.getPayload(), push.getScmNames());
     }
 
-    private String notify(Response response, List<String> webhookUrls, PushPayload payload) {
-        LOGGER.info("[WebHook] Noticed a git push to {} on branch {}.", payload.getFullName(), payload.getBranch());
+    private String notify(Response response, List<String> webhookUrls, PushPayload payload, List<String> scmNames) {
+        LOGGER.info("[WebHook] Noticed a git push to {} on branch {} with scm names {}.", payload.getFullName(), payload.getBranch(), scmNames);
 
-        if (materialUpdateService.updateGitMaterial(payload.getBranch(), webhookUrls)) {
+        if (materialUpdateService.updateGitMaterial(payload.getBranch(), webhookUrls, scmNames)) {
             return renderMessage(response, HttpStatus.ACCEPTED.value(), "OK!");
         }
         return renderMessage(response, HttpStatus.ACCEPTED.value(), "No matching materials!");

--- a/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/request/WebhookRequest.java
+++ b/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/request/WebhookRequest.java
@@ -24,13 +24,18 @@ import com.thoughtworks.go.config.exceptions.BadRequestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.MimeType;
+import spark.QueryParamsMap;
 import spark.Request;
 
 import java.lang.reflect.ParameterizedType;
+import java.util.List;
 
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 
 public abstract class WebhookRequest<T extends Payload> implements ValidatingRequest, RequestContents {
+    public static final String KEY_SCM_NAME = "SCM_NAME";
     protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
     private final Request request;
@@ -76,6 +81,11 @@ public abstract class WebhookRequest<T extends Payload> implements ValidatingReq
     protected Class<T> getParameterClass() {
         return ((Class<T>) ((ParameterizedType) getClass().getGenericSuperclass())
                 .getActualTypeArguments()[0]);
+    }
+
+    public List<String> getScmNames() {
+        QueryParamsMap queryMap = this.request.queryMap();
+        return queryMap.hasKey(KEY_SCM_NAME) ? asList(queryMap.get(KEY_SCM_NAME).values()) : emptyList();
     }
 
 }

--- a/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/request/mixins/bitbucketcloud/BitBucketCloudAuth.java
+++ b/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/request/mixins/bitbucketcloud/BitBucketCloudAuth.java
@@ -63,7 +63,7 @@ public interface BitBucketCloudAuth extends HasAuth {
             }
 
             String encodedCredentials = new String(Base64.getDecoder().decode(credentials), UTF_8);
-            return encodedCredentials.contains(":") ? split(encodedCredentials, ":", 2)[1] : encodedCredentials;
+            return encodedCredentials.contains(":") ? split(encodedCredentials, ":", 2)[0] : encodedCredentials;
         }
         return null;
     }

--- a/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/PushWebhookControllerV1Test.groovy
+++ b/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/PushWebhookControllerV1Test.groovy
@@ -25,10 +25,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
-import org.mockito.Mockito
 
-import static org.mockito.ArgumentMatchers.anyCollection
-import static org.mockito.ArgumentMatchers.eq
+import static org.mockito.ArgumentMatchers.*
+import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.when
 import static org.mockito.MockitoAnnotations.initMocks
 
 class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTrait<PushWebhookControllerV1> {
@@ -77,7 +77,7 @@ class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTra
         "X-Hub-Signature": "foobar",
         "X-GitHub-Event" : "push"
       ]
-      Mockito.when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
+      when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
 
       postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.GITHUB), headers, payload)
 
@@ -91,7 +91,7 @@ class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTra
         "X-Hub-Signature": "sha1=c699381b869f24e74db3ee95609c52ee1aad1a48",
         "X-GitHub-Event" : "ping"
       ]
-      Mockito.when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
+      when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
 
       postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.GITHUB), headers, payload)
 
@@ -106,8 +106,8 @@ class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTra
         "X-Hub-Signature": "sha1=c699381b869f24e74db3ee95609c52ee1aad1a48",
         "X-GitHub-Event" : "push"
       ]
-      Mockito.when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
-      Mockito.when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection())).thenReturn(false)
+      when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
+      when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection(), any(String[].class))).thenReturn(false)
 
       postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.GITHUB), headers, payload)
 
@@ -122,11 +122,28 @@ class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTra
         "X-Hub-Signature": "sha1=c699381b869f24e74db3ee95609c52ee1aad1a48",
         "X-GitHub-Event" : "push"
       ]
-      Mockito.when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
-      Mockito.when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection())).thenReturn(true)
+      when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
+      when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection(), anyList())).thenReturn(true)
 
       postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.GITHUB), headers, payload)
 
+      assertThatResponse()
+        .isAccepted()
+        .hasJsonMessage("OK!")
+    }
+
+    @Test
+    void 'should pass in the scm names to the service'() {
+      def headers = [
+        "X-Hub-Signature": "sha1=c699381b869f24e74db3ee95609c52ee1aad1a48",
+        "X-GitHub-Event" : "push"
+      ]
+      when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
+      when(materialUpdateService.updateGitMaterial(anyString(), anyCollection(), anyList())).thenReturn(true)
+
+      postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.GITHUB) + "?SCM_NAME=abc", headers, payload)
+
+      verify(materialUpdateService).updateGitMaterial(eq("release"), anyCollection(), eq(["abc"]))
       assertThatResponse()
         .isAccepted()
         .hasJsonMessage("OK!")
@@ -162,7 +179,7 @@ class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTra
         "X-Gitlab-Token": "foobar",
         "X-Gitlab-Event": "Push Hook"
       ]
-      Mockito.when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
+      when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
 
       postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.GITLAB), headers, payload)
 
@@ -176,8 +193,8 @@ class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTra
         "X-Gitlab-Token": "c699381b869f24e74db3ee95609c52ee1aad1a48",
         "X-Gitlab-Event": "Push Hook"
       ]
-      Mockito.when(serverConfigService.getWebhookSecret()).thenReturn("c699381b869f24e74db3ee95609c52ee1aad1a48")
-      Mockito.when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection())).thenReturn(false)
+      when(serverConfigService.getWebhookSecret()).thenReturn("c699381b869f24e74db3ee95609c52ee1aad1a48")
+      when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection(), anyList())).thenReturn(false)
 
       postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.GITLAB), headers, payload)
 
@@ -192,11 +209,28 @@ class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTra
         "X-Gitlab-Token": "c699381b869f24e74db3ee95609c52ee1aad1a48",
         "X-Gitlab-Event": "Push Hook"
       ]
-      Mockito.when(serverConfigService.getWebhookSecret()).thenReturn("c699381b869f24e74db3ee95609c52ee1aad1a48")
-      Mockito.when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection())).thenReturn(true)
+      when(serverConfigService.getWebhookSecret()).thenReturn("c699381b869f24e74db3ee95609c52ee1aad1a48")
+      when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection(), anyList())).thenReturn(true)
 
       postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.GITLAB), headers, payload)
 
+      assertThatResponse()
+        .isAccepted()
+        .hasJsonMessage("OK!")
+    }
+
+    @Test
+    void 'should pass in the scm names to the service'() {
+      def headers = [
+        "X-Gitlab-Token": "c699381b869f24e74db3ee95609c52ee1aad1a48",
+        "X-Gitlab-Event": "Push Hook"
+      ]
+      when(serverConfigService.getWebhookSecret()).thenReturn("c699381b869f24e74db3ee95609c52ee1aad1a48")
+      when(materialUpdateService.updateGitMaterial(anyString(), anyCollection(), anyList())).thenReturn(true)
+
+      postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.GITLAB) + "?SCM_NAME=abc", headers, payload)
+
+      verify(materialUpdateService).updateGitMaterial(eq("release"), anyCollection(), eq(["abc"]))
       assertThatResponse()
         .isAccepted()
         .hasJsonMessage("OK!")
@@ -237,7 +271,7 @@ class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTra
         "Authorization": "Basic ${encodeToBase64("c699381b869f24e74db3ee95609c52ee1aad1a48")}",
         "X-Event-Key"  : "repo:push"
       ]
-      Mockito.when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
+      when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
 
       postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.BIT_BUCKET_CLOUD), headers, payload)
 
@@ -251,8 +285,8 @@ class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTra
         "Authorization": "Basic ${encodeToBase64("c699381b869f24e74db3ee95609c52ee1aad1a48")}",
         "X-Event-Key"  : "repo:push"
       ]
-      Mockito.when(serverConfigService.getWebhookSecret()).thenReturn("c699381b869f24e74db3ee95609c52ee1aad1a48")
-      Mockito.when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection())).thenReturn(false)
+      when(serverConfigService.getWebhookSecret()).thenReturn("c699381b869f24e74db3ee95609c52ee1aad1a48")
+      when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection(), anyList())).thenReturn(false)
 
       postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.BIT_BUCKET_CLOUD), headers, payload)
 
@@ -267,11 +301,28 @@ class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTra
         "Authorization": "Basic ${encodeToBase64("c699381b869f24e74db3ee95609c52ee1aad1a48")}",
         "X-Event-Key"  : "repo:push"
       ]
-      Mockito.when(serverConfigService.getWebhookSecret()).thenReturn("c699381b869f24e74db3ee95609c52ee1aad1a48")
-      Mockito.when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection())).thenReturn(true)
+      when(serverConfigService.getWebhookSecret()).thenReturn("c699381b869f24e74db3ee95609c52ee1aad1a48")
+      when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection(), anyList())).thenReturn(true)
 
       postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.BIT_BUCKET_CLOUD), headers, payload)
 
+      assertThatResponse()
+        .isAccepted()
+        .hasJsonMessage("OK!")
+    }
+
+    @Test
+    void 'should send in the scm names to the service'() {
+      def headers = [
+        "Authorization": "Basic ${encodeToBase64("c699381b869f24e74db3ee95609c52ee1aad1a48")}",
+        "X-Event-Key"  : "repo:push"
+      ]
+      when(serverConfigService.getWebhookSecret()).thenReturn("c699381b869f24e74db3ee95609c52ee1aad1a48")
+      when(materialUpdateService.updateGitMaterial(anyString(), anyCollection(), anyList())).thenReturn(true)
+
+      postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.BIT_BUCKET_CLOUD) + "?SCM_NAME=abc", headers, payload)
+
+      verify(materialUpdateService).updateGitMaterial(eq("release"), anyCollection(), eq(["abc"]))
       assertThatResponse()
         .isAccepted()
         .hasJsonMessage("OK!")
@@ -312,7 +363,7 @@ class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTra
         "X-Hub-Signature": "sha256=invalid-signature",
         "X-Event-Key"    : "repo:refs_changed"
       ]
-      Mockito.when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
+      when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
 
       postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.BIT_BUCKET_SERVER), headers, payload)
 
@@ -326,8 +377,8 @@ class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTra
         "X-Hub-Signature": "sha256=5b421defd19aacb4772fa869beb40ad1518b76774c61e85d70552e2ec9169204",
         "X-Event-Key"    : "repo:refs_changed"
       ]
-      Mockito.when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
-      Mockito.when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection())).thenReturn(false)
+      when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
+      when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection(), anyList())).thenReturn(false)
 
       postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.BIT_BUCKET_SERVER), headers, payload)
 
@@ -342,11 +393,28 @@ class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTra
         "X-Hub-Signature": "sha256=5b421defd19aacb4772fa869beb40ad1518b76774c61e85d70552e2ec9169204",
         "X-Event-Key"    : "repo:refs_changed"
       ]
-      Mockito.when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
-      Mockito.when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection())).thenReturn(true)
+      when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
+      when(materialUpdateService.updateGitMaterial(eq("release"), anyCollection(), anyList())).thenReturn(true)
 
       postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.BIT_BUCKET_SERVER), headers, payload)
 
+      assertThatResponse()
+        .isAccepted()
+        .hasJsonMessage("OK!")
+    }
+
+    @Test
+    void 'should pass in the scm names to the service'() {
+      def headers = [
+        "X-Hub-Signature": "sha256=5b421defd19aacb4772fa869beb40ad1518b76774c61e85d70552e2ec9169204",
+        "X-Event-Key"    : "repo:refs_changed"
+      ]
+      when(serverConfigService.getWebhookSecret()).thenReturn("webhook-secret")
+      when(materialUpdateService.updateGitMaterial(anyString(), anyCollection(), anyList())).thenReturn(true)
+
+      postWithApiHeader(controller.controllerPath(Routes.Webhook.Push.BIT_BUCKET_SERVER) + "?SCM_NAME=abc", headers, payload)
+
+      verify(materialUpdateService).updateGitMaterial(eq("release"), anyCollection(), eq(["abc"]))
       assertThatResponse()
         .isAccepted()
         .hasJsonMessage("OK!")

--- a/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/push/BitBucketCloudPushRequestTest.java
+++ b/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/push/BitBucketCloudPushRequestTest.java
@@ -161,11 +161,10 @@ class BitBucketCloudPushRequestTest {
         void shouldBeValidWhenTokenMatches() {
             String body = "{ \"repository\": { \"scm\": \"git\" } }";
 
-            Request request = newRequestWithAuthorizationHeader("repo:push", "021757dde54540ff083dcf680688c4c9676e5c44", body);
+            Request request = newRequestWithAuthorizationHeader("repo:push", "021757dde54540ff083dcf680688c4c9676e5c44:x", body);
 
             assertThatCode(() -> new BitBucketCloudPushRequest(request).validate("021757dde54540ff083dcf680688c4c9676e5c44"))
                     .doesNotThrowAnyException();
-
         }
     }
 

--- a/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/push/BitBucketServerPushRequestTest.java
+++ b/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/push/BitBucketServerPushRequestTest.java
@@ -23,8 +23,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import spark.QueryParamsMap;
 import spark.Request;
 
+import static com.thoughtworks.go.apiv1.webhook.request.WebhookRequest.KEY_SCM_NAME;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -65,6 +67,26 @@ class BitBucketServerPushRequestTest {
                 .hasSize(2)
                 .contains("ssh://bitbucket-server/gocd/spaceship.git",
                         "http://bitbucket-server/scm/gocd/spaceship.git");
+    }
+
+    @ParameterizedTest
+    @FileSource(files = "/bitbucket-server-payload.json")
+    void shouldReturnScmNameIfAny(String body) {
+        Request request = newRequest("repo:refs_changed", "", body);
+
+        BitBucketServerPushRequest bitBucketServerPushRequest = new BitBucketServerPushRequest(request);
+        QueryParamsMap map = mock(QueryParamsMap.class);
+        when(request.queryMap()).thenReturn(map);
+        when(map.hasKey(KEY_SCM_NAME)).thenReturn(false);
+        assertThat(bitBucketServerPushRequest.getScmNames()).isEmpty();
+
+        when(request.queryMap()).thenReturn(map);
+        when(map.hasKey(KEY_SCM_NAME)).thenReturn(true);
+
+        QueryParamsMap value = mock(QueryParamsMap.class);
+        when(map.get(KEY_SCM_NAME)).thenReturn(value);
+        when(value.values()).thenReturn(new String[]{"scm1"});
+        assertThat(bitBucketServerPushRequest.getScmNames()).containsExactly("scm1");
     }
 
     @Nested

--- a/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/push/GitHubPushRequestTest.java
+++ b/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/push/GitHubPushRequestTest.java
@@ -24,8 +24,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.util.MimeType;
+import spark.QueryParamsMap;
 import spark.Request;
 
+import static com.thoughtworks.go.apiv1.webhook.request.WebhookRequest.KEY_SCM_NAME;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -102,6 +104,26 @@ class GitHubPushRequestTest {
                         "ssh://github.com/gocd/spaceship.git",
                         "ssh://github.com/gocd/spaceship.git/"
                 );
+    }
+
+    @ParameterizedTest
+    @FileSource(files = "/github-payload.json")
+    void shouldReturnScmNamesIfAny(String body) {
+        Request request = newRequest("push", "", body, APPLICATION_JSON);
+
+        QueryParamsMap map = mock(QueryParamsMap.class);
+        when(request.queryMap()).thenReturn(map);
+        when(map.hasKey(KEY_SCM_NAME)).thenReturn(false);
+        GitHubPushRequest request1 = new GitHubPushRequest(request);
+        assertThat(request1.getScmNames()).isEmpty();
+
+        when(request.queryMap()).thenReturn(map);
+        when(map.hasKey(KEY_SCM_NAME)).thenReturn(true);
+
+        QueryParamsMap value = mock(QueryParamsMap.class);
+        when(map.get(KEY_SCM_NAME)).thenReturn(value);
+        when(value.values()).thenReturn(new String[]{"scm1"});
+        assertThat(request1.getScmNames()).containsExactly("scm1");
     }
 
     @Nested

--- a/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/push/GitLabPushRequestTest.java
+++ b/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/push/GitLabPushRequestTest.java
@@ -23,8 +23,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import spark.QueryParamsMap;
 import spark.Request;
 
+import static com.thoughtworks.go.apiv1.webhook.request.WebhookRequest.KEY_SCM_NAME;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -93,6 +95,27 @@ class GitLabPushRequestTest {
                         "gitlab@gitlab.example.com:gocd/spaceship.git",
                         "gitlab@gitlab.example.com:gocd/spaceship.git/"
                 );
+    }
+
+    @ParameterizedTest
+    @FileSource(files = "/github-lab.json")
+    void shouldReturnScmNameIfAny(String body) {
+        Request request = newRequest("Push Hook", "", body);
+
+        GitLabPushRequest gitLabPushRequest = new GitLabPushRequest(request);
+        QueryParamsMap map = mock(QueryParamsMap.class);
+        when(request.queryMap()).thenReturn(map);
+        when(map.hasKey(KEY_SCM_NAME)).thenReturn(false);
+        assertThat(gitLabPushRequest.getScmNames()).isEmpty();
+
+        when(request.queryMap()).thenReturn(map);
+        when(map.hasKey(KEY_SCM_NAME)).thenReturn(true);
+
+        QueryParamsMap value = mock(QueryParamsMap.class);
+        when(map.get(KEY_SCM_NAME)).thenReturn(value);
+        when(value.values()).thenReturn(new String[]{"scm1"});
+        assertThat(gitLabPushRequest.getScmNames()).containsExactly("scm1");
+
     }
 
     @Nested

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/PipelineGroups.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/PipelineGroups.java
@@ -179,24 +179,6 @@ public class PipelineGroups extends BaseCollection<PipelineConfigs> implements V
         configErrors.add(fieldName, message);
     }
 
-    public Set<MaterialConfig> getAllUniquePostCommitSchedulableMaterials() {
-        Set<MaterialConfig> materialConfigs = new HashSet<>();
-        Set<String> uniqueMaterials = new HashSet<>();
-        for (PipelineConfigs pipelineConfigs : this) {
-            for (PipelineConfig pipelineConfig : pipelineConfigs) {
-                for (MaterialConfig materialConfig : pipelineConfig.materialConfigs()) {
-                    if ((materialConfig instanceof ScmMaterialConfig || materialConfig instanceof PluggableSCMMaterialConfig)
-                            && !materialConfig.isAutoUpdate()
-                            && !uniqueMaterials.contains(materialConfig.getFingerprint())) {
-                        materialConfigs.add(materialConfig);
-                        uniqueMaterials.add(materialConfig.getFingerprint());
-                    }
-                }
-            }
-        }
-        return materialConfigs;
-    }
-
     public Map<String, List<Pair<PipelineConfig, PipelineConfigs>>> getPackageUsageInPipelines() {
         if (packageToPipelineMap == null) {
             synchronized (this) {

--- a/server/src/main/java/com/thoughtworks/go/server/materials/MaterialUpdateService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/MaterialUpdateService.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.server.materials;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.GoConfigWatchList;
 import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.config.materials.PluggableSCMMaterial;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
 import com.thoughtworks.go.config.materials.git.GitMaterial;
 import com.thoughtworks.go.config.materials.svn.SvnMaterial;
@@ -170,11 +171,11 @@ public class MaterialUpdateService implements GoMessageListener<MaterialUpdateCo
         }
     }
 
-    public boolean updateGitMaterial(String branchName, Collection<String> possibleUrls) {
+    public boolean updateGitMaterial(String branchName, Collection<String> possibleUrls, List<String> scmNames) {
         final CruiseConfig cruiseConfig = goConfigService.currentCruiseConfig();
         Set<Material> allUniquePostCommitSchedulableMaterials = materialConfigConverter.toMaterials(cruiseConfig.getAllUniquePostCommitSchedulableMaterials());
 
-        Predicate<Material> predicate = new MaterialPredicate(branchName, possibleUrls);
+        Predicate<Material> predicate = scmNames.isEmpty() ? new MaterialPredicate(branchName, possibleUrls) : new PluggableScmPredicate(scmNames);
         Set<Material> allGitMaterials = allUniquePostCommitSchedulableMaterials.stream().filter(predicate).collect(Collectors.toSet());
 
         allGitMaterials.forEach(MaterialUpdateService.this::updateMaterial);
@@ -320,6 +321,20 @@ public class MaterialUpdateService implements GoMessageListener<MaterialUpdateCo
             return material instanceof GitMaterial &&
                     ((GitMaterial) material).getBranch().equals(branchName) &&
                     possibleUrls.contains(((GitMaterial) material).getUrlArgument().withoutCredentials());
+        }
+    }
+
+    private static class PluggableScmPredicate implements Predicate<Material> {
+        private final List<String> scmNames;
+
+        public PluggableScmPredicate(List<String> scmNames) {
+            this.scmNames = scmNames;
+        }
+
+        @Override
+        public boolean test(Material material) {
+            return material instanceof PluggableSCMMaterial &&
+                    scmNames.contains(((PluggableSCMMaterial) material).getScmConfig().getName());
         }
     }
 }


### PR DESCRIPTION
Issue: #8170 

Description:
 - added support for query param `SCM_NAME`. The param can be specified multiple times.
 - the names if received will be mapped w.r.t. schedulable pluggable scm materials - if matched, a MDU will be triggered fr the same.
 - the none-matches will be silently ignored
 - fixed the broken bitbucket authentication

#### TODO
 - [x] Test for Github
 - [x] Test for Gitlab
 - [x] Test for Bitbucket cloud
 - [ ] Update docs.


