### PR TITLE
Should not trim diff lines because we cannot reliably detect changes

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/config_change.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/stages/config_change.html.erb
@@ -9,10 +9,9 @@
     <% else %>
       <% changes_lines = @changes.strip.split("\n") %>
       <% changes_lines.each do |line|
-        trimmed_line = line.strip
-        css_class = 'add' if trimmed_line.start_with?('+')
-        css_class = 'remove' if trimmed_line.start_with?('-')
-        css_class = 'line-info' if trimmed_line.start_with?('@@')
+        css_class = 'add' if line.start_with?('+')
+        css_class = 'remove' if line.start_with?('-')
+        css_class = 'line-info' if line.start_with?('@@')
         css_class = 'context' unless css_class %>
         <tr class="<%= css_class -%>"><td><pre><%= html_escape(line) -%></pre></td></tr>
       <% end %>


### PR DESCRIPTION
Fixes #8899

Avoid `lstrip/trim` on diff lines before coloring syntax on config changes modal.