### PR TITLE
Fixed the incorrect console log link

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.tsx
@@ -220,7 +220,7 @@ export class StageOverview extends MithrilComponent<Attrs, State> {
                               inProgressStageFromPipeline={inProgressStageFromPipeline}
                               jobsVM={vnode.attrs.stageOverviewVM()!.jobsVM}/>
       <JobsListWidget stageName={vnode.attrs.stageName}
-                      stageCounter={vnode.attrs.stageCounter}
+                      stageCounter={vnode.state.userSelectedStageCounter()}
                       pipelineName={vnode.attrs.pipelineName}
                       pipelineCounter={vnode.attrs.pipelineCounter}
                       jobsVM={vnode.attrs.stageOverviewVM()!.jobsVM}


### PR DESCRIPTION
When the stage counter is changed via the counter selector, the console log should point to the one selected rather than the latest one


