### PR TITLE
Make the ignore_for_scheduling field readonly on pipeline config edit spa

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -143,7 +143,7 @@ export class DependencyFields extends MithrilComponent<Attrs, State> {
                    property={mat.stage} errorText={this.errs(mat, "stage")} required={true}>
         <SelectFieldOptions selected={mat.stage()} items={vnode.state.stages()}/>
       </SelectField>,
-      this.advanced(mat, vnode.attrs),
+      this.advanced(mat, vnode.attrs)
     ];
   }
 
@@ -154,7 +154,7 @@ export class DependencyFields extends MithrilComponent<Attrs, State> {
         <TextField label="Material Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} readonly={attrs.readonly}
                    placeholder="A human-friendly label for this material" property={mat.name}/>
 
-        <DependencyIgnoreSchedulingToggle toggle={mat.ignoreForScheduling} errors={mat.errors()} disabled={attrs.disabled}/>
+        <DependencyIgnoreSchedulingToggle toggle={mat.ignoreForScheduling} errors={mat.errors()} disabled={attrs.readonly}/>
       </AdvancedSettings>;
     }
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -33,8 +33,7 @@ describe("AddPipeline: Non-SCM Material Fields", () => {
 
   it("DependencyFields structure", () => {
     const material = new Material("dependency", new DependencyMaterialAttributes());
-    helper.mount(() => <DependencyFields material={material} cache={new DummyCache()}
-                                         showLocalWorkingCopyOptions={true}/>);
+    helper.mount(() => <DependencyFields material={material} cache={new DummyCache()} showLocalWorkingCopyOptions={true}/>);
 
     assertLabelledInputsPresent(helper, {
       "upstream-pipeline": "Upstream Pipeline*",
@@ -46,18 +45,23 @@ describe("AddPipeline: Non-SCM Material Fields", () => {
 
   it("does not display advanced settings when `showLocalWorkingCopyOptions` === false", () => {
     const material = new Material("dependency", new DependencyMaterialAttributes());
-    helper.mount(() => <DependencyFields material={material} cache={new DummyCache()}
-                                         showLocalWorkingCopyOptions={false}/>);
+    helper.mount(() => <DependencyFields material={material} cache={new DummyCache()} showLocalWorkingCopyOptions={false}/>);
 
     assertLabelledInputsPresent(helper, {
       "upstream-pipeline": "Upstream Pipeline*",
       "upstream-stage":    "Upstream Stage*",
     });
 
-    assertLabelledInputsAbsent(helper,
-                               "material-name",
-    );
+    assertLabelledInputsAbsent(helper, "material-name");
     assertIgnoreForSchedulingControlAbsent(helper);
+  });
+
+  it("should disable radio field when readonly is set to true", () => {
+    const material = new Material("dependency", new DependencyMaterialAttributes());
+    helper.mount(() => <DependencyFields material={material} cache={new DummyCache()} readonly={true} showLocalWorkingCopyOptions={true}/>);
+
+    expect(helper.byTestId('radio-manual')).toBeDisabled();
+    expect(helper.byTestId('radio-auto')).toBeDisabled();
   });
 });
 


### PR DESCRIPTION
Issue: 
when the pipeline is from a config repo - all the fields are readonly except the `ignore_for_scheduling` on dependency materials

Description : use `attrs.readonly` attribute instead of `attrs.disabled`.



