### PR TITLE
Remove logging nd syncing of the des cipher

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/addon/businesscontinuity/ConfigFileType.java
+++ b/server/src/main/java/com/thoughtworks/go/addon/businesscontinuity/ConfigFileType.java
@@ -26,8 +26,6 @@ public enum ConfigFileType {
         return new File(systemEnvironment.getCruiseConfigFile());
     }),
 
-    DES_CIPHER(SystemEnvironment::getDESCipherFile),
-
     AES_CIPHER(SystemEnvironment::getAESCipherFile),
 
     JETTY_XML(SystemEnvironment::getJettyConfigFile),

--- a/server/src/main/java/com/thoughtworks/go/addon/businesscontinuity/primary/controller/PrimaryStatusProviderController.java
+++ b/server/src/main/java/com/thoughtworks/go/addon/businesscontinuity/primary/controller/PrimaryStatusProviderController.java
@@ -99,11 +99,6 @@ public class PrimaryStatusProviderController {
         serveFile(ConfigFileType.USER_FEATURE_TOGGLE.load(systemEnvironment), response, "text/json");
     }
 
-    @RequestMapping(value = "/cipher", method = RequestMethod.GET)
-    public void getLatestDESCipher(HttpServletResponse response) {
-        serveFile(ConfigFileType.DES_CIPHER.load(systemEnvironment), response, "text/plain");
-    }
-
     @RequestMapping(value = "/cipher.aes", method = RequestMethod.GET)
     public void getLatestAESCipher(HttpServletResponse response) {
         serveFile(ConfigFileType.AES_CIPHER.load(systemEnvironment), response, "text/plain");

--- a/server/src/main/java/com/thoughtworks/go/addon/businesscontinuity/primary/service/GoFilesStatusProvider.java
+++ b/server/src/main/java/com/thoughtworks/go/addon/businesscontinuity/primary/service/GoFilesStatusProvider.java
@@ -65,7 +65,6 @@ public class GoFilesStatusProvider {
 
     void initializeFileStatus() {
         setFileStatus(ConfigFileType.CRUISE_CONFIG_XML, EMPTY);
-        setFileStatus(ConfigFileType.DES_CIPHER, EMPTY);
         setFileStatus(ConfigFileType.AES_CIPHER, EMPTY);
         setFileStatus(ConfigFileType.JETTY_XML, EMPTY);
         setFileStatus(ConfigFileType.USER_FEATURE_TOGGLE, EMPTY);
@@ -75,11 +74,7 @@ public class GoFilesStatusProvider {
         if (addOnConfiguration.isServerInStandby()) return;
         for (ConfigFileType configFileType : fileStatus.keySet()) {
             File file = configFileType.load(systemEnvironment);
-            if (!file.exists()) {
-                LOGGER.warn(String.format("Could not find file %s", file.getAbsolutePath()));
-                continue;
-            }
-            // TODO: in standby mode goConfigService.getCurrentConfig().getMd5() could always be null. handle the case.
+            if (!file.exists()) continue;
             if (configFileType.equals(ConfigFileType.CRUISE_CONFIG_XML) && goConfigService.getCurrentConfig().getMd5() != null) {
                 setFileStatus(ConfigFileType.CRUISE_CONFIG_XML, goConfigService.getCurrentConfig().getMd5());
             } else {

--- a/server/src/main/java/com/thoughtworks/go/addon/businesscontinuity/standby/service/PrimaryServerEndPoint.java
+++ b/server/src/main/java/com/thoughtworks/go/addon/businesscontinuity/standby/service/PrimaryServerEndPoint.java
@@ -39,7 +39,6 @@ public class PrimaryServerEndPoint {
     public PrimaryServerEndPoint(SystemEnvironment systemEnvironment) {
         this.systemEnvironment = systemEnvironment;
         urlMap.put(ConfigFileType.CRUISE_CONFIG_XML, createBusinessContinuityAddOnApiURLFor("/cruise_config"));
-        urlMap.put(ConfigFileType.DES_CIPHER, createBusinessContinuityAddOnApiURLFor("/cipher"));
         urlMap.put(ConfigFileType.AES_CIPHER, createBusinessContinuityAddOnApiURLFor("/cipher.aes"));
         urlMap.put(ConfigFileType.JETTY_XML, createBusinessContinuityAddOnApiURLFor("/jetty_config"));
         urlMap.put(ConfigFileType.USER_FEATURE_TOGGLE, createBusinessContinuityAddOnApiURLFor("/user_feature_toggle"));

--- a/server/src/test-fast/java/com/thoughtworks/go/addon/businesscontinuity/primary/controller/PrimaryStatusProviderControllerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/addon/businesscontinuity/primary/controller/PrimaryStatusProviderControllerTest.java
@@ -51,7 +51,6 @@ class PrimaryStatusProviderControllerTest {
     void shouldRespondWithLatestStatus() throws IOException {
         Map<ConfigFileType, String> latestStatus = new HashMap<>();
         latestStatus.put(ConfigFileType.CRUISE_CONFIG_XML, "a");
-        latestStatus.put(ConfigFileType.DES_CIPHER, "b");
         latestStatus.put(ConfigFileType.AES_CIPHER, "AES-CIPHER");
         latestStatus.put(ConfigFileType.JETTY_XML, "c");
         when(goFilesStatusProvider.getLatestStatusMap()).thenReturn(latestStatus);
@@ -62,7 +61,6 @@ class PrimaryStatusProviderControllerTest {
         ServerStatusResponse serverStatusResponse = new Gson().fromJson(httpServletResponse.getContentAsString(), ServerStatusResponse.class);
         assertThat(serverStatusResponse.getFileDetailsMap().size(), is(4));
         assertThat(serverStatusResponse.getFileDetailsMap().get(ConfigFileType.CRUISE_CONFIG_XML).getMd5(), is("a"));
-        assertThat(serverStatusResponse.getFileDetailsMap().get(ConfigFileType.DES_CIPHER).getMd5(), is("b"));
         assertThat(serverStatusResponse.getFileDetailsMap().get(ConfigFileType.AES_CIPHER).getMd5(), is("AES-CIPHER"));
         assertThat(serverStatusResponse.getFileDetailsMap().get(ConfigFileType.JETTY_XML).getMd5(), is("c"));
     }
@@ -76,17 +74,6 @@ class PrimaryStatusProviderControllerTest {
         assertThat(httpServletResponse.getContentType(), is("text/xml"));
         assertThat(httpServletResponse.getCharacterEncoding(), is("UTF-8"));
         assertThat(httpServletResponse.getContentAsByteArray(), is(FileUtils.readFileToByteArray(new File(systemEnvironment.getCruiseConfigFile()))));
-    }
-
-    @Test
-    void shouldRespondWithLatestDESCipher() throws Exception {
-        when(systemEnvironment.getDESCipherFile()).thenReturn(new File(configDirectory, "cipher"));
-
-        primaryStatusProviderController.getLatestDESCipher(httpServletResponse);
-
-        assertThat(httpServletResponse.getContentType(), is("text/plain"));
-        assertThat(httpServletResponse.getCharacterEncoding(), is("UTF-8"));
-        assertThat(httpServletResponse.getContentAsByteArray(), is(FileUtils.readFileToByteArray(systemEnvironment.getDESCipherFile())));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/addon/businesscontinuity/primary/controller/PrimaryStatusProviderControllerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/addon/businesscontinuity/primary/controller/PrimaryStatusProviderControllerTest.java
@@ -59,7 +59,7 @@ class PrimaryStatusProviderControllerTest {
         primaryStatusProviderController.latestStatus(httpServletResponse);
 
         ServerStatusResponse serverStatusResponse = new Gson().fromJson(httpServletResponse.getContentAsString(), ServerStatusResponse.class);
-        assertThat(serverStatusResponse.getFileDetailsMap().size(), is(4));
+        assertThat(serverStatusResponse.getFileDetailsMap().size(), is(3));
         assertThat(serverStatusResponse.getFileDetailsMap().get(ConfigFileType.CRUISE_CONFIG_XML).getMd5(), is("a"));
         assertThat(serverStatusResponse.getFileDetailsMap().get(ConfigFileType.AES_CIPHER).getMd5(), is("AES-CIPHER"));
         assertThat(serverStatusResponse.getFileDetailsMap().get(ConfigFileType.JETTY_XML).getMd5(), is("c"));

--- a/server/src/test-fast/java/com/thoughtworks/go/addon/businesscontinuity/primary/service/GoFilesStatusProviderTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/addon/businesscontinuity/primary/service/GoFilesStatusProviderTest.java
@@ -44,7 +44,6 @@ class GoFilesStatusProviderTest {
         String configDirForTest = getClass().getResource("/config_directory_1").getFile();
         when(systemEnvironment.getConfigDir()).thenReturn(configDirForTest);
         when(systemEnvironment.getCruiseConfigFile()).thenReturn(new File(configDirForTest, "cruise-config.xml").getAbsolutePath());
-        when(systemEnvironment.getDESCipherFile()).thenReturn(new File(configDirForTest, "cipher"));
         when(systemEnvironment.getAESCipherFile()).thenReturn(new File(configDirForTest, "cipher.aes"));
         when(systemEnvironment.getJettyConfigFile()).thenReturn(new File(configDirForTest, "jetty.xml"));
         when(cruiseConfig.getMd5()).thenReturn("cruise-config-md5");
@@ -56,7 +55,6 @@ class GoFilesStatusProviderTest {
     @Test
     void shouldInitializeFileStatusMapWithRequiredFilesAndInitializeUpdateThread() {
         assertThat(getFileStatus(ConfigFileType.CRUISE_CONFIG_XML), is(EMPTY));
-        assertThat(getFileStatus(ConfigFileType.DES_CIPHER), is(EMPTY));
         assertThat(getFileStatus(ConfigFileType.AES_CIPHER), is(EMPTY));
         assertThat(getFileStatus(ConfigFileType.JETTY_XML), is(EMPTY));
         assertThat(getFileStatus(ConfigFileType.USER_FEATURE_TOGGLE), is(EMPTY));
@@ -70,7 +68,6 @@ class GoFilesStatusProviderTest {
         goFilesStatusProvider = new GoFilesStatusProvider(goConfigService, systemEnvironment, new MockScheduledExecutorService(), addOnConfiguration);
 
         assertThat(getFileStatus(ConfigFileType.CRUISE_CONFIG_XML), is("cruise-config-md5"));
-        assertThat(getFileStatus(ConfigFileType.DES_CIPHER), is("e38bf9c7ca52c1327ac0ebb08d90b070"));
         assertThat(getFileStatus(ConfigFileType.AES_CIPHER), is("0b4335edfaeacf4d61c0db1ae0820ac3"));
         assertThat(getFileStatus(ConfigFileType.JETTY_XML), is("ee710ce0aa67ef28f22210c659deb6d2"));
         assertThat(getFileStatus(ConfigFileType.USER_FEATURE_TOGGLE), is("c08744f9efd2574c8f93a75bef98de1f"));

--- a/server/src/test-fast/java/com/thoughtworks/go/addon/businesscontinuity/standby/controller/DashBoardControllerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/addon/businesscontinuity/standby/controller/DashBoardControllerTest.java
@@ -182,7 +182,6 @@ class DashBoardControllerTest {
     void shouldGetStandbyServerDetails() {
         HashMap<ConfigFileType, String> fileMd5Map = new HashMap<>();
         fileMd5Map.put(ConfigFileType.CRUISE_CONFIG_XML, "md51");
-        fileMd5Map.put(ConfigFileType.DES_CIPHER, "md52");
         fileMd5Map.put(ConfigFileType.AES_CIPHER, "md53");
 
         Map<String, String> plugins = new HashMap<>();
@@ -200,7 +199,7 @@ class DashBoardControllerTest {
 
         JsonFluentAssert.assertThatJson(gson.toJson(standbyDetails)).isEqualTo("{\"CRUISE_CONFIG_XML\":\"md51\",\"lastUpdateTime\":\"" +
                 new SimpleDateFormat("MMM d, YYYY HH:mm:ss").format(new Date(time)) +
-                "\",\"primaryStatusCheckInterval\":60000,\"pluginStatus\":\"plugin-one=md51, plugin-two=md52\",\"DES_CIPHER\":\"md52\",\"AES_CIPHER\":\"md53\",\"latestReceivedDatabaseWalLocation\":\"12345\"}");
+                "\",\"primaryStatusCheckInterval\":60000,\"pluginStatus\":\"plugin-one=md51, plugin-two=md52\",\"AES_CIPHER\":\"md53\",\"latestReceivedDatabaseWalLocation\":\"12345\"}");
     }
 
     @Test
@@ -211,7 +210,6 @@ class DashBoardControllerTest {
 
         HashMap<ConfigFileType, FileDetails> fileDetailsMap = new HashMap<>();
         fileDetailsMap.put(ConfigFileType.CRUISE_CONFIG_XML, new FileDetails("md51"));
-        fileDetailsMap.put(ConfigFileType.DES_CIPHER, new FileDetails("md52"));
         fileDetailsMap.put(ConfigFileType.AES_CIPHER, new FileDetails("md53"));
 
         Map<String, String> pluginOne = new HashMap<>();
@@ -232,7 +230,7 @@ class DashBoardControllerTest {
         doReturn(plugins).when(primaryServerCommunicationService).getLatestPluginsStatus();
 
         Map<String, Object> primaryServerDetails = controller.primaryServerDetails();
-        JsonFluentAssert.assertThatJson(gson.toJson(primaryServerDetails)).isEqualTo("{\"CRUISE_CONFIG_XML\":{\"md5\":\"md51\"},\"configFilesUpdateInterval\":60000,\"latestDatabaseWalLocation\":\"12345\",\"pluginStatus\":\"plugin-one=md51, plugin-two=md52\",\"DES_CIPHER\":{\"md5\":\"md52\"},\"AES_CIPHER\":{\"md5\":\"md53\"},\"url\":\"https://localhost:8154\",\"lastConfigUpdateTime\":\"" +
+        JsonFluentAssert.assertThatJson(gson.toJson(primaryServerDetails)).isEqualTo("{\"CRUISE_CONFIG_XML\":{\"md5\":\"md51\"},\"configFilesUpdateInterval\":60000,\"latestDatabaseWalLocation\":\"12345\",\"pluginStatus\":\"plugin-one=md51, plugin-two=md52\",\"AES_CIPHER\":{\"md5\":\"md53\"},\"url\":\"https://localhost:8154\",\"lastConfigUpdateTime\":\"" +
                         new SimpleDateFormat("MMM d, YYYY HH:mm:ss").format(new Date(time)) + "\"}");
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/addon/businesscontinuity/standby/service/StandbyFileSyncServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/addon/businesscontinuity/standby/service/StandbyFileSyncServiceTest.java
@@ -70,7 +70,6 @@ public class StandbyFileSyncServiceTest {
             return null;
         };
         doAnswer(answerWithFile).when(primaryServerCommunicationService).downloadConfigFile(eq(ConfigFileType.CRUISE_CONFIG_XML), any(File.class));
-        doAnswer(answerWithFile).when(primaryServerCommunicationService).downloadConfigFile(eq(ConfigFileType.DES_CIPHER), any(File.class));
         doAnswer(answerWithFile).when(primaryServerCommunicationService).downloadConfigFile(eq(ConfigFileType.AES_CIPHER), any(File.class));
         doAnswer(answerWithFile).when(primaryServerCommunicationService).downloadConfigFile(eq(ConfigFileType.JETTY_XML), any(File.class));
 
@@ -85,7 +84,6 @@ public class StandbyFileSyncServiceTest {
     void shouldSyncConfigFiles() throws Exception {
         Map<ConfigFileType, FileDetails> latestStatusMap = new HashMap<ConfigFileType, FileDetails>() {{
             put(ConfigFileType.CRUISE_CONFIG_XML, new FileDetails("new-md5"));
-            put(ConfigFileType.DES_CIPHER, new FileDetails("new-md5"));
             put(ConfigFileType.AES_CIPHER, new FileDetails("new-md5"));
             put(ConfigFileType.JETTY_XML, new FileDetails("new-md5"));
         }};
@@ -99,7 +97,6 @@ public class StandbyFileSyncServiceTest {
         new StandbyFileSyncService(systemEnvironment, primaryServerCommunicationService, new MockScheduledExecutorService(), addOnConfiguration);
 
         assertThat(FileUtils.readFileToString(new File(systemEnvironment.getCruiseConfigFile()), UTF_8), is("CRUISE_CONFIG_XML contents"));
-        assertThat(FileUtils.readFileToString(systemEnvironment.getDESCipherFile(), UTF_8), is("DES_CIPHER contents"));
         assertThat(FileUtils.readFileToString(systemEnvironment.getAESCipherFile(), UTF_8), is("AES_CIPHER contents"));
         assertThat(FileUtils.readFileToString(systemEnvironment.getJettyConfigFile(), UTF_8), is("JETTY_XML contents"));
         verify(primaryServerCommunicationService).getLatestFileStatus();


### PR DESCRIPTION
Issue: #8915

Description:
 - remove warning logs while checking file status as the cruise-config, jetty and aes_cipher files need to be present for the server to get started.
 - also removed the syncing of the des cipher as the same is no longer required



