### PR TITLE
ClonerFactory to fix JDK 15 `deepClone()` issues

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/util/SystemEnvironmentTest.java
+++ b/common/src/test/java/com/thoughtworks/go/util/SystemEnvironmentTest.java
@@ -27,7 +27,7 @@ import java.util.Properties;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SystemEnvironmentTest {
-    private static final Cloner CLONER = new Cloner();
+    private static final Cloner CLONER = ClonerFactory.instance();
     private Properties original;
     private SystemEnvironment systemEnvironment;
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Agent.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Agent.java
@@ -15,11 +15,11 @@
  */
 package com.thoughtworks.go.config;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.IpAddress;
 import com.thoughtworks.go.domain.PersistentObject;
 import com.thoughtworks.go.remote.AgentIdentifier;
+import com.thoughtworks.go.util.ClonerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -233,7 +233,7 @@ public class Agent extends PersistentObject {
     }
 
     public Agent deepClone() {
-        return new Cloner().deepClone(this);
+        return ClonerFactory.instance().deepClone(this);
     }
 
     public boolean isFromLocalHost() {

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BasicCruiseConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BasicCruiseConfig.java
@@ -21,7 +21,6 @@ import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
 import com.thoughtworks.go.config.exceptions.StageNotFoundException;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
-import com.thoughtworks.go.config.materials.PackageMaterialConfig;
 import com.thoughtworks.go.config.materials.PluggableSCMMaterialConfig;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
@@ -39,10 +38,7 @@ import com.thoughtworks.go.domain.packagerepository.PackageRepository;
 import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.domain.scm.SCMs;
 import com.thoughtworks.go.security.GoCipher;
-import com.thoughtworks.go.util.DFSCycleDetector;
-import com.thoughtworks.go.util.GoConstants;
-import com.thoughtworks.go.util.Node;
-import com.thoughtworks.go.util.PipelineDependencyState;
+import com.thoughtworks.go.util.*;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -50,7 +46,6 @@ import javax.annotation.PostConstruct;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static com.thoughtworks.go.config.exceptions.EntityType.Pipeline;
 import static com.thoughtworks.go.config.exceptions.EntityType.Template;
@@ -499,7 +494,7 @@ public class BasicCruiseConfig implements CruiseConfig {
 
     @Override
     public CruiseConfig cloneForValidation() {
-        Cloner cloner = new Cloner();
+        Cloner cloner = ClonerFactory.instance();
         BasicCruiseConfig configForValidation = cloner.deepClone(BasicCruiseConfig.this);
         // This needs to be done clear the cached fields else the cloned object will all get them.
         configForValidation.resetAllPipelineConfigsCache();

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
@@ -35,6 +35,7 @@ import com.thoughtworks.go.domain.Task;
 import com.thoughtworks.go.domain.label.PipelineLabel;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.service.TaskFactory;
+import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.Node;
 import org.apache.commons.lang3.StringUtils;
 
@@ -60,7 +61,7 @@ import static org.apache.commons.lang3.StringUtils.substringsBetween;
 @ConfigCollection(StageConfig.class)
 public class PipelineConfig extends BaseCollection<StageConfig> implements ParamScope, ParamsAttributeAware,
         Validatable, EnvironmentVariableScope, ConfigOriginTraceable {
-    private static final Cloner CLONER = new Cloner();
+    private static final Cloner CLONER = ClonerFactory.instance();
 
     public static final String LABEL_TEMPLATE = "labelTemplate";
     public static final String TRACKING_TOOL = "trackingTool";

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfigTreeValidator.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfigTreeValidator.java
@@ -15,12 +15,14 @@
  */
 package com.thoughtworks.go.config;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.Task;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
-import com.thoughtworks.go.util.*;
+import com.thoughtworks.go.util.ClonerFactory;
+import com.thoughtworks.go.util.DFSCycleDetector;
+import com.thoughtworks.go.util.Node;
+import com.thoughtworks.go.util.PipelineDependencyState;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
@@ -99,7 +101,7 @@ public class PipelineConfigTreeValidator {
             if (dependencyNode.getPipelineName().equals(pipelineConfig.name())) {
                 for (MaterialConfig materialConfig : downstreamPipeline.materialConfigs()) {
                     if (materialConfig instanceof DependencyMaterialConfig) {
-                        DependencyMaterialConfig dependencyMaterialConfig = new Cloner().deepClone((DependencyMaterialConfig) materialConfig);
+                        DependencyMaterialConfig dependencyMaterialConfig = ClonerFactory.instance().deepClone((DependencyMaterialConfig) materialConfig);
                         dependencyMaterialConfig.validate(validationContext.withParent(downstreamPipeline));
                         List<String> allErrors = dependencyMaterialConfig.errors().getAll();
                         for (String error : allErrors) {
@@ -118,7 +120,7 @@ public class PipelineConfigTreeValidator {
                     if (task instanceof FetchTask) {
                         FetchTask fetchTask = (FetchTask) task;
                         if (fetchTask.getPipelineNamePathFromAncestor() != null && !StringUtils.isBlank(CaseInsensitiveString.str(fetchTask.getPipelineNamePathFromAncestor().getPath())) && fetchTask.getPipelineNamePathFromAncestor().pathIncludingAncestor().contains(pipelineConfig.name())) {
-                            fetchTask = new Cloner().deepClone(fetchTask);
+                            fetchTask = ClonerFactory.instance().deepClone(fetchTask);
                             fetchTask.validateTask(validationContext.withParent(downstreamPipeline).withParent(stageConfig).withParent(jobConfig));
                             List<String> allErrors = fetchTask.errors().getAll();
                             for (String error : allErrors) {

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineTemplateConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineTemplateConfig.java
@@ -24,6 +24,7 @@ import com.thoughtworks.go.config.validation.NameTypeValidator;
 import com.thoughtworks.go.domain.BaseCollection;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.Task;
+import com.thoughtworks.go.util.ClonerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -39,7 +40,7 @@ import static com.thoughtworks.go.config.Authorization.ALLOW_GROUP_ADMINS;
 @ConfigCollection(value = StageConfig.class)
 public class PipelineTemplateConfig extends BaseCollection<StageConfig> implements Validatable, ParamsAttributeAware {
     private static final ClassAttributeCache.FieldCache FIELD_CACHE = new ClassAttributeCache.FieldCache();
-    private static final Cloner CLONER = new Cloner();
+    private static final Cloner CLONER = ClonerFactory.instance();
 
     public static final String NAME = "name";
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/BasicCruiseConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/BasicCruiseConfigTest.java
@@ -15,7 +15,6 @@
  */
 package com.thoughtworks.go.config;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.config.exceptions.UnprocessableEntityException;
@@ -30,8 +29,9 @@ import com.thoughtworks.go.domain.config.Configuration;
 import com.thoughtworks.go.domain.config.ConfigurationKey;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
 import com.thoughtworks.go.domain.config.ConfigurationValue;
-import com.thoughtworks.go.domain.packagerepository.PackageDefinition;
-import com.thoughtworks.go.helper.*;
+import com.thoughtworks.go.helper.GoConfigMother;
+import com.thoughtworks.go.helper.PartialConfigMother;
+import com.thoughtworks.go.helper.StageConfigMother;
 import com.thoughtworks.go.plugin.access.artifact.ArtifactMetadataStore;
 import com.thoughtworks.go.plugin.access.authorization.AuthorizationMetadataStore;
 import com.thoughtworks.go.plugin.access.elastic.ElasticAgentMetadataStore;
@@ -47,6 +47,7 @@ import com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo;
 import com.thoughtworks.go.security.CryptoException;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.security.ResetCipher;
+import com.thoughtworks.go.util.ClonerFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -323,7 +324,7 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
                 new ConfigurationProperty(new ConfigurationKey("k3"), new ConfigurationValue("pub_v3"))));
         jobConfig.artifactTypeConfigs().add(artifactConfig);
 
-        BasicCruiseConfig preprocessed = new Cloner().deepClone(cruiseConfig);
+        BasicCruiseConfig preprocessed = ClonerFactory.instance().deepClone(cruiseConfig);
         new ConfigParamPreprocessor().process(preprocessed);
         cruiseConfig.encryptSecureProperties(preprocessed);
 
@@ -355,7 +356,7 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
 
         cruiseConfig.server().security().getRoles().add(pluginRole);
 
-        BasicCruiseConfig preprocessed = new Cloner().deepClone(cruiseConfig);
+        BasicCruiseConfig preprocessed = ClonerFactory.instance().deepClone(cruiseConfig);
         new ConfigParamPreprocessor().process(preprocessed);
         cruiseConfig.encryptSecureProperties(preprocessed);
 
@@ -387,7 +388,7 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
 
         cruiseConfig.getElasticConfig().getProfiles().add(elasticProfile);
 
-        BasicCruiseConfig preprocessed = new Cloner().deepClone(cruiseConfig);
+        BasicCruiseConfig preprocessed = ClonerFactory.instance().deepClone(cruiseConfig);
         new ConfigParamPreprocessor().process(preprocessed);
         cruiseConfig.encryptSecureProperties(preprocessed);
 
@@ -411,7 +412,7 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
 
         resetCipher.setupAESCipherFile();
         BasicCruiseConfig config = setupPipelines();
-        BasicCruiseConfig preprocessed = new Cloner().deepClone(config);
+        BasicCruiseConfig preprocessed = ClonerFactory.instance().deepClone(config);
         new ConfigParamPreprocessor().process(preprocessed);
         config.encryptSecureProperties(preprocessed);
         PipelineConfig ancestor = config.pipelineConfigByName(new CaseInsensitiveString("ancestor"));

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/EnvironmentConfigTestBase.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/EnvironmentConfigTestBase.java
@@ -15,9 +15,9 @@
  */
 package com.thoughtworks.go.config;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.domain.EnvironmentPipelineMatcher;
 import com.thoughtworks.go.helper.GoConfigMother;
+import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -164,7 +164,7 @@ public abstract class EnvironmentConfigTestBase {
 
     @Test
     void shouldNotUpdateAnythingForNullAttributes() {
-        EnvironmentConfig beforeUpdate = new Cloner().deepClone(environmentConfig);
+        EnvironmentConfig beforeUpdate = ClonerFactory.instance().deepClone(environmentConfig);
         environmentConfig.setConfigAttributes(null);
         assertThat(environmentConfig).isEqualTo(beforeUpdate);
     }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/MergeCruiseConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/MergeCruiseConfigTest.java
@@ -25,6 +25,7 @@ import com.thoughtworks.go.domain.config.Configuration;
 import com.thoughtworks.go.domain.config.PluginConfiguration;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.helper.*;
+import com.thoughtworks.go.util.ClonerFactory;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -356,7 +357,7 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
         PartialConfig partialConfig = PartialConfigMother.withPipelineInGroup("pipeline-1", "g2");
         partialConfig.setOrigin(new RepoConfigOrigin());
         CruiseConfig config = new BasicCruiseConfig(mainCruiseConfig, partialConfig);
-        Cloner CLONER = new Cloner();
+        Cloner CLONER = ClonerFactory.instance();
         CruiseConfig cloned = CLONER.deepClone(config);
 
         List<ConfigErrors> allErrors = cloned.validateAfterPreprocess();

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigValidationTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigValidationTest.java
@@ -15,7 +15,6 @@
  */
 package com.thoughtworks.go.config;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.materials.PackageMaterialConfig;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
@@ -26,6 +25,7 @@ import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.packagerepository.PackageDefinitionMother;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.helper.MaterialConfigsMother;
+import com.thoughtworks.go.util.ClonerFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -378,7 +378,7 @@ class PipelineConfigValidationTest {
         p3.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("p2"), new CaseInsensitiveString("stage")));
 
         PipelineConfig p1 = cruiseConfig.getPipelineConfigByName(new CaseInsensitiveString(pipelineName));
-        p1 = new Cloner().deepClone(p1); // Do not remove cloning else it changes the underlying cache object defeating the purpose of the test.
+        p1 = ClonerFactory.instance().deepClone(p1); // Do not remove cloning else it changes the underlying cache object defeating the purpose of the test.
         p1.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("p3"), new CaseInsensitiveString("stage")));
         p1.validateTree(PipelineConfigSaveValidationContext.forChain(true, cruiseConfig.getGroups().first().getGroup(), cruiseConfig, p1));
         assertThat(p1.materialConfigs().errors().isEmpty()).isFalse();

--- a/config/config-api/src/test/java/com/thoughtworks/go/helper/PipelineConfigMother.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/helper/PipelineConfigMother.java
@@ -15,13 +15,13 @@
  */
 package com.thoughtworks.go.helper;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.remote.FileConfigOrigin;
 import com.thoughtworks.go.domain.label.PipelineLabel;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.security.GoCipher;
+import com.thoughtworks.go.util.ClonerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -127,7 +127,7 @@ public class PipelineConfigMother {
     }
 
     public static PipelineConfig renamePipeline(PipelineConfig oldConfig, String newPipelineName) {
-        PipelineConfig newConfig = new Cloner().deepClone(oldConfig);
+        PipelineConfig newConfig = ClonerFactory.instance().deepClone(oldConfig);
         HashMap attributes = new HashMap();
         attributes.put(PipelineConfig.NAME, newPipelineName);
         newConfig.setConfigAttributes(attributes);

--- a/config/config-server/src/main/java/com/thoughtworks/go/config/GoConfigCloner.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/config/GoConfigCloner.java
@@ -19,6 +19,7 @@ import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.BasicCruiseConfig.AllPipelineConfigs;
 import com.thoughtworks.go.config.BasicCruiseConfig.AllTemplatesWithAssociatedPipelines;
 import com.thoughtworks.go.config.BasicCruiseConfig.PipelineNameToConfigMap;
+import com.thoughtworks.go.util.ClonerFactory;
 
 // Cloner to handle nullification of specific classes in config objects.
 // A specific field can be ignored from being cloned by setting `cloner.setNullTransient(true)` and marking the field as 'transient',
@@ -36,5 +37,6 @@ public class GoConfigCloner extends Cloner {
                 PipelineNameToConfigMap.class,
                 CachedPluggableArtifactConfigs.class,
                 CachedFetchPluggableArtifactTasks.class);
+        ClonerFactory.applyFixes(this);
     }
 }

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/GoConfigClonerTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/GoConfigClonerTest.java
@@ -22,11 +22,22 @@ import com.thoughtworks.go.util.ReflectionUtil;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class GoConfigClonerTest {
+    @Test
+    public void fixesApplied_canCloneList12() {
+        final List<String> original = List.of("single element list");
+        final List<String> dupe = new GoConfigCloner().deepClone(original);
+        assertEquals(1, dupe.size());
+        assertEquals("single element list", dupe.get(0));
+        assertEquals(dupe, original);
+    }
+
     @Test
     public void shouldNotCloneAllPipelineConfigs() {
         BasicCruiseConfig config = GoConfigMother.configWithPipelines("p1", "p2");

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/GoConfigParallelGraphWalkerTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/GoConfigParallelGraphWalkerTest.java
@@ -15,16 +15,16 @@
  */
 package com.thoughtworks.go.config;
 
-import java.util.List;
-
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.domain.BaseCollection;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.helper.JobConfigMother;
 import com.thoughtworks.go.helper.MaterialConfigsMother;
 import com.thoughtworks.go.helper.PipelineConfigMother;
+import com.thoughtworks.go.util.ClonerFactory;
 import org.junit.Test;
+
+import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
@@ -35,7 +35,7 @@ public class GoConfigParallelGraphWalkerTest {
     @Test
     public void shouldWalkCruiseConfigObjectsParallelly() {
         CruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("bad pipeline name");
-        CruiseConfig rawCruiseConfig = new Cloner().deepClone(cruiseConfig);
+        CruiseConfig rawCruiseConfig = ClonerFactory.instance().deepClone(cruiseConfig);
         MagicalGoConfigXmlLoader.validate(cruiseConfig);
         cruiseConfig.copyErrorsTo(rawCruiseConfig);
         assertThat(rawCruiseConfig.pipelineConfigByName(new CaseInsensitiveString("bad pipeline name")).errors(),
@@ -52,7 +52,7 @@ public class GoConfigParallelGraphWalkerTest {
         pipelineWithTemplate.setTemplateName(new CaseInsensitiveString("template-1"));
         cruiseConfig.getGroups().get(0).add(pipelineWithTemplate);
 
-        CruiseConfig rawCruiseConfig = new Cloner().deepClone(cruiseConfig);
+        CruiseConfig rawCruiseConfig = ClonerFactory.instance().deepClone(cruiseConfig);
         MagicalGoConfigXmlLoader.validate(cruiseConfig);
         cruiseConfig.copyErrorsTo(rawCruiseConfig);
         assertThat(rawCruiseConfig.pipelineConfigByName(new CaseInsensitiveString("pipeline-with-template")).errors().isEmpty(), is(true));
@@ -71,7 +71,7 @@ public class GoConfigParallelGraphWalkerTest {
         pipelineWithTemplate.setTemplateName(new CaseInsensitiveString("invalid template name"));
         cruiseConfig.getGroups().get(0).add(pipelineWithTemplate);
 
-        CruiseConfig rawCruiseConfig = new Cloner().deepClone(cruiseConfig);
+        CruiseConfig rawCruiseConfig = ClonerFactory.instance().deepClone(cruiseConfig);
         MagicalGoConfigXmlLoader.validate(cruiseConfig);
         cruiseConfig.copyErrorsTo(rawCruiseConfig);
 
@@ -119,7 +119,7 @@ public class GoConfigParallelGraphWalkerTest {
         PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline", MaterialConfigsMother.defaultMaterialConfigs(), new JobConfigs(JobConfigMother.createJobConfigWithJobNameAndEmptyResources()));
         pipelineConfig.setVariables(new EnvironmentVariablesConfig(asList(new EnvironmentVariableConfig("name", "value"))));
 
-        PipelineConfig pipelineWithErrors = new Cloner().deepClone(pipelineConfig);
+        PipelineConfig pipelineWithErrors = ClonerFactory.instance().deepClone(pipelineConfig);
         pipelineWithErrors.getVariables().get(0).addError("name", "error on environment variable");
         pipelineWithErrors.first().addError("name", "error on stage");
         pipelineWithErrors.first().getJobs().first().addError("name", "error on job");

--- a/domain/src/main/java/com/thoughtworks/go/domain/Stage.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/Stage.java
@@ -18,9 +18,10 @@ package com.thoughtworks.go.domain;
 import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.StageConfig;
 import com.thoughtworks.go.util.Clock;
-import org.slf4j.Logger;
+import com.thoughtworks.go.util.ClonerFactory;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Timestamp;
@@ -50,7 +51,7 @@ public class Stage extends PersistentObject {
     private boolean artifactsDeleted;
 
     private static final StageResult DEFAULT_RESULT = StageResult.Unknown;
-    private static final Cloner CLONER = new Cloner();
+    private static final Cloner CLONER = ClonerFactory.instance();
     private String configVersion = null;
     private StageIdentifier previousStage;
 

--- a/domain/src/test/java/com/thoughtworks/go/domain/ResourceTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/ResourceTest.java
@@ -15,7 +15,7 @@
  */
 package com.thoughtworks.go.domain;
 
-import com.rits.cloning.Cloner;
+import com.thoughtworks.go.util.ClonerFactory;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,6 +28,6 @@ class ResourceTest {
         existingResource.setBuildId(10);
 
         assertThat(existingResource).isEqualTo(new Resource(existingResource));
-        assertThat(existingResource).isEqualTo(new Cloner().deepClone(existingResource));
+        assertThat(existingResource).isEqualTo(ClonerFactory.instance().deepClone(existingResource));
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -45,6 +45,7 @@ import com.thoughtworks.go.plugin.configrepo.contract.tasks.*;
 import com.thoughtworks.go.security.CryptoException;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.server.service.AgentService;
+import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.command.CommandLine;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -64,7 +65,7 @@ public class ConfigConverter {
     private final GoCipher cipher;
     private final CachedGoConfig cachedGoConfig;
     private AgentService agentService;
-    private Cloner cloner = new Cloner();
+    private Cloner cloner = ClonerFactory.instance();
 
     public ConfigConverter(GoCipher goCipher, CachedGoConfig cachedGoConfig, AgentService agentService) {
         this.cipher = goCipher;

--- a/server/src/main/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/PartialConfigUpdateCommand.java
@@ -18,9 +18,10 @@ package com.thoughtworks.go.config.update;
 import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.util.ClonerFactory;
 
 public class PartialConfigUpdateCommand implements UpdateConfigCommand {
-    private static final Cloner CLONER = new Cloner();
+    private static final Cloner CLONER = ClonerFactory.instance();
 
     private final PartialConfig partial;
     private final String fingerprint;

--- a/server/src/main/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDao.java
@@ -33,6 +33,7 @@ import com.thoughtworks.go.server.transaction.SqlMapClientDaoSupport;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.server.ui.SortOrder;
+import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.SystemEnvironment;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Ehcache;
@@ -65,7 +66,7 @@ public class JobInstanceSqlMapDao extends SqlMapClientDaoSupport implements JobI
     private TransactionTemplate transactionTemplate;
     private EnvironmentVariableDao environmentVariableDao;
     private JobAgentMetadataDao jobAgentMetadataDao;
-    private Cloner cloner = new Cloner();
+    private Cloner cloner = ClonerFactory.instance();
     private ResourceRepository resourceRepository;
     private ArtifactPlanRepository artifactPlanRepository;
     private final ClusterProfilesService clusterProfilesService;

--- a/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
@@ -38,6 +38,7 @@ import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.server.util.Pagination;
 import com.thoughtworks.go.util.Clock;
+import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TimeProvider;
 import net.sf.ehcache.Cache;
@@ -80,7 +81,7 @@ public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Initial
     private TransactionTemplate transactionTemplate;
     private TransactionSynchronizationManager transactionSynchronizationManager;
     private final GoConfigDao configFileDao;
-    private final Cloner cloner = new Cloner();
+    private final Cloner cloner = ClonerFactory.instance();
     private Clock timeProvider;
     private final ReadWriteLock activePipelineRWLock = new ReentrantReadWriteLock();
     private final Lock activePipelineReadLock = activePipelineRWLock.readLock();

--- a/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
@@ -37,6 +37,7 @@ import com.thoughtworks.go.server.transaction.SqlMapClientDaoSupport;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.server.util.Pagination;
+import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.DynamicReadWriteLock;
 import com.thoughtworks.go.util.IBatisUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -68,7 +69,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
     private JobInstanceSqlMapDao buildInstanceDao;
     private Cache cache;
     private TransactionSynchronizationManager transactionSynchronizationManager;
-    private Cloner cloner = new Cloner();
+    private Cloner cloner = ClonerFactory.instance();
     private DynamicReadWriteLock readWriteLock = new DynamicReadWriteLock();
 
     @Autowired

--- a/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimeline.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimeline.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.listener.TimelineUpdateListener;
 import com.thoughtworks.go.server.persistence.PipelineRepository;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
+import com.thoughtworks.go.util.ClonerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,7 +50,7 @@ public class PipelineTimeline {
     private TimelineUpdateListener[] listeners;
     private final ReadWriteLock naturalOrderLock = new ReentrantReadWriteLock();
     private final ReadWriteLock scheduleOrderLock = new ReentrantReadWriteLock();
-    private final Cloner cloner = new Cloner();
+    private final Cloner cloner = ClonerFactory.instance();
 
     @Autowired
     public PipelineTimeline(PipelineRepository pipelineRepository, TransactionTemplate transactionTemplate, TransactionSynchronizationManager transactionSynchronizationManager,

--- a/server/src/main/java/com/thoughtworks/go/server/service/EnvironmentConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EnvironmentConfigService.java
@@ -39,10 +39,14 @@ import com.thoughtworks.go.presentation.environment.EnvironmentPipelineModel;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.server.ui.EnvironmentViewModel;
+import com.thoughtworks.go.util.ClonerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.thoughtworks.go.config.CaseInsensitiveString.str;
@@ -62,7 +66,7 @@ public class EnvironmentConfigService implements ConfigChangedListener, AgentCha
 
     private EnvironmentsConfig environments;
     private EnvironmentPipelineMatchers matchers;
-    private static final Cloner cloner = new Cloner();
+    private static final Cloner cloner = ClonerFactory.instance();
 
     public EnvironmentConfigService() {
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/StageService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/StageService.java
@@ -51,6 +51,7 @@ import com.thoughtworks.go.server.ui.StageSummaryModels;
 import com.thoughtworks.go.server.util.Pagination;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
+import com.thoughtworks.go.util.ClonerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -84,7 +85,7 @@ public class StageService implements StageFinder {
     private List<StageStatusListener> stageStatusListeners;
     private StageStatusTopic stageStatusTopic;
     private StageStatusCache stageStatusCache;
-    private Cloner cloner = new Cloner();
+    private Cloner cloner = ClonerFactory.instance();
     private GoCache goCache;
     private static final String NOT_AUTHORIZED_TO_VIEW_PIPELINE = "Not authorized to view pipeline";
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filters/InvalidateAuthenticationOnSecurityConfigChangeFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filters/InvalidateAuthenticationOnSecurityConfigChangeFilterTest.java
@@ -15,7 +15,6 @@
  */
 package com.thoughtworks.go.server.newsecurity.filters;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.BasicCruiseConfig;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.http.mocks.HttpRequestBuilder;
@@ -30,6 +29,7 @@ import com.thoughtworks.go.server.security.userdetail.GoUserPrinciple;
 import com.thoughtworks.go.server.service.AuthorizationExtensionCacheService;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.PluginRoleService;
+import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TestingClock;
 import org.junit.jupiter.api.BeforeEach;
@@ -85,7 +85,7 @@ class InvalidateAuthenticationOnSecurityConfigChangeFilterTest {
         filter = new InvalidateAuthenticationOnSecurityConfigChangeFilter(goConfigService, clock, cacheService, pluginRoleService);
         filter.initialize();
         filter.onPluginRoleChange();
-        filter.onConfigChange(new Cloner().deepClone(cruiseConfig));
+        filter.onConfigChange(ClonerFactory.instance().deepClone(cruiseConfig));
         reset(cacheService);
     }
 
@@ -118,7 +118,7 @@ class InvalidateAuthenticationOnSecurityConfigChangeFilterTest {
 
         clock.addSeconds(1);
         cruiseConfig.addEnvironment("Foo");
-        filter.onConfigChange(new Cloner().deepClone(cruiseConfig));
+        filter.onConfigChange(ClonerFactory.instance().deepClone(cruiseConfig));
 
         response.reset();
         filter.doFilter(request, response, filterChain);
@@ -144,7 +144,7 @@ class InvalidateAuthenticationOnSecurityConfigChangeFilterTest {
 
         clock.addSeconds(1);
         GoConfigMother.addUserAsSuperAdmin(cruiseConfig, "bob");
-        filter.onConfigChange(new Cloner().deepClone(cruiseConfig));
+        filter.onConfigChange(ClonerFactory.instance().deepClone(cruiseConfig));
 
         response.reset();
         filter.doFilter(request, response, filterChain);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
@@ -16,7 +16,6 @@
 package com.thoughtworks.go.server.service;
 
 import com.google.common.collect.ImmutableMap;
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
@@ -29,6 +28,7 @@ import com.thoughtworks.go.presentation.environment.EnvironmentPipelineModel;
 import com.thoughtworks.go.server.domain.AgentInstances;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,12 +46,9 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.*;
 
 class EnvironmentConfigServiceTest {
@@ -116,7 +113,7 @@ class EnvironmentConfigServiceTest {
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         BasicEnvironmentConfig env = (BasicEnvironmentConfig) environmentConfigService.getEnvironmentConfig(uat).getLocal();
         cruiseConfig.addEnvironment(env);
-        BasicEnvironmentConfig expectedToEdit = new Cloner().deepClone(env);
+        BasicEnvironmentConfig expectedToEdit = ClonerFactory.instance().deepClone(env);
 
         when(mockGoConfigService.getConfigForEditing()).thenReturn(cruiseConfig);
 
@@ -143,7 +140,7 @@ class EnvironmentConfigServiceTest {
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         BasicEnvironmentConfig env = (BasicEnvironmentConfig) environmentConfigService.getEnvironmentConfig(uat).getLocal();
         cruiseConfig.addEnvironment(env);
-        List<BasicEnvironmentConfig> expectedToEdit = singletonList(new Cloner().deepClone(env));
+        List<BasicEnvironmentConfig> expectedToEdit = singletonList(ClonerFactory.instance().deepClone(env));
 
         when(mockGoConfigService.getConfigForEditing()).thenReturn(cruiseConfig);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
@@ -15,7 +15,6 @@
  */
 package com.thoughtworks.go.server.service;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
 import com.thoughtworks.go.config.pluggabletask.PluggableTask;
@@ -26,6 +25,7 @@ import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.presentation.CanDeleteResult;
 import com.thoughtworks.go.server.service.tasks.PluggableTaskService;
+import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.ReflectionUtil;
 import org.junit.Before;
 import org.junit.Test;
@@ -143,7 +143,7 @@ public class PipelineConfigServiceTest {
 
     @Test
     public void pipelineCountShouldIncludeConfigRepoPipelinesAsWell() {
-        CruiseConfig mergedCruiseConfig = new Cloner().deepClone(cruiseConfig);
+        CruiseConfig mergedCruiseConfig = ClonerFactory.instance().deepClone(cruiseConfig);
         ReflectionUtil.setField(mergedCruiseConfig, "allPipelineConfigs", null);
         mergedCruiseConfig.addPipeline("default", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
         when(goConfigService.cruiseConfig()).thenReturn(mergedCruiseConfig);
@@ -155,7 +155,7 @@ public class PipelineConfigServiceTest {
 
     @Test
     public void shouldGetAllViewableMergePipelineConfigs() throws Exception {
-        CruiseConfig mergedCruiseConfig = new Cloner().deepClone(cruiseConfig);
+        CruiseConfig mergedCruiseConfig = ClonerFactory.instance().deepClone(cruiseConfig);
         ReflectionUtil.setField(mergedCruiseConfig, "allPipelineConfigs", null);
         mergedCruiseConfig.addPipeline("group1", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
         mergedCruiseConfig.addPipeline("group2", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
@@ -180,7 +180,7 @@ public class PipelineConfigServiceTest {
 
     @Test
     public void shouldGetAllViewableGroups() throws Exception {
-        CruiseConfig cruiseConfig = new Cloner().deepClone(this.cruiseConfig);
+        CruiseConfig cruiseConfig = ClonerFactory.instance().deepClone(this.cruiseConfig);
         ReflectionUtil.setField(cruiseConfig, "allPipelineConfigs", null);
         cruiseConfig.addPipeline("group1", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
         cruiseConfig.addPipeline("group2", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));

--- a/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
@@ -15,7 +15,6 @@
  */
 package com.thoughtworks.go.config;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig;
@@ -55,10 +54,7 @@ import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.serverhealth.ServerHealthState;
 import com.thoughtworks.go.service.ConfigRepository;
-import com.thoughtworks.go.util.GoConfigFileHelper;
-import com.thoughtworks.go.util.GoConstants;
-import com.thoughtworks.go.util.ReflectionUtil;
-import com.thoughtworks.go.util.SystemEnvironment;
+import com.thoughtworks.go.util.*;
 import com.thoughtworks.go.util.command.CommandLine;
 import com.thoughtworks.go.util.command.ConsoleResult;
 import org.apache.commons.io.FileUtils;
@@ -889,7 +885,7 @@ public class CachedGoConfigIntegrationTest {
         String remoteDownstream = "remote-downstream";
         setupExternalConfigRepoWithDependencyMaterialOnPipelineInMainXml(upstream, remoteDownstream);
 
-        PartialConfig partialWithStageRenamed = new Cloner().deepClone(cachedGoPartials.lastValidPartials().get(0));
+        PartialConfig partialWithStageRenamed = ClonerFactory.instance().deepClone(cachedGoPartials.lastValidPartials().get(0));
         PipelineConfig pipelineInRemoteConfigRepo = partialWithStageRenamed.getGroups().get(0).getPipelines().get(0);
         pipelineInRemoteConfigRepo.materialConfigs().getDependencyMaterial().setStageName(new CaseInsensitiveString("new_name"));
         partialWithStageRenamed.setOrigin(new RepoConfigOrigin(configRepo, "r2"));
@@ -941,7 +937,7 @@ public class CachedGoConfigIntegrationTest {
         cachedGoPartials.clear();
         PartialConfig invalidPartial = PartialConfigMother.invalidPartial("invalid", new RepoConfigOrigin(configRepo, "revision1"));
         partialConfigService.onSuccessPartialConfig(configRepo, invalidPartial);
-        CruiseConfig updatedConfig = new Cloner().deepClone(goConfigService.getConfigForEditing());
+        CruiseConfig updatedConfig = ClonerFactory.instance().deepClone(goConfigService.getConfigForEditing());
         updatedConfig.server().setCommandRepositoryLocation("foo");
         String updatedXml = goFileConfigDataSource.configAsXml(updatedConfig, false);
         FileUtils.writeStringToFile(new File(goConfigDao.fileLocation()), updatedXml, UTF_8);
@@ -1068,7 +1064,7 @@ public class CachedGoConfigIntegrationTest {
         assertThat(cachedGoPartials.lastValidPartials().contains(validPartial)).isTrue();
         assertThat(cachedGoPartials.lastKnownPartials().contains(validPartial)).isTrue();
 
-        CruiseConfig config = new Cloner().deepClone(cachedGoConfig.loadForEditing());
+        CruiseConfig config = ClonerFactory.instance().deepClone(cachedGoConfig.loadForEditing());
 
         config.addEnvironment(UUID.randomUUID().toString());
 
@@ -1096,7 +1092,7 @@ public class CachedGoConfigIntegrationTest {
         assertThat(cachedGoPartials.lastValidPartials().isEmpty()).isTrue();
         assertThat(cachedGoPartials.lastKnownPartials().contains(invalidPartial)).isTrue();
 
-        CruiseConfig config = new Cloner().deepClone(cachedGoConfig.loadForEditing());
+        CruiseConfig config = ClonerFactory.instance().deepClone(cachedGoConfig.loadForEditing());
 
         config.addEnvironment(UUID.randomUUID().toString());
 
@@ -1126,7 +1122,7 @@ public class CachedGoConfigIntegrationTest {
         assertThat(cachedGoPartials.lastValidPartials().contains(validPartial)).isTrue();
         assertThat(cachedGoPartials.lastKnownPartials().contains(invalidPartial)).isTrue();
 
-        CruiseConfig config = new Cloner().deepClone(cachedGoConfig.loadForEditing());
+        CruiseConfig config = ClonerFactory.instance().deepClone(cachedGoConfig.loadForEditing());
 
         config.addEnvironment(UUID.randomUUID().toString());
 
@@ -1150,7 +1146,7 @@ public class CachedGoConfigIntegrationTest {
         setupExternalConfigRepoWithDependencyMaterialOnPipelineInMainXml("upstream", "downstream");
         String gitShaBeforeSave = configRepository.getCurrentRevCommit().getName();
         CruiseConfig originalConfig = cachedGoConfig.loadForEditing();
-        CruiseConfig editedConfig = new Cloner().deepClone(originalConfig);
+        CruiseConfig editedConfig = ClonerFactory.instance().deepClone(originalConfig);
 
         editedConfig.getGroups().remove(editedConfig.findGroup("default"));
 
@@ -1181,7 +1177,7 @@ public class CachedGoConfigIntegrationTest {
         assertThat(cachedGoPartials.lastValidPartials().isEmpty()).isTrue();
 
         CruiseConfig originalConfig = cachedGoConfig.loadForEditing();
-        CruiseConfig editedConfig = new Cloner().deepClone(originalConfig);
+        CruiseConfig editedConfig = ClonerFactory.instance().deepClone(originalConfig);
 
         editedConfig.addPipeline("default", upstream);
         ConfigSaveState state = cachedGoConfig.writeFullConfigWithLock(new FullConfigUpdateCommand(editedConfig, goConfigService.configFileMd5()));

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
@@ -16,7 +16,6 @@
 package com.thoughtworks.go.config;
 
 import ch.qos.logback.classic.Level;
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.CurrentGoCDVersion;
 import com.thoughtworks.go.config.exceptions.ConfigFileHasChangedException;
 import com.thoughtworks.go.config.exceptions.ConfigMergeException;
@@ -614,7 +613,7 @@ public class GoFileConfigDataSourceIntegrationTest {
 
     private void updateConfigOnFileSystem(UpdateConfig updateConfig) throws Exception {
         String cruiseConfigFile = systemEnvironment.getCruiseConfigFile();
-        CruiseConfig updatedConfig = new Cloner().deepClone(goConfigService.getConfigForEditing());
+        CruiseConfig updatedConfig = ClonerFactory.instance().deepClone(goConfigService.getConfigForEditing());
         updateConfig.update(updatedConfig);
         File configFile = new File(cruiseConfigFile);
         FileOutputStream outputStream = new FileOutputStream(configFile);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/controller/AgentRegistrationControllerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/controller/AgentRegistrationControllerIntegrationTest.java
@@ -24,6 +24,7 @@ import com.thoughtworks.go.server.service.AgentService;
 import com.thoughtworks.go.server.service.EphemeralAutoRegisterKeyService;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.util.UuidGenerator;
+import com.thoughtworks.go.util.ClonerFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,7 +71,7 @@ public class AgentRegistrationControllerIntegrationTest {
     @Autowired
     EphemeralAutoRegisterKeyService ephemeralAutoRegisterKeyService;
 
-    static final Cloner CLONER = new Cloner();
+    static final Cloner CLONER = ClonerFactory.instance();
     private Properties original;
 
     @BeforeEach

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
@@ -38,6 +38,7 @@ import com.thoughtworks.go.server.service.InstanceFactory;
 import com.thoughtworks.go.server.service.ScheduleTestUtil;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
+import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.util.TimeProvider;
 import org.joda.time.DateTime;
@@ -57,9 +58,7 @@ import static com.thoughtworks.go.helper.ModificationsMother.oneModifiedFile;
 import static com.thoughtworks.go.helper.PipelineConfigMother.createPipelineConfig;
 import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
 import static com.thoughtworks.go.util.DataStructureUtils.a;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -92,7 +91,7 @@ public class PipelineRepositoryIntegrationTest {
 
     private GoConfigFileHelper configHelper = new GoConfigFileHelper();
     private static final String PIPELINE_NAME = "pipeline";
-    public static final Cloner CLONER = new Cloner();
+    public static final Cloner CLONER = ClonerFactory.instance();
 
     @Before
     public void setup() throws Exception {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/AutoTriggerDependencyResolutionTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/AutoTriggerDependencyResolutionTest.java
@@ -41,6 +41,7 @@ import com.thoughtworks.go.server.materials.MaterialChecker;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.service.dd.MaxBackTrackLimitReachedException;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
+import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.After;
@@ -68,7 +69,7 @@ import static org.mockito.Mockito.when;
 })
 public class AutoTriggerDependencyResolutionTest {
     public static final String STAGE_NAME = "s";
-    public static final Cloner CLONER = new Cloner();
+    public static final Cloner CLONER = ClonerFactory.instance();
     @Autowired private DatabaseAccessHelper dbHelper;
     @Autowired private GoCache goCache;
     @Autowired private GoConfigDao goConfigDao;

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
@@ -15,7 +15,6 @@
  */
 package com.thoughtworks.go.server.service;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
@@ -301,7 +300,7 @@ public class BuildAssignmentServiceIntegrationTest {
         buildAssignmentService.onTimer();
 
         PipelineConfig originalPipelineConfig = configHelper.getCachedGoConfig().currentConfig().getPipelineConfigByName(new CaseInsensitiveString(fixture.pipelineName));
-        PipelineConfig pipelineConfig = new Cloner().deepClone(originalPipelineConfig);
+        PipelineConfig pipelineConfig = ClonerFactory.instance().deepClone(originalPipelineConfig);
         String md5 = entityHashingService.hashForEntity(originalPipelineConfig, fixture.groupName);
         StageConfig devStage = pipelineConfig.findBy(new CaseInsensitiveString(fixture.devStage));
         pipelineConfig.remove(devStage);
@@ -328,7 +327,7 @@ public class BuildAssignmentServiceIntegrationTest {
         buildAssignmentService.onTimer();
 
         PipelineConfig originalPipelineConfig = configHelper.getCachedGoConfig().currentConfig().getPipelineConfigByName(new CaseInsensitiveString(fixture.pipelineName));
-        PipelineConfig pipelineConfig = new Cloner().deepClone(originalPipelineConfig);
+        PipelineConfig pipelineConfig = ClonerFactory.instance().deepClone(originalPipelineConfig);
         String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(pipelineConfig);
         String md5 = entityHashingService.hashForEntity(originalPipelineConfig, fixture.groupName);
         StageConfig devStage = pipelineConfig.findBy(new CaseInsensitiveString(fixture.devStage));
@@ -358,7 +357,7 @@ public class BuildAssignmentServiceIntegrationTest {
 
         buildAssignmentService.onTimer();
 
-        PipelineConfig pipelineConfig = new Cloner().deepClone(configHelper.getCachedGoConfig().currentConfig().getPipelineConfigByName(new CaseInsensitiveString(fixture.pipelineName)));
+        PipelineConfig pipelineConfig = ClonerFactory.instance().deepClone(configHelper.getCachedGoConfig().currentConfig().getPipelineConfigByName(new CaseInsensitiveString(fixture.pipelineName)));
 
         pipelineConfigService.deletePipelineConfig(loserUser, pipelineConfig, new HttpLocalizedOperationResult());
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
@@ -16,7 +16,6 @@
 package com.thoughtworks.go.server.service;
 
 import com.google.gson.Gson;
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.ConfigReposConfig;
@@ -29,6 +28,7 @@ import com.thoughtworks.go.helper.PartialConfigMother;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.server.service.support.ServerStatusService;
+import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
@@ -248,7 +248,7 @@ public class ConfigSaveDeadlockDetectionIntegrationTest {
             public void run() {
                 try {
                     CruiseConfig cruiseConfig = cachedGoConfig.loadForEditing();
-                    CruiseConfig cruiseConfig1 = new Cloner().deepClone(cruiseConfig);
+                    CruiseConfig cruiseConfig1 = ClonerFactory.instance().deepClone(cruiseConfig);
                     cruiseConfig1.addEnvironment(UUID.randomUUID().toString());
 
                     goConfigDao.updateFullConfig(new FullConfigUpdateCommand(cruiseConfig1, cruiseConfig.getMd5()));

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   api group: 'org.springframework', name: 'spring-webmvc', version: project.versions.spring
   api group: 'javax.servlet', name: 'javax.servlet-api', version: project.versions.servletApi
   api group: 'com.google.code.gson', name: 'gson', version: project.versions.gson
+  api group: 'uk.com.robust-it', name: 'cloning', version: project.versions.cloning
   testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
   testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -22,7 +22,7 @@ dependencies {
   api group: 'org.springframework', name: 'spring-webmvc', version: project.versions.spring
   api group: 'javax.servlet', name: 'javax.servlet-api', version: project.versions.servletApi
   api group: 'com.google.code.gson', name: 'gson', version: project.versions.gson
-  api group: 'uk.com.robust-it', name: 'cloning', version: project.versions.cloning
+  implementation group: 'uk.com.robust-it', name: 'cloning', version: project.versions.cloning
   testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
   testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5

--- a/util/src/main/java/com/thoughtworks/go/util/ClonerFactory.java
+++ b/util/src/main/java/com/thoughtworks/go/util/ClonerFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.util;
+
+import com.rits.cloning.Cloner;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Provides a preconfigured {@link Cloner} instance for deep cloning objects.
+ * <p>
+ * <strong>NOTE</strong>: This was built to address {@link Cloner#deepClone(Object)} issues
+ * introduced by JDK 15. Specifically, the specialized/optimized {@link List} and {@link Set}
+ * implementations are problematic for {@link Cloner#deepClone(Object)} (ImmutableCollections.List12
+ * and ImmutableCollections.Set12, to be exact) and require a custom clone implementation to work
+ * properly.
+ * <p>
+ * Without these custom clone implementations, the cloned output of such {@link List}s and {@link Set}s
+ * may break equality with their origiinals. See git commit `efdbe0c1cccbce8be9e262727dbaa8dd9cfc7130`
+ * for more details.
+ */
+public class ClonerFactory {
+
+    private static class Builder {
+
+        private static final List<?> LIST_1_2 = List.of("");
+        private static final Set<?> SET_1_2 = Set.of("");
+
+        // Lazy-init, thread-safe singleton
+        private static final Cloner INSTANCE = create(new Cloner());
+
+        private static Cloner create(final Cloner cloner) {
+            cloner.registerFastCloner(LIST_1_2.getClass(), (t, _1, _2) -> {
+                final Object[] a = ((List<?>) t).toArray();
+                return (1 == a.length) ? List.of(a[0]) : List.of(a[0], a[1]);
+            });
+
+            cloner.registerFastCloner(SET_1_2.getClass(), (t, _1, _2) -> {
+                final Object[] a = ((Set<?>) t).toArray();
+                return (1 == a.length) ? Set.of(a[0]) : Set.of(a[0], a[1]);
+            });
+
+            return cloner;
+        }
+
+    }
+
+    public static Cloner instance() {
+        return Builder.INSTANCE;
+    }
+
+    public static Cloner applyFixes(Cloner cloner) {
+        return Builder.create(cloner);
+    }
+
+    private ClonerFactory() {
+    }
+}

--- a/util/src/test/java/com/thoughtworks/go/util/ClonerFactoryTest.java
+++ b/util/src/test/java/com/thoughtworks/go/util/ClonerFactoryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.util;
+
+import com.rits.cloning.Cloner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClonerFactoryTest {
+    private Cloner cloner;
+
+    @BeforeEach
+    void setup() {
+        cloner = ClonerFactory.instance();
+    }
+
+    @Test
+    void cloningList12() {
+        final List<Boolean> list = List.of(true);
+        final List<Boolean> dupe = cloner.deepClone(list);
+
+        assertEquals(1, dupe.size());
+        assertEquals(list.get(0), dupe.get(0));
+        assertEquals(list, dupe);
+    }
+
+    @Test
+    void cloningList12_two_items() {
+        final List<Boolean> list = List.of(true, false);
+        final List<Boolean> dupe = cloner.deepClone(list);
+
+        assertEquals(2, dupe.size());
+        assertEquals(list.get(0), dupe.get(0));
+        assertEquals(list.get(1), dupe.get(1));
+        assertEquals(list, dupe);
+    }
+
+    @Test
+    void cloningSet12() {
+        final Set<Boolean> set = Set.of(true);
+        final Set<Boolean> dupe = cloner.deepClone(set);
+
+        assertEquals(1, dupe.size());
+        assertTrue(dupe.contains(true));
+        assertEquals(set, dupe);
+    }
+
+    @Test
+    void cloningSet12_two_items() {
+        final Set<Boolean> set = Set.of(true, false);
+        final Set<Boolean> dupe = cloner.deepClone(set);
+
+        assertEquals(2, dupe.size());
+        assertTrue(dupe.contains(true));
+        assertTrue(dupe.contains(false));
+        assertEquals(set, dupe);
+    }
+
+    @Test
+    void cloneBiggerList() {
+        final List<Integer> list = List.of(1, 2, 3, 4, 5);
+        final List<Integer> dupe = cloner.deepClone(list);
+
+        assertEquals(5, dupe.size());
+        assertEquals(list, dupe);
+    }
+
+    @Test
+    void cloneBiggerSet() {
+        final Set<Integer> set = Set.of(1, 2, 3, 4, 5);
+        final Set<Integer> dupe = cloner.deepClone(set);
+
+        assertEquals(5, dupe.size());
+        assertEquals(set, dupe);
+    }
+
+}


### PR DESCRIPTION
We need a special `Cloner` instance to handle `ImmutableCollections.{List12,Set12}` instances because their peculiar implementation results in an incorrect output from `deepClone()`.