### PR TITLE
Don't use md5Header when it's null

### DIFF
--- a/agent/src/main/java/com/thoughtworks/go/agent/service/AgentUpgradeService.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/service/AgentUpgradeService.java
@@ -106,6 +106,7 @@ public class AgentUpgradeService {
         LOGGER.debug("[Agent Upgrade Validate MD5] validating MD5 for {}, currentMD5:{}, responseMD5:{}, headerKey:{}", what, currentMd5, md5Header, agentContentMd5Header);
         if (md5Header == null) {
             LOGGER.debug("[Agent Upgrade Validate MD5] Did not find {} MD5 header in response {}.", agentContentMd5Header, response);
+            return;
         }
         if (!"".equals(currentMd5)) {
             if (!currentMd5.equals(md5Header.getValue())) {


### PR DESCRIPTION
When `md5Header` is null, there's no point in going further as `md5Header.getValue()` will throw a null exception.

Issue: (none yet)

Description:

Every half hour the following exception is written to the agent log (`go-agent.log`, debugging enabled):
```
2020-11-16 10:53:57,241 DEBUG [scheduler-2] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for itself, currentMD5:b548dd3d84355a40333062171a6e724c, responseMD5:null, headerKey:Agent-Content-MD5
2020-11-16 10:53:57,241 DEBUG [scheduler-2] AgentUpgradeService:108 - [Agent Upgrade Validate MD5] Did not find Agent-Content-MD5 MD5 header in response HttpResponseProxy{HTTP/1.1 200 OK [Date: Mon, 16 Nov 2020 10:53:57 GMT, X-XSS-Protection: 1; mode=block, X-Content-Type-Options: nosniff, X-Frame-Options: SAMEORIGIN, X-UA-Compatible: chrome=1, Cache-Control: max-age=0, private, must-revalidate, X-Runtime: 1, Content-Type: text/html;charset=utf-8, Vary: Accept-Encoding, User-Agent, Transfer-Encoding: chunked] org.apache.http.client.entity.DecompressingEntity@b1d4b0}.
2020-11-16 10:53:57,241 ERROR [scheduler-2] AgentController:92 - [Agent Loop] Error occurred during loop: 
java.lang.NullPointerException: null
	at com.thoughtworks.go.agent.service.AgentUpgradeService.validateMd5(AgentUpgradeService.java:111)
	at com.thoughtworks.go.agent.service.AgentUpgradeService.checkForUpgradeAndExtraProperties(AgentUpgradeService.java:84)
	at com.thoughtworks.go.agent.service.AgentUpgradeService.checkForUpgradeAndExtraProperties(AgentUpgradeService.java:72)
	at com.thoughtworks.go.agent.AgentController.loop(AgentController.java:84)
	at jdk.internal.reflect.GeneratedMethodAccessor8.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:65)
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.runAndReset(Unknown Source)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```

Why the server isn't sending the `Agent-Content-MD5` every 30 minutes, I don't know.
But the code shouldn't continue using `md5Header` and throw a `NullPointerException` in `md5Header.getValue()`.

---
As an aside:
The MD5 check is currently happening every 10 seconds:
```
2020-11-16 10:53:07,156 DEBUG [scheduler-1] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for itself, currentMD5:b548dd3d84355a40333062171a6e724c, responseMD5:Agent-Content-MD5: b548dd3d84355a40333062171a6e724c, headerKey:Agent-Content-MD5
2020-11-16 10:53:07,156 DEBUG [scheduler-1] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for launcher, currentMD5:26dc3b38c771fba4b0d9015943cb64e9, responseMD5:Agent-Launcher-Content-MD5: 26dc3b38c771fba4b0d9015943cb64e9, headerKey:Agent-Launcher-Content-MD5
2020-11-16 10:53:07,156 DEBUG [scheduler-1] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for plugins, currentMD5:e5526aeb60cebda2963a36d936474d4a, responseMD5:Agent-Plugins-Content-MD5: e5526aeb60cebda2963a36d936474d4a, headerKey:Agent-Plugins-Content-MD5
2020-11-16 10:53:07,156 DEBUG [scheduler-1] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for tfs-impl jar, currentMD5:4b23cf075c78cac7616f9c5b05088d4b, responseMD5:TFS-SDK-Content-MD5: 4b23cf075c78cac7616f9c5b05088d4b, headerKey:TFS-SDK-Content-MD5
2020-11-16 10:53:17,177 DEBUG [scheduler-1] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for itself, currentMD5:b548dd3d84355a40333062171a6e724c, responseMD5:Agent-Content-MD5: b548dd3d84355a40333062171a6e724c, headerKey:Agent-Content-MD5
2020-11-16 10:53:17,177 DEBUG [scheduler-1] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for launcher, currentMD5:26dc3b38c771fba4b0d9015943cb64e9, responseMD5:Agent-Launcher-Content-MD5: 26dc3b38c771fba4b0d9015943cb64e9, headerKey:Agent-Launcher-Content-MD5
2020-11-16 10:53:17,177 DEBUG [scheduler-1] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for plugins, currentMD5:e5526aeb60cebda2963a36d936474d4a, responseMD5:Agent-Plugins-Content-MD5: e5526aeb60cebda2963a36d936474d4a, headerKey:Agent-Plugins-Content-MD5
2020-11-16 10:53:17,177 DEBUG [scheduler-1] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for tfs-impl jar, currentMD5:4b23cf075c78cac7616f9c5b05088d4b, responseMD5:TFS-SDK-Content-MD5: 4b23cf075c78cac7616f9c5b05088d4b, headerKey:TFS-SDK-Content-MD5
2020-11-16 10:53:27,192 DEBUG [scheduler-1] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for itself, currentMD5:b548dd3d84355a40333062171a6e724c, responseMD5:Agent-Content-MD5: b548dd3d84355a40333062171a6e724c, headerKey:Agent-Content-MD5
2020-11-16 10:53:27,192 DEBUG [scheduler-1] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for launcher, currentMD5:26dc3b38c771fba4b0d9015943cb64e9, responseMD5:Agent-Launcher-Content-MD5: 26dc3b38c771fba4b0d9015943cb64e9, headerKey:Agent-Launcher-Content-MD5
2020-11-16 10:53:27,192 DEBUG [scheduler-1] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for plugins, currentMD5:e5526aeb60cebda2963a36d936474d4a, responseMD5:Agent-Plugins-Content-MD5: e5526aeb60cebda2963a36d936474d4a, headerKey:Agent-Plugins-Content-MD5
2020-11-16 10:53:27,192 DEBUG [scheduler-1] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for tfs-impl jar, currentMD5:4b23cf075c78cac7616f9c5b05088d4b, responseMD5:TFS-SDK-Content-MD5: 4b23cf075c78cac7616f9c5b05088d4b, headerKey:TFS-SDK-Content-MD5
2020-11-16 10:53:37,209 DEBUG [scheduler-2] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for itself, currentMD5:b548dd3d84355a40333062171a6e724c, responseMD5:Agent-Content-MD5: b548dd3d84355a40333062171a6e724c, headerKey:Agent-Content-MD5
2020-11-16 10:53:37,209 DEBUG [scheduler-2] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for launcher, currentMD5:26dc3b38c771fba4b0d9015943cb64e9, responseMD5:Agent-Launcher-Content-MD5: 26dc3b38c771fba4b0d9015943cb64e9, headerKey:Agent-Launcher-Content-MD5
2020-11-16 10:53:37,209 DEBUG [scheduler-2] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for plugins, currentMD5:e5526aeb60cebda2963a36d936474d4a, responseMD5:Agent-Plugins-Content-MD5: e5526aeb60cebda2963a36d936474d4a, headerKey:Agent-Plugins-Content-MD5
2020-11-16 10:53:37,209 DEBUG [scheduler-2] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for tfs-impl jar, currentMD5:4b23cf075c78cac7616f9c5b05088d4b, responseMD5:TFS-SDK-Content-MD5: 4b23cf075c78cac7616f9c5b05088d4b, headerKey:TFS-SDK-Content-MD5
2020-11-16 10:53:47,222 DEBUG [scheduler-2] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for itself, currentMD5:b548dd3d84355a40333062171a6e724c, responseMD5:Agent-Content-MD5: b548dd3d84355a40333062171a6e724c, headerKey:Agent-Content-MD5
2020-11-16 10:53:47,222 DEBUG [scheduler-2] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for launcher, currentMD5:26dc3b38c771fba4b0d9015943cb64e9, responseMD5:Agent-Launcher-Content-MD5: 26dc3b38c771fba4b0d9015943cb64e9, headerKey:Agent-Launcher-Content-MD5
2020-11-16 10:53:47,222 DEBUG [scheduler-2] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for plugins, currentMD5:e5526aeb60cebda2963a36d936474d4a, responseMD5:Agent-Plugins-Content-MD5: e5526aeb60cebda2963a36d936474d4a, headerKey:Agent-Plugins-Content-MD5
2020-11-16 10:53:47,222 DEBUG [scheduler-2] AgentUpgradeService:106 - [Agent Upgrade Validate MD5] validating MD5 for tfs-impl jar, currentMD5:4b23cf075c78cac7616f9c5b05088d4b, responseMD5:TFS-SDK-Content-MD5: 4b23cf075c78cac7616f9c5b05088d4b, headerKey:TFS-SDK-Content-MD5
```
Isn't that a bit too often?