### PR TITLE
Agent Client Impl

### DIFF
--- a/agent/src/main/java/com/thoughtworks/go/agent/AgentHTTPClientController.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/AgentHTTPClientController.java
@@ -92,6 +92,8 @@ public class AgentHTTPClientController extends AgentController {
         this.artifactExtension = artifactExtension;
         this.pluginRequestProcessorRegistry = pluginRequestProcessorRegistry;
         this.pluginJarLocationMonitor = pluginJarLocationMonitor;
+
+        LOG.info("Configured remoting type: {}", remote().getClass().getSimpleName());
     }
 
     @Override

--- a/agent/src/main/java/com/thoughtworks/go/agent/AgentHTTPClientController.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/AgentHTTPClientController.java
@@ -29,8 +29,8 @@ import com.thoughtworks.go.plugin.infra.PluginRequestProcessorRegistry;
 import com.thoughtworks.go.plugin.infra.monitor.PluginJarLocationMonitor;
 import com.thoughtworks.go.publishers.GoArtifactsManipulator;
 import com.thoughtworks.go.remote.AgentIdentifier;
-import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.remote.AgentInstruction;
+import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.remote.work.AgentWorkContext;
 import com.thoughtworks.go.remote.work.NoWork;
 import com.thoughtworks.go.remote.work.Work;
@@ -39,29 +39,34 @@ import com.thoughtworks.go.util.SystemEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import static com.thoughtworks.go.remote.AgentInstruction.NONE;
+import static java.util.Objects.requireNonNullElse;
 
 @Component
 public class AgentHTTPClientController extends AgentController {
     private static final Logger LOG = LoggerFactory.getLogger(AgentHTTPClientController.class);
 
-    private BuildRepositoryRemote server;
-    private GoArtifactsManipulator manipulator;
-    private SslInfrastructureService sslInfrastructureService;
+    private final RemotingClient client;
+    private final BuildRepositoryRemote legacyRmi;
+    private final GoArtifactsManipulator manipulator;
+    private final SslInfrastructureService sslInfrastructureService;
     private final ArtifactExtension artifactExtension;
     private final PluginRequestProcessorRegistry pluginRequestProcessorRegistry;
     private final PluginJarLocationMonitor pluginJarLocationMonitor;
 
     private JobRunner runner;
-    private PackageRepositoryExtension packageRepositoryExtension;
-    private SCMExtension scmExtension;
-    private TaskExtension taskExtension;
+    private final PackageRepositoryExtension packageRepositoryExtension;
+    private final SCMExtension scmExtension;
+    private final TaskExtension taskExtension;
     private AgentInstruction agentInstruction = NONE;
 
     @Autowired
-    public AgentHTTPClientController(BuildRepositoryRemote server,
+    public AgentHTTPClientController(RemotingClient client,
+                                     @Qualifier("buildLoopServer")
+                                     BuildRepositoryRemote legacyRmi,
                                      GoArtifactsManipulator manipulator,
                                      SslInfrastructureService sslInfrastructureService,
                                      AgentRegistry agentRegistry,
@@ -77,10 +82,11 @@ public class AgentHTTPClientController extends AgentController {
                                      AgentHealthHolder agentHealthHolder,
                                      PluginJarLocationMonitor pluginJarLocationMonitor) {
         super(sslInfrastructureService, systemEnvironment, agentRegistry, pluginManager, subprocessLogger, agentUpgradeService, agentHealthHolder);
+        this.client = client;
         this.packageRepositoryExtension = packageRepositoryExtension;
         this.scmExtension = scmExtension;
         this.taskExtension = taskExtension;
-        this.server = server;
+        this.legacyRmi = legacyRmi;
         this.manipulator = manipulator;
         this.sslInfrastructureService = sslInfrastructureService;
         this.artifactExtension = artifactExtension;
@@ -90,16 +96,17 @@ public class AgentHTTPClientController extends AgentController {
 
     @Override
     public void ping() {
+        final BuildRepositoryRemote client = remote();
         try {
             if (sslInfrastructureService.isRegistered()) {
                 AgentIdentifier agent = agentIdentifier();
-                LOG.trace("{} is pinging server [{}]", agent, server);
+                LOG.trace("{} is pinging server [{}]", agent, client);
 
                 getAgentRuntimeInfo().refreshUsableSpace();
 
-                agentInstruction = server.ping(getAgentRuntimeInfo());
+                agentInstruction = client.ping(getAgentRuntimeInfo());
                 pingSuccess();
-                LOG.trace("{} pinged server [{}]", agent, server);
+                LOG.trace("{} pinged server [{}]", agent, client);
             }
         } catch (Throwable e) {
             LOG.error("Error occurred when agent tried to ping server: ", e);
@@ -128,24 +135,25 @@ public class AgentHTTPClientController extends AgentController {
     private void retrieveCookieIfNecessary() {
         if (!getAgentRuntimeInfo().hasCookie() && sslInfrastructureService.isRegistered()) {
             LOG.info("About to get cookie from the server.");
-            String cookie = server.getCookie(getAgentRuntimeInfo());
+            String cookie = remote().getCookie(getAgentRuntimeInfo());
             getAgentRuntimeInfo().setCookie(cookie);
             LOG.info("Got cookie: {}", cookie);
         }
     }
 
     void retrieveWork() {
+        final BuildRepositoryRemote client = remote();
         AgentIdentifier agentIdentifier = agentIdentifier();
         LOG.debug("[Agent Loop] {} is checking for work from Go", agentIdentifier);
         Work work;
         try {
             getAgentRuntimeInfo().idle();
-            work = server.getWork(getAgentRuntimeInfo());
+            work = client.getWork(getAgentRuntimeInfo());
             if (!(work instanceof NoWork)) {
                 LOG.debug("[Agent Loop] Got work from server: [{}]", work.description());
             }
             runner = new JobRunner();
-            final AgentWorkContext agentWorkContext = new AgentWorkContext(agentIdentifier, server, manipulator, getAgentRuntimeInfo(), packageRepositoryExtension, scmExtension, taskExtension, artifactExtension, pluginRequestProcessorRegistry);
+            final AgentWorkContext agentWorkContext = new AgentWorkContext(agentIdentifier, client, manipulator, getAgentRuntimeInfo(), packageRepositoryExtension, scmExtension, taskExtension, artifactExtension, pluginRequestProcessorRegistry);
             runner.run(work, agentWorkContext);
         } catch (UnregisteredAgentException e) {
             LOG.warn("[Agent Loop] Invalid agent certificate with fingerprint {}. Registering with server on next iteration.", e.getUuid());
@@ -155,4 +163,16 @@ public class AgentHTTPClientController extends AgentController {
         }
     }
 
+    private BuildRepositoryRemote remote() {
+        return useLegacy() ? legacyRmi : client;
+    }
+
+    private boolean useLegacy() {
+        return "true".equalsIgnoreCase(
+                requireNonNullElse(
+                        System.getProperty("gocd.agent.remoting.legacy"),
+                        "false"
+                ).trim()
+        );
+    }
 }

--- a/agent/src/main/java/com/thoughtworks/go/agent/GoHttpClientHttpInvokerRequestExecutor.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/GoHttpClientHttpInvokerRequestExecutor.java
@@ -39,6 +39,9 @@ import java.util.zip.GZIPInputStream;
 
 import static com.thoughtworks.go.CurrentGoCDVersion.docsUrl;
 
+@Deprecated(forRemoval = true)
+// This class should be removed once we remove the RMI buildRepository endpoint because RMI is vulnerable to a remote
+// execution attack payload. This will be superceded by RemotingClient.
 public class GoHttpClientHttpInvokerRequestExecutor extends AbstractHttpInvokerRequestExecutor {
 
     private final GoAgentServerHttpClient goAgentServerHttpClient;

--- a/agent/src/main/java/com/thoughtworks/go/agent/GoHttpClientHttpInvokerRequestExecutor.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/GoHttpClientHttpInvokerRequestExecutor.java
@@ -42,7 +42,7 @@ import static com.thoughtworks.go.CurrentGoCDVersion.docsUrl;
 public class GoHttpClientHttpInvokerRequestExecutor extends AbstractHttpInvokerRequestExecutor {
 
     private final GoAgentServerHttpClient goAgentServerHttpClient;
-    private DefaultAgentRegistry defaultAgentRegistry;
+    private final DefaultAgentRegistry defaultAgentRegistry;
 
     public GoHttpClientHttpInvokerRequestExecutor(GoAgentServerHttpClient goAgentServerHttpClient, DefaultAgentRegistry defaultAgentRegistry) {
         this.goAgentServerHttpClient = goAgentServerHttpClient;

--- a/agent/src/main/java/com/thoughtworks/go/agent/RemotingClient.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/RemotingClient.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.agent;
+
+import com.google.gson.Gson;
+import com.thoughtworks.go.agent.common.ssl.GoAgentServerHttpClient;
+import com.thoughtworks.go.config.DefaultAgentRegistry;
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.domain.JobResult;
+import com.thoughtworks.go.domain.JobState;
+import com.thoughtworks.go.remote.AgentInstruction;
+import com.thoughtworks.go.remote.BuildRepositoryRemote;
+import com.thoughtworks.go.remote.Serialization;
+import com.thoughtworks.go.remote.request.*;
+import com.thoughtworks.go.remote.work.Work;
+import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.util.URLService;
+import org.apache.http.HttpResponse;
+import org.apache.http.NoHttpResponseException;
+import org.apache.http.StatusLine;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.thoughtworks.go.CurrentGoCDVersion.docsUrl;
+import static com.thoughtworks.go.agent.ResponseHelpers.readBodyAsString;
+import static com.thoughtworks.go.agent.ResponseHelpers.readBodyAsStringOrElse;
+import static java.lang.String.format;
+
+@Component
+public class RemotingClient implements BuildRepositoryRemote {
+    private static final Logger LOG = LoggerFactory.getLogger(RemotingClient.class);
+    private static final String UUID_HEADER = "X-Agent-GUID";
+    private static final String AUTH_HEADER = "Authorization";
+    private static final Gson GSON = Serialization.instance();
+
+    private final GoAgentServerHttpClient client;
+    private final DefaultAgentRegistry agent;
+    private final URLService urls;
+
+    @Autowired
+    public RemotingClient(GoAgentServerHttpClient client, DefaultAgentRegistry agent, URLService urls) {
+        this.client = client;
+        this.agent = agent;
+        this.urls = urls;
+    }
+
+    @Override
+    public AgentInstruction ping(AgentRuntimeInfo info) {
+        return GSON.fromJson(post("ping", new PingRequest(info)), AgentInstruction.class);
+    }
+
+    @Override
+    public Work getWork(AgentRuntimeInfo info) {
+        return GSON.fromJson(post("get_work", new GetWorkRequest(info)), Work.class);
+    }
+
+    @Override
+    public void reportCurrentStatus(AgentRuntimeInfo info, JobIdentifier jobId, JobState state) {
+        post("report_current_status", new ReportCurrentStatusRequest(info, jobId, state));
+    }
+
+    @Override
+    public void reportCompleting(AgentRuntimeInfo info, JobIdentifier jobId, JobResult result) {
+        post("report_completing", new ReportCompleteStatusRequest(info, jobId, result));
+    }
+
+    @Override
+    public void reportCompleted(AgentRuntimeInfo info, JobIdentifier jobId, JobResult result) {
+        post("report_completed", new ReportCompleteStatusRequest(info, jobId, result));
+    }
+
+    @Override
+    public boolean isIgnored(AgentRuntimeInfo info, JobIdentifier jobId) {
+        return Boolean.parseBoolean(post("is_ignored", new IsIgnoredRequest(info, jobId)));
+    }
+
+    @Override
+    public String getCookie(AgentRuntimeInfo info) {
+        return post("get_cookie", new GetCookieRequest(info));
+    }
+
+    private String post(final String action, final AgentRequest payload) {
+        try {
+            try (CloseableHttpResponse response = client.execute(
+                    injectCredentials(
+                            postRequestFor(action, payload)
+                    ))) {
+                validateResponse(response, action);
+                return readBodyAsString(response);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private HttpRequestBase injectCredentials(final HttpRequestBase request) {
+        request.setHeader(UUID_HEADER, agent.uuid());
+        request.setHeader(AUTH_HEADER, agent.token());
+        return request;
+    }
+
+    private void validateResponse(final HttpResponse response, final String action) throws IOException {
+        final StatusLine status = response.getStatusLine();
+
+        if (status.getStatusCode() >= 500) {
+            logFailure(response, action);
+            throw new ClientProtocolException(
+                    format("The server returned an error with status code %d (%s); please check the server logs for the corresponding error.",
+                            status.getStatusCode(), status.getReasonPhrase())
+            );
+        }
+
+        if (status.getStatusCode() >= 400) {
+            logFailure(response, action);
+            throw new ClientProtocolException(String.join("\n   - ", List.of(
+                    format("The server returned status code %d. Possible reasons include:", status.getStatusCode()),
+                    "This agent has been deleted from the configuration",
+                    "This agent is pending approval",
+                    "There is possibly a reverse proxy (or load balancer) that has been misconfigured. See "
+                            + docsUrl("/installation/configure-reverse-proxy.html#agents-and-reverse-proxies") +
+                            " for details."
+            )));
+        }
+
+        if (status.getStatusCode() >= 300) {
+            throw new NoHttpResponseException(format("Did not receive successful HTTP response: status code = %d, status message = [%s]", status.getStatusCode(), status.getReasonPhrase()));
+        }
+    }
+
+    private HttpRequestBase postRequestFor(String action, AgentRequest payload) {
+        final HttpPost request = new HttpPost(urls.remotingUrlFor(action));
+        request.setEntity(new StringEntity(GSON.toJson(payload), ContentType.APPLICATION_JSON));
+        return request;
+    }
+
+    private void logFailure(final HttpResponse response, final String action) {
+        final StatusLine status = response.getStatusLine();
+        final String body = readBodyAsStringOrElse(response, "<ERROR: UNABLE TO READ RESPONSE BODY>");
+        LOG.error(format("Server responded to action `%s` with: status[%d %s], body[%s]",
+                action, status.getStatusCode(), status.getReasonPhrase(), body));
+    }
+}

--- a/agent/src/main/java/com/thoughtworks/go/agent/RemotingClient.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/RemotingClient.java
@@ -96,12 +96,13 @@ public class RemotingClient implements BuildRepositoryRemote {
 
     @Override
     public boolean isIgnored(AgentRuntimeInfo info, JobIdentifier jobId) {
+        // Boolean.parseBoolean is JSON compatible for this specific case, but probably faster/simpler than Gson
         return Boolean.parseBoolean(post("is_ignored", new IsIgnoredRequest(info, jobId)));
     }
 
     @Override
     public String getCookie(AgentRuntimeInfo info) {
-        return post("get_cookie", new GetCookieRequest(info));
+        return GSON.fromJson(post("get_cookie", new GetCookieRequest(info)), String.class);
     }
 
     private String post(final String action, final AgentRequest payload) {
@@ -154,6 +155,7 @@ public class RemotingClient implements BuildRepositoryRemote {
 
     private HttpRequestBase postRequestFor(String action, AgentRequest payload) {
         final HttpPost request = new HttpPost(urls.remotingUrlFor(action));
+        request.addHeader("Accept", "application/vnd.go.cd+json");
         request.setEntity(new StringEntity(GSON.toJson(payload), ContentType.APPLICATION_JSON));
         return request;
     }

--- a/agent/src/main/java/com/thoughtworks/go/agent/ResponseHelpers.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/ResponseHelpers.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.agent;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
+
+public class ResponseHelpers {
+    private ResponseHelpers() {
+    }
+
+    public static String readBodyAsString(HttpResponse response) throws IOException {
+        try (InputStream responseBody = bodyStream(response)) {
+            return IOUtils.toString(responseBody, StandardCharsets.UTF_8);
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    public static String readBodyAsStringOrElse(HttpResponse response, String defaultValue) {
+        try {
+            return readBodyAsString(response);
+        } catch (IOException ignored) {
+            return defaultValue;
+        }
+    }
+
+    public static InputStream bodyStream(HttpResponse response) throws IOException {
+        final Header encodingHeader = response.getFirstHeader("Content-Encoding");
+        final boolean isCompressed = encodingHeader != null &&
+                encodingHeader.getValue() != null &&
+                encodingHeader.getValue().toLowerCase().contains("gzip");
+
+        return isCompressed ? new GZIPInputStream(response.getEntity().getContent()) :
+                response.getEntity().getContent();
+    }
+}

--- a/agent/src/main/resources/applicationContext.xml
+++ b/agent/src/main/resources/applicationContext.xml
@@ -61,6 +61,7 @@
   <bean id="scmExtension" class="com.thoughtworks.go.plugin.access.scm.SCMExtension"/>
   <bean id="taskExtension" class="com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension"/>
   <bean id="artifactExtension" class="com.thoughtworks.go.plugin.access.artifact.ArtifactExtension"/>
+  <bean id="remoting" class="com.thoughtworks.go.agent.RemotingClient"/>
   <bean id="httpClient" class="com.thoughtworks.go.agent.common.ssl.GoAgentServerHttpClient">
     <constructor-arg ref="httpClientBuilder"/>
   </bean>

--- a/agent/src/test/java/com/thoughtworks/go/agent/AgentHTTPClientControllerTest.java
+++ b/agent/src/test/java/com/thoughtworks/go/agent/AgentHTTPClientControllerTest.java
@@ -27,8 +27,6 @@ import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.PluginManagerReference;
 import com.thoughtworks.go.plugin.infra.monitor.PluginJarLocationMonitor;
 import com.thoughtworks.go.publishers.GoArtifactsManipulator;
-import com.thoughtworks.go.remote.AgentIdentifier;
-import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.remote.work.AgentWorkContext;
 import com.thoughtworks.go.remote.work.Work;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
@@ -54,7 +52,7 @@ public class AgentHTTPClientControllerTest {
     @Rule
     public final TemporaryFolder folder = new TemporaryFolder();
     @Mock
-    private BuildRepositoryRemote loopServer;
+    private RemotingClient loopServer;
     @Mock
     private GoArtifactsManipulator artifactsManipulator;
     @Mock
@@ -81,7 +79,7 @@ public class AgentHTTPClientControllerTest {
     private ArtifactExtension artifactExtension;
     @Mock
     private PluginJarLocationMonitor pluginJarLocationMonitor;
-    private String agentUuid = "uuid";
+    private final String agentUuid = "uuid";
     private AgentHTTPClientController agentController;
 
     @BeforeEach
@@ -129,7 +127,7 @@ public class AgentHTTPClientControllerTest {
         agentController = createAgentController();
         agentController.init();
 
-        when(loopServer.getCookie(agentController.getAgentRuntimeInfo())).thenReturn("cookie");
+        when(loopServer.getCookie(eq(agentController.getAgentRuntimeInfo()))).thenReturn("cookie");
         when(sslInfrastructureService.isRegistered()).thenReturn(true);
         when(loopServer.getWork(agentController.getAgentRuntimeInfo())).thenReturn(work);
         when(agentRegistry.uuid()).thenReturn(agentUuid);
@@ -153,7 +151,7 @@ public class AgentHTTPClientControllerTest {
     void shouldRegisterSubprocessLoggerAtExit() throws Exception {
         SslInfrastructureService sslInfrastructureService = mock(SslInfrastructureService.class);
         AgentRegistry agentRegistry = mock(AgentRegistry.class);
-        agentController = new AgentHTTPClientController(loopServer, artifactsManipulator, sslInfrastructureService,
+        agentController = new AgentHTTPClientController(loopServer, loopServer, artifactsManipulator, sslInfrastructureService,
                 agentRegistry, agentUpgradeService, subprocessLogger, systemEnvironment, pluginManager,
                 packageRepositoryExtension, scmExtension, taskExtension, artifactExtension, null, null, pluginJarLocationMonitor);
         agentController.init();
@@ -185,7 +183,7 @@ public class AgentHTTPClientControllerTest {
     private AgentHTTPClientController createAgentController() {
 
         return new AgentHTTPClientController(
-                loopServer,
+                loopServer, loopServer,
                 artifactsManipulator,
                 sslInfrastructureService,
                 agentRegistry,

--- a/common/src/main/java/com/thoughtworks/go/util/URLService.java
+++ b/common/src/main/java/com/thoughtworks/go/util/URLService.java
@@ -45,6 +45,7 @@ public class URLService implements ServerUrlGenerator {
         return format("%s/%s/%s", baseRemotingURL, "remoting/api/agent", action);
     }
 
+    @Deprecated(forRemoval = true) // TODO: remove this when we drop support for RMI
     public String getBuildRepositoryURL() {
         return baseRemotingURL + "/remoting/remoteBuildRepository";
     }

--- a/common/src/main/java/com/thoughtworks/go/util/URLService.java
+++ b/common/src/main/java/com/thoughtworks/go/util/URLService.java
@@ -22,8 +22,8 @@ import org.springframework.stereotype.Component;
 import static java.lang.String.format;
 
 @Component
-public class URLService implements ServerUrlGenerator{
-    private String baseRemotingURL;
+public class URLService implements ServerUrlGenerator {
+    private final String baseRemotingURL;
 
     public URLService() {
         String url = new SystemEnvironment().getServiceUrl();
@@ -39,6 +39,10 @@ public class URLService implements ServerUrlGenerator{
 
     public String baseRemoteURL() {
         return baseRemotingURL;
+    }
+
+    public String remotingUrlFor(String action) {
+        return format("%s/%s/%s", baseRemotingURL, "remoting/api/agent", action);
     }
 
     public String getBuildRepositoryURL() {
@@ -80,9 +84,9 @@ public class URLService implements ServerUrlGenerator{
     }
 
     /*
-    * Agent will use this method, the baseUrl will be injected from config xml in agent side.
-    *   This is used to fix security issues with the agent uploading artifacts when security is enabled.
-    */
+     * Agent will use this method, the baseUrl will be injected from config xml in agent side.
+     *   This is used to fix security issues with the agent uploading artifacts when security is enabled.
+     */
     public String getPropertiesUrl(JobIdentifier jobIdentifier, String propertyName) {
         return format("%s/%s/%s/%s",
                 baseRemotingURL, "remoting", "properties", jobIdentifier.propertyLocator(propertyName));

--- a/common/src/test/java/com/thoughtworks/go/agent/testhelpers/FakeBuildRepositoryRemote.java
+++ b/common/src/test/java/com/thoughtworks/go/agent/testhelpers/FakeBuildRepositoryRemote.java
@@ -19,9 +19,8 @@ import com.thoughtworks.go.domain.AgentRuntimeStatus;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.domain.JobResult;
 import com.thoughtworks.go.domain.JobState;
-import com.thoughtworks.go.remote.AgentIdentifier;
-import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.remote.AgentInstruction;
+import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.remote.work.Work;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -44,7 +43,7 @@ public class FakeBuildRepositoryRemote implements BuildRepositoryRemote {
     public static final String STAGE_NAME = "pipeline";
     public static final String JOB_PLAN_NAME = "cruise-test-data";
 
-    private static BlockingQueue<Boolean> buildResult = new LinkedBlockingQueue<>();
+    private static final BlockingQueue<Boolean> buildResult = new LinkedBlockingQueue<>();
 
     @Override
     public AgentInstruction ping(AgentRuntimeInfo info) {

--- a/common/src/test/java/com/thoughtworks/go/remote/work/BuildRepositoryRemoteStub.java
+++ b/common/src/test/java/com/thoughtworks/go/remote/work/BuildRepositoryRemoteStub.java
@@ -20,8 +20,8 @@ import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.domain.JobResult;
 import com.thoughtworks.go.domain.JobState;
 import com.thoughtworks.go.remote.AgentIdentifier;
-import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.remote.AgentInstruction;
+import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 
 import java.util.ArrayList;
@@ -77,4 +77,5 @@ public class BuildRepositoryRemoteStub implements BuildRepositoryRemote {
     public String getCookie(AgentRuntimeInfo agentRuntimeInfo) {
         throw new RuntimeException("implement me");
     }
+
 }

--- a/server/src/main/java/com/thoughtworks/go/server/messaging/BuildRepositoryMessageProducer.java
+++ b/server/src/main/java/com/thoughtworks/go/server/messaging/BuildRepositoryMessageProducer.java
@@ -18,7 +18,9 @@ package com.thoughtworks.go.server.messaging;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.domain.JobResult;
 import com.thoughtworks.go.domain.JobState;
-import com.thoughtworks.go.remote.*;
+import com.thoughtworks.go.remote.AgentInstruction;
+import com.thoughtworks.go.remote.BuildRepositoryRemote;
+import com.thoughtworks.go.remote.BuildRepositoryRemoteImpl;
 import com.thoughtworks.go.remote.work.Work;
 import com.thoughtworks.go.server.messaging.scheduling.WorkAssignments;
 import com.thoughtworks.go.server.perf.WorkAssignmentPerformanceLogger;
@@ -28,9 +30,9 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class BuildRepositoryMessageProducer implements BuildRepositoryRemote {
-    private BuildRepositoryRemoteImpl buildRepository;
-    private WorkAssignments workAssignments;
-    private WorkAssignmentPerformanceLogger workAssignmentPerformanceLogger;
+    private final BuildRepositoryRemoteImpl buildRepository;
+    private final WorkAssignments workAssignments;
+    private final WorkAssignmentPerformanceLogger workAssignmentPerformanceLogger;
 
     @Autowired
     public BuildRepositoryMessageProducer(BuildRepositoryRemoteImpl buildRepository, WorkAssignments workAssignments, WorkAssignmentPerformanceLogger workAssignmentPerformanceLogger) {


### PR DESCRIPTION
## How to toggle back to RMI:

### Static agents

Configure `wrapper-properties.conf` to set the following property: `-Dgocd.agent.remoting.legacy=true`

### Elastic agents:

Set the `AGENT_STARTUP_ARGS` to include `-Dgocd.agent.remoting.legacy=true`

~This is a temporary PR while #8880 is being cleaned up. Just want to be able to run builds against it, then will merge into #8880 when ready and close this one.~

This PR will be cherry-picked into and superseded by #8880, after which will be closed.