### PR TITLE
Fix comparison spa failure for view users

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare.tsx
@@ -88,7 +88,9 @@ export class ComparePage extends Page<null, State> {
                             (successResponse) => {
                               this.pageState = PageState.OK;
                               vnode.state.pipelineConfig(PipelineConfig.fromJSON(JSON.parse(successResponse.body)));
-                            }, this.setErrorState);
+                            }, () => {
+                              vnode.state.pipelineConfig(new PipelineConfig());
+                            });
 
                           result[2].do((successResponse) => {
                             this.pageState = PageState.OK;


### PR DESCRIPTION
Description:
When a user with `view` access to a pipeline visits the comparison page - it fails. This is due to get pipeline config API call failing as the same is accessible to only admins/group admins.
Fixed it by not setting the error state when the said call fails.

