### PR TITLE
Add workaround to allow agent `docker-dind` images to build again

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -193,8 +193,15 @@ enum Distro implements DistroBehavior {
 
     @Override
     List<DistroVersion> getSupportedVersions() {
+      def installSasl = [
+              'apk add --no-cache libsasl sudo',
+              // Workaround for https://github.com/docker-library/docker/commit/75e26edc9ea7fff4aa3212fafa5966f4d6b00022
+              // which causes a clash with glibc, which is installed later for AdoptOpenJDK and will serve the same purpose
+              'apk del --purge libc6-compat'
+      ]
+
       return [
-        new DistroVersion(version: 'dind', releaseName: 'dind', eolDate: parseDate('2099-01-01'), installPrerequisitesCommands: ['apk add --no-cache libsasl sudo'])
+        new DistroVersion(version: 'dind', releaseName: 'dind', eolDate: parseDate('2099-01-01'), installPrerequisitesCommands: installSasl)
       ]
     }
 


### PR DESCRIPTION
Builds currently fail as `glibc` cannot be installed over the top of `libc6-compat` which has been added in `docker:dind` base image to workaround an issue within `containerd`.

This commit should be reverted as soon as the builds start failing again (when `libc6-compat` is eventually removed from the base image)

See https://github.com/docker-library/docker/commit/75e26edc9ea7fff4aa3212fafa5966f4d6b00022 and https://github.com/containerd/containerd/issues/5824