### PR TITLE
Downgrade mockito-core from 3.12.1 to 3.11.2

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -83,7 +83,7 @@ final Map<String, String> libraries = [
   logback             : 'ch.qos.logback:logback-classic:1.2.5',
   lombok              : 'org.projectlombok:lombok:1.18.20',
   mail                : 'com.sun.mail:mailapi:1.6.1',
-  mockito             : 'org.mockito:mockito-core:3.12.1',
+  mockito             : 'org.mockito:mockito-core:3.11.2',
   mybatis             : 'org.mybatis:mybatis:3.5.7',
   mybatisSpring       : 'org.mybatis:mybatis-spring:2.0.6',
   mysql               : 'mysql:mysql-connector-java:8.0.26',


### PR DESCRIPTION
We seem to be getting some strange instability on Mockito 3.12.0 and 3.12.1. Reverting to see if things stabilise or whether this is a red herring. https://github.com/mockito/mockito/issues/2399