### PR TITLE
Set default connection pool settings for h2 datasource #000

### DIFF
--- a/db-support/db-support-base/src/main/java/com/thoughtworks/go/server/database/h2/DefaultH2DataSource.java
+++ b/db-support/db-support-base/src/main/java/com/thoughtworks/go/server/database/h2/DefaultH2DataSource.java
@@ -33,7 +33,6 @@ public class DefaultH2DataSource {
         String defaultH2Url = "jdbc:h2:./db/h2db/cruise" +
                 ";DB_CLOSE_DELAY=-1" +
                 ";DB_CLOSE_ON_EXIT=FALSE" + // do not close the DB on JVM exit
-//                ";MVCC=TRUE" +
                 ";CACHE_SIZE=" + defaultCacheSizeInMB +
                 ";TRACE_MAX_FILE_SIZE=16" + // http://www.h2database.com/html/features.html#trace_options
                 ";TRACE_LEVEL_FILE=1" // http://www.h2database.com/html/features.html#trace_options
@@ -42,6 +41,8 @@ public class DefaultH2DataSource {
         basicDataSource.setUrl(defaultH2Url);
         basicDataSource.setUsername(StringUtils.defaultIfBlank(properties.user(), "sa"));
         basicDataSource.setPassword(StringUtils.stripToEmpty(properties.password()));
+        basicDataSource.setMaxIdle(properties.maxIdle());
+        basicDataSource.setMaxTotal(properties.maxTotal());
         return basicDataSource;
     }
 }


### PR DESCRIPTION
* DefaultH2DataSource maxIdle and maxTotal defaults to 32 connections.
  This is same as the defaults we had prior to adding support for
  multiple databases.

* H2 db url no longer supports MVCC flag, hence removing it.
  Check H2 1.4.200 changelog - https://github.com/h2database/h2database/releases/tag/version-1.4.200


