### PR TITLE
Revert "Upgrade BC version to '1.65' to fix #8624"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,7 @@ rootProject.ext.versions = [
   aspectj               : '1.9.5',
   assertJ               : '3.12.2',
   assertJ_DB            : '1.3.0',
-  bouncyCastle          : '1.65', // bouncycastle version has to be compatible with the jruby version
+  bouncyCastle          : '1.59', // bouncycastle version has to be compatible with the jruby version
   bundler               : '2.1.1',
   cglib                 : '3.3.0',
   cloning               : '1.9.11',

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile
@@ -15,7 +15,6 @@ gem 'representable', '2.1.7'
 gem 'js-routes'
 gem 'ts_routes'
 gem 'versionist'
-gem 'jruby-openssl', '0.10.5' #Check BC version before upgrading, require '0.10.5' since it's compatible with Bouncy Castle 1.65
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -80,7 +80,6 @@ GEM
     jasmine_selenium_runner (3.0.0)
       jasmine (~> 3.0)
       selenium-webdriver (~> 3.8)
-    jruby-openssl (0.10.5-java)
     js-routes (1.4.9)
       railties (>= 4)
       sprockets-rails
@@ -238,7 +237,6 @@ DEPENDENCIES
   jasmine
   jasmine-jquery-rails
   jasmine_selenium_runner
-  jruby-openssl (= 0.10.5)
   js-routes
   pry-debugger-jruby
   rails (= 5.2.4.3)


### PR DESCRIPTION
Reverts gocd/gocd#8716

The BC upgrade ends up breaking multiple plugins. The GitHub oAUTH and Maven poller plugin fail with the below exception,

```
Caused by: java.security.InvalidKeyException: cannot identify XDH private key
	at org.bouncycastle.jcajce.provider.asymmetric.edec.KeyAgreementSpi.engineDoPhase(Unknown Source)
	at java.base/javax.crypto.KeyAgreement.doPhase(Unknown Source)
```

Reverting the upgrade for now, we will continue to look the original PostgreSQL auth issue. 