### PR TITLE
 Update error message for git version validation

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -56,7 +56,7 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
     public static final String GO_MATERIAL_BRANCH = "GO_MATERIAL_BRANCH";
     //TODO: use iBatis to set the type for us, and we can get rid of this field.
     public static final String TYPE = "GitMaterial";
-    public static final String ERR_GIT_OLD_VERSION = "Please install Git-core 1.6 or above. ";
+    public static final String ERR_GIT_OLD_VERSION = "Please install Git-core 1.9 or above. Currently installed version is ";
     private static final Logger LOG = LoggerFactory.getLogger(GitMaterial.class);
     private static final String ERR_GIT_NOT_FOUND = "Failed to find 'git' on your PATH. Please ensure 'git' is executable by the Go Server and on the Go Agents where this material will be used.";
     private final UrlArgument url;
@@ -176,7 +176,7 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
         ValidationBean defaultResponse = ValidationBean.notValid(e.getMessage());
         try {
             if (!gitVersion.isMinimumSupportedVersionOrHigher()) {
-                return ValidationBean.notValid(ERR_GIT_OLD_VERSION + gitVersion.toString());
+                return ValidationBean.notValid(ERR_GIT_OLD_VERSION + gitVersion.getVersion().toString());
             } else {
                 return defaultResponse;
             }

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
@@ -428,7 +428,7 @@ public class GitMaterialTest {
     void shouldReturnInvalidBeanWithRootCauseAsLowerVersionInstalled() {
         ValidationBean validationBean = new GitMaterial("http://0.0.0.0").handleException(new Exception(), GIT_VERSION_1_5);
         assertThat(validationBean.isValid()).isFalse();
-        assertThat(validationBean.getError()).contains(GitMaterial.ERR_GIT_OLD_VERSION);
+        assertThat(validationBean.getError()).isEqualTo("Please install Git-core 1.9 or above. Currently installed version is 1.5.4");
     }
 
     @Test


### PR DESCRIPTION
Issue: #8650 

Description:
GoCD requires min 1.9 git version. If not, the error message specified 1.6 which was wrong.
Update the message to show the correct version.

