### PR TITLE
Do not build alpine 3.9 as it has reached EOL

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -26,7 +26,6 @@ enum Distro implements DistroBehavior {
       def installSasl_Post_3_9 = ['apk add --no-cache cyrus-sasl cyrus-sasl-plain']
 
       return [
-        new DistroVersion(version: '3.9', releaseName: '3.9', eolDate: parseDate('2020-11-01'), installPrerequisitesCommands: installSasl_Post_3_9, continueToBuild: true),
         new DistroVersion(version: '3.10', releaseName: '3.10', eolDate: parseDate('2021-05-01'), installPrerequisitesCommands: installSasl_Post_3_9),
         new DistroVersion(version: '3.11', releaseName: '3.11', eolDate: parseDate('2021-11-01'), installPrerequisitesCommands: installSasl_Post_3_9),
         new DistroVersion(version: '3.12', releaseName: '3.12', eolDate: parseDate('2022-05-01'), installPrerequisitesCommands: installSasl_Post_3_9)


### PR DESCRIPTION
Description:
Stop building Alpine 3.9 based images as the same has reached EOL
Ref: https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases

