### PR TITLE
Revert "Bump @types/mithril from 2.0.6 to 2.0.8 in /server/src/main/webapp/WEB-INF/rails"

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -75,7 +75,7 @@
     "@types/lodash": "^4.14.172",
     "@types/lru-cache": "^5.1.0",
     "@types/mini-css-extract-plugin": "^1.4.3",
-    "@types/mithril": "2.0.8",
+    "@types/mithril": "2.0.6",
     "@types/node": "^15.6.2",
     "@types/optimize-css-assets-webpack-plugin": "^5.0.3",
     "@types/prismjs": "^1.16.5",

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -1255,10 +1255,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
   integrity sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==
 
-"@types/mithril@2.0.8":
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/@types/mithril/-/mithril-2.0.8.tgz#b7b6f58bdc7b244802f5ff919805e947d8e45b4e"
-  integrity sha512-QzVV70DqUhWfLFpMFDBI9rRxtzeUUpbhiFDpUJYSV92AePgl+Qfficgv2MOb1Ceb+lBOQU8+L+Hjf2UielQjEw==
+"@types/mithril@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/mithril/-/mithril-2.0.6.tgz#1e2a482b0d8bcfe83f4d61e4c370ec8534903984"
+  integrity sha512-oOyFr99rKH+94uKHjIVKTL9uaUaxtXJgtZOZkjhWIAY8twr9YzxfEmYARMJkWC3aVg52We8d4wtLhqQ99+fXpw==
 
 "@types/node@*":
   version "16.6.0"


### PR DESCRIPTION
Reverts gocd/gocd#9499

Broke build in https://build.gocd.org/go/tab/build/detail/build-linux/5535/build-non-server/1/Jasmine