### PR TITLE
Update modal button UI to showcase error

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/entity_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/entity_modal.tsx
@@ -23,9 +23,10 @@ import {PluginInfo, PluginInfos} from "models/shared/plugin_infos_new/plugin_inf
 import * as Buttons from "views/components/buttons";
 import {ButtonGroup} from "views/components/buttons";
 import {FlashMessage, FlashMessageModel} from "views/components/flash_message";
-import {Modal, ModalState, Size} from "views/components/modal/index";
+import {InfoCircle} from "views/components/icons";
 import * as foundationStyles from "views/pages/new_plugins/foundation_hax.scss";
 import {OperationState} from "views/pages/page_operations";
+import {Modal, ModalState, Size} from "./index";
 import styles from "./index.scss";
 
 const foundationClassNames = bind(foundationStyles);
@@ -35,6 +36,7 @@ export abstract class EntityModal<T extends ValidatableMixin> extends Modal {
   protected readonly pluginInfos: PluginInfos;
   protected readonly flashMessage: FlashMessageModel;
   protected readonly onSuccessfulSave: (msg: m.Children) => any;
+  protected saveFailureIdentifier: m.Children;
   protected readonly isStale              = Stream(true);
   protected readonly etag: Stream<string> = Stream();
   protected ajaxOperationMonitor          = Stream<OperationState>(OperationState.UNKNOWN);
@@ -65,7 +67,8 @@ export abstract class EntityModal<T extends ValidatableMixin> extends Modal {
       return Promise.resolve();
     }
 
-    this.modalState = ModalState.LOADING;
+    this.modalState            = ModalState.LOADING;
+    this.saveFailureIdentifier = undefined;
     return this.operationPromise().then(this.onSaveResult.bind(this));
   }
 
@@ -97,6 +100,7 @@ export abstract class EntityModal<T extends ValidatableMixin> extends Modal {
                          disabled={this.isLoading()}
                          ajaxOperationMonitor={this.ajaxOperationMonitor}
                          ajaxOperation={this.performOperation.bind(this)}>Save</Buttons.Primary>
+        {this.saveFailureIdentifier}
       </ButtonGroup>
     ];
   }
@@ -182,6 +186,7 @@ export abstract class EntityModal<T extends ValidatableMixin> extends Modal {
       }
     }
     this.operationError(errorResponse, statusCode);
+    this.saveFailureIdentifier = <div className={styles.warning}><InfoCircle iconOnly={true} data-test-id="update-failure"/></div>;
   }
 }
 
@@ -208,9 +213,11 @@ export abstract class EntityModalWithCheckConnection<T extends ValidatableMixin>
                          disabled={this.isLoading()}
                          ajaxOperationMonitor={this.ajaxOperationMonitor}
                          ajaxOperation={this.performOperation.bind(this)}>Save</Buttons.Primary>
+        {this.saveFailureIdentifier}
       </ButtonGroup>
     ];
   }
+
   protected abstract verifyConnectionOperationPromise(): Promise<any>;
 
   private onVerifyConnectionResult(result: ApiResult<any>) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss
@@ -169,3 +169,9 @@ $error-message-margin-bottom: 40px;
 .error-wrapper {
   margin-bottom: $error-message-margin-bottom;
 }
+
+.warning {
+  color:      $failed;
+  margin-top: 5px;
+  font-size:  15px;
+}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss.d.ts
@@ -22,3 +22,4 @@ export const sources: string;
 export const sourcesContent: string;
 export const spinnerWrapper: string;
 export const version: string;
+export const warning: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs/modals.tsx
@@ -69,6 +69,7 @@ abstract class AuthConfigModal extends EntityModal<AuthConfig> {
                          disabled={this.isStale()}
                          ajaxOperationMonitor={this.ajaxOperationMonitor}
                          ajaxOperation={this.performOperation.bind(this)}>Save</Buttons.Primary>
+        {this.saveFailureIdentifier}
       </ButtonGroup>
     ];
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/modals.tsx
@@ -78,6 +78,7 @@ abstract class PluggableScmModal extends EntityModal<Scm> {
                          disabled={this.isLoading()}
                          ajaxOperationMonitor={this.ajaxOperationMonitor}
                          ajaxOperation={this.performOperation.bind(this)}>Save</Buttons.Primary>
+        {this.saveFailureIdentifier}
       </ButtonGroup>,
 
       <div className={styles.alignLeft}>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/preferences/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/preferences/modals.tsx
@@ -23,7 +23,9 @@ import {ButtonGroup, Cancel, Primary} from "views/components/buttons";
 import {FlashMessage, FlashMessageModel} from "views/components/flash_message";
 import {FormBody} from "views/components/forms/form";
 import {CheckboxField, Option, SelectField, SelectFieldOptions} from "views/components/forms/input_fields";
-import {Modal, Size} from "views/components/modal";
+import {InfoCircle} from "views/components/icons";
+import {Modal, ModalState, Size} from "views/components/modal";
+import styles from "views/components/modal/index.scss";
 import {OperationState} from "views/pages/page_operations";
 
 class FilterPipelineAndStage {
@@ -60,6 +62,7 @@ abstract class BaseModal extends Modal {
 
   protected selectedPipeline: Stream<string>;
   protected stagesOptions: Stream<string[]>;
+  protected saveFailureIdentifier: m.Children;
 
   protected constructor(filter: NotificationFilter,
                         pipelineGroups: Stream<PipelineGroups>,
@@ -113,6 +116,7 @@ abstract class BaseModal extends Modal {
                  disabled={this.isLoading()}
                  ajaxOperationMonitor={this.ajaxOperationMonitor}
                  ajaxOperation={this.performOperation.bind(this)}>Save</Primary>
+        {this.saveFailureIdentifier}
       </ButtonGroup>
     ];
   }
@@ -123,6 +127,8 @@ abstract class BaseModal extends Modal {
       this.flashMessage.alert("Validation Errors!");
       return Promise.reject();
     }
+    this.saveFailureIdentifier = undefined;
+    this.modalState            = ModalState.LOADING;
     return this.operationPromise()
                .then(this.onOperationResult.bind(this));
   }
@@ -147,6 +153,8 @@ abstract class BaseModal extends Modal {
     } else {
       this.flashMessage.alert(errorResponse.message);
     }
+    this.saveFailureIdentifier = <div className={styles.warning}><InfoCircle iconOnly={true} data-test-id="update-failure"/></div>;
+    this.modalState            = ModalState.OK;
   }
 
   private onSuccess(successResponse: SuccessResponse<ObjectWithEtag<NotificationFilter>>) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/modals.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/modals.tsx
@@ -71,9 +71,6 @@ export abstract class SecretConfigModal extends EntityModal<SecretConfig> {
   }
 
   protected modalBody(): m.Children {
-    if (this.isLoading()) {
-      return;
-    }
     const pluginList     = _.map(this.pluginInfos, (pluginInfo: PluginInfo) => {
       return {id: pluginInfo.id, text: pluginInfo.about.name};
     });


### PR DESCRIPTION
Description:
 - Post save in our modal - add a error icon to the save button. This will ensure that the user gets notified of a failure in cases wherein the field with error is not in view

<img width="1108" alt="Screen Shot 2020-11-04 at 4 24 11 PM" src="https://user-images.githubusercontent.com/41165891/98102897-32cd5580-1eba-11eb-97cc-cf48c1e81c2c.png">


