### PR TITLE
Clean up license report metadata

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
@@ -52,6 +52,7 @@ class LicenseReport {
     CDDL_1_1_GPL_2_0,
     EDL_1_0,
     EPL_1_0,
+    EPL_2_0,
     GPL_2_0_CLASSPATH_EXCEPTION,
     LGPL_2_1,
     LGPL_3_0,

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/SpdxLicense.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/SpdxLicense.groovy
@@ -58,7 +58,7 @@ enum SpdxLicense {
   BSD_2_CLAUSE("BSD-2-Clause", "BSD 2-clause \"Simplified\" License", "The 2-Clause BSD License"),
   BSD_2_CLAUSE_FREEBSD("BSD-2-Clause-FreeBSD", "BSD 2-clause FreeBSD License"),
   BSD_2_CLAUSE_NETBSD("BSD-2-Clause-NetBSD", "BSD 2-clause NetBSD License"),
-  BSD_3_CLAUSE("BSD-3-Clause", "BSD 3-clause \"New\" or \"Revised\" License", "BSD 3-Clause", "The BSD 3-Clause License", "The 3-Clause BSD License"),
+  BSD_3_CLAUSE("BSD-3-Clause", "BSD 3-clause \"New\" or \"Revised\" License", "BSD 3-Clause", "The BSD 3-Clause License", "The 3-Clause BSD License", "BSD License 2.0"),
   BSD_3_CLAUSE_CLEAR("BSD-3-Clause-Clear", "BSD 3-clause Clear License"),
   BSD_4_ClAUSE("BSD-4-Clause", "BSD 4-clause \"Original\" or \"Old\" License"),
   BSD_PROTECTION("BSD-Protection", "BSD Protection License"),

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/SpdxLicense.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/SpdxLicense.groovy
@@ -130,6 +130,7 @@ enum SpdxLicense {
   DSDP("DSDP", "DSDP License"),
   DVIPDFM("dvipdfm", "dvipdfm License"),
   EPL_1_0("EPL-1.0", "Eclipse Public License 1.0", "Eclipse Public License - v 1.0", "Eclipse Public License - Version 1.0"),
+  EPL_2_0("EPL-2.0", "Eclipse Public License 2.0", "Eclipse Public License - v 2.0", "Eclipse Public License - Version 2.0"),
   ECL_1_0("ECL-1.0", "Educational Community License v1.0"),
   ECL_2_0("ECL-2.0", "Educational Community License v2.0"),
   EGENIX("eGenix", "eGenix.com Public License 1.1.0"),

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -952,27 +952,14 @@ task licenseReportAggregate {
       ]
     ],
     [
-      moduleName    : 'net.sf.ehcache:ehcache',
-      moduleVersion : '2.10.5',
+      moduleName    : 'org.ow2.asm:asm',
+      moduleVersion : '7.1',
       moduleUrls    : [
-        "http://ehcache.org",
-        'http://www.terracotta.org'
+        "https://asm.ow2.io/"
       ],
       moduleLicenses: [
         [
-          moduleLicense   : 'Apache License, Version 2.0',
-          moduleLicenseUrl: "http://www.apache.org/licenses/LICENSE-2.0"
-        ]
-      ]
-    ],
-    [
-      moduleName    : 'asm:asm',
-      moduleVersion : '1.5.3',
-      moduleUrls    : [
-        "http://asm.objectweb.org/"
-      ],
-      moduleLicenses: [
-        [
+          // License is automatically detected as 0BSD by gradle-license-report, but appears to actually be BSD-3-Clause in nature
           moduleLicense   : 'BSD-3-Clause',
           moduleLicenseUrl: "https://spdx.org/licenses/BSD-3-Clause.html"
         ]
@@ -1009,19 +996,6 @@ task licenseReportAggregate {
       moduleVersion : project.versions.jolt,
       moduleUrls    : [
         "https://github.com/bazaarvoice/jolt"
-      ],
-      moduleLicenses: [
-        [
-          moduleLicense   : 'Apache-2.0',
-          moduleLicenseUrl: "https://spdx.org/licenses/Apache-2.0.html"
-        ]
-      ]
-    ],
-    [
-      moduleName    : 'com.googlecode.javaewah:JavaEWAH',
-      moduleVersion : '1.1.7',
-      moduleUrls    : [
-        "https://github.com/lemire/javaewah"
       ],
       moduleLicenses: [
         [
@@ -1073,15 +1047,16 @@ task licenseReportAggregate {
       moduleName    : 'jaxen:jaxen',
       moduleVersion : project.versions.jaxen,
       moduleUrls    : [
-        "http://jaxen.codehaus.org/"
+        "http://www.cafeconleche.org/jaxen/"
       ],
       moduleLicenses: [
         [
+          // License is automatically detected as 0BSD by gradle-license-report, but appears to actually be BSD-3-Clause in nature
           moduleLicense   : 'BSD-3-Clause',
           moduleLicenseUrl: "https://spdx.org/licenses/BSD-3-Clause.html"
         ]
       ]
-    ]
+    ],
   ]
 
   def goCDJarsWithoutLicenses = ['agent-launcher.jar',


### PR DESCRIPTION
- Adds EPL 2.0 SPDX license (which Eclipse projects are transiting towards, see https://www.eclipse.org/legal/epl-2.0/faq.php#h.hz76esowpykz )
- Removes license metadata overrides for libraries which are now unused, or which publish license information in an automatically discoverable way
- Corrects a couple of the overrides which have had "drift" from the underlying transitive dependencies over time

See #9464 for a library recently re-licensed under EPL 2.0 (AspectJ, per https://github.com/eclipse/org.aspectj/commit/49cb924f5402c9d24379ae1af62def6fa5892649) requiring this to proceed