### PR TITLE
Add missing Content-Type check

### DIFF
--- a/api/api-backup-config-v1/src/main/java/com/thoughtworks/go/apiv1/backupconfig/BackupConfigControllerV1.java
+++ b/api/api-backup-config-v1/src/main/java/com/thoughtworks/go/apiv1/backupconfig/BackupConfigControllerV1.java
@@ -65,7 +65,9 @@ public class BackupConfigControllerV1 extends ApiController implements SparkSpri
     public void setupRoutes() {
         path(controllerBasePath(), () -> {
             before("", mimeType, this::setContentType);
-
+            before("/*", mimeType, this::setContentType);
+            before("", mimeType, this::verifyContentType);
+            before("/*", mimeType, this::verifyContentType);
 
             // change the line below to enable appropriate security
             before("", mimeType, this.apiAuthenticationHelper::checkAdminUserAnd403);


### PR DESCRIPTION
Without this, `POST` calls without the `Content-Type: application/json` header will go through.
