### PR TITLE
Bump mockito-core from 3.12.0 to 3.12.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -83,7 +83,7 @@ final Map<String, String> libraries = [
   logback             : 'ch.qos.logback:logback-classic:1.2.5',
   lombok              : 'org.projectlombok:lombok:1.18.20',
   mail                : 'com.sun.mail:mailapi:1.6.1',
-  mockito             : 'org.mockito:mockito-core:3.12.0',
+  mockito             : 'org.mockito:mockito-core:3.12.1',
   mybatis             : 'org.mybatis:mybatis:3.5.7',
   mybatisSpring       : 'org.mybatis:mybatis-spring:2.0.6',
   mysql               : 'mysql:mysql-connector-java:8.0.26',


### PR DESCRIPTION
There has been a bit of instability in Mockito tests with weird values since bump to 3.12.0. Attempting 3.12.1 patch to see if things come back to normal.

https://github.com/mockito/mockito/releases/tag/v3.12.1