### PR TITLE
Fix issues related to autoUpdate UI

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/forms/input_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/forms/input_fields.tsx
@@ -687,6 +687,7 @@ export class RadioField<T extends string = string> extends RestyleViewComponent<
       <div class={this.inlined(vnode.attrs.inline)}>
         {this.renderInputField(vnode)}
       </div>
+      <ErrorText {...vnode.attrs} errorId={`${this.id}-error-text`}/>
     </li>;
   }
 
@@ -696,7 +697,7 @@ export class RadioField<T extends string = string> extends RestyleViewComponent<
     }
   }
 
-  private label({ label, required }: RadioButtonAttrs<T>) {
+  private label({label, required}: RadioButtonAttrs<T>) {
     if (label) {
       return <label for={this.id} class={this.css.formLabel} data-test-id="form-field-label">
         {label}{this.requiredMarker(required)}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_auto_update_toggle.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_auto_update_toggle.tsx
@@ -32,8 +32,8 @@ interface Attrs {
 
 export class MaterialAutoUpdateToggle extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs>) {
-    const { noun, toggle, errors } = withDefaults(vnode.attrs);
-    const autoUpdate = this.radioState(toggle);
+    const {noun, toggle, errors} = withDefaults(vnode.attrs);
+    const autoUpdate             = this.radioState(toggle);
 
     return <RadioField<AutoUpdateRadioOptions>
       label={`${_.capitalize(noun)} polling behavior:`}
@@ -57,7 +57,7 @@ export class MaterialAutoUpdateToggle extends MithrilViewComponent<Attrs> {
 
 export class DependencyIgnoreSchedulingToggle extends MithrilViewComponent<Omit<Attrs, "noun">> {
   view(vnode: m.Vnode<Omit<Attrs, "noun">>) {
-    const { toggle, errors } = vnode.attrs;
+    const {toggle, errors}    = vnode.attrs;
     const ignoreForScheduling = this.radioState(toggle);
 
     return <RadioField<AutoUpdateRadioOptions>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_auto_update_toggle_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_auto_update_toggle_spec.tsx
@@ -16,6 +16,7 @@
 
 import m from "mithril";
 import {basicAccessor} from "models/base/accessor";
+import {Errors} from "models/mixins/errors";
 import {TestHelper} from "views/pages/spec/test_helper";
 import {DependencyIgnoreSchedulingToggle, MaterialAutoUpdateToggle} from "../material_auto_update_toggle";
 
@@ -54,6 +55,16 @@ describe("MaterialAutoUpdateToggle", () => {
       "Regularly fetch updates to this peacock",
       "Fetch updates to this peacock only on webhook or manual trigger",
     ]);
+  });
+
+  it('should render error text if any', () => {
+    const errors = new Errors();
+    errors.add('autoUpdate', 'some error message');
+    const toggle = basicAccessor<boolean>(true);
+    helper.mount(() => <MaterialAutoUpdateToggle toggle={toggle} errors={errors}/>);
+
+    expect(helper.q('span[class*="forms__form-error-text__"]')).toBeInDOM();
+    expect(helper.q('span[class*="forms__form-error-text__"]').textContent).toBe('some error message.');
   });
 });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/index.scss
@@ -29,4 +29,8 @@
   label:after {
     margin-top: 0.15rem;
   }
+
+  input[type="radio"] { // sass-lint:disable-line no-qualifying-elements
+    margin: 0;
+  }
 }


### PR DESCRIPTION
Issue: https://github.com/gocd/gocd/pull/8688#issuecomment-718422581

Description:
 - Showcase error text w.r.t. material auto update toggle on the widget

  <img width="728" alt="Screen Shot 2020-11-02 at 10 33 42 AM" src="https://user-images.githubusercontent.com/41165891/97834094-f4d70280-1cfc-11eb-8a7f-23327e6a0ad1.png">


 - The foundation hax styles were applying which caused an additional 1em margin bottom to the radio input.
Rectified that by explicitly setting margin to zero.
