### PR TITLE
Improve logging during build of docker images on test failure

### DIFF
--- a/docker/gocd-agent/build.gradle
+++ b/docker/gocd-agent/build.gradle
@@ -3,6 +3,7 @@ import com.thoughtworks.go.build.docker.Distro
 import com.thoughtworks.go.build.docker.DistroVersion
 import com.thoughtworks.go.build.docker.ImageType
 import groovy.json.JsonOutput
+import org.apache.tools.ant.util.TeeOutputStream
 
 /*
  * Copyright 2021 ThoughtWorks, Inc.
@@ -100,43 +101,52 @@ subprojects {
 
     task.verifyHelper = {
       // test image
+
       // daemonize the container
       project.exec {
         workingDir = project.rootProject.projectDir
-        commandLine = ["docker", "run", "--rm", "-e", "GO_SERVER_URL=http://localhost:8153/go", "-d", "--name", docker.dockerImageName, docker.imageNameWithTag]
+        commandLine = ["docker", "run", "-e", "GO_SERVER_URL=http://localhost:8153/go", "-d", "--name", docker.dockerImageName, docker.imageNameWithTag]
         standardOutput = System.out
         errorOutput = System.err
       }
 
       Thread.sleep(5000)
 
-      ByteArrayOutputStream baos = new ByteArrayOutputStream()
+      ByteArrayOutputStream containerOutput = new ByteArrayOutputStream()
+      project.exec {
+        workingDir = project.rootProject.projectDir
+        commandLine = ["docker", "logs", docker.dockerImageName]
+        standardOutput = containerOutput
+        errorOutput = containerOutput
+        ignoreExitValue = true
+      }
 
       // run a `ps aux`
+      ByteArrayOutputStream psOutput = new ByteArrayOutputStream()
       project.exec {
         workingDir = project.rootProject.projectDir
         commandLine = ["docker", "exec", docker.dockerImageName, "ps", "aux"]
-        standardOutput = baos
-        errorOutput = baos
+        standardOutput = new TeeOutputStream(psOutput, System.out)
+        errorOutput = new TeeOutputStream(psOutput, System.err)
+        ignoreExitValue = true
       }
 
-      // stop the container
+      // remove the container
       project.exec {
         workingDir = project.rootProject.projectDir
-        commandLine = ["docker", "stop", docker.dockerImageName]
+        commandLine = ["docker", "rm", "--force", docker.dockerImageName]
         standardOutput = System.out
         errorOutput = System.err
       }
 
       // assert if process was running
       def expectedString = "lib/agent-bootstrapper.jar -serverUrl http://localhost:8153/go"
-      def processList = baos.toString()
+      def processList = psOutput.toString()
       if (!processList.contains(expectedString)) {
-        throw new GradleException("Expected process output to contain ${expectedString}, but was: ${processList}".toString())
+        throw new GradleException("Expected process output to contain [${expectedString}], but was: [${processList}]\n\nContainer output:\n${containerOutput.toString()}")
       }
     }
   }
-  //create a task for git push - depends on dockerfile
 }
 
 task generateManifest() {

--- a/docker/gocd-server/build.gradle
+++ b/docker/gocd-server/build.gradle
@@ -3,6 +3,7 @@ import com.thoughtworks.go.build.docker.Distro
 import com.thoughtworks.go.build.docker.DistroVersion
 import com.thoughtworks.go.build.docker.ImageType
 import groovy.json.JsonOutput
+import org.apache.tools.ant.util.TeeOutputStream
 
 /*
  * Copyright 2021 ThoughtWorks, Inc.
@@ -95,36 +96,45 @@ subprojects {
       // daemonize the container
       project.exec {
         workingDir = project.rootProject.projectDir
-        commandLine = ["docker", "run", "--rm", "-d", "--name", docker.dockerImageName, docker.imageNameWithTag]
+        commandLine = ["docker", "run", "-d", "--name", docker.dockerImageName, docker.imageNameWithTag]
         standardOutput = System.out
         errorOutput = System.err
       }
 
       Thread.sleep(10000)
 
-      ByteArrayOutputStream baos = new ByteArrayOutputStream()
+      ByteArrayOutputStream containerOutput = new ByteArrayOutputStream()
+      project.exec {
+        workingDir = project.rootProject.projectDir
+        commandLine = ["docker", "logs", docker.dockerImageName]
+        standardOutput = containerOutput
+        errorOutput = containerOutput
+        ignoreExitValue = true
+      }
 
       // run a `ps aux`
+      ByteArrayOutputStream psOutput = new ByteArrayOutputStream()
       project.exec {
         workingDir = project.rootProject.projectDir
         commandLine = ["docker", "exec", docker.dockerImageName, "ps", "aux"]
-        standardOutput = baos
-        errorOutput = baos
+        standardOutput = new TeeOutputStream(psOutput, System.out)
+        errorOutput = new TeeOutputStream(psOutput, System.err)
+        ignoreExitValue = true
       }
 
-      // stop the container
+      // remove the container
       project.exec {
         workingDir = project.rootProject.projectDir
-        commandLine = ["docker", "stop", docker.dockerImageName]
+        commandLine = ["docker", "rm", "--force", docker.dockerImageName]
         standardOutput = System.out
         errorOutput = System.err
       }
 
       // assert if process was running
-      def processList = baos.toString()
       def expectedString = "lib/go.jar"
+      def processList = psOutput.toString()
       if (!processList.contains(expectedString)) {
-        throw new GradleException("Expected process output to contain ${expectedString}, but was: ${processList}".toString())
+        throw new GradleException("Expected process output to contain ${expectedString}, but was: [${processList}]\n\nContainer output:\n${containerOutput.toString()}")
       }
     }
   }

--- a/installers/generic.gradle
+++ b/installers/generic.gradle
@@ -205,12 +205,17 @@ def configureGenericZip(Zip zipTask, InstallerType installerType) {
       rename 'wrapper.conf.in', 'wrapper.conf'
     }
 
+    zipTask.inputs.file("include/wrapper-license-relative-path-${installerType.baseName}.conf")
+    zipTask.inputs.file("include/additional-properties.conf")
+
     // the actual default config file
     from("include/wrapper-properties-${installerType.baseName}.conf") {
       into 'wrapper-config'
       rename ".*", "wrapper-properties.conf"
       filter(ConcatFilter, append: file("include/wrapper-properties.${installerType.baseName}.conf.example"))
     }
+
+    zipTask.inputs.file("include/wrapper-properties.${installerType.baseName}.conf.example")
 
     from("${extractDeltaPack.outputs.files.singleFile.path}/wrapper-delta-pack-${project.versions.tanuki}-st/bin") {
       include 'wrapper-*'

--- a/installers/include/wrapper-license-relative-path-go-server.conf
+++ b/installers/include/wrapper-license-relative-path-go-server.conf
@@ -1,6 +1,6 @@
 # Tanuki license keys for GoCD Server using absolute paths (uses the following license params):
 # wrapper.java.mainclass=org.tanukisoftware.wrapper.WrapperJarApp
-# wrapper.app.parameter.1=lib/agent-bootstrapper.jar
+# wrapper.app.parameter.1=lib/go.jar
 
 #encoding=UTF-8
 wrapper.license.type=DEV


### PR DESCRIPTION
As noted at https://github.com/gocd/gocd/pull/9481#issuecomment-883529025 currently the Docker agent image builds are [failing on build](https://build.gocd.org/go/tab/build/detail/installers-pull_9481/1/docker/1/docker-agent) due to an issue with the Tanuki wrapper license keys for agents.

However in the case where the container fails to start and immediately exits, there is no log output feedback to determine why, making it difficult to debug either locally or on CI.

This PR improves that by
- removing the `--rm` during run of the container to allow logs to be captured on exit
- always calling `docker logs` to capture container stdout/err
- logging the `docker exec ps aux` output so you can see what is happening when it runs
- allowing Gradle to continue on exec failure so the logs can be output
- replacing the `--rm` with a specific `docker rm --force` to clean up the container rather than `docker stop`
- Including the container output any time the "test" for the running non-wrapper process fails

Other minor related changes
- Gradle currently considers the tasks UP-TO-DATE even if the wrapper license config changes, as it is not aware of these additional input files via `filter`s in the `from` tasks. Makes it easier to iterate locally rather than have to do clean builds or force run tasks.
- Fixes minor typo in a comment in the server license


Example log output when it fails

```
Execution failed for task ':docker:gocd-agent:alpine-3.13:docker'.
> Expected process output to contain [lib/agent-bootstrapper.jar -serverUrl http://localhost:8153/go], but was: [Error response from daemon: Container 0ca24dc2719a46c599ad994b51429582991d7aead7d34b0d0446ac7b7826901c is not running
  ]

  Container output:
  /docker-entrypoint.sh: Creating directories and symlinks to hold GoCD configuration, data, and logs
  $ mkdir -v /godata/config
  $ ln -sv /godata/config /go/config
  $ mkdir -v /godata/logs
  $ ln -sv /godata/logs /go/logs
  $ mkdir -v /godata/pipelines
  $ ln -sv /godata/pipelines /go/pipelines
  /docker-entrypoint.sh: Creating directories and symlinks to hold GoCD wrapper binaries
  $ ln -sv /go-agent/bin /go/bin
  $ ln -sv /go-agent/lib /go/lib
  $ ln -sv /go-agent/run /go/run
  $ ln -sv /go-agent/wrapper /go/wrapper
  $ ln -sv /go-agent/wrapper-config /go/wrapper-config
  $ cp -rfv /go-agent/config/agent-bootstrapper-logback-include.xml /go/config/agent-bootstrapper-logback-include.xml
  $ cp -rfv /go-agent/config/agent-launcher-logback-include.xml /go/config/agent-launcher-logback-include.xml
  created directory: '/godata/config'
  '/go/config' -> '/godata/config'
  created directory: '/godata/logs'
  '/go/logs' -> '/godata/logs'
  created directory: '/godata/pipelines'
  '/go/pipelines' -> '/godata/pipelines'
  '/go/bin' -> '/go-agent/bin'
  '/go/lib' -> '/go-agent/lib'
  '/go/run' -> '/go-agent/run'
  '/go/wrapper' -> '/go-agent/wrapper'
  '/go/wrapper-config' -> '/go-agent/wrapper-config'
  '/go-agent/config/agent-bootstrapper-logback-include.xml' -> '/go/config/agent-bootstrapper-logback-include.xml'
  '/go-agent/config/agent-launcher-logback-include.xml' -> '/go/config/agent-launcher-logback-include.xml'
  '/go-agent/config/agent-logback-include.xml' -> '/go/config/agent-logback-include.xml'
  Running go-agent...
  $ cp -rfv /go-agent/config/agent-logback-include.xml /go/config/agent-logback-include.xml
  /docker-entrypoint.sh: Running custom scripts in /docker-entrypoint.d/ ...
  $ sed -i -e s@wrapper.logfile=.*@/wrapper.logfile=/go/logs/go-agent-bootstrapper-wrapper.log@g -e s@wrapper.java.command=.*@wrapper.java.command=/gocd-jre/bin/java@g -e s@wrapper.working.dir=.*@wrapper.working.dir=/go@g /go-agent/wrapper-config/wrapper.conf
  $ exec /usr/local/sbin/tini -g -- /go/bin/go-agent console
  wrapper  | License Error:
  wrapper  | The License Key, 202105080000006, was found but failed to be validated.
  wrapper  | Please verify that the wrapper.license.* properties match exactly and have
  wrapper  | not been modified.  Also verify that the following property values match
  wrapper  | those specified when generating the license:
  wrapper  |   wrapper.java.mainclass=org.tanukisoftware.wrapper.WrapperJarApp
  wrapper  |   wrapper.app.parameter.1=lib/agent-bootstrapper.jar
  wrapper  |
  wrapper  | The Java Service Wrapper requires a License Key to activate the
  wrapper  | software.  Licenses can be purchased on the Java Service Wrapper
  wrapper  | web site:
  wrapper  |   http://wrapper.tanukisoftware.com/purchase
  wrapper  |
  wrapper  | You can also immediately obtain a one-month Free trial license:
  wrapper  |   http://wrapper.tanukisoftware.com/trial
  wrapper  |
  wrapper  | License Keys can be generated for the following HostId:
  wrapper  |   HostId #1 (eth0):       0242ac110003
  wrapper  |
  wrapper  | You may include license keys for several servers within a single file by
  wrapper  |   prefixing the property names of each key with their respective
  wrapper  |   server host name or HostId. Please use the following syntax:
  wrapper  |   wrapper.<hostname|hostid>.license.*.
  wrapper  |   The host name of this machine is: 0ca24dc2719a
  wrapper  |
  wrapper  | --> Wrapper Started as Console
  wrapper  | Java Service Wrapper Standard Edition 64-bit 3.5.41
  wrapper  |   Copyright (C) 1999-2019 Tanuki Software, Ltd. All Rights Reserved.
  wrapper  |     http://wrapper.tanukisoftware.com
  wrapper  |
  wrapper  | <-- Wrapper Stopped
```
