### PR TITLE
trim spaces of arguments in Custom Command

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/ExecTask.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/ExecTask.java
@@ -106,7 +106,7 @@ public class ExecTask extends AbstractTask implements CommandTask {
             if (!StringUtils.isBlank(value)) {
                 String[] arguments = value.split("\\R");
                 for (String arg : arguments) {
-                    argList.add(new Argument(arg));
+                    argList.add(new Argument(arg.trim()));
                 }
             }
         }
@@ -123,7 +123,7 @@ public class ExecTask extends AbstractTask implements CommandTask {
     public void setArgsList(String[] arguments) {
         clearCurrentArgsAndArgList();
         for (String arg : arguments) {
-            argList.add(new Argument(arg));
+            argList.add(new Argument(arg.trim()));
         }
     }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/ExecTaskTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/ExecTaskTest.java
@@ -248,4 +248,17 @@ public class ExecTaskTest {
         assertThat(exec.getArgList().get(2), is(new Argument("&&")));
         assertThat(exec.getArgList().get(3), is(new Argument("pwd")));
     }
+
+    @Test
+    public void shouldSetConfigAttributesTrimSpacesOfArgments() {
+        ExecTask exec = new ExecTask();
+        exec.setConfigAttributes(m(ExecTask.COMMAND, null, ExecTask.ARG_LIST_STRING, "ls\r\n -al \r\n&&\npwd"));
+        assertThat(exec.command(), is(nullValue()));
+        assertThat(exec.getArgListString(), is("ls\n-al\n&&\npwd"));
+        assertThat(exec.getArgList().size(), is(4));
+        assertThat(exec.getArgList().get(0), is(new Argument("ls")));
+        assertThat(exec.getArgList().get(1), is(new Argument("-al")));
+        assertThat(exec.getArgList().get(2), is(new Argument("&&")));
+        assertThat(exec.getArgList().get(3), is(new Argument("pwd")));
+    }
 }


### PR DESCRIPTION
Issue: #8916

Description: trim spaces of arguments when define and use Custom Command

