### PR TITLE
Bump commons-io from 2.6 to 2.11.0

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -43,7 +43,7 @@ final Map<String, String> libraries = [
   commonsDbcp         : 'org.apache.commons:commons-dbcp2:2.8.0',
   commonsDigester     : 'commons-digester:commons-digester:2.1',
   commonsFileUpload   : 'commons-fileupload:commons-fileupload:1.4',
-  commonsIO           : 'commons-io:commons-io:2.6',
+  commonsIO           : 'commons-io:commons-io:2.11.0',
   commonsLang         : 'commons-lang:commons-lang:2.6',
   commonsLang3        : 'org.apache.commons:commons-lang3:3.12.0',
   commonsPool         : 'org.apache.commons:commons-pool2:2.10.0',


### PR DESCRIPTION
Issue: Fixes #9397 

Description: As noted in https://github.com/gocd/gocd/issues/9397#issuecomment-880813088 it seems the original reason the bump to `2.8` was reverted caused the tests to fail, and subsequently fixed in `2.9`, so this should be fine to upgrade now assuming the tests are all good.