### PR TITLE
Fix temporary directory usage in Tests on Windows

### DIFF
--- a/base/src/test/java/com/thoughtworks/go/util/ZipUtilTest.java
+++ b/base/src/test/java/com/thoughtworks/go/util/ZipUtilTest.java
@@ -52,7 +52,7 @@ public class ZipUtilTest {
     private File emptyDir;
 
     private static String fileContent(File file) throws IOException {
-        return IOUtils.toString(new FileInputStream(file), UTF_8);
+        return Files.readString(file.toPath());
     }
 
     @BeforeEach

--- a/common/src/test/java/com/thoughtworks/go/domain/TestArtifactPlanTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/TestArtifactPlanTest.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.domain;
 import com.thoughtworks.go.util.TempDirUtils;
 import com.thoughtworks.go.work.DefaultGoPublisher;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -50,7 +51,8 @@ public class TestArtifactPlanTest {
         );
         compositeTestArtifact.publishBuiltInArtifacts(mockArtifactPublisher, rootPath.toFile());
         verify(mockArtifactPublisher).taggedConsumeLineWithPrefix(DefaultGoPublisher.PUBLISH_ERR,
-                String.format("The Directory %s/some_random_path_that_does_not_exist specified as a test artifact was not found. Please check your configuration", rootPath.toString()));
+                String.format("The Directory %s specified as a test artifact was not found. Please check your configuration",
+                        FilenameUtils.separatorsToUnix(rootPath.resolve("some_random_path_that_does_not_exist").toString())));
     }
 
     @Test


### PR DESCRIPTION
Follows up on #9624 by fixing some test expectations on Windows.

- The JUnit5 temporary directory cleanup is more strict than the old JUnit4 one, and will complain if it cannot delete files in the temporary directory it created, e.g due to file locks
- Some test expectations were accidentally FileSystem sensitive