### PR TITLE
Authorize agents remoting by UUID

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/remote/AgentRemoteInvokerServiceExporter.java
+++ b/server/src/main/java/com/thoughtworks/go/remote/AgentRemoteInvokerServiceExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ThoughtWorks, Inc.
+ * Copyright 2021 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/com/thoughtworks/go/remote/AgentRemoteInvokerServiceExporter.java
+++ b/server/src/main/java/com/thoughtworks/go/remote/AgentRemoteInvokerServiceExporter.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.remote;
+
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.domain.JobResult;
+import com.thoughtworks.go.domain.JobState;
+import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import org.slf4j.LoggerFactory;
+import org.springframework.remoting.httpinvoker.HttpInvokerServiceExporter;
+import org.springframework.remoting.support.RemoteInvocation;
+import org.springframework.remoting.support.RemoteInvocationResult;
+import org.springframework.web.util.NestedServletException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+import static java.lang.String.format;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+
+/**
+ * Custom invoker service exporter that validates UUID authorization on agent requests. This prevents compromised agents
+ * (or any other attack masquerading as an authenticated agent) from acting on behalf of another agent.
+ */
+public class AgentRemoteInvokerServiceExporter extends HttpInvokerServiceExporter {
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(AgentRemoteInvokerServiceExporter.class);
+    private static final Set<MethodSignature> SKIP_AUTH = Set.of(new MethodSignature("isIgnored", JobIdentifier.class));
+    private static final Map<MethodSignature, Function<Object[], String>> KNOWN_METHODS_NEEDING_UUID_VALIDATION = Map.of(
+            new MethodSignature("ping", AgentRuntimeInfo.class), AgentUUID::fromRuntimeInfo0,
+            new MethodSignature("getWork", AgentRuntimeInfo.class), AgentUUID::fromRuntimeInfo0,
+            new MethodSignature("reportCurrentStatus", AgentRuntimeInfo.class, JobIdentifier.class, JobState.class), AgentUUID::fromRuntimeInfo0,
+            new MethodSignature("reportCompleting", AgentRuntimeInfo.class, JobIdentifier.class, JobResult.class), AgentUUID::fromRuntimeInfo0,
+            new MethodSignature("reportCompleted", AgentRuntimeInfo.class, JobIdentifier.class, JobResult.class), AgentUUID::fromRuntimeInfo0,
+            new MethodSignature("getCookie", AgentIdentifier.class, String.class), AgentUUID::fromIdentifier0
+    );
+
+    @Override
+    public void handleRequest(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        try {
+            RemoteInvocation invocation = readRemoteInvocation(request);
+
+            if (!authorized(request, response, invocation)) {
+                return;
+            }
+
+            RemoteInvocationResult result = invokeAndCreateResult(invocation, getProxy());
+            writeRemoteInvocationResult(request, response, result);
+        } catch (ClassNotFoundException ex) {
+            throw new NestedServletException("Class not found during deserialization", ex);
+        }
+    }
+
+    /**
+     * Verifies that the agent UUID from the deserialized payload matches the UUID permitted by the agent authentication
+     * filter.
+     *
+     * @param request    the {@link HttpServletRequest}
+     * @param response   the {@link HttpServletResponse}
+     * @param invocation the deserialized {@link RemoteInvocation} payload
+     * @return true if authorized; false otherwise
+     * @throws IOException on error while writing a response back to the client
+     */
+    private boolean authorized(HttpServletRequest request, HttpServletResponse response, RemoteInvocation invocation) throws IOException {
+        final String uuid = request.getHeader("X-Agent-GUID"); // should never be null since we passed the auth filter
+        final MethodSignature current = new MethodSignature(invocation);
+
+        LOG.debug(format("Checking authorization for agent [%s] on invocation: %s", uuid, invocation));
+
+        if (SKIP_AUTH.contains(current)) {
+            LOG.debug(format("ALLOWING REQUEST: Agent [%s] does not need authorization for: %s", uuid, invocation));
+            return true;
+        }
+
+        if (KNOWN_METHODS_NEEDING_UUID_VALIDATION.containsKey(current)) {
+            final String askingFor = KNOWN_METHODS_NEEDING_UUID_VALIDATION.get(current).apply(invocation.getArguments());
+
+            if (!uuid.equals(askingFor)) {
+                LOG.error(format("DENYING REQUEST: Agent [%s] is attempting a request on behalf of [%s]: %s", uuid, askingFor, invocation));
+                reject(response, SC_FORBIDDEN, "Not allowing request on behalf of another agent");
+                return false;
+            }
+        } else {
+            LOG.error(format("DENYING REQUEST: Agent [%s] is requesting an unknown method invocation: %s", uuid, invocation));
+            reject(response, SC_BAD_REQUEST, format("Unknown invocation: %s", invocation));
+            return false;
+        }
+
+        LOG.debug(format("ALLOWING REQUEST: Agent [%s] is authorized to invoke: %s", uuid, invocation));
+        return true;
+    }
+
+    /**
+     * Returns a plaintext error response back to the agent on failure
+     *
+     * @param response   the {@link HttpServletResponse}
+     * @param statusCode the HTTP status code
+     * @param msg        the error message
+     * @throws IOException on error while writing a response back to the client
+     */
+    private void reject(HttpServletResponse response, int statusCode, String msg) throws IOException {
+        response.setStatus(statusCode);
+        response.setContentType("text/plain");
+        final PrintWriter writer = response.getWriter();
+        writer.println(msg);
+        writer.flush();
+        writer.close();
+    }
+
+    /**
+     * Just a container class to hold functions to extract the agent UUID from deserialized payloads
+     */
+    private static class AgentUUID {
+        private static String fromRuntimeInfo0(Object[] args) {
+            return ((AgentRuntimeInfo) args[0]).getIdentifier().getUuid();
+        }
+
+        private static String fromIdentifier0(Object[] args) {
+            return ((AgentIdentifier) args[0]).getUuid();
+        }
+    }
+
+    /**
+     * Helper class to make RMI method matching easier
+     */
+    private static class MethodSignature {
+        private final String name;
+        private final Class<?>[] paramTypes;
+
+        private MethodSignature(RemoteInvocation invocation) {
+            this(invocation.getMethodName(), invocation.getParameterTypes());
+        }
+
+        private MethodSignature(String name, Class<?>... paramTypes) {
+            this.name = name;
+            this.paramTypes = paramTypes;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            MethodSignature that = (MethodSignature) o;
+            return Objects.equals(name, that.name) && Arrays.equals(paramTypes, that.paramTypes);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Objects.hash(name);
+            result = 31 * result + Arrays.hashCode(paramTypes);
+            return result;
+        }
+    }
+}

--- a/server/src/main/resources/spring-cruise-remoting-servlet.xml
+++ b/server/src/main/resources/spring-cruise-remoting-servlet.xml
@@ -73,7 +73,7 @@
                     fixed-delay="${gocd.accesstoken.lastused.update.interval}"/>
   </task:scheduled-tasks>
 
-  <bean name="/remoteBuildRepository" class="org.springframework.remoting.httpinvoker.HttpInvokerServiceExporter"
+  <bean name="/remoteBuildRepository" class="com.thoughtworks.go.remote.AgentRemoteInvokerServiceExporter"
         p:service-ref="buildRepositoryImpl"
         p:serviceInterface="com.thoughtworks.go.remote.BuildRepositoryRemote"/>
 

--- a/server/src/test-fast/java/com/thoughtworks/go/remote/AgentRemoteInvokerServiceExporterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/remote/AgentRemoteInvokerServiceExporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ThoughtWorks, Inc.
+ * Copyright 2021 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test-fast/java/com/thoughtworks/go/remote/AgentRemoteInvokerServiceExporterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/remote/AgentRemoteInvokerServiceExporterTest.java
@@ -24,7 +24,6 @@ import com.thoughtworks.go.http.mocks.MockHttpServletResponse;
 import com.thoughtworks.go.server.messaging.BuildRepositoryMessageProducer;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.remoting.support.RemoteInvocation;
@@ -58,135 +57,139 @@ public class AgentRemoteInvokerServiceExporterTest {
         res = new MockHttpServletResponse();
     }
 
-    @Nested
-    class NoAuthorization {
-        @Test
-        void isIgnoredIsAllowed() throws Exception {
-            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("isIgnored", new Class[]{JobIdentifier.class}, new Object[]{null}), target);
-            invoker.handleRequest(req, res);
-            verify(target, only()).isIgnored(null);
-            assertEquals(SC_OK, res.getStatus());
-        }
+    @Test
+    void isIgnored_allowedForSameUUID() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("isIgnored", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class}, new Object[]{agent, null}), target);
+        invoker.handleRequest(req, res);
+        verify(target, only()).isIgnored(agent, null);
+        assertEquals(SC_OK, res.getStatus());
     }
 
-    @Nested
-    class RequiresAuthorization {
-        @Test
-        void ping_allowedForSameUUID() throws Exception {
-            final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
-            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("ping", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
-            invoker.handleRequest(req, res);
-            verify(target, only()).ping(agent);
-            assertEquals(SC_OK, res.getStatus());
-        }
+    @Test
+    void isIgnored_rejectedForDifferentUUID() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo("other");
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("isIgnored", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class}, new Object[]{agent, null}), target);
+        invoker.handleRequest(req, res);
+        verify(target, never()).isIgnored(any(AgentRuntimeInfo.class), any(JobIdentifier.class));
+        assertEquals(SC_FORBIDDEN, res.getStatus());
+    }
 
-        @Test
-        void ping_rejectedForDifferentUUID() throws Exception {
-            final AgentRuntimeInfo agent = runtimeInfo("other");
-            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("ping", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
-            invoker.handleRequest(req, res);
-            verify(target, never()).ping(any(AgentRuntimeInfo.class));
-            assertEquals(SC_FORBIDDEN, res.getStatus());
-        }
+    @Test
+    void ping_allowedForSameUUID() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("ping", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
+        invoker.handleRequest(req, res);
+        verify(target, only()).ping(agent);
+        assertEquals(SC_OK, res.getStatus());
+    }
 
-        @Test
-        void getWork_allowedForSameUUID() throws Exception {
-            final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
-            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("getWork", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
-            invoker.handleRequest(req, res);
-            verify(target, only()).getWork(agent);
-            assertEquals(SC_OK, res.getStatus());
-        }
+    @Test
+    void ping_rejectedForDifferentUUID() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo("other");
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("ping", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
+        invoker.handleRequest(req, res);
+        verify(target, never()).ping(any(AgentRuntimeInfo.class));
+        assertEquals(SC_FORBIDDEN, res.getStatus());
+    }
 
-        @Test
-        void getWork_rejectedForDifferentUUID() throws Exception {
-            final AgentRuntimeInfo agent = runtimeInfo("other");
-            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("getWork", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
-            invoker.handleRequest(req, res);
-            verify(target, never()).getWork(any(AgentRuntimeInfo.class));
-            assertEquals(SC_FORBIDDEN, res.getStatus());
-        }
+    @Test
+    void getWork_allowedForSameUUID() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("getWork", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
+        invoker.handleRequest(req, res);
+        verify(target, only()).getWork(agent);
+        assertEquals(SC_OK, res.getStatus());
+    }
 
-        @Test
-        void getCookie_allowedForSameUUID() throws Exception {
-            final AgentIdentifier agent = identifier(AGENT_UUID);
-            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("getCookie", new Class[]{AgentIdentifier.class, String.class}, new Object[]{agent, ""}), target);
-            invoker.handleRequest(req, res);
-            verify(target, only()).getCookie(agent, "");
-            assertEquals(SC_OK, res.getStatus());
-        }
+    @Test
+    void getWork_rejectedForDifferentUUID() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo("other");
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("getWork", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
+        invoker.handleRequest(req, res);
+        verify(target, never()).getWork(any(AgentRuntimeInfo.class));
+        assertEquals(SC_FORBIDDEN, res.getStatus());
+    }
 
-        @Test
-        void getCookie_rejectedForDifferentUUID() throws Exception {
-            final AgentIdentifier agent = identifier("other");
-            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("getCookie", new Class[]{AgentIdentifier.class, String.class}, new Object[]{agent, ""}), target);
-            invoker.handleRequest(req, res);
-            verify(target, never()).getCookie(any(AgentIdentifier.class), any(String.class));
-            assertEquals(SC_FORBIDDEN, res.getStatus());
-        }
+    @Test
+    void getCookie_allowedForSameUUID() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("getCookie", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
+        invoker.handleRequest(req, res);
+        verify(target, only()).getCookie(agent);
+        assertEquals(SC_OK, res.getStatus());
+    }
 
-        @Test
-        void reportCurrentStatus_allowedForSameUUID() throws Exception {
-            final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
-            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCurrentStatus", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobState.class}, new Object[]{agent, null, null}), target);
-            invoker.handleRequest(req, res);
-            verify(target, only()).reportCurrentStatus(agent, null, null);
-            assertEquals(SC_OK, res.getStatus());
-        }
+    @Test
+    void getCookie_rejectedForDifferentUUID() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo("other");
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("getCookie", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
+        invoker.handleRequest(req, res);
+        verify(target, never()).getCookie(any(AgentRuntimeInfo.class));
+        assertEquals(SC_FORBIDDEN, res.getStatus());
+    }
 
-        @Test
-        void reportCurrentStatus_rejectedForDifferentUUID() throws Exception {
-            final AgentRuntimeInfo agent = runtimeInfo("other");
-            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCurrentStatus", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobState.class}, new Object[]{agent, null, null}), target);
-            invoker.handleRequest(req, res);
-            verify(target, never()).reportCurrentStatus(any(AgentRuntimeInfo.class), any(JobIdentifier.class), any(JobState.class));
-            assertEquals(SC_FORBIDDEN, res.getStatus());
-        }
+    @Test
+    void reportCurrentStatus_allowedForSameUUID() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCurrentStatus", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobState.class}, new Object[]{agent, null, null}), target);
+        invoker.handleRequest(req, res);
+        verify(target, only()).reportCurrentStatus(agent, null, null);
+        assertEquals(SC_OK, res.getStatus());
+    }
 
-        @Test
-        void reportCompleting_allowedForSameUUID() throws Exception {
-            final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
-            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCompleting", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobResult.class}, new Object[]{agent, null, null}), target);
-            invoker.handleRequest(req, res);
-            verify(target, only()).reportCompleting(agent, null, null);
-            assertEquals(SC_OK, res.getStatus());
-        }
+    @Test
+    void reportCurrentStatus_rejectedForDifferentUUID() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo("other");
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCurrentStatus", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobState.class}, new Object[]{agent, null, null}), target);
+        invoker.handleRequest(req, res);
+        verify(target, never()).reportCurrentStatus(any(AgentRuntimeInfo.class), any(JobIdentifier.class), any(JobState.class));
+        assertEquals(SC_FORBIDDEN, res.getStatus());
+    }
 
-        @Test
-        void reportCompleting_rejectedForDifferentUUID() throws Exception {
-            final AgentRuntimeInfo agent = runtimeInfo("other");
-            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCompleting", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobResult.class}, new Object[]{agent, null, null}), target);
-            invoker.handleRequest(req, res);
-            verify(target, never()).reportCompleting(any(AgentRuntimeInfo.class), any(JobIdentifier.class), any(JobResult.class));
-            assertEquals(SC_FORBIDDEN, res.getStatus());
-        }
+    @Test
+    void reportCompleting_allowedForSameUUID() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCompleting", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobResult.class}, new Object[]{agent, null, null}), target);
+        invoker.handleRequest(req, res);
+        verify(target, only()).reportCompleting(agent, null, null);
+        assertEquals(SC_OK, res.getStatus());
+    }
 
-        @Test
-        void reportCompleted_allowedForSameUUID() throws Exception {
-            final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
-            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCompleted", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobResult.class}, new Object[]{agent, null, null}), target);
-            invoker.handleRequest(req, res);
-            verify(target, only()).reportCompleted(agent, null, null);
-            assertEquals(SC_OK, res.getStatus());
-        }
+    @Test
+    void reportCompleting_rejectedForDifferentUUID() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo("other");
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCompleting", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobResult.class}, new Object[]{agent, null, null}), target);
+        invoker.handleRequest(req, res);
+        verify(target, never()).reportCompleting(any(AgentRuntimeInfo.class), any(JobIdentifier.class), any(JobResult.class));
+        assertEquals(SC_FORBIDDEN, res.getStatus());
+    }
 
-        @Test
-        void reportCompleted_rejectedForDifferentUUID() throws Exception {
-            final AgentRuntimeInfo agent = runtimeInfo("other");
-            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCompleted", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobResult.class}, new Object[]{agent, null, null}), target);
-            invoker.handleRequest(req, res);
-            verify(target, never()).reportCompleted(any(AgentRuntimeInfo.class), any(JobIdentifier.class), any(JobResult.class));
-            assertEquals(SC_FORBIDDEN, res.getStatus());
-        }
+    @Test
+    void reportCompleted_allowedForSameUUID() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCompleted", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobResult.class}, new Object[]{agent, null, null}), target);
+        invoker.handleRequest(req, res);
+        verify(target, only()).reportCompleted(agent, null, null);
+        assertEquals(SC_OK, res.getStatus());
+    }
 
-        @Test
-        void rejectsUnknownMethod() throws Exception {
-            final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
-            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("nonexistent", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
-            invoker.handleRequest(req, res);
-            verifyNoInteractions(target);
-            assertEquals(SC_BAD_REQUEST, res.getStatus());
-        }
+    @Test
+    void reportCompleted_rejectedForDifferentUUID() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo("other");
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCompleted", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobResult.class}, new Object[]{agent, null, null}), target);
+        invoker.handleRequest(req, res);
+        verify(target, never()).reportCompleted(any(AgentRuntimeInfo.class), any(JobIdentifier.class), any(JobResult.class));
+        assertEquals(SC_FORBIDDEN, res.getStatus());
+    }
+
+    @Test
+    void rejectsUnknownMethod() throws Exception {
+        final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
+        final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("nonexistent", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
+        invoker.handleRequest(req, res);
+        verifyNoInteractions(target);
+        assertEquals(SC_BAD_REQUEST, res.getStatus());
     }
 
     private AgentRuntimeInfo runtimeInfo(String uuid) {

--- a/server/src/test-fast/java/com/thoughtworks/go/remote/AgentRemoteInvokerServiceExporterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/remote/AgentRemoteInvokerServiceExporterTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.remote;
+
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.domain.JobResult;
+import com.thoughtworks.go.domain.JobState;
+import com.thoughtworks.go.http.mocks.MockHttpServletRequest;
+import com.thoughtworks.go.http.mocks.MockHttpServletResponse;
+import com.thoughtworks.go.server.messaging.BuildRepositoryMessageProducer;
+import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.remoting.support.RemoteInvocation;
+import org.springframework.remoting.support.RemoteInvocationResult;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.lang.reflect.InvocationTargetException;
+
+import static javax.servlet.http.HttpServletResponse.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class AgentRemoteInvokerServiceExporterTest {
+    private static final String AGENT_UUID = "123-456-789";
+
+    private MockHttpServletRequest req;
+
+    private MockHttpServletResponse res;
+
+    @Mock
+    private BuildRepositoryMessageProducer target;
+
+    @BeforeEach
+    void setup() throws Exception {
+        openMocks(this).close();
+        req = new MockHttpServletRequest();
+        req.addHeader("X-Agent-GUID", AGENT_UUID);
+        res = new MockHttpServletResponse();
+    }
+
+    @Nested
+    class NoAuthorization {
+        @Test
+        void isIgnoredIsAllowed() throws Exception {
+            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("isIgnored", new Class[]{JobIdentifier.class}, new Object[]{null}), target);
+            invoker.handleRequest(req, res);
+            verify(target, only()).isIgnored(null);
+            assertEquals(SC_OK, res.getStatus());
+        }
+    }
+
+    @Nested
+    class RequiresAuthorization {
+        @Test
+        void ping_allowedForSameUUID() throws Exception {
+            final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
+            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("ping", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
+            invoker.handleRequest(req, res);
+            verify(target, only()).ping(agent);
+            assertEquals(SC_OK, res.getStatus());
+        }
+
+        @Test
+        void ping_rejectedForDifferentUUID() throws Exception {
+            final AgentRuntimeInfo agent = runtimeInfo("other");
+            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("ping", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
+            invoker.handleRequest(req, res);
+            verify(target, never()).ping(any(AgentRuntimeInfo.class));
+            assertEquals(SC_FORBIDDEN, res.getStatus());
+        }
+
+        @Test
+        void getWork_allowedForSameUUID() throws Exception {
+            final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
+            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("getWork", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
+            invoker.handleRequest(req, res);
+            verify(target, only()).getWork(agent);
+            assertEquals(SC_OK, res.getStatus());
+        }
+
+        @Test
+        void getWork_rejectedForDifferentUUID() throws Exception {
+            final AgentRuntimeInfo agent = runtimeInfo("other");
+            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("getWork", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
+            invoker.handleRequest(req, res);
+            verify(target, never()).getWork(any(AgentRuntimeInfo.class));
+            assertEquals(SC_FORBIDDEN, res.getStatus());
+        }
+
+        @Test
+        void getCookie_allowedForSameUUID() throws Exception {
+            final AgentIdentifier agent = identifier(AGENT_UUID);
+            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("getCookie", new Class[]{AgentIdentifier.class, String.class}, new Object[]{agent, ""}), target);
+            invoker.handleRequest(req, res);
+            verify(target, only()).getCookie(agent, "");
+            assertEquals(SC_OK, res.getStatus());
+        }
+
+        @Test
+        void getCookie_rejectedForDifferentUUID() throws Exception {
+            final AgentIdentifier agent = identifier("other");
+            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("getCookie", new Class[]{AgentIdentifier.class, String.class}, new Object[]{agent, ""}), target);
+            invoker.handleRequest(req, res);
+            verify(target, never()).getCookie(any(AgentIdentifier.class), any(String.class));
+            assertEquals(SC_FORBIDDEN, res.getStatus());
+        }
+
+        @Test
+        void reportCurrentStatus_allowedForSameUUID() throws Exception {
+            final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
+            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCurrentStatus", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobState.class}, new Object[]{agent, null, null}), target);
+            invoker.handleRequest(req, res);
+            verify(target, only()).reportCurrentStatus(agent, null, null);
+            assertEquals(SC_OK, res.getStatus());
+        }
+
+        @Test
+        void reportCurrentStatus_rejectedForDifferentUUID() throws Exception {
+            final AgentRuntimeInfo agent = runtimeInfo("other");
+            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCurrentStatus", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobState.class}, new Object[]{agent, null, null}), target);
+            invoker.handleRequest(req, res);
+            verify(target, never()).reportCurrentStatus(any(AgentRuntimeInfo.class), any(JobIdentifier.class), any(JobState.class));
+            assertEquals(SC_FORBIDDEN, res.getStatus());
+        }
+
+        @Test
+        void reportCompleting_allowedForSameUUID() throws Exception {
+            final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
+            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCompleting", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobResult.class}, new Object[]{agent, null, null}), target);
+            invoker.handleRequest(req, res);
+            verify(target, only()).reportCompleting(agent, null, null);
+            assertEquals(SC_OK, res.getStatus());
+        }
+
+        @Test
+        void reportCompleting_rejectedForDifferentUUID() throws Exception {
+            final AgentRuntimeInfo agent = runtimeInfo("other");
+            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCompleting", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobResult.class}, new Object[]{agent, null, null}), target);
+            invoker.handleRequest(req, res);
+            verify(target, never()).reportCompleting(any(AgentRuntimeInfo.class), any(JobIdentifier.class), any(JobResult.class));
+            assertEquals(SC_FORBIDDEN, res.getStatus());
+        }
+
+        @Test
+        void reportCompleted_allowedForSameUUID() throws Exception {
+            final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
+            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCompleted", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobResult.class}, new Object[]{agent, null, null}), target);
+            invoker.handleRequest(req, res);
+            verify(target, only()).reportCompleted(agent, null, null);
+            assertEquals(SC_OK, res.getStatus());
+        }
+
+        @Test
+        void reportCompleted_rejectedForDifferentUUID() throws Exception {
+            final AgentRuntimeInfo agent = runtimeInfo("other");
+            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("reportCompleted", new Class[]{AgentRuntimeInfo.class, JobIdentifier.class, JobResult.class}, new Object[]{agent, null, null}), target);
+            invoker.handleRequest(req, res);
+            verify(target, never()).reportCompleted(any(AgentRuntimeInfo.class), any(JobIdentifier.class), any(JobResult.class));
+            assertEquals(SC_FORBIDDEN, res.getStatus());
+        }
+
+        @Test
+        void rejectsUnknownMethod() throws Exception {
+            final AgentRuntimeInfo agent = runtimeInfo(AGENT_UUID);
+            final AgentRemoteInvokerServiceExporter invoker = deserializingWith(new RemoteInvocation("nonexistent", new Class[]{AgentRuntimeInfo.class}, new Object[]{agent}), target);
+            invoker.handleRequest(req, res);
+            verifyNoInteractions(target);
+            assertEquals(SC_BAD_REQUEST, res.getStatus());
+        }
+    }
+
+    private AgentRuntimeInfo runtimeInfo(String uuid) {
+        return new AgentRuntimeInfo(identifier(uuid), null, null, null);
+    }
+
+    private AgentIdentifier identifier(String uuid) {
+        return new AgentIdentifier(null, null, uuid);
+    }
+
+    private static AgentRemoteInvokerServiceExporter deserializingWith(final RemoteInvocation invocation, final BuildRepositoryMessageProducer proxy) {
+        final AgentRemoteInvokerServiceExporter invoker = new AgentRemoteInvokerServiceExporter() {
+            @Override
+            protected Object getProxyForService() {
+                return proxy;
+            }
+
+            @Override
+            protected RemoteInvocation readRemoteInvocation(HttpServletRequest request) {
+                return invocation;
+            }
+
+            @Override
+            protected RemoteInvocationResult invokeAndCreateResult(RemoteInvocation invocation, Object targetObject) {
+                try {
+                    invocation.invoke(targetObject);
+                    return new RemoteInvocationResult(true);
+                } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                    e.printStackTrace();
+                    fail("invoke() failed; should never get here. error: " + e.getMessage());
+                    return new RemoteInvocationResult(false);
+                }
+            }
+
+            @Override
+            protected void writeRemoteInvocationResult(HttpServletRequest request, HttpServletResponse response, RemoteInvocationResult result) {
+                if ((Boolean) result.getValue()) {
+                    response.setStatus(SC_OK);
+                } else {
+                    response.setStatus(SC_INTERNAL_SERVER_ERROR);
+                }
+            }
+        };
+        invoker.prepare();
+        return invoker;
+    }
+}


### PR DESCRIPTION
# Validate agent UUID during remoting requests to prevent clients from acting on behalf of other agents

Prior to this change, it was possible for an authenticated agent to act on behalf of another agent. This is a security issue because if one agent is compromised, an attacker could request work or perform other duties intended for other agents. This was possible because the UUID to perform work was sourced from the deserialized object stream and not verified to be the same UUID that was permitted by the authentication filter. Essentially, an authenticated client could request work for any arbitrary agent. This would give access to decrypted secrets for a build.

This commit introduces a custom `HttpInvokerServiceExporter` that validates the UUID from the `X-Agent-GUID` header matches the UUID from the deserialized `AgentRuntimeInfo` and `AgentIdentifier` objects and returns an appropriate error code when this validation fails.
