### PR TITLE
Fix expectation for JavaEWAH version post JGit `5.11.1` bump

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -790,7 +790,7 @@ task verifyWar(type: VerifyJarTask) {
       ((project(':api').subprojects + project(':spark').subprojects).collect { eachProject -> eachProject.jar.archiveFile.get().asFile.name })
         + [
         "FastInfoset-1.2.15.jar",
-        "JavaEWAH-1.1.6.jar",
+        "JavaEWAH-1.1.7.jar",
         "activation-1.1.jar",
         "activemq-broker-${project.versions.activeMQ}.jar",
         "activemq-client-${project.versions.activeMQ}.jar",
@@ -1019,7 +1019,7 @@ task licenseReportAggregate {
     ],
     [
       moduleName    : 'com.googlecode.javaewah:JavaEWAH',
-      moduleVersion : '1.1.6',
+      moduleVersion : '1.1.7',
       moduleUrls    : [
         "https://github.com/lemire/javaewah"
       ],


### PR DESCRIPTION
In #9380, JGit was bumped, which brought in a newer transitive dependency version of JavaEWAH (`1.16` -> `1.17`).

```
|    +--- org.eclipse.jgit:org.eclipse.jgit:5.11.1.202105131744-r
|    |    +--- com.googlecode.javaewah:JavaEWAH:1.1.7
```

Current build is failing due to this: https://build.gocd.org/go/tab/build/detail/installers/2564/dist/1/dist