### PR TITLE
Unify the `autoUpdate` and `ignoreForScheduling` UI widgets

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos_crud.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos_crud.ts
@@ -44,14 +44,14 @@ export class ConfigReposCRUD {
   }
 
   static update(response: ObjectWithEtag<ConfigRepo>) {
-    return ApiRequestBuilder.PUT(SparkRoutes.ApiConfigRepoPath(response.object.id()!), this.API_VERSION_HEADER,
+    return ApiRequestBuilder.PUT(SparkRoutes.ApiConfigRepoPath(response.object.id()), this.API_VERSION_HEADER,
                                  {payload: configRepoToSnakeCaseJSON(response.object), etag: response.etag})
     .then(this.extractObjectWithEtag());
 
   }
 
   static delete(repo: ConfigRepo) {
-    return ApiRequestBuilder.DELETE(SparkRoutes.ApiConfigRepoPath(repo.id()!), this.API_VERSION_HEADER)
+    return ApiRequestBuilder.DELETE(SparkRoutes.ApiConfigRepoPath(repo.id()), this.API_VERSION_HEADER)
     .then((result: ApiResult<string>) => result.map((body) => JSON.parse(body)));
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/spec/config_repos_crud_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/spec/config_repos_crud_spec.ts
@@ -108,7 +108,7 @@ describe('ConfigRepoCRUD', () => {
       const responseJSON = response.unwrap() as SuccessResponse<any>;
       const configRepo   = (responseJSON.body as ObjectWithEtag<ConfigRepo>).object;
       expect(configRepo.id()).toBe("config-repo-id-1");
-      expect(configRepo.material()!.materialUrl()).toBe("http://foo.com [ master ]");
+      expect(configRepo.material().materialUrl()).toBe("http://foo.com [ master ]");
       done();
     });
 
@@ -129,7 +129,7 @@ describe('ConfigRepoCRUD', () => {
       const responseJSON = response.unwrap() as SuccessResponse<any>;
       const configRepo   = (responseJSON.body as ObjectWithEtag<ConfigRepo>).object;
       expect(configRepo.id()).toBe("config-repo-id-1");
-      expect(configRepo.material()!.materialUrl()).toBe("http://foo.com [ master ]");
+      expect(configRepo.material().materialUrl()).toBe("http://foo.com [ master ]");
       done();
     });
 
@@ -151,7 +151,7 @@ describe('ConfigRepoCRUD', () => {
       const responseJSON = response.unwrap() as SuccessResponse<any>;
       const configRepo   = (responseJSON.body as ObjectWithEtag<ConfigRepo>).object;
       expect(configRepo.id()).toBe("config-repo-id-1");
-      expect(configRepo.material()!.materialUrl()).toBe("http://foo.com [ master ]");
+      expect(configRepo.material().materialUrl()).toBe("http://foo.com [ master ]");
       done();
     });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/spec/types_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/config_repos/spec/types_spec.ts
@@ -34,28 +34,28 @@ describe("Config Repo Types", () => {
       const configRepo = new ConfigRepo("id", "pluginId", new Material("git", new GitMaterialAttributes()));
       expect(configRepo.isValid()).toBe(false);
       expect(configRepo.errors().count()).toBe(0);
-      expect(configRepo.material()!.errors().count()).toBe(0);
-      expect(configRepo.material()!.attributes()!.errors().count()).toBe(1);
-      expect(configRepo.material()!.attributes()!.errors().keys()).toEqual(["url"]);
+      expect(configRepo.material().errors().count()).toBe(0);
+      expect(configRepo.material().attributes()!.errors().count()).toBe(1);
+      expect(configRepo.material().attributes()!.errors().keys()).toEqual(["url"]);
     });
 
     it("should should validate SVN material attributes", () => {
       const configRepo = new ConfigRepo("id", "pluginId", new Material("svn", new SvnMaterialAttributes()));
       expect(configRepo.isValid()).toBe(false);
       expect(configRepo.errors().count()).toBe(0);
-      expect(configRepo.material()!.errors().count()).toBe(0);
-      expect(configRepo.material()!.attributes()!.errors().count()).toBe(1);
-      expect(configRepo.material()!.attributes()!.errors().keys()).toEqual(["url"]);
+      expect(configRepo.material().errors().count()).toBe(0);
+      expect(configRepo.material().attributes()!.errors().count()).toBe(1);
+      expect(configRepo.material().attributes()!.errors().keys()).toEqual(["url"]);
     });
 
     it("should should validate P4 material attributes", () => {
       const configRepo = new ConfigRepo("id", "pluginId", new Material("p4", new P4MaterialAttributes()));
       expect(configRepo.isValid()).toBe(false);
       expect(configRepo.errors().count()).toBe(0);
-      expect(configRepo.material()!.errors().count()).toBe(0);
-      expect(configRepo.material()!.attributes()!.errors().count()).toBe(2);
-      expect(configRepo.material()!.attributes()!.errors().keys()).toEqual(["view", "port"]);
-      expect(configRepo.material()!.attributes()!.errors().errorsForDisplay("port"))
+      expect(configRepo.material().errors().count()).toBe(0);
+      expect(configRepo.material().attributes()!.errors().count()).toBe(2);
+      expect(configRepo.material().attributes()!.errors().keys()).toEqual(["view", "port"]);
+      expect(configRepo.material().attributes()!.errors().errorsForDisplay("port"))
         .toEqual("Host and port must be present.");
     });
 
@@ -63,18 +63,18 @@ describe("Config Repo Types", () => {
       const configRepo = new ConfigRepo("id", "pluginId", new Material("hg", new HgMaterialAttributes()));
       expect(configRepo.isValid()).toBe(false);
       expect(configRepo.errors().count()).toBe(0);
-      expect(configRepo.material()!.errors().count()).toBe(0);
-      expect(configRepo.material()!.attributes()!.errors().count()).toBe(1);
-      expect(configRepo.material()!.attributes()!.errors().keys()).toEqual(["url"]);
+      expect(configRepo.material().errors().count()).toBe(0);
+      expect(configRepo.material().attributes()!.errors().count()).toBe(1);
+      expect(configRepo.material().attributes()!.errors().keys()).toEqual(["url"]);
     });
 
     it("should should validate TFS material attributes", () => {
       const configRepo = new ConfigRepo("id", "pluginId", new Material("tfs", new TfsMaterialAttributes()));
       expect(configRepo.isValid()).toBe(false);
       expect(configRepo.errors().count()).toBe(0);
-      expect(configRepo.material()!.errors().count()).toBe(0);
-      expect(configRepo.material()!.attributes()!.errors().count()).toBe(3);
-      expect(configRepo.material()!.attributes()!.errors().keys()).toEqual(["url", "projectPath", "username"]);
+      expect(configRepo.material().errors().count()).toBe(0);
+      expect(configRepo.material().attributes()!.errors().count()).toBe(3);
+      expect(configRepo.material().attributes()!.errors().keys()).toEqual(["url", "projectPath", "username"]);
     });
 
     it("validates configuration properties", () => {
@@ -164,7 +164,7 @@ describe("Config Repo Types", () => {
       const material           = new Material("git", attributes);
       const goodModification   = new MaterialModification("developer", "dev@github.com", "2cda5f702c5775714c060124ff03957d", "Not my best work", "19:30");
       const latestModification = new MaterialModification("jrDev", "jrDev@github.com", "4926940143a238fefb7566141ba24a96", "My first commit", "19:30");
-      const lastParse          = new ParseInfo(latestModification, goodModification, null);
+      const lastParse          = new ParseInfo(latestModification, goodModification, void 0);
 
       return new ConfigRepo("All_Test_Pipelines", "PluginId", material, false, [], lastParse);
     }
@@ -216,8 +216,8 @@ describe("Config Repo Types", () => {
 
     expect(configRepo.id()).toBe(inputJson.id);
     expect(configRepo.pluginId()).toBe(inputJson.plugin_id);
-    expect(configRepo.material()!.type()).toEqual(inputJson.material.type);
-    expect(configRepo.material()!.name()).toEqual(inputJson.material.attributes.name);
+    expect(configRepo.material().type()).toEqual(inputJson.material.type);
+    expect(configRepo.material().name()).toEqual(inputJson.material.attributes.name);
     expect(configRepo.canAdminister()).toEqual(inputJson.can_administer);
     expect(configRepo.configuration()).not.toBeUndefined();
     expect(configRepo.lastParse()).not.toBeUndefined();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/types_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/spec/types_spec.ts
@@ -265,7 +265,7 @@ describe("Material Types", () => {
 
   describe('Serialization', () => {
     it('should serialize dependency materials', () => {
-      const dependencyAttrs = new DependencyMaterialAttributes("name", false, "pipeline", "stage", false);
+      const dependencyAttrs = new DependencyMaterialAttributes("name", "pipeline", "stage", false);
 
       expect(Object.keys(dependencyAttrs.toJSON())).not.toContain('destination');
     });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
@@ -227,12 +227,12 @@ export class Material extends ValidatableMixin {
 
 export abstract class MaterialAttributes extends ValidatableMixin {
   name: Stream<string | undefined>;
-  autoUpdate: Stream<boolean | undefined>;
+  autoUpdate: Stream<boolean>;
 
   protected constructor(name?: string, autoUpdate?: boolean) {
     super();
     this.name       = Stream(name);
-    this.autoUpdate = Stream(autoUpdate);
+    this.autoUpdate = Stream(autoUpdate === void 0 || autoUpdate);
     this.validateIdFormat("name");
   }
 
@@ -594,15 +594,15 @@ export class TfsMaterialAttributes extends ScmMaterialAttributes {
 }
 
 export class DependencyMaterialAttributes extends MaterialAttributes {
-  pipeline: Stream<string | undefined>;
-  stage: Stream<string | undefined>;
-  ignoreForScheduling: Stream<boolean | undefined>;
+  pipeline: Stream<string>;
+  stage: Stream<string>;
+  ignoreForScheduling = Stream<boolean>(false);
 
-  constructor(name?: string, autoUpdate?: boolean, pipeline?: string, stage?: string, ignoreForScheduling?: boolean) {
-    super(name, autoUpdate);
-    this.pipeline            = Stream(pipeline);
-    this.stage               = Stream(stage);
-    this.ignoreForScheduling = Stream(ignoreForScheduling);
+  constructor(name?: string, pipeline?: string, stage?: string, ignoreForScheduling?: boolean) {
+    super(name, true /* autoUpdate is always `true` in the backend domain model */);
+    this.pipeline            = Stream(pipeline!);
+    this.stage               = Stream(stage!);
+    this.ignoreForScheduling = Stream(!!ignoreForScheduling);
 
     this.validatePresenceOf("pipeline");
     this.validatePresenceOf("stage");
@@ -611,7 +611,6 @@ export class DependencyMaterialAttributes extends MaterialAttributes {
   static fromJSON(json: Partial<DependencyMaterialAttributesJSON>) {
     const attrs = new DependencyMaterialAttributes(
       json.name,
-      json.auto_update,
       json.pipeline,
       json.stage,
       json.ignore_for_scheduling

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos.tsx
@@ -228,12 +228,12 @@ export class ConfigReposPage extends Page<null, State> {
 
     permissionsResponse.do((permissions) => {
       const repoPermissions = permissions.body.for(SupportedEntity.config_repo);
-      configRepos.forEach((repo) => repo.canAdminister(repoPermissions.canAdminister(repo.id()!)));
+      configRepos.forEach((repo) => repo.canAdminister(repoPermissions.canAdminister(repo.id())));
     }, (e) => onError(e.body!));
 
     const reusedCaches = new Map<string, ObjectCache<DefinedStructures>>();
     const models = _.map(configRepos, (repo) => {
-      const vm = new ConfigRepoVM(repo, vnode.state, this.resultCaches.get(repo.id()!));
+      const vm = new ConfigRepoVM(repo, vnode.state, this.resultCaches.get(repo.id()));
       vm.results.invalidate(); // always refresh definitions when getting new config repo data
       // persist results cache to the next poll; this eliminates the flicker when pulling new data after the first load
       reusedCaches.set(repo.id()!, vm.results);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repo_attribute_helper.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repo_attribute_helper.ts
@@ -31,8 +31,8 @@ export function resolveHumanReadableAttributes(obj: object) {
 }
 
 export function allAttributes(repo: ConfigRepo): Map<string, string> {
-  const initial            = new Map([["Type", repo.material()!.type()!]]);
-  const filteredAttributes = _.reduce(repo.material()!.attributes(),
+  const initial            = new Map([["Type", repo.material().type()!]]);
+  const filteredAttributes = _.reduce(repo.material().attributes(),
     resolveKeyValueForAttribute,
     initial);
   return _.reduce(repo.knownProps(),

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repo_view_model.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repo_view_model.ts
@@ -77,7 +77,7 @@ export class ConfigRepoVM {
   showDeleteModal: (e: Propagable) => void;
 
   constructor(repo: ConfigRepo, page: PageResources, results?: ObjectCache<DefinedStructures>) {
-    const cache = results || new CRResultCache(repo.id()!);
+    const cache = results || new CRResultCache(repo.id());
 
     Object.assign(ConfigRepoVM.prototype, EventAware.prototype);
     EventAware.call(this);
@@ -92,7 +92,7 @@ export class ConfigRepoVM {
       e.stopPropagation();
       page.flash.clear();
 
-      const repoId = this.repo.id()!;
+      const repoId = this.repo.id();
 
       return ConfigReposCRUD.triggerUpdate(repoId).then((result: ApiResult<any>) => {
         repo.materialUpdateInProgress(true);
@@ -109,7 +109,7 @@ export class ConfigRepoVM {
       e.stopPropagation();
       page.flash.clear();
 
-      new EditConfigRepoModal(this.repo.id()!,
+      new EditConfigRepoModal(this.repo.id(),
                               page.onSuccessfulSave,
                               page.onError,
                               page.pluginInfos,

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
@@ -54,7 +54,7 @@ class HeaderWidget extends MithrilViewComponent<SingleAttrs> {
 
   view(vnode: m.Vnode<SingleAttrs>): m.Children | void | null {
     const repo        = vnode.attrs.vm.repo;
-    const materialUrl = repo.material()!.materialUrl();
+    const materialUrl = repo.material().materialUrl();
     return [
       this.pluginIcon(vnode.attrs.pluginInfo),
       <div class={styles.headerTitle}>
@@ -197,7 +197,7 @@ class ConfigRepoWidget extends MithrilComponent<SingleAttrs> {
 
     const title = !repo.canAdminister() ? "You are not authorised to perform this action!" : "";
 
-    return <Anchor id={repo.id()!} sm={sm} onnavigate={() => this.expanded(true)}>
+    return <Anchor id={repo.id()} sm={sm} onnavigate={() => this.expanded(true)}>
       <CollapsiblePanel error={configRepoHasErrors}
                         header={<HeaderWidget {...vnode.attrs}/>}
                         dataTestId={"config-repo-details-panel"}
@@ -214,7 +214,7 @@ class ConfigRepoWidget extends MithrilComponent<SingleAttrs> {
         {this.renderedConfigs(parseInfo, vm)}
         {this.latestModificationDetails(parseInfo)}
         {this.lastGoodModificationDetails(parseInfo)}
-        {this.configRepoMetaConfigDetails(repo.id()!, repo.pluginId()!)}
+        {this.configRepoMetaConfigDetails(repo.id(), repo.pluginId())}
         {this.materialConfigDetails(repo)}
         {this.userPropertiesDetails(repo)}
         <ShowRulesWidget rules={repo.rules}/>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_widget_spec.tsx
@@ -267,8 +267,8 @@ describe("ConfigReposWidget", () => {
     expect(helper.byTestId("plugin-icon"))
       .toHaveAttr("src", "http://localhost:8153/go/api/plugin_images/json.config.plugin/f787");
 
-    expect(repoIds[0]).toContainText(repo1.id()!);
-    expect(repoIds[1]).toContainText(repo2.id()!);
+    expect(repoIds[0]).toContainText(repo1.id());
+    expect(repoIds[1]).toContainText(repo2.id());
   });
 
   it("should render config repo's plugin-id, material url, commit-message, username and revision in header", () => {
@@ -326,7 +326,7 @@ describe("ConfigReposWidget", () => {
 
   it("should render a warning message when parsing did not finish", () => {
     const repo = createConfigRepoParsedWithError();
-    repo.lastParse(null);
+    repo.lastParse(void 0);
     models([vm(repo)]);
     pluginInfos(new PluginInfos(configRepoPluginInfo()));
     helper.redraw();
@@ -372,9 +372,8 @@ describe("ConfigReposWidget", () => {
 
   it("should not render top border and keep the widget collapsed when there is no error", () => {
     const repo = createConfigRepoParsedWithError({});
-    if (repo.lastParse()) {
-      repo.lastParse()!.error(null);
-    }
+    repo.lastParse()?.error(void 0);
+
     models([vm(repo)]);
     pluginInfos(new PluginInfos(configRepoPluginInfo()));
     helper.redraw();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_modal_body.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_modal_body.tsx
@@ -23,8 +23,8 @@ import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_inf
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {Form, FormHeader} from "views/components/forms/form";
 import {SelectField, SelectFieldOptions, TextField} from "views/components/forms/input_fields";
-import {SwitchBtn} from "views/components/switch";
 import {PluginView} from "views/pages/package_repositories/package_repo_plugin_view";
+import {MaterialAutoUpdateToggle} from "views/pages/pipelines/material_auto_update_toggle";
 
 interface Attrs {
   pluginInfos: PluginInfos;
@@ -77,12 +77,7 @@ export class PackageModalBody extends MithrilViewComponent<Attrs> {
         </Form>
       </FormHeader>
 
-      <SwitchBtn label="Poll for new changes"
-                 helpText="By default, GoCD polls the package for changes automatically. If turned off, then GoCD will not poll the package for changes"
-                 dataTestId="auto-update-package"
-                 small={true}
-                 field={vnode.attrs.package.autoUpdate}
-                 errorText={vnode.attrs.package.errors().errorsForDisplay("autoUpdate")}/>
+      <MaterialAutoUpdateToggle noun="package" toggle={vnode.attrs.package.autoUpdate} errors={vnode.attrs.package.errors()}/>
 
       <PluginView pluginSettings={(pluginInfo.extensions[0] as PackageRepoExtension).packageSettings}
                   configurations={vnode.attrs.package.configuration()}/>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_modal_body_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/spec/package_modal_body_spec.tsx
@@ -63,8 +63,9 @@ describe('PackageModalBodySpec', () => {
     expect(helper.byTestId('form-field-input-package-repository')).not.toBeDisabled();
     expect(helper.byTestId("form-field-input-package-repository").children[0].textContent).toBe(pkg.packageRepo().name());
 
-    expect(helper.byTestId('auto-update-package')).toBeInDOM();
-    expect(helper.byTestId('auto-update-package')).not.toBeDisabled();
+    expect(helper.byTestId('material-auto-update')).toBeInDOM();
+    expect(helper.byTestId('material-auto-update')).not.toBeDisabled();
+    expect(helper.textByTestId('form-field-label', helper.byTestId('material-auto-update'))).toBe('Package polling behavior:');
   });
 
   it('should call the spy method on package repo change', () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_auto_update_toggle.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_auto_update_toggle.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MithrilViewComponent} from "jsx/mithril-component";
+import _ from "lodash";
+import m from "mithril";
+import {Accessor, bidirectionalTransform} from "models/base/accessor";
+import {Errors} from "models/mixins/errors";
+import {RadioField} from "views/components/forms/input_fields";
+
+type AutoUpdateRadioOptions = "auto" | "manual";
+
+interface Attrs {
+  noun?:     string; // i.e., the speciic word used to describe this material; default is "repository"
+  disabled?: boolean;
+  toggle: Accessor<boolean>;
+  errors?: Errors;
+}
+
+export class MaterialAutoUpdateToggle extends MithrilViewComponent<Attrs> {
+  view(vnode: m.Vnode<Attrs>) {
+    const { noun, toggle, errors } = withDefaults(vnode.attrs);
+    const autoUpdate = this.radioState(toggle);
+
+    return <RadioField<AutoUpdateRadioOptions>
+      label={`${_.capitalize(noun)} polling behavior:`}
+      property={autoUpdate}
+      readonly={!!vnode.attrs.disabled}
+      errorText={errors?.errorsForDisplay("autoUpdate")}
+      dataTestId="material-auto-update"
+      possibleValues={[
+        {label: `Regularly fetch updates to this ${noun}`, value: "auto"},
+        {label: `Fetch updates to this ${noun} only on webhook or manual trigger`, value: "manual"},
+      ]}/>;
+  }
+
+  radioState(backing: Accessor<boolean>) {
+    return bidirectionalTransform(backing, MaterialAutoUpdateToggle.optsToBool, MaterialAutoUpdateToggle.boolToOpts);
+  }
+
+  private static optsToBool = (v: AutoUpdateRadioOptions) => (v || "auto").toLowerCase() === "auto"; // "auto" => true; "manual" => false
+  private static boolToOpts: (v: boolean) => AutoUpdateRadioOptions = (v) => (v === void 0 || v) ? "auto" : "manual";
+}
+
+export class DependencyIgnoreSchedulingToggle extends MithrilViewComponent<Omit<Attrs, "noun">> {
+  view(vnode: m.Vnode<Omit<Attrs, "noun">>) {
+    const { toggle, errors } = vnode.attrs;
+    const ignoreForScheduling = this.radioState(toggle);
+
+    return <RadioField<AutoUpdateRadioOptions>
+      label={["Whenever the ", <em>upstream pipeline</em>, " passes:"]}
+      property={ignoreForScheduling}
+      readonly={!!vnode.attrs.disabled}
+      errorText={errors?.errorsForDisplay("ignoreForScheduling")}
+      dataTestId="material-ignore-for-scheduling"
+      possibleValues={[
+        {label: "Run this pipeline", value: "auto"},
+        {label: "Do not run this pipeline", value: "manual"},
+      ]}/>;
+  }
+
+  radioState(backing: Accessor<boolean>) {
+    return bidirectionalTransform(backing, DependencyIgnoreSchedulingToggle.optsToBool, DependencyIgnoreSchedulingToggle.boolToOpts);
+  }
+
+  private static optsToBool = (v: AutoUpdateRadioOptions) => (v || "manual").toLowerCase() === "manual"; // "auto" => false; "manual" => true
+  private static boolToOpts: (v: boolean) => AutoUpdateRadioOptions = (v) => (v === void 0 || !v) ? "auto" : "manual";
+}
+
+function withDefaults(attrs: Attrs): Attrs {
+  return _.assign({ noun: DEFAULT_NOUN }, attrs);
+}
+
+const DEFAULT_NOUN = "repository";

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
@@ -101,6 +101,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
     if (!scmOnly) {
       options.push({id: "dependency", text: "Another Pipeline"});
     }
+
     if (showExtraMaterials) {
       options.push({id: "package", text: "Package Materials"});
       options.push({id: "plugin", text: "Plugin Materials"});

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -36,11 +36,11 @@ import {FlashMessage, MessageType} from "views/components/flash_message";
 import {AutocompleteField, SuggestionProvider} from "views/components/forms/autocomplete";
 import {CheckboxField, Option, SelectField, SelectFieldOptions, TextField} from "views/components/forms/input_fields";
 import {Link} from "views/components/link";
-import {SwitchBtn} from "views/components/switch";
 import * as Tooltip from "views/components/tooltip";
 import {TooltipSize} from "views/components/tooltip";
 import {ConfigurationDetailsWidget} from "views/pages/package_repositories/configuration_details_widget";
 import {AdvancedSettings} from "views/pages/pipelines/advanced_settings";
+import {DependencyIgnoreSchedulingToggle} from "views/pages/pipelines/material_auto_update_toggle";
 import styles from "./advanced_settings.scss";
 import {DENYLIST_HELP_MESSAGE, DESTINATION_DIR_HELP_MESSAGE, IDENTIFIER_FORMAT_HELP_MESSAGE} from "./messages";
 
@@ -118,7 +118,7 @@ export class DependencyFields extends MithrilComponent<Attrs, State> {
     vnode.state.stages    = Stream(EMPTY);
 
     vnode.state.provider = new DependencySuggestionProvider(vnode.attrs.cache, vnode.attrs.parentPipelineName);
-    vnode.state.stages   = () => mat.pipeline() ? EMPTY.concat(cache.stages(mat.pipeline()!)) : [];
+    vnode.state.stages   = () => mat.pipeline() ? EMPTY.concat(cache.stages(mat.pipeline())) : [];
   }
 
   view(vnode: m.Vnode<Attrs, State>): m.Children {
@@ -154,15 +154,7 @@ export class DependencyFields extends MithrilComponent<Attrs, State> {
         <TextField label="Material Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} readonly={attrs.readonly}
                    placeholder="A human-friendly label for this material" property={mat.name}/>
 
-        <SwitchBtn label="Do not schedule the pipeline when this material is updated"
-                   helpText="When set to true, the pipeline will not be automatically scheduled for changes to this material."
-                   docLink={"/configuration/configuration_reference.html#pipeline-1"}
-                   dataTestId="material-ignore-for-scheduling"
-                   small={true}
-                   css={styles}
-                   disabled={attrs.readonly}
-                   field={mat.ignoreForScheduling}
-                   errorText={this.errs(mat, "ignoreForScheduling")}/>
+        <DependencyIgnoreSchedulingToggle toggle={mat.ignoreForScheduling} errors={mat.errors()} disabled={attrs.disabled}/>
       </AdvancedSettings>;
     }
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
@@ -30,11 +30,10 @@ import {
 } from "models/materials/types";
 import {CheckboxField, FormField, PasswordField, TextField} from "views/components/forms/input_fields";
 import {TestConnection} from "views/components/materials/test_connection";
-import {SwitchBtn} from "views/components/switch";
 import * as Tooltip from "views/components/tooltip";
 import {TooltipSize} from "views/components/tooltip";
 import {AdvancedSettings} from "views/pages/pipelines/advanced_settings";
-import styles from "./advanced_settings.scss";
+import {MaterialAutoUpdateToggle} from "views/pages/pipelines/material_auto_update_toggle";
 import {DENYLIST_HELP_MESSAGE, DESTINATION_DIR_HELP_MESSAGE, IDENTIFIER_FORMAT_HELP_MESSAGE} from "./messages";
 
 interface Attrs {
@@ -124,14 +123,7 @@ abstract class ScmFields extends MithrilViewComponent<Attrs> {
                    placeholder="A human-friendly label for this material" property={mattrs.name}
                    errorText={this.errs(mattrs, "name")}/>,
 
-        <SwitchBtn label="Poll for new changes"
-                   helpText="By default GoCD polls the repository for changes automatically. If set to false, then GoCD will not poll the repository for changes"
-                   dataTestId="auto-update-material"
-                   small={true}
-                   css={styles}
-                   disabled={vnode.attrs.readonly}
-                   field={mattrs.autoUpdate}
-                   errorText={this.errs(mattrs, "autoUpdate")}/>,
+        <MaterialAutoUpdateToggle toggle={mattrs.autoUpdate} errors={mattrs.errors()} disabled={vnode.attrs.disabled}/>,
 
         <TextField label="Denylist" helpText={DENYLIST_HELP_MESSAGE}
                    property={this.filterValue}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_auto_update_toggle_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_auto_update_toggle_spec.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import m from "mithril";
+import {basicAccessor} from "models/base/accessor";
+import {TestHelper} from "views/pages/spec/test_helper";
+import {DependencyIgnoreSchedulingToggle, MaterialAutoUpdateToggle} from "../material_auto_update_toggle";
+
+const helper = new TestHelper();
+
+describe("MaterialAutoUpdateToggle", () => {
+  afterEach(helper.unmount.bind(helper));
+
+  it("maps \"auto\" => true and \"manual\" => false", () => {
+    const toggle = basicAccessor<boolean>(true);
+    helper.mount(() => <MaterialAutoUpdateToggle toggle={toggle}/>);
+
+    expect(toggle()).toBe(true);
+    expect(helper.byTestId("radio-auto")).toBeChecked();
+    expect(helper.byTestId("radio-manual")).not.toBeChecked();
+
+    helper.clickByTestId("radio-manual");
+
+    expect(toggle()).toBe(false);
+    expect(helper.byTestId("radio-auto")).not.toBeChecked();
+    expect(helper.byTestId("radio-manual")).toBeChecked();
+
+    helper.clickByTestId("radio-auto");
+
+    expect(toggle()).toBe(true);
+    expect(helper.byTestId("radio-auto")).toBeChecked();
+    expect(helper.byTestId("radio-manual")).not.toBeChecked();
+  });
+
+  it("accepts a noun to change the wording", () => {
+    const toggle = basicAccessor<boolean>(true);
+    helper.mount(() => <MaterialAutoUpdateToggle toggle={toggle} noun="peacock"/>);
+
+    expect(helper.textAllByTestId("form-field-label")).toEqual([
+      "Peacock polling behavior:",
+      "Regularly fetch updates to this peacock",
+      "Fetch updates to this peacock only on webhook or manual trigger",
+    ]);
+  });
+});
+
+describe("DependencyIgnoreSchedulingToggle", () => {
+  afterEach(helper.unmount.bind(helper));
+
+  it("maps \"auto\" => false and \"manual\" => true", () => {
+    const toggle = basicAccessor<boolean>(false);
+    helper.mount(() => <DependencyIgnoreSchedulingToggle toggle={toggle}/>);
+
+    expect(toggle()).toBe(false);
+    expect(helper.byTestId("radio-auto")).toBeChecked();
+    expect(helper.byTestId("radio-manual")).not.toBeChecked();
+
+    helper.clickByTestId("radio-manual");
+
+    expect(toggle()).toBe(true);
+    expect(helper.byTestId("radio-auto")).not.toBeChecked();
+    expect(helper.byTestId("radio-manual")).toBeChecked();
+
+    helper.clickByTestId("radio-auto");
+
+    expect(toggle()).toBe(false);
+    expect(helper.byTestId("radio-auto")).toBeChecked();
+    expect(helper.byTestId("radio-manual")).not.toBeChecked();
+  });
+});

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {docsUrl} from "gen/gocd_version";
 import {SparkRoutes} from "helpers/spark_routes";
 import m from "mithril";
 import {Filter} from "models/maintenance_mode/material";
@@ -42,7 +41,7 @@ describe("AddPipeline: Non-SCM Material Fields", () => {
       "upstream-stage":    "Upstream Stage*",
       "material-name":     "Material Name",
     });
-    assertIgnoreForSchedulingSwitchPresent(helper);
+    assertIgnoreForSchedulingControlPresent(helper);
   });
 
   it("does not display advanced settings when `showLocalWorkingCopyOptions` === false", () => {
@@ -58,7 +57,7 @@ describe("AddPipeline: Non-SCM Material Fields", () => {
     assertLabelledInputsAbsent(helper,
                                "material-name",
     );
-    assertIgnoreForSchedulingSwitchAbsent(helper);
+    assertIgnoreForSchedulingControlAbsent(helper);
   });
 });
 
@@ -268,16 +267,16 @@ function assertLabelledInputsAbsent(helper: TestHelper, ...keys: string[]) {
   }
 }
 
-function assertIgnoreForSchedulingSwitchPresent(helper: TestHelper) {
-  const helpTextElement = helper.q('#switch-btn-help-text');
+function assertIgnoreForSchedulingControlPresent(helper: TestHelper) {
+  const control = helper.byTestId('material-ignore-for-scheduling');
 
-  expect(helper.byTestId('material-ignore-for-scheduling')).toBeInDOM();
-  expect(helper.textByTestId('switch-label')).toBe('Do not schedule the pipeline when this material is updated');
-  expect(helpTextElement.textContent!.startsWith("When set to true, the pipeline will not be automatically scheduled for changes to this material.")).toBeTrue();
-  expect(helper.q('a', helpTextElement)).toHaveAttr('href', docsUrl("configuration/configuration_reference.html#pipeline-1"));
+  expect(control).toBeInDOM();
+  expect(helper.textByTestId('form-field-label', control)).toBe('Whenever the upstream pipeline passes:');
+  expect(helper.textByTestId('input-field-for-auto', control)).toBe('Run this pipeline');
+  expect(helper.textByTestId('input-field-for-manual', control)).toBe('Do not run this pipeline');
 }
 
-function assertIgnoreForSchedulingSwitchAbsent(helper: TestHelper) {
+function assertIgnoreForSchedulingControlAbsent(helper: TestHelper) {
   expect(helper.byTestId('material-ignore-for-scheduling')).not.toBeInDOM();
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
@@ -45,7 +45,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "material-name": "Material Name",
       "denylist": "Denylist"
     });
-    assertAutoUpdateSwitchPresent();
+    assertAutoUpdateControlPresent();
 
     expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
@@ -65,7 +65,7 @@ describe("AddPipeline: SCM Material Fields", () => {
                                 });
 
     assertLabelledInputsAbsent("shallow-clone-recommended-for-large-repositories");
-    assertAutoUpdateSwitchPresent();
+    assertAutoUpdateControlPresent();
 
     expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
@@ -83,7 +83,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "material-name":           "Material Name",
       "denylist":               "Denylist"
     });
-    assertAutoUpdateSwitchPresent();
+    assertAutoUpdateControlPresent();
 
     expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
@@ -101,7 +101,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "material-name":           "Material Name",
       "denylist":               "Denylist"
     });
-    assertAutoUpdateSwitchPresent();
+    assertAutoUpdateControlPresent();
 
     expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
@@ -120,7 +120,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "material-name":             "Material Name",
       "denylist":                 "Denylist"
     });
-    assertAutoUpdateSwitchPresent();
+    assertAutoUpdateControlPresent();
 
     expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
@@ -139,7 +139,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "material-name":           "Material Name",
       "denylist":                "Denylist"
     });
-    assertAutoUpdateSwitchPresent();
+    assertAutoUpdateControlPresent();
 
     expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
@@ -157,7 +157,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "material-name":           "Material Name",
       "denylist":                "Denylist"
     });
-    assertAutoUpdateSwitchPresent();
+    assertAutoUpdateControlPresent();
 
     expect(helper.byTestId("test-connection-button")).toBe(null!);
   });
@@ -185,7 +185,7 @@ describe("AddPipeline: SCM Material Fields", () => {
       "material-name",
       "denylist"
     );
-    assertAutoUpdateSwitchAbsent();
+    assertAutoUpdateControlAbsent();
 
     expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
@@ -210,15 +210,16 @@ describe("AddPipeline: SCM Material Fields", () => {
     }
   }
 
-  function assertAutoUpdateSwitchPresent() {
-    const helpTextElement = helper.q('#switch-btn-help-text');
+  function assertAutoUpdateControlPresent() {
+    const control = helper.byTestId('material-auto-update');
 
-    expect(helper.byTestId('auto-update-material')).toBeInDOM();
-    expect(helper.textByTestId('switch-label')).toBe('Poll for new changes');
-    expect(helpTextElement.textContent).toEqual("By default GoCD polls the repository for changes automatically. If set to false, then GoCD will not poll the repository for changes");
+    expect(control).toBeInDOM();
+    expect(helper.textByTestId('form-field-label', control)).toBe('Repository polling behavior:');
+    expect(helper.textByTestId('input-field-for-auto', control)).toBe('Regularly fetch updates to this repository');
+    expect(helper.textByTestId('input-field-for-manual', control)).toBe('Fetch updates to this repository only on webhook or manual trigger');
   }
 
-  function assertAutoUpdateSwitchAbsent() {
-    expect(helper.byTestId('auto-update-material')).not.toBeInDOM();
+  function assertAutoUpdateControlAbsent() {
+    expect(helper.byTestId('material-auto-update')).not.toBeInDOM();
   }
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines_as_code.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines_as_code.tsx
@@ -147,7 +147,7 @@ export class PipelinesAsCodeCreatePage extends Page {
               }}
             />
 
-            <MaterialEditor readonly={false} material={this.configRepo().material()!} hideTestConnection={syncConfigRepoWithMaterial()} scmOnly={true} showLocalWorkingCopyOptions={false} showGitMaterialShallowClone={false} disabled={syncConfigRepoWithMaterial()}/>
+            <MaterialEditor readonly={false} material={this.configRepo().material()} hideTestConnection={syncConfigRepoWithMaterial()} scmOnly={true} showLocalWorkingCopyOptions={false} showGitMaterialShallowClone={false} disabled={syncConfigRepoWithMaterial()}/>
 
             <IdentifierInputField label="Name This Connection" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} placeholder="e.g., Pipelines-as-Code-Repository" property={this.configRepo().id} errorText={this.configRepo().errors().errorsForDisplay("id")} required={true}/>
           </UserInputPane>
@@ -167,7 +167,7 @@ export class PipelinesAsCodeCreatePage extends Page {
           </UserInputPane>
 
           <UserInputPane>
-            <MaterialCheck pluginId={this.pluginId()} material={this.configRepo().material()!} align="right" prerequisite={() => this.configRepo().isValid()} label={
+            <MaterialCheck pluginId={this.pluginId()} material={this.configRepo().material()} align="right" prerequisite={() => this.configRepo().isValid()} label={
                 <h4 class={css.minorHeading}>Verify that GoCD can find the configuration file in your repository:</h4>
               } success={(data: MaterialConfigFilesJSON, _: string) => {
                 this.allowCreate(!!data.plugins.find((p) => !!p.files.length));

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_modal_body.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_modal_body.tsx
@@ -25,7 +25,7 @@ import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_inf
 import {FlashMessage, FlashMessageModel} from "views/components/flash_message";
 import {Form, FormHeader} from "views/components/forms/form";
 import {SelectField, SelectFieldOptions, TextField} from "views/components/forms/input_fields";
-import {SwitchBtn} from "views/components/switch";
+import {MaterialAutoUpdateToggle} from "views/pages/pipelines/material_auto_update_toggle";
 import styles from "./index.scss";
 
 const AngularPluginNew = require("views/shared/angular_plugin_new").AngularPluginNew;
@@ -53,40 +53,38 @@ export class PluggableScmModalBody extends MithrilViewComponent<Attrs> {
       ? <FlashMessage type={vnode.attrs.message.type} message={vnode.attrs.message.message}/>
       : undefined;
     const settings = (selectedPluginInfo.extensionOfType(ExtensionTypeString.SCM) as ScmExtension).scmSettings;
+
+    const scm = vnode.attrs.scm;
+
     return <div>
       <FormHeader>
         {mayBeMsg}
         <Form>
           <TextField label="Name"
                      readonly={vnode.attrs.disableId}
-                     property={vnode.attrs.scm.name}
+                     property={scm.name}
                      placeholder={"Enter the pluggable scm name"}
-                     errorText={vnode.attrs.scm.errors().errorsForDisplay("name") || vnode.attrs.scm.errors().errorsForDisplay("scmId")}
+                     errorText={scm.errors().errorsForDisplay("name") || scm.errors().errorsForDisplay("scmId")}
                      required={true}/>
 
           <SelectField label="Plugin"
                        property={vnode.attrs.pluginIdProxy.bind(this)}
                        required={true} readonly={vnode.attrs.disablePluginId}
-                       errorText={vnode.attrs.scm.errors().errorsForDisplay("pluginId")}>
-            <SelectFieldOptions selected={vnode.attrs.scm.pluginMetadata().id()}
+                       errorText={scm.errors().errorsForDisplay("pluginId")}>
+            <SelectFieldOptions selected={scm.pluginMetadata().id()}
                                 items={pluginList}/>
           </SelectField>
         </Form>
       </FormHeader>
 
       <div className={styles.switchWrapper}>
-        <SwitchBtn label="Poll for new changes"
-                   helpText="By default, GoCD polls the repository for changes automatically. If turned off, then GoCD will not poll the repository for changes"
-                   dataTestId="auto-update-scm"
-                   small={true}
-                   field={vnode.attrs.scm.autoUpdate}
-                   errorText={vnode.attrs.scm.errors().errorsForDisplay("autoUpdate")}/>
+        <MaterialAutoUpdateToggle toggle={scm.autoUpdate} errors={scm.errors()}/>
       </div>
 
       <div className="row collapse">
         <AngularPluginNew
           pluginInfoSettings={Stream(settings)}
-          configuration={vnode.attrs.scm.configuration()}
+          configuration={scm.configuration()}
           key={selectedPluginInfo.id}/>
       </div>
     </div>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_modal_body_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_modal_body_spec.tsx
@@ -59,8 +59,8 @@ describe('PluggableScmModalBodySpec', () => {
     expect(helper.byTestId("form-field-input-plugin").children.length).toBe(1);
     expect(helper.byTestId("form-field-input-plugin").children[0].textContent).toBe('SCM Plugin');
 
-    expect(helper.byTestId('auto-update-scm')).toBeInDOM();
-    expect(helper.byTestId('auto-update-scm')).not.toBeDisabled();
+    expect(helper.byTestId('material-auto-update')).toBeInDOM();
+    expect(helper.byTestId('material-auto-update')).not.toBeDisabled();
   });
 
   it('should render the name as readonly', () => {


### PR DESCRIPTION
- Extract the autoUpdate radio button toggle as a common component
- Make a variant for ignoreForScheduling under the same file
- Refactor typings for ConfigRepo, Material, Scm, and Package to be more
  convenient (and more sensible?)
- Minor refactoring on RadioField component to allow for better value
  type-checking and clearer implementation
