### PR TITLE
Suppress additional CVEs off the bundled JRuby JQuery

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -70,6 +70,8 @@
         <cve>CVE-2015-9251</cve>
         <cve>CVE-2012-6708</cve>
         <cve>CVE-2019-11358</cve>
+        <cve>CVE-2020-11022</cve>
+        <cve>CVE-2020-11023</cve>
     </suppress>
 
     <suppress>


### PR DESCRIPTION
Suppresses a couple of additional CVEs raised against the JRuby-bundled JQuery version that have occured since the issues on the lib were initially suppressed some time ago.