### PR TITLE
Resolve Gradle 7 docker task deprecations

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
@@ -26,9 +26,9 @@ trait DistroBehavior {
   }
 
   DistroVersion getVersion(String version) {
-    return supportedVersions.find { supportedVersion ->
+    return (supportedVersions.find { supportedVersion ->
       supportedVersion.version == version
-    }
+    }) ?: {throw new RuntimeException("Version [${version}] is not defined for this distro.")}()
   }
 
   List<String> getCreateUserAndGroupCommands() {


### PR DESCRIPTION
Currently there are Gradle 7 deprecation warnings for all of the docker image tasks. This PR

- does some minor cleanup to define the types of properties on this task to avoid the warnings; but likely does not change behaviour since we currently appear to disable output cachine and `UP-TO-DATE` checking on the tasks anyway
- adds ability to tell Gradle to keep images after build with `-PdockerBuildKeepImages` (it's very annoying when trying to do local testing or image security scanned that by default it `rm`s the images)
- (slightly unrelated) gives nicer feedback when you declare a dependency on an undeclared `DistroVersion`