### PR TITLE
Improve compatibility for cloning of config repo via Docker entrypoint

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-server/git-clone-config
+++ b/buildSrc/src/main/resources/gocd-docker-server/git-clone-config
@@ -7,7 +7,7 @@ try() { echo "$ $@" 1>&2; "$@" || die "cannot $*"; }
 try cd /godata/config
 # somehow this script and install-gocd-plugins called 2 times
 # so check if git repo already exists
-if [ ! -z "$CONFIG_GIT_REPO" ] && [ ! `git status` ]; then 
+if [ -n "$CONFIG_GIT_REPO" ] && ! git status; then
   yell "fill /godata/config from $CONFIG_GIT_REPO"
   BRANCH=$([ ! -z $CONFIG_GIT_BRANCH ] && echo $CONFIG_GIT_BRANCH || echo "master" )
   try git init


### PR DESCRIPTION
Issue: likely fixes #8878

Description: Currently this feature can fail (maybe only on some bash versions, still working out a specific reprod), I believe because the output of `git status` is a string with multiple args which can break single-bracket tests (`/usr/local/sbin/git-clone-config: line 10: [: too many arguments`).

The test bracketing seems unnecessary here given we just want to check the exit code of a command.