### PR TITLE
Add the tracking tool link in the commit message on the comparison SPA and make the columns align

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/comparison_result_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/comparison_result_widget.tsx
@@ -20,6 +20,7 @@ import _ from "lodash";
 import m from "mithril";
 import {Comparison, DependencyRevisions, MaterialRevisions} from "models/compare/compare";
 import {DependencyMaterialAttributes} from "models/compare/material";
+import {PipelineConfig} from "models/pipeline_configs/pipeline_config";
 import {InfoCircle} from "views/components/icons";
 import {Link} from "views/components/link";
 import {DependencyRevisionsWidget} from "./dependency_revisions_widget";
@@ -28,6 +29,7 @@ import {MaterialRevisionsWidget} from "./material_revisions_widget";
 
 interface Attrs {
   comparisonResult: Comparison;
+  pipelineConfig: PipelineConfig;
 }
 
 export class ComparisonResultWidget extends MithrilViewComponent<Attrs> {
@@ -60,7 +62,7 @@ export class ComparisonResultWidget extends MithrilViewComponent<Attrs> {
                 break;
               default:
                 viewBody = <div>
-                  <MaterialRevisionsWidget result={change.revision as MaterialRevisions}/>
+                  <MaterialRevisionsWidget pipelineConfig={vnode.attrs.pipelineConfig} result={change.revision as MaterialRevisions}/>
                 </div>;
             }
             return <div data-test-id="material-changes">

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/index.scss
@@ -170,11 +170,12 @@ $dropdown-button-content-z-index: 5;
 .material-modifications {
   table td {
     &:nth-child(1) {
-      width: 10%;
+      width: 15%;
     }
 
     &:nth-child(2) {
-      width: 20%;
+      width:      20%;
+      word-break: break-word;
     }
 
     &:nth-child(3) {
@@ -183,8 +184,20 @@ $dropdown-button-content-z-index: 5;
   }
 }
 
-.dependency_materials {
+.dependency-materials {
   table td:first-child {
     width: 40%;
+  }
+}
+
+.truncate {
+  position: relative;
+
+  span {
+    position:      absolute;
+    max-width:     100%;
+    overflow:      hidden;
+    text-overflow: ellipsis;
+    white-space:   pre;
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/index.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/index.scss.d.ts
@@ -22,6 +22,7 @@ export const sourceRoot: string;
 export const sources: string;
 export const sourcesContent: string;
 export const spinnerWrapper: string;
+export const truncate: string;
 export const value: string;
 export const version: string;
 export const warning: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/material_revisions_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/material_revisions_widget.tsx
@@ -14,15 +14,19 @@
  * limitations under the License.
  */
 
+import {TrackingTool} from "helpers/render_comment";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import m from "mithril";
 import {MaterialRevisions} from "models/compare/compare";
+import {PipelineConfig, TrackingTool as Tool} from "models/pipeline_configs/pipeline_config";
 import {Table} from "views/components/table";
+import {CommentRenderWidget} from "views/dashboard/comment_render_widget";
 import styles from "./index.scss";
 import {PipelineInstanceWidget} from "./pipeline_instance_widget";
 
 interface MaterialRevisionsAttrs {
   result: MaterialRevisions;
+  pipelineConfig: PipelineConfig;
 }
 
 export class MaterialRevisionsWidget extends MithrilViewComponent<MaterialRevisionsAttrs> {
@@ -32,7 +36,9 @@ export class MaterialRevisionsWidget extends MithrilViewComponent<MaterialRevisi
         <div>{materialRev.revisionSha}</div>
         , <div>{materialRev.modifiedBy}</div>
         , <div>{PipelineInstanceWidget.getTimeToDisplay(materialRev.modifiedAt)}</div>
-        , <div className={styles.commitMsg}>{materialRev.commitMessage}</div>];
+        , <div className={styles.commitMsg}>
+          <CommentRenderWidget text={materialRev.commitMessage} trackingTool={this.createTrackingTool(vnode.attrs.pipelineConfig.trackingTool())}/>
+        </div>];
     });
     return <div data-test-id="material-revisions-widget" className={styles.materialModifications}>
       <Table headers={MaterialRevisionsWidget.headers()} data={data}/>
@@ -47,4 +53,21 @@ export class MaterialRevisionsWidget extends MithrilViewComponent<MaterialRevisi
       , "Comment"
     ];
   }
+
+  private createTrackingTool(tool: Tool) {
+    let trackingTool: TrackingTool;
+    if (tool) {
+      trackingTool = {link: tool.urlPattern(), regex: escapeDoubleHash(tool.regex())};
+    } else {
+      trackingTool = {link: "", regex: ""};
+    }
+    return trackingTool;
+  }
+}
+
+function escapeDoubleHash(regex: string) {
+  if (regex) {
+    return regex.replace(/(##)/g, '#');
+  }
+  return regex;
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/material_revisions_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/material_revisions_widget.tsx
@@ -33,7 +33,7 @@ export class MaterialRevisionsWidget extends MithrilViewComponent<MaterialRevisi
   view(vnode: m.Vnode<MaterialRevisionsAttrs, this>): m.Children | void | null {
     const data = vnode.attrs.result.map((materialRev) => {
       return [
-        <div>{materialRev.revisionSha}</div>
+        <div className={styles.truncate}><span title={materialRev.revisionSha}>{materialRev.revisionSha}</span></div>
         , <div>{materialRev.modifiedBy}</div>
         , <div>{PipelineInstanceWidget.getTimeToDisplay(materialRev.modifiedAt)}</div>
         , <div className={styles.commitMsg}>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/spec/comparison_result_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/spec/comparison_result_widget_spec.tsx
@@ -18,6 +18,7 @@ import {docsUrl} from "gen/gocd_version";
 import m from "mithril";
 import {Comparison} from "models/compare/compare";
 import {ComparisonData} from "models/compare/spec/test_data";
+import {PipelineConfig} from "models/pipeline_configs/pipeline_config";
 import {TestHelper} from "views/pages/spec/test_helper";
 import {ComparisonResultWidget} from "../comparison_result_widget";
 
@@ -31,7 +32,7 @@ describe('ComparisonResultWidgetSpec', () => {
   afterEach((done) => helper.unmount(done));
 
   function mount(comparison: Comparison) {
-    helper.mount(() => <ComparisonResultWidget comparisonResult={comparison}/>);
+    helper.mount(() => <ComparisonResultWidget comparisonResult={comparison} pipelineConfig={new PipelineConfig()}/>);
   }
 
   it('should showcase comparison result', () => {


### PR DESCRIPTION
Issue: #8685 

Description:
 - The tracking tool link was not hyperlinked on the comparison SPA. This PR fixes the same.
- In case of longer username and/or email address, the various SCM materials revisions tables were not aligned properly. Fixed that as well.
