### PR TITLE
Bump cloning from 1.9.12 to 1.10.3

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,7 +35,7 @@ final Map<String, String> libraries = [
   bouncyCastle        : 'org.bouncycastle:bcprov-jdk15on:1.68', // This version of BC is not compatible with the jruby-opensssl version, since we are not using jruby-opensssl going ahead with the upgrade.
   bundler             : 'rubygems:bundler:2.1.1',
   cglib               : 'cglib:cglib:3.3.0',
-  cloning             : 'uk.com.robust-it:cloning:1.9.12',
+  cloning             : 'io.github.kostaskougios:cloning:1.10.3',
   commonsBeanUtils    : 'commons-beanutils:commons-beanutils:1.9.4',
   commonsCodec        : 'commons-codec:commons-codec:1.15',
   commonsCollections  : 'commons-collections:commons-collections:3.2.2',


### PR DESCRIPTION
As mentioned in https://github.com/gocd/gocd/issues/9469#issuecomment-880525788 the `cloning` library has moved to new Maven coordinates and maintained at https://github.com/kostaskougios/cloning

Primary author appears to be the same; no license change.

While this version won't fix all the issues in #9469 to allow GoCD to work correctly on Java 16 without startup JVM flags, it would probably be good to get the dependency onto a maintained version, assuming it works OK.