### PR TITLE
Bump Apache Felix Framework from 5.6.10 to 5.6.12

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -51,7 +51,7 @@ final Map<String, String> libraries = [
   dbunit              : 'org.dbunit:dbunit:2.7.2',
   dom4j               : 'dom4j:dom4j:1.6.1',
   ehcache             : 'net.sf.ehcache:ehcache:2.10.9.2',
-  felix               : 'org.apache.felix:org.apache.felix.framework:5.6.10',
+  felix               : 'org.apache.felix:org.apache.felix.framework:5.6.12',
   freemarker          : 'org.freemarker:freemarker:2.3.31',
   gradleDownload      : 'de.undercouch:gradle-download-task:4.1.2',
   grolifant           : 'org.ysb33r.gradle:grolifant:0.17.0',


### PR DESCRIPTION
Only fix is https://issues.apache.org/jira/browse/FELIX-6035 which may be useful/required for Java 16 support without `add-opens` (in case we haven't gone to Felix 6 by then)

https://github.com/apache/felix-dev/compare/org.apache.felix.framework-5.6.10...org.apache.felix.framework-5.6.12
