### PR TITLE
Use latest version of API for secret config spa

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/secret_configs/secret_configs_crud.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/secret_configs/secret_configs_crud.ts
@@ -20,7 +20,7 @@ import {SecretConfig, SecretConfigs, SecretConfigsWithSuggestions} from "models/
 import {SecretConfigsJSON, SecretConfigsWithSuggestionsJSON} from "models/secret_configs/secret_configs_json";
 
 export class SecretConfigsCRUD {
-  private static API_VERSION_HEADER = ApiVersion.v1;
+  private static API_VERSION_HEADER = ApiVersion.latest;
 
   static all() {
     return ApiRequestBuilder.GET(SparkRoutes.apiSecretConfigsPath(), this.API_VERSION_HEADER)

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/secret_configs/spec/secret_configs_crud_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/secret_configs/spec/secret_configs_crud_spec.ts
@@ -39,7 +39,7 @@ describe("SecretConfigsCRUD", () => {
     const request = jasmine.Ajax.requests.mostRecent();
     expect(request.url).toEqual(BASE_PATH);
     expect(request.method).toEqual("GET");
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
   });
 
   it("should get all secret configs along with autocomplete suggestions", (done) => {
@@ -61,7 +61,7 @@ describe("SecretConfigsCRUD", () => {
     const request = jasmine.Ajax.requests.mostRecent();
     expect(request.url).toEqual(api);
     expect(request.method).toEqual("GET");
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
   });
 
   it("should get a secret config", (done) => {
@@ -81,7 +81,7 @@ describe("SecretConfigsCRUD", () => {
     const request = jasmine.Ajax.requests.mostRecent();
     expect(request.url).toEqual("/go/api/admin/secret_configs/secrets_id");
     expect(request.method).toEqual("GET");
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
   });
 
   it("should create a secret config", () => {
@@ -99,7 +99,7 @@ describe("SecretConfigsCRUD", () => {
     const request = jasmine.Ajax.requests.mostRecent();
     expect(request.url).toEqual(BASE_PATH);
     expect(request.method).toEqual("POST");
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
   });
 
   it("should delete a secret config", () => {
@@ -118,7 +118,7 @@ describe("SecretConfigsCRUD", () => {
     const request = jasmine.Ajax.requests.mostRecent();
     expect(request.url).toEqual("/go/api/admin/secret_configs/secrets_id");
     expect(request.method).toEqual("DELETE");
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
   });
 
   it("should update a secret config", () => {
@@ -137,7 +137,7 @@ describe("SecretConfigsCRUD", () => {
     const request = jasmine.Ajax.requests.mostRecent();
     expect(request.url).toEqual("/go/api/admin/secret_configs/secrets_id");
     expect(request.method).toEqual("PUT");
-    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd+json");
     expect(request.requestHeaders["If-Match"]).toEqual("current-etag");
   });
 });


### PR DESCRIPTION
Issue: Not able to add a secret config. The modal shows no error but the error icon comes up

Description: Secret Config API v1 was recently removed which was used on the SPA. Using `latest` instead of a specific version.

