### PR TITLE
Handle NullPointerException in ValueStreamMapService

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/ValueStreamMapService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ValueStreamMapService.java
@@ -45,6 +45,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 public class ValueStreamMapService {
@@ -204,8 +205,12 @@ public class ValueStreamMapService {
                 }
 
                 pipelineDependencyNode.setCanEdit(goConfigService.canEditPipeline(pipelineName, username, new HttpLocalizedOperationResult()));
-                CaseInsensitiveString templateName = goConfigService.findPipelineByName(new CaseInsensitiveString(pipelineName)).getTemplateName();
-                pipelineDependencyNode.setTemplateName(templateName != null ? templateName.toString() : null);
+                pipelineDependencyNode.setTemplateName(
+                        Optional.ofNullable(goConfigService.findPipelineByName(new CaseInsensitiveString(pipelineName)))
+                                .map(PipelineConfig::getTemplateName)
+                                .map(CaseInsensitiveString::toString)
+                                .orElse(null))
+                ;
             }
         }
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ValueStreamMapServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ValueStreamMapServiceTest.java
@@ -827,6 +827,7 @@ public class ValueStreamMapServiceTest {
 
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
         when(goConfigService.hasPipelineNamed(new CaseInsensitiveString("p1"))).thenReturn(false);
+        when(goConfigService.findPipelineByName(new CaseInsensitiveString("p1"))).thenReturn(null);
         when(pipelineService.findPipelineByNameAndCounter("p3", 1)).thenReturn(new Pipeline("p3", "p3-label", p3buildCause, new EnvironmentVariables()));
 
         ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap(new CaseInsensitiveString("p3"), 1, user, result);


### PR DESCRIPTION

Issue: #9509

Description:

With this, we should be able to view old VSM pages whose dependent pipelines are renamed or deleted. In VSM, deleted pipelines is shown as "Pipeline has been deleted"
