### PR TITLE
Bump Gradle from 6.6.1 to 6.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -240,7 +240,6 @@ allprojects {
 
   repositories {
     mavenCentral()
-    maven { url "https://repo1.maven.org/maven2/" } // for things that disappeared from repo.maven.apache.org
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -245,8 +245,8 @@ allprojects {
 
 idea {
   project {
-    jdkName = '11'
-    languageLevel = '11'
+    jdkName = project.compilerOptions.targetCompatibility
+    languageLevel = project.compilerOptions.sourceCompatibility
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ List<String> partitionFiles(Collection originalFiles) {
 
   def allPartitions = files.collate(testsPerBucket)
   def currentPartition = allPartitions[currentWorkerIndex - 1]
-  return currentPartition ?: []
+  return currentPartition ?: [] as List<String>
 }
 
 def GO_VERSION_PREVIOUS = '21.2.0'
@@ -415,7 +415,6 @@ subprojects {
 
     pmd {
       ignoreFailures = true
-      toolVersion = '6.17.0'
       ruleSetFiles = files(rootProject.file('buildSrc/pmd.xml'))
       ruleSets = []
       incrementalAnalysis = true

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -19,12 +19,6 @@ apply plugin: "groovy"
 
 repositories {
   mavenCentral()
-  jcenter {
-    content {
-      // this repository contains everything BUT artifacts with group starting with "my.company"
-      includeModule "org.ysb33r.gradle", "grolifant"
-    }
-  }
 }
 
 dependencies {

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/DownloaderTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/DownloaderTask.groovy
@@ -18,26 +18,27 @@ package com.thoughtworks.go.build
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
-import org.ysb33r.grolifant.api.AbstractDistributionInstaller
-import org.ysb33r.grolifant.api.OperatingSystem
+import org.ysb33r.grolifant.api.core.OperatingSystem
+import org.ysb33r.grolifant.api.core.ProjectOperations
+import org.ysb33r.grolifant.api.v4.downloader.AbstractDistributionInstaller
 
 class DownloaderTask extends DefaultTask {
   String executable
   String url
-  String packageName;
-  String packageVersion;
+  String packageName
+  String packageVersion
 
   @TaskAction
-  public void perform() {
+  void perform() {
     AbstractDistributionInstaller installer = createInstaller()
     // perform the download
-    File distributionRoot = installer.getDistributionRoot()
+    File distributionRoot = installer.getDistributionRoot(packageVersion).get()
     extensions.ext.outputDir = distributionRoot
-    extensions.ext.absoluteBinaryPath = project.file("${distributionRoot}/${OperatingSystem.current().getExecutableName(executable)}")
+    extensions.ext.absoluteBinaryPath = project.file("${distributionRoot}/${OperatingSystem.current().getExecutableNames(executable).first()}")
   }
 
   private AbstractDistributionInstaller createInstaller() {
-    new AbstractDistributionInstaller(packageName, packageVersion, "download/${packageName}/${packageVersion}", project) {
+    new AbstractDistributionInstaller(packageName, "download/${packageName}/${packageVersion}", ProjectOperations.find(project)) {
 
       @Override
       URI uriFromVersion(String version) {
@@ -45,7 +46,7 @@ class DownloaderTask extends DefaultTask {
       }
 
       @Override
-      protected File getAndVerifyDistributionRoot(File distDir, String distributionDescription) {
+      protected File verifyDistributionRoot(File distDir) {
         distDir
       }
     }

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/DownloaderTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/DownloaderTask.groovy
@@ -17,15 +17,20 @@
 package com.thoughtworks.go.build
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.ysb33r.grolifant.api.core.OperatingSystem
 import org.ysb33r.grolifant.api.core.ProjectOperations
 import org.ysb33r.grolifant.api.v4.downloader.AbstractDistributionInstaller
 
 class DownloaderTask extends DefaultTask {
+  @Input
   String executable
+  @Input
   String url
+  @Input
   String packageName
+  @Input
   String packageVersion
 
   @TaskAction

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -54,7 +54,7 @@ final Map<String, String> libraries = [
   felix               : 'org.apache.felix:org.apache.felix.framework:5.6.12',
   freemarker          : 'org.freemarker:freemarker:2.3.31',
   gradleDownload      : 'de.undercouch:gradle-download-task:4.1.2',
-  grolifant           : 'org.ysb33r.gradle:grolifant:0.17.0',
+  grolifant           : 'org.ysb33r.gradle:grolifant60:1.1.0',
   gson                : 'com.google.code.gson:gson:2.8.8',
   guava               : 'com.google.guava:guava:30.1.1-jre',
   h2                  : 'com.h2database:h2:1.4.200',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Reduces the delta from Gradle 7 by ensuring we have the latest set of deprecation warnings and features.

Additionally, this PR
- upgrades Grolifant library to latest version; resolving some deprecations
- removes use of JCenter entirely
- removes use of legacy Maven Central direct URL repo which does not seem to be required now
- Avoids hard-coding PMD toolVersion which will end up coupling to plugin version and Gradle version