### PR TITLE
Do not purge the config repo defined structures cache on polled fetch

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/base/cache.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/base/cache.ts
@@ -88,8 +88,12 @@ export abstract class AbstractObjCache<T> implements ObjectCache<T> {
   }
 
   invalidate() {
-    this.empty();
+    this.markStale();
     this.primed = false;
+  }
+
+  protected markStale() {
+    this.empty();
   }
 
   protected empty() {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repo_view_model.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repo_view_model.ts
@@ -58,9 +58,9 @@ class CRResultCache extends AbstractObjCache<DefinedStructures> {
     }).catch(rejectAsString(reject));
   }
 
-  empty() {
-    // don't dump contents, just force a fresh set of data
-    this.etag = Stream();
+  markStale() {
+    // don't dump old contents, just overwrite on next fetch; this eliminates the flicker
+    // caused by redraw (data quickly cycles from full -> empty -> full) on each poll
   }
 }
 


### PR DESCRIPTION
This fixes a UI flicker when a config repo widget is expanded. Previously, the
defined pipeline structure graph would quickly blank out, then reappear each time
GoCD fetched config repo data on interval. This was caused by mithril redrawing
an empty pipeline structures data cache (resulting in an empty graph with a loading
message) followed only milliseconds later by a redraw when data was full again on
fetch response. On most connections, even those that are relatively slow, this looks
like a UI "glitch" because it happens so quickly.

Even though the caches were designed to not clear their contents on `invalidate()`
precisely to address this issue, it was happening anyway because a new cache object
was recreated on each fetch. This commit fixes this by persisting object caches over
intervals for reuse. Data is still updated when it changes, but no longer flickers
because the widget continues to display stale data while waiting for the API response
until fresh data overwrites it upon response completion.

Here's what I'm talking about (slowed down network so it can be seen on GIF, but imagine this happens much more quickly so it looks like a flash)

![config-repo-flicker](https://user-images.githubusercontent.com/723642/96052337-2b260e00-0e32-11eb-9c62-19d18e824079.gif)
