### PR TITLE
Show appropriate stage duration on the stage overview across mithril redraws.

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/models/stage_instance.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/models/stage_instance.ts
@@ -125,7 +125,10 @@ export class StageInstance {
   }
 
   stageScheduledTime(): number {
-    return this.json.jobs[0].scheduled_date / 1000;
+    return this.json.jobs.reduce((minTime, next) => {
+      const jobScheduledTime = next.scheduled_date / 1000;
+      return minTime < jobScheduledTime ? minTime : jobScheduledTime;
+    }, Infinity);
   }
 
   private isStageInProgress(): boolean {


### PR DESCRIPTION
Issue: #8595

Description:

* Compute stage compute time based on the oldest scheduled job from
  the stage. In case of reruning a single job, jobs from the stage will
  have different scheduled times. In such cases, pick the job with
  the oldest scheduled time.


