### PR TITLE
Fixing shell linting issues for docker entrypoint files

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-agent/docker-entrypoint.sh
+++ b/buildSrc/src/main/resources/gocd-docker-agent/docker-entrypoint.sh
@@ -16,7 +16,7 @@
 
 yell() { echo "$0: $*" >&2; }
 die() { yell "$*"; exit 111; }
-try() { echo "$ $@" 1>&2; "$@" || die "cannot $*"; }
+try() { echo "$ $*" 1>&2; "$@" || die "cannot $*"; }
 
 declare -a _stringToArgs
 function stringToArgsArray() {
@@ -24,23 +24,25 @@ function stringToArgsArray() {
 }
 
 setup_autoregister_properties_file_for_elastic_agent() {
-  echo "agent.auto.register.key=${GO_EA_AUTO_REGISTER_KEY}" >> $1
-  echo "agent.auto.register.environments=${GO_EA_AUTO_REGISTER_ENVIRONMENT}" >> $1
-  echo "agent.auto.register.elasticAgent.agentId=${GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID}" >> $1
-  echo "agent.auto.register.elasticAgent.pluginId=${GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID}" >> $1
-  echo "agent.auto.register.hostname=${AGENT_AUTO_REGISTER_HOSTNAME}" >> $1
-
+ {
+    echo "agent.auto.register.key=${GO_EA_AUTO_REGISTER_KEY}"
+    echo "agent.auto.register.environments=${GO_EA_AUTO_REGISTER_ENVIRONMENT}"
+    echo "agent.auto.register.elasticAgent.agentId=${GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID}"
+    echo "agent.auto.register.elasticAgent.pluginId=${GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID}"
+    echo "agent.auto.register.hostname=${AGENT_AUTO_REGISTER_HOSTNAME}"
+  } >> "$1"
   export GO_SERVER_URL="${GO_EA_SERVER_URL}"
   # unset variables, so we don't pollute and leak sensitive stuff to the agent process...
   unset GO_EA_AUTO_REGISTER_KEY GO_EA_AUTO_REGISTER_ENVIRONMENT GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID GO_EA_SERVER_URL AGENT_AUTO_REGISTER_HOSTNAME
 }
 
 setup_autoregister_properties_file_for_normal_agent() {
-  echo "agent.auto.register.key=${AGENT_AUTO_REGISTER_KEY}" >> $1
-  echo "agent.auto.register.resources=${AGENT_AUTO_REGISTER_RESOURCES}" >> $1
-  echo "agent.auto.register.environments=${AGENT_AUTO_REGISTER_ENVIRONMENTS}" >> $1
-  echo "agent.auto.register.hostname=${AGENT_AUTO_REGISTER_HOSTNAME}" >> $1
-
+  {
+    echo "agent.auto.register.key=${AGENT_AUTO_REGISTER_KEY}"
+    echo "agent.auto.register.resources=${AGENT_AUTO_REGISTER_RESOURCES}"
+    echo "agent.auto.register.environments=${AGENT_AUTO_REGISTER_ENVIRONMENTS}"
+    echo "agent.auto.register.hostname=${AGENT_AUTO_REGISTER_HOSTNAME}"
+  } >> "$1"
   # unset variables, so we don't pollute and leak sensitive stuff to the agent process...
   unset AGENT_AUTO_REGISTER_KEY AGENT_AUTO_REGISTER_RESOURCES AGENT_AUTO_REGISTER_ENVIRONMENTS AGENT_AUTO_REGISTER_HOSTNAME
 }
@@ -138,7 +140,7 @@ if [ "$1" = "${AGENT_WORK_DIR}/bin/go-agent" ]; then
   AGENT_BOOTSTRAPPER_JVM_ARGS+=("-Dgo.console.stdout=true")
   for array_index in "${!AGENT_BOOTSTRAPPER_JVM_ARGS[@]}"
   do
-    tanuki_index=$(($array_index + 100))
+    tanuki_index=$((array_index + 100))
     echo "wrapper.java.additional.${tanuki_index}=${AGENT_BOOTSTRAPPER_JVM_ARGS[$array_index]}" >> /go-agent/wrapper-config/wrapper-properties.conf
   done
 
@@ -148,7 +150,7 @@ if [ "$1" = "${AGENT_WORK_DIR}/bin/go-agent" ]; then
 
   for array_index in "${!AGENT_BOOTSTRAPPER_ARGS[@]}"
   do
-    tanuki_index=$(($array_index + 200))
+    tanuki_index=$((array_index + 200))
     echo "wrapper.app.parameter.${tanuki_index}=${AGENT_BOOTSTRAPPER_ARGS[$array_index]}" >> /go-agent/wrapper-config/wrapper-properties.conf
   done
 

--- a/buildSrc/src/main/resources/gocd-docker-server/docker-entrypoint.sh
+++ b/buildSrc/src/main/resources/gocd-docker-server/docker-entrypoint.sh
@@ -16,7 +16,7 @@
 
 yell() { echo "$0: $*" >&2; }
 die() { yell "$*"; exit 111; }
-try() { echo "$ $@" 1>&2; "$@" || die "cannot $*"; }
+try() { echo "$ $*" 1>&2; "$@" || die "cannot $*"; }
 
 declare -a _stringToArgs
 function stringToArgsArray() {
@@ -96,7 +96,7 @@ if [ "$1" = "${SERVER_WORK_DIR}/bin/go-server" ]; then
   # write out each system property using its own index
   for array_index in "${!GOCD_SERVER_JVM_OPTS[@]}"
   do
-    tanuki_index=$(($array_index + 100))
+    tanuki_index=$((array_index + 100))
     echo "wrapper.java.additional.${tanuki_index}=${GOCD_SERVER_JVM_OPTS[$array_index]}" >> /go-server/wrapper-config/wrapper-properties.conf
   done
 


### PR DESCRIPTION
Issue: #9298 


Description:
Fixes shell lint  failures
```
$ shellcheck gocd/buildSrc/src/main/resources/gocd-docker-server/docker-entrypoint.sh
$
```

```
$ shellcheck gocd/buildSrc/src/main/resources/gocd-docker-server/docker-entrypoint.sh
$
```