### PR TITLE
Temporarily revert the Tanuki wrapper agent license changes

### DIFF
--- a/installers/include/wrapper-license-linux-go-agent.conf
+++ b/installers/include/wrapper-license-linux-go-agent.conf
@@ -4,14 +4,14 @@
 
 #encoding=UTF-8
 wrapper.license.type=DEV
-wrapper.license.id=202105080000024
+wrapper.license.id=202005280000044
 wrapper.license.licensee=ThoughtWorks
 wrapper.license.group=Go
 wrapper.license.dev_application=GoCD Agent On Linux
 wrapper.license.features=64bit
 wrapper.license.upgrade_term.begin_date=2008-06-03
-wrapper.license.upgrade_term.end_date=2022-06-03
-wrapper.license.key.1=1646-0b59-6dcb-3664
-wrapper.license.key.2=8e3f-ac5d-da87-59ed
-wrapper.license.key.3=e007-e28b-b9bc-33fd
-wrapper.license.key.4=6d9c-50fb-48de-3c32
+wrapper.license.upgrade_term.end_date=2021-06-03
+wrapper.license.key.1=3761-9c40-619b-5734
+wrapper.license.key.2=dbd9-8496-accb-7246
+wrapper.license.key.3=b87e-dec6-55b7-70f8
+wrapper.license.key.4=1972-88a8-dd0c-76ba

--- a/installers/include/wrapper-license-relative-path-go-agent.conf
+++ b/installers/include/wrapper-license-relative-path-go-agent.conf
@@ -4,14 +4,14 @@
 
 #encoding=UTF-8
 wrapper.license.type=DEV
-wrapper.license.id=202105080000006
+wrapper.license.id=202005280000063
 wrapper.license.licensee=ThoughtWorks
 wrapper.license.group=Go
 wrapper.license.dev_application=GoCD Agent
 wrapper.license.features=64bit
 wrapper.license.upgrade_term.begin_date=2008-06-03
-wrapper.license.upgrade_term.end_date=2022-06-03
-wrapper.license.key.1=efc0-eb52-aa12-7e09
-wrapper.license.key.2=4120-f870-fe68-e025
-wrapper.license.key.3=814e-be2f-02f8-c4c1
-wrapper.license.key.4=f1cf-8b71-23e1-32c6
+wrapper.license.upgrade_term.end_date=2021-06-03
+wrapper.license.key.1=5164-d32b-26a0-7133
+wrapper.license.key.2=cb32-608a-2394-58d8
+wrapper.license.key.3=a963-6b27-a993-fca2
+wrapper.license.key.4=78fb-eed1-e24c-35cf


### PR DESCRIPTION
As discussed in #9547, reverting these until we can get the relative license corrected, at least.