### PR TITLE
Corrects usage of filesize library to the previous behaviour

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/agents/agents.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/agents/agents.ts
@@ -150,7 +150,7 @@ export class Agent {
   readableFreeSpace() {
     try {
       if (_.isNumber(this.freeSpace)) {
-        return filesize(this.freeSpace);
+        return filesize(this.freeSpace, {base: 2, standard: "jedec"});
       } else {
         return "Unknown";
       }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/server_info/server_info_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/server_info/server_info_widget.tsx
@@ -33,7 +33,7 @@ export class ServerInfoWidget extends MithrilViewComponent<Attrs> {
       [<div class={styles.key}>Go Server Version:</div>, meta.go_server_version],
       [<div class={styles.key}>JVM version:</div>, meta.jvm_version],
       [<div class={styles.key}>OS Information:</div>, meta.os_information],
-      [<div class={styles.key}>Usable space in artifacts repository:</div>, filesize(meta.usable_space_in_artifacts_repository)],
+      [<div class={styles.key}>Usable space in artifacts repository:</div>, filesize(meta.usable_space_in_artifacts_repository, {base: 2, standard: "jedec"})],
       [<div class={styles.key}>Pipelines Count:</div>, meta.pipeline_count],
     ];
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/server_info/spec/server_info_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/server_info/spec/server_info_widget_spec.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import filesize from "filesize";
 import m from "mithril";
 import {ServerInfoWidget} from "views/pages/server_info/server_info_widget";
 import {TestHelper} from "views/pages/spec/test_helper";
@@ -31,7 +30,7 @@ describe("Server Info Widget", () => {
     os_information: "Linux 4.14.104-95.84.amzn2.x86_64",
   };
 
-  it("should show Sever Information", () => {
+  it("should show Server Information", () => {
     mount();
 
     expect(helper.textByTestId("about-page")).toContain("Go Server Version:");
@@ -44,7 +43,7 @@ describe("Server Info Widget", () => {
     expect(helper.textByTestId("about-page")).toContain(metaInfo.os_information);
 
     expect(helper.textByTestId("about-page")).toContain("Usable space in artifacts repository:");
-    expect(helper.textByTestId("about-page")).toContain(filesize(metaInfo.usable_space_in_artifacts_repository));
+    expect(helper.textByTestId("about-page")).toContain("117.73 MB");
 
     expect(helper.textByTestId("about-page")).toContain("Pipelines Count:");
     expect(helper.textByTestId("about-page")).toContain(`${metaInfo.pipeline_count}`);


### PR DESCRIPTION
In v8 (#9615) `filesize` changed the default to IEC standard for base 2 units (KiB, MiB, GiB etc) , and default to base 10, which would use SI units of display. We seem to be using base 2 with KB/MB/GB etc (JEDEC standard?) in other places such as the server backup size, and Commons IO is written that way for some server-side stuff, so not changing at this stage, even though it's probably not desirable.

There is an argument that we'd be better to use base 10 (w/ IEC units) rather than base 2, however rather than change this behaviour this just keeps the original behaviour. (ref policies such as https://wiki.ubuntu.com/UnitsPolicy )

https://github.com/avoidwork/filesize.js/compare/7.0.0...8.0.0