### PR TITLE
Fix performance issues in GET agents API

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentVariableConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentVariableConfig.java
@@ -116,13 +116,13 @@ public class EnvironmentVariableConfig implements Serializable, Validatable, Par
         if (isSecure != that.isSecure) {
             return false;
         }
-        if (!goCipher.passwordEquals(encryptedValue, that.encryptedValue)) {
-            return false;
-        }
         if (name != null ? !name.equals(that.name) : that.name != null) {
             return false;
         }
         if (value != null ? !value.equals(that.value) : that.value != null) {
+            return false;
+        }
+        if (!goCipher.passwordEquals(encryptedValue, that.encryptedValue)) {
             return false;
         }
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/merge/MergeEnvironmentConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/merge/MergeEnvironmentConfig.java
@@ -450,7 +450,8 @@ public class MergeEnvironmentConfig extends BaseCollection<EnvironmentConfig> im
         int result = (this.name() != null ? this.name().hashCode() : 0);
         result = 31 * result + (this.getAgents() != null ? this.getAgents().hashCode() : 0);
         result = 31 * result + (this.getPipelines() != null ? this.getPipelines().hashCode() : 0);
-        result = 31 * result + (this.getVariables() != null ? this.getVariables().hashCode() : 0);
+        EnvironmentVariablesConfig variablesConfig = this.getVariables();
+        result = 31 * result + (variablesConfig != null ? variablesConfig.hashCode() : 0);
         return result;
     }
 


### PR DESCRIPTION
Issue: #8767

Description:

1. MergeEnvironmentConfig class, hashCode method is the slowest after some debugging. This calls getVariables method twice. In getVariables() method, allVariables is getting constructed by comparing with all other variables in the list. Basically O(n2). This method can be called once by storing in a variable.

2. In EnvironmentVariableConfig class equals method, decrypting both values can be last. This will add some performance benefit because in an environment no 2 variables will have same name.

If there are 100 agents with each agent associated to 10 environments and each environment has 100 secure variables, then for each GET /go/api/agents - AES decryption will happen 100 * 10 * 100 * 100 * 2 * 2 = 4,00,00,000 times

Breakdown:

100 - Number of agents
10 - Number of environments
100 * 100 * 2 - Worst case scenario of getVariables method calling decrypt
2 - Getvariables getting called twice in MergeEnvironment

After this commit, decrypt function will be called 100 * 10 = 1000 times because in an environment no 2 secure variables will have the same name.

However decrypt will be called when computing hashcode.