### PR TITLE
Revert "Bump bcprov-jdk15on from 1.68 to 1.69"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -32,7 +32,7 @@ final Map<String, String> libraries = [
   aspectj             : 'org.aspectj:aspectjrt:1.9.6',
   assertJ             : 'org.assertj:assertj-core:3.20.2',
   assertJ_DB          : 'org.assertj:assertj-db:2.0.2',
-  bouncyCastle        : 'org.bouncycastle:bcprov-jdk15on:1.69', // This version of BC is not compatible with the jruby-opensssl version, since we are not using jruby-opensssl going ahead with the upgrade.
+  bouncyCastle        : 'org.bouncycastle:bcprov-jdk15on:1.68', // This version of BC is not compatible with the jruby-opensssl version, since we are not using jruby-opensssl going ahead with the upgrade.
   bundler             : 'rubygems:bundler:2.1.1',
   cglib               : 'cglib:cglib:3.3.0',
   cloning             : 'io.github.kostaskougios:cloning:1.10.3',

--- a/server-launcher/build.gradle
+++ b/server-launcher/build.gradle
@@ -197,7 +197,6 @@ task verifyFatJar(type: VerifyJarTask) {
       "tfs-impl-14.jar",
     ],
     "lib"         : [
-      "bcutil-jdk15on-${project.versions.bouncyCastle}.jar",
       "bcpkix-jdk15on-${project.versions.bouncyCastle}.jar",
       "bcprov-jdk15on-${project.versions.bouncyCastle}.jar",
       "commons-io-${project.versions.commonsIO}.jar",


### PR DESCRIPTION
Reverts gocd/gocd#9579

Reverting this, as I have noted that Bouncy Castle is packaged inside `agent-launcher` and `agent` fat jars in some way that is different to the server. The `packagingOnly` configuration is excluding transitives so this new `bcutil` jar is not available by default in `agent-launcher` or `agent` jars.

While the builds are fine, I need some more context to determine the right thing to do here to ensure there aren't class loader issues or `ClassNotFoundException`s with agents upon bootstrapping/launching.