### PR TITLE
Correct OWASP dependency check NIST NVD URLs to the `1.1` versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:6.2.0'
+    classpath 'org.owasp:dependency-check-gradle:6.2.2'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.39.0'
     classpath 'gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0'
     classpath 'com.github.jk1:gradle-license-report:1.16'
@@ -182,8 +182,8 @@ dependencyCheck {
       baseUrl = "https://nvd.nist.gov/feeds"
     }
 
-    urlModified = "${baseUrl}/json/cve/1.0/nvdcve-1.0-modified.json.gz"
-    urlBase = "${baseUrl}/json/cve/1.0/nvdcve-1.0-%d.json.gz"
+    urlModified = "${baseUrl}/json/cve/1.1/nvdcve-1.1-modified.json.gz"
+    urlBase = "${baseUrl}/json/cve/1.1/nvdcve-1.1-%d.json.gz"
   }
 
   suppressionFile = rootProject.file('buildSrc/dependency-check-suppress.xml').toPath().toString()


### PR DESCRIPTION
These are now the default; there is no 2021 dataset for the `1.0` versions, which is causing the [current build failure](https://build.gocd.org/go/tab/build/detail/Security-Checks/4050/test/1/dependency-check).