### PR TITLE
Perform some basic test & deprecation cleanup

### DIFF
--- a/agent/src/test/java/com/thoughtworks/go/agent/service/TokenRequesterTest.java
+++ b/agent/src/test/java/com/thoughtworks/go/agent/service/TokenRequesterTest.java
@@ -68,7 +68,7 @@ class TokenRequesterTest {
         verify(httpClient).execute(argumentCaptor.capture());
 
         final HttpRequestBase requestBase = argumentCaptor.getValue();
-        final List<NameValuePair> nameValuePairs = URLEncodedUtils.parse(requestBase.getURI(), StandardCharsets.UTF_8.name());
+        final List<NameValuePair> nameValuePairs = URLEncodedUtils.parse(requestBase.getURI(), StandardCharsets.UTF_8);
 
         assertThat(token).isEqualTo("token-from-server");
         assertThat(findParam(nameValuePairs, "uuid").getValue()).isEqualTo("agent-uuid");

--- a/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/AdminUserAccessTokenControllerV1Test.groovy
+++ b/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/AdminUserAccessTokenControllerV1Test.groovy
@@ -43,6 +43,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 import spark.servlet.SparkFilter
 
 import javax.servlet.FilterConfig
@@ -53,17 +55,12 @@ import static com.thoughtworks.go.apiv1.accessToken.representers.AccessTokenRepr
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AdminUserAccessTokenControllerV1Test implements ControllerTrait<AdminUserAccessTokenControllerV1>, SecurityServiceTrait {
   @Mock
   AccessTokenService accessTokenService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
-
+  
   @Override
   AdminUserAccessTokenControllerV1 createControllerInstance() {
     return new AdminUserAccessTokenControllerV1(new ApiAuthenticationHelper(securityService, goConfigService), accessTokenService)

--- a/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1Test.groovy
+++ b/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1Test.groovy
@@ -47,6 +47,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 import spark.servlet.SparkFilter
 
 import javax.servlet.FilterConfig
@@ -56,8 +58,8 @@ import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.apiv1.accessToken.representers.AccessTokenRepresenterTest.randomAccessToken
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class CurrentUserAccessTokenControllerV1Test implements ControllerTrait<CurrentUserAccessTokenControllerV1>, SecurityServiceTrait {
   @Mock
   SecurityAuthConfigService authConfigService
@@ -65,11 +67,6 @@ class CurrentUserAccessTokenControllerV1Test implements ControllerTrait<CurrentU
   AccessTokenService accessTokenService
   @Mock
   AuthorizationExtension extension
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   CurrentUserAccessTokenControllerV1 createControllerInstance() {

--- a/api/api-admins-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2Test.groovy
+++ b/api/api-admins-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2Test.groovy
@@ -101,7 +101,7 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
           .isOk()
           .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(config, AdminsConfigRepresenter)
+          .hasBodyWithJsonObject(AdminsConfigRepresenter, config)
       }
 
       @Test
@@ -127,7 +127,7 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
           .isOk()
           .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(config, AdminsConfigRepresenter)
+          .hasBodyWithJsonObject(AdminsConfigRepresenter, config)
       }
     }
   }
@@ -185,7 +185,7 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(configFromRequest, AdminsConfigRepresenter)
+          .hasBodyWithJsonObject(AdminsConfigRepresenter, configFromRequest)
       }
 
       @Test
@@ -291,7 +291,7 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(expectedConfig, AdminsConfigRepresenter)
+          .hasBodyWithJsonObject(AdminsConfigRepresenter, expectedConfig)
       }
 
       @Test
@@ -317,7 +317,7 @@ class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, Secur
         assertThatResponse()
           .isUnprocessableEntity()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(result, BulkUpdateFailureResultRepresenter.class)
+          .hasBodyWithJsonObject(BulkUpdateFailureResultRepresenter.class, result)
       }
     }
   }

--- a/api/api-admins-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2Test.groovy
+++ b/api/api-admins-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2Test.groovy
@@ -36,24 +36,21 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.verify
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, SecurityServiceTrait {
   @Mock
   private AdminsConfigService adminsConfigService
   @Mock
   private EntityHashingService entityHashingService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   AdminControllerV2 createControllerInstance() {

--- a/api/api-agent-job-history-v1/src/test/groovy/com/thoughtworks/go/apiv1/agentjobhistory/AgentJobHistoryControllerV1Test.groovy
+++ b/api/api-agent-job-history-v1/src/test/groovy/com/thoughtworks/go/apiv1/agentjobhistory/AgentJobHistoryControllerV1Test.groovy
@@ -35,22 +35,19 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AgentJobHistoryControllerV1Test implements SecurityServiceTrait, ControllerTrait<AgentJobHistoryControllerV1> {
 
   @Mock
   JobInstanceService jobInstanceService
   @Mock
   AgentService agentService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   AgentJobHistoryControllerV1 createControllerInstance() {

--- a/api/api-agents-v7/src/test/groovy/com/thoughtworks/go/apiv7/agents/AgentsControllerV7Test.groovy
+++ b/api/api-agents-v7/src/test/groovy/com/thoughtworks/go/apiv7/agents/AgentsControllerV7Test.groovy
@@ -36,11 +36,12 @@ import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.util.TriState
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import java.util.stream.Stream
 
@@ -54,19 +55,14 @@ import static java.util.Collections.*
 import static java.util.stream.Collectors.toSet
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AgentsControllerV7Test implements SecurityServiceTrait, ControllerTrait<AgentsControllerV7> {
   @Mock
   private AgentService agentService
 
   @Mock
   private EnvironmentConfigService environmentConfigService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   AgentsControllerV7 createControllerInstance() {

--- a/api/api-agents-v7/src/test/groovy/com/thoughtworks/go/apiv7/agents/representers/AgentRepresenterTest.groovy
+++ b/api/api-agents-v7/src/test/groovy/com/thoughtworks/go/apiv7/agents/representers/AgentRepresenterTest.groovy
@@ -27,6 +27,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import java.util.stream.Stream
 
@@ -39,16 +41,11 @@ import static org.assertj.core.api.Assertions.assertThat
 import static org.mockito.ArgumentMatchers.anyString
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AgentRepresenterTest {
   @Mock
   private SecurityService securityService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Test
   void 'renders an agent with hal representation'() {

--- a/api/api-agents-v7/src/test/groovy/com/thoughtworks/go/apiv7/agents/representers/AgentsRepresenterTest.groovy
+++ b/api/api-agents-v7/src/test/groovy/com/thoughtworks/go/apiv7/agents/representers/AgentsRepresenterTest.groovy
@@ -20,9 +20,10 @@ import com.thoughtworks.go.domain.AgentInstance
 import com.thoughtworks.go.server.domain.Username
 import com.thoughtworks.go.server.service.SecurityService
 import com.thoughtworks.go.util.SystemUtil
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
@@ -33,16 +34,11 @@ import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.anyString
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AgentsRepresenterTest {
   @Mock
   private SecurityService securityService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Test
   void 'should represent agents'() {

--- a/api/api-api-info-v1/src/test/groovy/com/thoughtworks/go/apiv1/apiinfo/ApiInfoControllerV1Test.groovy
+++ b/api/api-api-info-v1/src/test/groovy/com/thoughtworks/go/apiv1/apiinfo/ApiInfoControllerV1Test.groovy
@@ -29,18 +29,14 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 import spark.route.HttpMethod
 
-import static org.mockito.MockitoAnnotations.initMocks
-
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ApiInfoControllerV1Test implements SecurityServiceTrait, ControllerTrait<ApiInfoControllerV1> {
   @Mock
   private RouteInformationProvider provider
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   ApiInfoControllerV1 createControllerInstance() {

--- a/api/api-artifact-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/artifactconfig/ArtifactConfigControllerV1Test.groovy
+++ b/api/api-artifact-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/artifactconfig/ArtifactConfigControllerV1Test.groovy
@@ -30,12 +30,14 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.apiv1.artifactconfig.represernter.ArtifactConfigRepresenter.toJSON
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ArtifactConfigControllerV1Test implements SecurityServiceTrait, ControllerTrait<ArtifactConfigControllerV1> {
 
     @Mock
@@ -43,11 +45,6 @@ class ArtifactConfigControllerV1Test implements SecurityServiceTrait, Controller
 
     @Mock
     EntityHashingService entityHashingService
-
-    @BeforeEach
-    void setUp() {
-        initMocks(this)
-    }
 
     @Override
     ArtifactConfigControllerV1 createControllerInstance() {

--- a/api/api-artifact-store-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/artifactstoreconfig/ArtifactStoreConfigControllerTest.groovy
+++ b/api/api-artifact-store-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/artifactstoreconfig/ArtifactStoreConfigControllerTest.groovy
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectWithoutLinks
@@ -44,8 +46,8 @@ import static com.thoughtworks.go.api.util.HaltApiMessages.*
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStoreConfigController>, SecurityServiceTrait {
 
   @Mock
@@ -53,11 +55,6 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
 
   @Mock
   EntityHashingService entityHashingService
-
-  @BeforeEach
-  void setup() {
-    initMocks(this)
-  }
 
   @Override
   ArtifactStoreConfigController createControllerInstance() {

--- a/api/api-artifact-store-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/artifactstoreconfig/ArtifactStoreConfigControllerTest.groovy
+++ b/api/api-artifact-store-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/artifactstoreconfig/ArtifactStoreConfigControllerTest.groovy
@@ -98,7 +98,7 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(artifactStores, ArtifactStoresRepresenter)
+          .hasBodyWithJsonObject(ArtifactStoresRepresenter, artifactStores)
       }
     }
   }
@@ -148,7 +148,7 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
           .isOk()
           .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(artifactStore, ArtifactStoreRepresenter)
+          .hasBodyWithJsonObject(ArtifactStoreRepresenter, artifactStore)
       }
 
       @Test
@@ -190,7 +190,7 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
           .isOk()
           .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(artifactStore, ArtifactStoreRepresenter)
+          .hasBodyWithJsonObject(ArtifactStoreRepresenter, artifactStore)
       }
     }
   }
@@ -233,7 +233,7 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
           .isOk()
           .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(artifactStore, ArtifactStoreRepresenter)
+          .hasBodyWithJsonObject(ArtifactStoreRepresenter, artifactStore)
       }
 
       @Test
@@ -352,7 +352,7 @@ class ArtifactStoreConfigControllerTest implements ControllerTrait<ArtifactStore
           .isOk()
           .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(newArtifactStore, ArtifactStoreRepresenter)
+          .hasBodyWithJsonObject(ArtifactStoreRepresenter, newArtifactStore)
       }
 
       @Test

--- a/api/api-backup-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/backupconfig/BackupConfigControllerV1Test.groovy
+++ b/api/api-backup-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/backupconfig/BackupConfigControllerV1Test.groovy
@@ -28,23 +28,20 @@ import com.thoughtworks.go.spark.SecurityServiceTrait
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.ArgumentMatchers.isA
 import static org.mockito.Mockito.verify
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class BackupConfigControllerV1Test implements SecurityServiceTrait, ControllerTrait<BackupConfigControllerV1> {
   @Override
   BackupConfigControllerV1 createControllerInstance() {
     new BackupConfigControllerV1(new ApiAuthenticationHelper(securityService, goConfigService), goConfigService)
-  }
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
   }
 
   @Nested

--- a/api/api-backups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/backups/BackupsControllerTest.groovy
+++ b/api/api-backups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/backups/BackupsControllerTest.groovy
@@ -21,16 +21,13 @@ import com.thoughtworks.go.apiv1.admin.backups.representers.BackupRepresenter
 import com.thoughtworks.go.server.domain.BackupStatus
 import com.thoughtworks.go.server.domain.ServerBackup
 import com.thoughtworks.go.server.service.BackupService
-import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult
 import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.invocation.InvocationOnMock
 
 import static com.thoughtworks.go.api.util.HaltApiMessages.deprecatedConfirmHeaderMissing
-import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
 
@@ -71,7 +68,7 @@ class BackupsControllerTest implements ControllerTrait<BackupsController>, Secur
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(backup, BackupRepresenter.class)
+          .hasBodyWithJsonObject(BackupRepresenter.class, backup)
       }
     }
 

--- a/api/api-backups-v2/src/test/groovy/com/thoughtworks/go/apiv2/backups/BackupsControllerV2Test.groovy
+++ b/api/api-backups-v2/src/test/groovy/com/thoughtworks/go/apiv2/backups/BackupsControllerV2Test.groovy
@@ -138,7 +138,7 @@ class BackupsControllerV2Test implements SecurityServiceTrait, ControllerTrait<B
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject(backup, BackupRepresenter.class)
+          .hasBodyWithJsonObject(BackupRepresenter.class, backup)
           .hasContentType(controller.mimeType)
       }
 
@@ -151,7 +151,7 @@ class BackupsControllerV2Test implements SecurityServiceTrait, ControllerTrait<B
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject(backup, BackupRepresenter.class)
+          .hasBodyWithJsonObject(BackupRepresenter.class, backup)
           .hasContentType(controller.mimeType)
       }
 

--- a/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/RerouteLatestApisImplTest.groovy
+++ b/api/api-base/src/test/groovy/com/thoughtworks/go/api/spring/RerouteLatestApisImplTest.groovy
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 import org.springframework.context.ApplicationContext
 import spark.*
 import spark.servlet.SparkFilter
@@ -40,9 +42,9 @@ import java.util.stream.Collectors
 import static org.assertj.core.api.Assertions.assertThat
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 import static spark.Spark.*
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class RerouteLatestApisImplTest {
     @Mock
     Filter apiv11BeforeFilter1
@@ -97,7 +99,6 @@ class RerouteLatestApisImplTest {
 
     @BeforeEach
     void setUp() {
-        initMocks(this)
         routeInformationProvider = new RouteInformationProvider()
 
         controller1 = new SparkController() {

--- a/api/api-build_cause-v1/src/test/groovy/com/thoughtworks/go/apiv1/buildcause/BuildCauseControllerTest.groovy
+++ b/api/api-build_cause-v1/src/test/groovy/com/thoughtworks/go/apiv1/buildcause/BuildCauseControllerTest.groovy
@@ -34,22 +34,19 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.doAnswer
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class BuildCauseControllerTest implements ControllerTrait<BuildCauseController>, SecurityServiceTrait {
 
   @Mock
   private PipelineHistoryService pipelineHistoryService
-
-  @BeforeEach
-  void setup() {
-    initMocks(this)
-  }
 
   @Override
   BuildCauseController createControllerInstance() {

--- a/api/api-build_cause-v1/src/test/groovy/com/thoughtworks/go/apiv1/buildcause/BuildCauseControllerTest.groovy
+++ b/api/api-build_cause-v1/src/test/groovy/com/thoughtworks/go/apiv1/buildcause/BuildCauseControllerTest.groovy
@@ -91,7 +91,7 @@ class BuildCauseControllerTest implements ControllerTrait<BuildCauseController>,
 
       assertThatResponse()
         .isOk()
-        .hasBodyWithJsonObject(pipelineInstanceModel.buildCause, BuildCauseRepresenter)
+        .hasBodyWithJsonObject(BuildCauseRepresenter, pipelineInstanceModel.buildCause)
     }
 
     @Test

--- a/api/api-cctray/src/test/groovy/com/thoughtworks/go/api/cctray/CctrayControllerTest.groovy
+++ b/api/api-cctray/src/test/groovy/com/thoughtworks/go/api/cctray/CctrayControllerTest.groovy
@@ -21,27 +21,23 @@ import com.thoughtworks.go.server.service.CcTrayService
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import java.util.function.Consumer
 
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class CctrayControllerTest implements SecurityServiceTrait, ControllerTrait<CctrayController> {
   @Mock
   private CcTrayService ccTrayService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   CctrayController createControllerInstance() {

--- a/api/api-cluster-profiles-v1/src/test/groovy/com/thoughtworks/go/apiv1/clusterprofiles/ClusterProfilesControllerV1Test.groovy
+++ b/api/api-cluster-profiles-v1/src/test/groovy/com/thoughtworks/go/apiv1/clusterprofiles/ClusterProfilesControllerV1Test.groovy
@@ -95,7 +95,7 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(new ClusterProfiles(clusterProfile), ClusterProfilesRepresenter.class)
+          .hasBodyWithJsonObject(ClusterProfilesRepresenter.class, new ClusterProfiles(clusterProfile))
       }
     }
   }
@@ -139,7 +139,7 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
           .isOk()
           .hasContentType(controller.mimeType)
           .hasEtag('"digest"')
-          .hasBodyWithJsonObject(clusterProfile, ClusterProfileRepresenter.class)
+          .hasBodyWithJsonObject(ClusterProfileRepresenter.class, clusterProfile)
       }
 
       @Test
@@ -204,7 +204,7 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
           .isOk()
           .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(clusterProfile, ClusterProfileRepresenter)
+          .hasBodyWithJsonObject(ClusterProfileRepresenter, clusterProfile)
       }
 
       @Test
@@ -361,7 +361,7 @@ class ClusterProfilesControllerV1Test implements SecurityServiceTrait, Controlle
           .isOk()
           .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(updatedCluster, ClusterProfileRepresenter)
+          .hasBodyWithJsonObject(ClusterProfileRepresenter, updatedCluster)
       }
 
       @Test

--- a/api/api-cluster-profiles-v1/src/test/groovy/com/thoughtworks/go/apiv1/clusterprofiles/ClusterProfilesControllerV1Test.groovy
+++ b/api/api-cluster-profiles-v1/src/test/groovy/com/thoughtworks/go/apiv1/clusterprofiles/ClusterProfilesControllerV1Test.groovy
@@ -36,24 +36,22 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
-import static com.thoughtworks.go.api.util.HaltApiMessages.*
+import static com.thoughtworks.go.api.util.HaltApiMessages.etagDoesNotMatch
+import static com.thoughtworks.go.api.util.HaltApiMessages.renameOfEntityIsNotSupportedMessage
 import static com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother.create
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ClusterProfilesControllerV1Test implements SecurityServiceTrait, ControllerTrait<ClusterProfilesControllerV1> {
   @Mock
   ClusterProfilesService clusterProfilesService
 
   @Mock
   EntityHashingService entityHashingService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   ClusterProfilesControllerV1 createControllerInstance() {

--- a/api/api-compare-v2/src/test/groovy/com/thoughtworks/go/apiv2/compare/CompareControllerV2Test.groovy
+++ b/api/api-compare-v2/src/test/groovy/com/thoughtworks/go/apiv2/compare/CompareControllerV2Test.groovy
@@ -35,13 +35,15 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.apiv2.compare.representers.MaterialRevisionsRepresenterTest.getRevisions
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class CompareControllerV2Test implements SecurityServiceTrait, ControllerTrait<CompareControllerV2> {
 
   @Mock
@@ -49,11 +51,6 @@ class CompareControllerV2Test implements SecurityServiceTrait, ControllerTrait<C
 
   @Mock
   PipelineService pipelineService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   CompareControllerV2 createControllerInstance() {

--- a/api/api-compare-v2/src/test/groovy/com/thoughtworks/go/apiv2/compare/InternalCompareControllerV2Test.groovy
+++ b/api/api-compare-v2/src/test/groovy/com/thoughtworks/go/apiv2/compare/InternalCompareControllerV2Test.groovy
@@ -38,6 +38,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import java.util.stream.Stream
 
@@ -45,8 +47,8 @@ import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.verify
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class InternalCompareControllerV2Test implements SecurityServiceTrait, ControllerTrait<InternalCompareControllerV2> {
   @Mock
   private PipelineHistoryService pipelineHistoryService
@@ -54,11 +56,6 @@ class InternalCompareControllerV2Test implements SecurityServiceTrait, Controlle
   @Override
   InternalCompareControllerV2 createControllerInstance() {
     return new InternalCompareControllerV2(new ApiAuthenticationHelper(securityService, goConfigService), pipelineHistoryService)
-  }
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
   }
 
   @Nested

--- a/api/api-config-repo-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepooperations/ConfigRepoOperationsControllerV1Test.groovy
+++ b/api/api-config-repo-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepooperations/ConfigRepoOperationsControllerV1Test.groovy
@@ -33,12 +33,14 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.spark.Routes.ConfigRepos.PREFLIGHT_PATH
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ConfigRepoOperationsControllerV1Test implements SecurityServiceTrait, ControllerTrait<ConfigRepoOperationsControllerV1> {
     private static final String PLUGIN_ID = "test.plugin"
     private static final String REPO_ID = "test-repo"
@@ -54,11 +56,6 @@ class ConfigRepoOperationsControllerV1Test implements SecurityServiceTrait, Cont
 
     @Mock
     PartialConfigService partialConfigService
-
-    @BeforeEach
-    void setUp() {
-        initMocks(this)
-    }
 
     @Override
     ConfigRepoOperationsControllerV1 createControllerInstance() {

--- a/api/api-config-repos-v4/src/test/groovy/com/thoughtworks/go/apiv4/configrepos/ConfigReposControllerV4Test.groovy
+++ b/api/api-config-repos-v4/src/test/groovy/com/thoughtworks/go/apiv4/configrepos/ConfigReposControllerV4Test.groovy
@@ -43,6 +43,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import java.util.stream.Collectors
 
@@ -50,9 +52,9 @@ import static com.thoughtworks.go.helper.MaterialConfigsMother.hg
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 import static org.mockito.internal.verification.VerificationModeFactory.times
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ConfigReposControllerV4Test implements SecurityServiceTrait, ControllerTrait<ConfigReposControllerV4> {
   private static final String TEST_PLUGIN_ID = "test.configrepo.plugin"
   private static final String TEST_REPO_URL = "https://fakeurl.com"
@@ -73,11 +75,6 @@ class ConfigReposControllerV4Test implements SecurityServiceTrait, ControllerTra
 
   @Mock
   private MaterialConfigConverter converter
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   ConfigReposControllerV4 createControllerInstance() {

--- a/api/api-config-repos-v4/src/test/groovy/com/thoughtworks/go/apiv4/configrepos/ConfigReposInternalControllerV4Test.groovy
+++ b/api/api-config-repos-v4/src/test/groovy/com/thoughtworks/go/apiv4/configrepos/ConfigReposInternalControllerV4Test.groovy
@@ -43,6 +43,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.helper.MaterialConfigsMother.hg
 import static com.thoughtworks.go.server.util.DigestMixin.digestMany
@@ -50,8 +52,8 @@ import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.anyString
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ConfigReposInternalControllerV4Test implements SecurityServiceTrait, ControllerTrait<ConfigReposInternalControllerV4> {
     private static final String TEST_PLUGIN_ID = "test.configrepo.plugin"
     private static final String TEST_REPO_URL = "https://fakeurl.com"
@@ -93,7 +95,6 @@ class ConfigReposInternalControllerV4Test implements SecurityServiceTrait, Contr
 
     @BeforeEach
     void setUp() {
-        initMocks(this)
         Policy directives = new Policy()
         directives.add(new Allow("administer", "config_repo", "repo-*"))
         RoleConfig roleConfig = new RoleConfig(new CaseInsensitiveString("role"), new Users(), directives)

--- a/api/api-config-repos-v4/src/test/groovy/com/thoughtworks/go/apiv4/configrepos/representers/SvnMaterialRepresenterTest.groovy
+++ b/api/api-config-repos-v4/src/test/groovy/com/thoughtworks/go/apiv4/configrepos/representers/SvnMaterialRepresenterTest.groovy
@@ -20,7 +20,6 @@ import com.thoughtworks.go.api.util.GsonTransformer
 import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig
 import com.thoughtworks.go.domain.materials.MaterialConfig
 import com.thoughtworks.go.security.GoCipher
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
@@ -28,15 +27,11 @@ import static com.thoughtworks.go.helper.MaterialConfigsMother.svn
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertTrue
-import static org.mockito.MockitoAnnotations.initMocks
 
 class SvnMaterialRepresenterTest {
   private static final String REPO_URL = "svn+ssh://username:password@10.106.191.164/home/svn/shproject"
   private static final String USER = "user"
   private static final String PASSWORD = "it's secret!"
-
-  @BeforeEach
-  void setup() { initMocks(this) }
 
   @Test
   void toJSON() {

--- a/api/api-current-user-v1/src/test/groovy/com/thoughtworks/go/apiv1/currentuser/CurrentUserControllerTest.groovy
+++ b/api/api-current-user-v1/src/test/groovy/com/thoughtworks/go/apiv1/currentuser/CurrentUserControllerTest.groovy
@@ -31,23 +31,20 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.doAnswer
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class CurrentUserControllerTest implements ControllerTrait<CurrentUserController>, SecurityServiceTrait {
 
   @Mock
   UserService userService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Nested
   class Show {

--- a/api/api-current-user-v1/src/test/groovy/com/thoughtworks/go/apiv1/currentuser/CurrentUserControllerTest.groovy
+++ b/api/api-current-user-v1/src/test/groovy/com/thoughtworks/go/apiv1/currentuser/CurrentUserControllerTest.groovy
@@ -85,7 +85,7 @@ class CurrentUserControllerTest implements ControllerTrait<CurrentUserController
           .isOk()
           .hasEtag(etag)
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(user, UserRepresenter.class)
+          .hasBodyWithJsonObject(UserRepresenter.class, user)
       }
 
       @Test
@@ -152,7 +152,7 @@ class CurrentUserControllerTest implements ControllerTrait<CurrentUserController
           .isOk()
           .hasEtag(etag)
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(newUser, UserRepresenter.class)
+          .hasBodyWithJsonObject(UserRepresenter.class, newUser)
       }
 
       @Test

--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/DashboardControllerV3Test.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/DashboardControllerV3Test.groovy
@@ -90,7 +90,7 @@ class DashboardControllerV3Test implements SecurityServiceTrait, ControllerTrait
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject(new DashboardFor([group], [env], currentUsername(), PipelineSelections.ALL.etag()), DashboardRepresenter)
+          .hasBodyWithJsonObject(DashboardRepresenter, new DashboardFor([group], [env], currentUsername(), PipelineSelections.ALL.etag()))
       }
 
       @Test
@@ -128,7 +128,7 @@ class DashboardControllerV3Test implements SecurityServiceTrait, ControllerTrait
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(new DashboardFor([], [], currentUsername(), pipelineSelections.etag()), DashboardRepresenter)
+          .hasBodyWithJsonObject(DashboardRepresenter, new DashboardFor([], [], currentUsername(), pipelineSelections.etag()))
       }
 
       @Test

--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/DashboardControllerV3Test.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/DashboardControllerV3Test.groovy
@@ -32,15 +32,16 @@ import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import org.apache.commons.codec.digest.DigestUtils
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class DashboardControllerV3Test implements SecurityServiceTrait, ControllerTrait<DashboardControllerV3> {
 
   @Mock
@@ -48,12 +49,6 @@ class DashboardControllerV3Test implements SecurityServiceTrait, ControllerTrait
 
   @Mock
   private PipelineSelectionsService pipelineSelectionsService
-
-  @BeforeEach
-  void setup() {
-    initMocks(this)
-
-  }
 
   @Override
   DashboardControllerV3 createControllerInstance() {

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/DashboardControllerV4Test.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/DashboardControllerV4Test.groovy
@@ -39,11 +39,13 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class DashboardControllerV4Test implements SecurityServiceTrait, ControllerTrait<DashboardControllerV4> {
   @Mock
   private FeatureToggleService featureToggleService;
@@ -56,7 +58,6 @@ class DashboardControllerV4Test implements SecurityServiceTrait, ControllerTrait
 
   @BeforeEach
   void setup() {
-    initMocks(this)
     Toggles.initializeWith(featureToggleService);
     when(featureToggleService.isToggleOn(Toggles.ALLOW_EMPTY_PIPELINE_GROUPS_DASHBOARD)).thenReturn(false)
   }

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/DashboardControllerV4Test.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/DashboardControllerV4Test.groovy
@@ -107,7 +107,7 @@ class DashboardControllerV4Test implements SecurityServiceTrait, ControllerTrait
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject(new DashboardFor([group], [env], currentUsername(), PipelineSelections.ALL.etag()), DashboardRepresenter)
+          .hasBodyWithJsonObject(DashboardRepresenter, new DashboardFor([group], [env], currentUsername(), PipelineSelections.ALL.etag()))
       }
 
       @Test
@@ -145,7 +145,7 @@ class DashboardControllerV4Test implements SecurityServiceTrait, ControllerTrait
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(new DashboardFor([], [], currentUsername(), pipelineSelections.etag()), DashboardRepresenter)
+          .hasBodyWithJsonObject(DashboardRepresenter, new DashboardFor([], [], currentUsername(), pipelineSelections.etag()))
       }
 
       @Test

--- a/api/api-default-job-timeout-v1/src/test/groovy/com/thoughtworks/go/apiv1/defaultjobtimeout/DefaultJobTimeoutControllerV1Test.groovy
+++ b/api/api-default-job-timeout-v1/src/test/groovy/com/thoughtworks/go/apiv1/defaultjobtimeout/DefaultJobTimeoutControllerV1Test.groovy
@@ -29,11 +29,13 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class DefaultJobTimeoutControllerV1Test implements SecurityServiceTrait, ControllerTrait<DefaultJobTimeoutControllerV1> {
 
   @Mock
@@ -41,11 +43,6 @@ class DefaultJobTimeoutControllerV1Test implements SecurityServiceTrait, Control
 
   @Mock
   ServerConfigService serverConfigService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   DefaultJobTimeoutControllerV1 createControllerInstance() {

--- a/api/api-dependency-material-autocomplete-v1/src/test/groovy/com/thoughtworks/go/apiv1/dependencymaterialautocomplete/DependencyMaterialAutocompleteControllerV1Test.groovy
+++ b/api/api-dependency-material-autocomplete-v1/src/test/groovy/com/thoughtworks/go/apiv1/dependencymaterialautocomplete/DependencyMaterialAutocompleteControllerV1Test.groovy
@@ -69,7 +69,7 @@ class DependencyMaterialAutocompleteControllerV1Test implements SecurityServiceT
       assertThatResponse()
         .isOk()
         .hasContentType(controller.mimeType)
-        .hasBodyWithJsonArray(suggestions, SuggestionsRepresenter.class)
+        .hasBodyWithJsonArray(SuggestionsRepresenter.class, suggestions)
     }
 
     private CaseInsensitiveString ident(String name) {

--- a/api/api-dependency-material-autocomplete-v1/src/test/groovy/com/thoughtworks/go/apiv1/dependencymaterialautocomplete/DependencyMaterialAutocompleteControllerV1Test.groovy
+++ b/api/api-dependency-material-autocomplete-v1/src/test/groovy/com/thoughtworks/go/apiv1/dependencymaterialautocomplete/DependencyMaterialAutocompleteControllerV1Test.groovy
@@ -24,19 +24,15 @@ import com.thoughtworks.go.config.StageConfig
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.GroupAdminUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class DependencyMaterialAutocompleteControllerV1Test implements SecurityServiceTrait, ControllerTrait<DependencyMaterialAutocompleteControllerV1> {
-
-  @BeforeEach
-  void setup() {
-    initMocks(this)
-  }
 
   @Override
   DependencyMaterialAutocompleteControllerV1 createControllerInstance() {

--- a/api/api-elastic-profile-operation-v1/src/test/groovy/com/thoughtworks/go/apiv1/elasticprofileoperation/ElasticProfileOperationControllerV1Test.groovy
+++ b/api/api-elastic-profile-operation-v1/src/test/groovy/com/thoughtworks/go/apiv1/elasticprofileoperation/ElasticProfileOperationControllerV1Test.groovy
@@ -30,10 +30,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ElasticProfileOperationControllerV1Test implements SecurityServiceTrait, ControllerTrait<ElasticProfileOperationControllerV1> {
 
   @Mock
@@ -41,7 +43,6 @@ class ElasticProfileOperationControllerV1Test implements SecurityServiceTrait, C
 
   @BeforeEach
   void setup() {
-    initMocks(this)
     when(elasticProfileService.findProfile("docker")).thenReturn(new ElasticProfile("docker", "cluster"))
   }
 

--- a/api/api-elastic-profile-v2/src/test/groovy/com/thoughtworks/go/apiv2/elasticprofile/ElasticProfileControllerV2Test.groovy
+++ b/api/api-elastic-profile-v2/src/test/groovy/com/thoughtworks/go/apiv2/elasticprofile/ElasticProfileControllerV2Test.groovy
@@ -40,6 +40,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.util.HaltApiMessages.etagDoesNotMatch
 import static com.thoughtworks.go.api.util.HaltApiMessages.renameOfEntityIsNotSupportedMessage
@@ -48,8 +50,8 @@ import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.doAnswer
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ElasticProfileControllerV2Test implements SecurityServiceTrait, ControllerTrait<ElasticProfileControllerV2> {
   @Mock
   private ElasticProfileService elasticProfileService
@@ -59,11 +61,6 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
 
   @Mock
   private ClusterProfilesService clusterProfileService
-
-  @BeforeEach
-  void setup() {
-    initMocks(this)
-  }
 
   @Override
   ElasticProfileControllerV2 createControllerInstance() {

--- a/api/api-elastic-profile-v2/src/test/groovy/com/thoughtworks/go/apiv2/elasticprofile/ElasticProfileControllerV2Test.groovy
+++ b/api/api-elastic-profile-v2/src/test/groovy/com/thoughtworks/go/apiv2/elasticprofile/ElasticProfileControllerV2Test.groovy
@@ -106,7 +106,7 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(elasticProfiles, ElasticProfilesRepresenter)
+          .hasBodyWithJsonObject(ElasticProfilesRepresenter, elasticProfiles)
       }
     }
   }
@@ -152,7 +152,7 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
           .isOk()
           .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(dockerElasticProfile, ElasticProfileRepresenter)
+          .hasBodyWithJsonObject(ElasticProfileRepresenter, dockerElasticProfile)
       }
 
       @Test
@@ -194,7 +194,7 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
           .isOk()
           .hasEtag('"digest-new"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(dockerElasticProfile, ElasticProfileRepresenter)
+          .hasBodyWithJsonObject(ElasticProfileRepresenter, dockerElasticProfile)
       }
     }
   }
@@ -245,7 +245,7 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
           .isOk()
           .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(new ElasticProfile("docker", "prod-cluster", create("DockerURI", false, "http://foo")), ElasticProfileRepresenter)
+          .hasBodyWithJsonObject(ElasticProfileRepresenter, new ElasticProfile("docker", "prod-cluster", create("DockerURI", false, "http://foo")))
       }
 
       @Test
@@ -398,7 +398,7 @@ class ElasticProfileControllerV2Test implements SecurityServiceTrait, Controller
           .isOk()
           .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(updatedProfile, ElasticProfileRepresenter)
+          .hasBodyWithJsonObject(ElasticProfileRepresenter, updatedProfile)
       }
 
       @Test

--- a/api/api-encryption-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/encryption/EncryptionControllerDelegateTest.groovy
+++ b/api/api-encryption-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/encryption/EncryptionControllerDelegateTest.groovy
@@ -70,7 +70,7 @@ class EncryptionControllerDelegateTest implements SecurityServiceTrait, Controll
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(cipher.encrypt("foo"), EncryptedValueRepresenter.class)
+          .hasBodyWithJsonObject(EncryptedValueRepresenter.class, cipher.encrypt("foo"))
       }
 
       @Test
@@ -117,7 +117,7 @@ class EncryptionControllerDelegateTest implements SecurityServiceTrait, Controll
               .hasContentType(controller.mimeType)
               .hasHeader("X-RateLimit-Limit", REQUESTS_PER_MINUTE.toString())
               .hasHeader("X-RateLimit-Remaining", (REQUESTS_PER_MINUTE - i).toString())
-              .hasBodyWithJsonObject(cipher.encrypt("foo"), EncryptedValueRepresenter.class)
+              .hasBodyWithJsonObject(EncryptedValueRepresenter.class, cipher.encrypt("foo"))
           }
 
           postWithApiHeader(controller.controllerBasePath(), [value: 'foo'])
@@ -143,7 +143,7 @@ class EncryptionControllerDelegateTest implements SecurityServiceTrait, Controll
               .hasContentType(controller.mimeType)
               .hasHeader("X-RateLimit-Limit", REQUESTS_PER_MINUTE.toString())
               .hasHeader("X-RateLimit-Remaining", (REQUESTS_PER_MINUTE - i).toString())
-              .hasBodyWithJsonObject(cipher.encrypt("foo"), EncryptedValueRepresenter.class)
+              .hasBodyWithJsonObject(EncryptedValueRepresenter.class, cipher.encrypt("foo"))
           }
         }
 
@@ -158,7 +158,7 @@ class EncryptionControllerDelegateTest implements SecurityServiceTrait, Controll
               .hasContentType(controller.mimeType)
               .hasHeader("X-RateLimit-Limit", REQUESTS_PER_MINUTE.toString())
               .hasHeader("X-RateLimit-Remaining", REQUESTS_PER_MINUTE.toString())
-              .hasBodyWithJsonObject(cipher.encrypt("foo"), EncryptedValueRepresenter.class)
+              .hasBodyWithJsonObject(EncryptedValueRepresenter.class, cipher.encrypt("foo"))
           }
         }
 

--- a/api/api-environments-v3/src/test/groovy/com/thoughtworks/go/apiv3/environments/EnvironmentsControllerV3Test.groovy
+++ b/api/api-environments-v3/src/test/groovy/com/thoughtworks/go/apiv3/environments/EnvironmentsControllerV3Test.groovy
@@ -36,12 +36,14 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTrait<EnvironmentsControllerV3> {
 
   @Mock
@@ -54,11 +56,6 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
   EnvironmentsControllerV3 createControllerInstance() {
     new EnvironmentsControllerV3(new ApiAuthenticationHelper(securityService, goConfigService), environmentConfigService, entityHashingService)
 
-  }
-
-  @BeforeEach
-  void setup() {
-    initMocks(this)
   }
 
   @Nested

--- a/api/api-environments-v3/src/test/groovy/com/thoughtworks/go/apiv3/environments/EnvironmentsControllerV3Test.groovy
+++ b/api/api-environments-v3/src/test/groovy/com/thoughtworks/go/apiv3/environments/EnvironmentsControllerV3Test.groovy
@@ -97,7 +97,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         getWithApiHeader(controller.controllerBasePath())
 
         def sortedEnvConfigList = [devEnv, prodEnv, qaEnv]
-        assertThatResponse().hasBodyWithJsonObject(sortedEnvConfigList, EnvironmentsRepresenter)
+        assertThatResponse().hasBodyWithJsonObject(EnvironmentsRepresenter, sortedEnvConfigList)
       }
 
       @Test
@@ -123,7 +123,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
 
         getWithApiHeader(controller.controllerBasePath())
 
-        assertThatResponse().hasBodyWithJsonObject([], EnvironmentsRepresenter)
+        assertThatResponse().hasBodyWithJsonObject(EnvironmentsRepresenter, [])
       }
 
       @Test
@@ -150,7 +150,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         getWithApiHeader(controller.controllerBasePath())
 
         def sortedEnvConfigList = [prodEnv1, prodEnv2]
-        assertThatResponse().hasBodyWithJsonObject(sortedEnvConfigList, EnvironmentsRepresenter)
+        assertThatResponse().hasBodyWithJsonObject(EnvironmentsRepresenter, sortedEnvConfigList)
       }
 
       @Test
@@ -232,7 +232,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         assertThatResponse()
           .isOk()
           .hasEtag('"digest-hash"')
-          .hasBodyWithJsonObject(env1, EnvironmentRepresenter)
+          .hasBodyWithJsonObject(EnvironmentRepresenter, env1)
       }
 
       @Test
@@ -279,7 +279,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         assertThatResponse()
           .isOk()
           .hasEtag('"digest-hash"')
-          .hasBodyWithJsonObject(env1, EnvironmentRepresenter)
+          .hasBodyWithJsonObject(EnvironmentRepresenter, env1)
       }
     }
   }
@@ -378,7 +378,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         assertThatResponse()
           .isOk()
           .hasEtag('"digest-hash"')
-          .hasBodyWithJsonObject(env1, EnvironmentRepresenter)
+          .hasBodyWithJsonObject(EnvironmentRepresenter, env1)
       }
     }
   }
@@ -448,7 +448,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         assertThatResponse()
           .isOk()
           .hasEtag('"ffff"')
-          .hasBodyWithJsonObject(newConfig, EnvironmentRepresenter)
+          .hasBodyWithJsonObject(EnvironmentRepresenter, newConfig)
       }
 
       @Test
@@ -496,7 +496,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         assertThatResponse()
           .isOk()
           .hasEtag('"ffff"')
-          .hasBodyWithJsonObject(env1, EnvironmentRepresenter)
+          .hasBodyWithJsonObject(EnvironmentRepresenter, env1)
       }
 
       @Test
@@ -655,7 +655,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
         assertThatResponse()
           .isOk()
           .hasEtag('"digest-hash"')
-          .hasBodyWithJsonObject(updatedConfig, EnvironmentRepresenter)
+          .hasBodyWithJsonObject(EnvironmentRepresenter, updatedConfig)
       }
 
       @Test

--- a/api/api-export-v1/src/test/groovy/com/thoughtworks/go/apiv1/export/ExportControllerV1Test.groovy
+++ b/api/api-export-v1/src/test/groovy/com/thoughtworks/go/apiv1/export/ExportControllerV1Test.groovy
@@ -32,12 +32,14 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.plugin.access.configrepo.ExportedConfig.from
 import static com.thoughtworks.go.spark.Routes.Export
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ExportControllerV1Test implements SecurityServiceTrait, ControllerTrait<ExportControllerV1> {
 
   @Mock
@@ -54,10 +56,6 @@ class ExportControllerV1Test implements SecurityServiceTrait, ControllerTrait<Ex
     new ExportControllerV1(new ApiAuthenticationHelper(securityService, goConfigService), goConfigPluginService, goConfigService, entityHashingService)
   }
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Nested
   class ExportPipeline {

--- a/api/api-feature-toggles-v1/src/test/groovy/com/thoughtworks/go/apiv1/featuretoggles/FeatureTogglesControllerV1Test.groovy
+++ b/api/api-feature-toggles-v1/src/test/groovy/com/thoughtworks/go/apiv1/featuretoggles/FeatureTogglesControllerV1Test.groovy
@@ -29,20 +29,18 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.Mockito.verify
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class FeatureTogglesControllerV1Test implements SecurityServiceTrait, ControllerTrait<FeatureTogglesControllerV1> {
 
   @Mock
   FeatureToggleService featureToggleService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   FeatureTogglesControllerV1 createControllerInstance() {

--- a/api/api-feeds-api-v1/src/test/groovy/com/thoughtworks/go/apiv1/feedsapi/FeedsApiControllerV1Test.groovy
+++ b/api/api-feeds-api-v1/src/test/groovy/com/thoughtworks/go/apiv1/feedsapi/FeedsApiControllerV1Test.groovy
@@ -29,17 +29,14 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
-import static org.mockito.MockitoAnnotations.initMocks
-
+@MockitoSettings(strictness = Strictness.LENIENT)
 class FeedsApiControllerV1Test implements SecurityServiceTrait, ControllerTrait<FeedsApiControllerV1> {
   @Mock
   private FeedService feedService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   FeedsApiControllerV1 createControllerInstance() {

--- a/api/api-internal-agent-v1/src/test/groovy/com/thoughtworks/go/apiv1/templateauthorization/InternalAgentControllerV1Test.groovy
+++ b/api/api-internal-agent-v1/src/test/groovy/com/thoughtworks/go/apiv1/templateauthorization/InternalAgentControllerV1Test.groovy
@@ -29,24 +29,21 @@ import com.thoughtworks.go.remote.work.NoWork
 import com.thoughtworks.go.server.messaging.BuildRepositoryMessageProducer
 import com.thoughtworks.go.server.service.AgentRuntimeInfo
 import com.thoughtworks.go.spark.ControllerTrait
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.util.SystemUtil.currentWorkingDirectory
 import static org.mockito.Mockito.verify
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class InternalAgentControllerV1Test implements ControllerTrait<InternalAgentControllerV1> {
   @Mock
   BuildRepositoryMessageProducer buildRepositoryMessageProducer;
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   InternalAgentControllerV1 createControllerInstance() {

--- a/api/api-internal-dependency-pipelines-v1/src/test/groovy/com/thoughtworks/go/apiv1/internaldependencypipelines/InternalDependencyPipelinesControllerV1Test.groovy
+++ b/api/api-internal-dependency-pipelines-v1/src/test/groovy/com/thoughtworks/go/apiv1/internaldependencypipelines/InternalDependencyPipelinesControllerV1Test.groovy
@@ -18,33 +18,26 @@ package com.thoughtworks.go.apiv1.internaldependencypipelines
 
 import com.thoughtworks.go.api.SecurityTestTrait
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
-import com.thoughtworks.go.config.BasicCruiseConfig
-import com.thoughtworks.go.config.CaseInsensitiveString
-import com.thoughtworks.go.config.JobConfigs
-import com.thoughtworks.go.config.PipelineTemplateConfig
-import com.thoughtworks.go.config.StageConfig
+import com.thoughtworks.go.config.*
 import com.thoughtworks.go.helper.PipelineConfigMother
 import com.thoughtworks.go.server.service.GoConfigService
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.util.SystemEnvironment
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class InternalDependencyPipelinesControllerV1Test implements SecurityServiceTrait, ControllerTrait<InternalDependencyPipelinesControllerV1> {
   @Mock
   GoConfigService goConfigService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   InternalDependencyPipelinesControllerV1 createControllerInstance() {

--- a/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/InternalEnvironmentsControllerV1Test.groovy
+++ b/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/InternalEnvironmentsControllerV1Test.groovy
@@ -39,14 +39,16 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static java.util.Arrays.asList
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.doThrow
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class InternalEnvironmentsControllerV1Test implements SecurityServiceTrait, ControllerTrait<InternalEnvironmentsControllerV1> {
 
   @Mock
@@ -54,10 +56,6 @@ class InternalEnvironmentsControllerV1Test implements SecurityServiceTrait, Cont
   @Mock
   private AgentService agentService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   InternalEnvironmentsControllerV1 createControllerInstance() {

--- a/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/EnvironmentAgentRepresenterTest.groovy
+++ b/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/EnvironmentAgentRepresenterTest.groovy
@@ -20,24 +20,20 @@ import com.thoughtworks.go.config.merge.MergeEnvironmentConfig
 import com.thoughtworks.go.config.remote.ConfigRepoConfig
 import com.thoughtworks.go.config.remote.RepoConfigOrigin
 import com.thoughtworks.go.helper.MaterialConfigsMother
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class EnvironmentAgentRepresenterTest {
   @Mock
   MergeEnvironmentConfig environmentConfig
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Test
   void 'should represent agent with config xml origin'() {

--- a/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/EnvironmentEnvironmentVariableRepresenterTest.groovy
+++ b/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/EnvironmentEnvironmentVariableRepresenterTest.groovy
@@ -20,24 +20,21 @@ import com.thoughtworks.go.config.merge.MergeEnvironmentConfig
 import com.thoughtworks.go.config.remote.ConfigRepoConfig
 import com.thoughtworks.go.config.remote.RepoConfigOrigin
 import com.thoughtworks.go.helper.MaterialConfigsMother
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class EnvironmentEnvironmentVariableRepresenterTest {
   @Mock
   MergeEnvironmentConfig environmentConfig
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Test
   void 'should represent environmentVariable with config xml origin'() {

--- a/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/EnvironmentPipelineRepresenterTest.groovy
+++ b/api/api-internal-environments-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalenvironments/representers/EnvironmentPipelineRepresenterTest.groovy
@@ -20,24 +20,21 @@ import com.thoughtworks.go.config.merge.MergeEnvironmentConfig
 import com.thoughtworks.go.config.remote.ConfigRepoConfig
 import com.thoughtworks.go.config.remote.RepoConfigOrigin
 import com.thoughtworks.go.helper.MaterialConfigsMother
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class EnvironmentPipelineRepresenterTest {
   @Mock
   MergeEnvironmentConfig environmentConfig
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Test
   void 'should represent pipeline with config xml origin'() {

--- a/api/api-internal-material-test-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterialtest/InternalMaterialTestControllerV1Test.groovy
+++ b/api/api-internal-material-test-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterialtest/InternalMaterialTestControllerV1Test.groovy
@@ -35,12 +35,14 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class InternalMaterialTestControllerV1Test implements SecurityServiceTrait, ControllerTrait<InternalMaterialTestControllerV1> {
 
   @Mock
@@ -57,10 +59,6 @@ class InternalMaterialTestControllerV1Test implements SecurityServiceTrait, Cont
   @Mock
   SecretParamResolver secretParamResolver
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   InternalMaterialTestControllerV1 createControllerInstance() {

--- a/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/InternalMaterialModificationsControllerV1Test.groovy
+++ b/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/InternalMaterialModificationsControllerV1Test.groovy
@@ -40,23 +40,21 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import java.util.stream.Stream
 
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class InternalMaterialModificationsControllerV1Test implements SecurityServiceTrait, ControllerTrait<InternalMaterialModificationsControllerV1> {
   @Mock
   private MaterialConfigService materialConfigService
   @Mock
   private MaterialService materialService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   InternalMaterialModificationsControllerV1 createControllerInstance() {

--- a/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/InternalMaterialsControllerV1Test.groovy
+++ b/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/InternalMaterialsControllerV1Test.groovy
@@ -41,12 +41,15 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static java.util.Collections.emptyMap
-import static org.mockito.ArgumentMatchers.*
+import static org.mockito.ArgumentMatchers.any
+import static org.mockito.ArgumentMatchers.anyString
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class InternalMaterialsControllerV1Test implements SecurityServiceTrait, ControllerTrait<InternalMaterialsControllerV1> {
   @Mock
   private MaterialConfigService materialConfigService
@@ -61,10 +64,6 @@ class InternalMaterialsControllerV1Test implements SecurityServiceTrait, Control
   @Mock
   private ServerHealthService serverHealthService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   InternalMaterialsControllerV1 createControllerInstance() {

--- a/api/api-internal-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalpipelinegroups/InternalPipelineGroupsControllerV1Test.groovy
+++ b/api/api-internal-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalpipelinegroups/InternalPipelineGroupsControllerV1Test.groovy
@@ -36,22 +36,19 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class InternalPipelineGroupsControllerV1Test implements SecurityServiceTrait, ControllerTrait<InternalPipelineGroupsControllerV1> {
 
   @Mock
   PipelineConfigService pipelineConfigService
   @Mock
   EnvironmentConfigService environmentConfigService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   InternalPipelineGroupsControllerV1 createControllerInstance() {

--- a/api/api-internal-pipeline-structure-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalpipelinestructure/InternalPipelineStructureControllerV1Test.groovy
+++ b/api/api-internal-pipeline-structure-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalpipelinestructure/InternalPipelineStructureControllerV1Test.groovy
@@ -35,13 +35,15 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static java.util.Arrays.asList
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class InternalPipelineStructureControllerV1Test implements SecurityServiceTrait, ControllerTrait<InternalPipelineStructureControllerV1> {
 
   @Mock
@@ -53,10 +55,6 @@ class InternalPipelineStructureControllerV1Test implements SecurityServiceTrait,
   @Mock
   private UserService userService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   InternalPipelineStructureControllerV1 createControllerInstance() {

--- a/api/api-internal-resources-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalresources/InternalResourcesControllerV1Test.groovy
+++ b/api/api-internal-resources-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalresources/InternalResourcesControllerV1Test.groovy
@@ -26,20 +26,18 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class InternalResourcesControllerV1Test implements SecurityServiceTrait, ControllerTrait<InternalResourcesControllerV1> {
   @Mock
   GoConfigService goConfigService
   @Mock
   AgentService agentService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   InternalResourcesControllerV1 createControllerInstance() {

--- a/api/api-internal-scms-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalscms/InternalSCMsControllerV1Test.groovy
+++ b/api/api-internal-scms-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalscms/InternalSCMsControllerV1Test.groovy
@@ -24,8 +24,6 @@ import com.thoughtworks.go.domain.config.Configuration
 import com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother
 import com.thoughtworks.go.domain.scm.SCM
 import com.thoughtworks.go.domain.scm.SCMMother
-import com.thoughtworks.go.plugin.api.response.Result
-import com.thoughtworks.go.server.service.EntityHashingService
 import com.thoughtworks.go.server.service.materials.PluggableScmService
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult
 import com.thoughtworks.go.spark.ControllerTrait
@@ -35,20 +33,18 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
-import static org.mockito.ArgumentMatchers.any
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class InternalSCMsControllerV1Test implements SecurityServiceTrait, ControllerTrait<InternalSCMsControllerV1> {
   @Mock
   PluggableScmService pluggableScmService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   InternalSCMsControllerV1 createControllerInstance() {

--- a/api/api-internal-secret-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalsecretconfig/InternalSecretConfigControllerV1Test.groovy
+++ b/api/api-internal-secret-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalsecretconfig/InternalSecretConfigControllerV1Test.groovy
@@ -43,13 +43,15 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.domain.packagerepository.PackageRepositoryMother.create
 import static com.thoughtworks.go.helper.PipelineConfigMother.pipelineConfig
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class InternalSecretConfigControllerV1Test implements SecurityServiceTrait, ControllerTrait<InternalSecretConfigControllerV1> {
   @Mock
   private SecretConfigService secretConfigService
@@ -64,10 +66,6 @@ class InternalSecretConfigControllerV1Test implements SecurityServiceTrait, Cont
   @Mock
   private ClusterProfilesService clusterProfilesService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   InternalSecretConfigControllerV1 createControllerInstance() {

--- a/api/api-job-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/jobinstance/JobInstanceControllerV1Test.groovy
+++ b/api/api-job-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/jobinstance/JobInstanceControllerV1Test.groovy
@@ -39,23 +39,21 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import java.util.stream.Stream
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class JobInstanceControllerV1Test implements SecurityServiceTrait, ControllerTrait<JobInstanceControllerV1> {
 
   @Mock
   private JobInstanceService jobInstanceService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   JobInstanceControllerV1 createControllerInstance() {

--- a/api/api-mail-server-v1/src/test/groovy/com/thoughtworks/go/apiv1/mailserver/MailServerControllerV1Test.groovy
+++ b/api/api-mail-server-v1/src/test/groovy/com/thoughtworks/go/apiv1/mailserver/MailServerControllerV1Test.groovy
@@ -33,13 +33,15 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.verify
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class MailServerControllerV1Test implements SecurityServiceTrait, ControllerTrait<MailServerControllerV1> {
 
   @Mock
@@ -47,10 +49,6 @@ class MailServerControllerV1Test implements SecurityServiceTrait, ControllerTrai
 
   MailHost mailHost = new MailHost("ghost.name", 25, "loser", "boozer", true, false, "go@foo.mail.com", "admin@foo.mail.com")
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   MailServerControllerV1 createControllerInstance() {

--- a/api/api-mail-server-v1/src/test/groovy/com/thoughtworks/go/apiv1/mailserver/MailServerControllerV1Test.groovy
+++ b/api/api-mail-server-v1/src/test/groovy/com/thoughtworks/go/apiv1/mailserver/MailServerControllerV1Test.groovy
@@ -87,7 +87,7 @@ class MailServerControllerV1Test implements SecurityServiceTrait, ControllerTrai
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(mailHost, MailServerRepresenter)
+          .hasBodyWithJsonObject(MailServerRepresenter, mailHost)
       }
 
       @Test
@@ -148,7 +148,7 @@ class MailServerControllerV1Test implements SecurityServiceTrait, ControllerTrai
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(mailHost, MailServerRepresenter)
+          .hasBodyWithJsonObject(MailServerRepresenter, mailHost)
       }
     }
   }
@@ -198,7 +198,7 @@ class MailServerControllerV1Test implements SecurityServiceTrait, ControllerTrai
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(mailHost, MailServerRepresenter)
+          .hasBodyWithJsonObject(MailServerRepresenter, mailHost)
       }
     }
   }

--- a/api/api-material-search-v1/src/test/groovy/com/thoughtworks/go/apiv1/materialsearch/MaterialSearchControllerTest.groovy
+++ b/api/api-material-search-v1/src/test/groovy/com/thoughtworks/go/apiv1/materialsearch/MaterialSearchControllerTest.groovy
@@ -28,27 +28,24 @@ import com.thoughtworks.go.serverhealth.HealthStateType
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.PipelineGroupOperateUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class MaterialSearchControllerTest implements ControllerTrait<MaterialSearchController>, SecurityServiceTrait {
 
   @Mock
   MaterialService materialService
 
-  @BeforeEach
-  void setup() {
-    initMocks(this)
-  }
 
   @Override
   MaterialSearchController createControllerInstance() {

--- a/api/api-material-search-v1/src/test/groovy/com/thoughtworks/go/apiv1/materialsearch/MaterialSearchControllerTest.groovy
+++ b/api/api-material-search-v1/src/test/groovy/com/thoughtworks/go/apiv1/materialsearch/MaterialSearchControllerTest.groovy
@@ -87,7 +87,7 @@ class MaterialSearchControllerTest implements ControllerTrait<MaterialSearchCont
       assertThatResponse()
         .isOk()
         .hasContentType(controller.mimeType)
-        .hasBodyWithJsonArray(matchedRevisions, MatchedRevisionRepresenter.class)
+        .hasBodyWithJsonArray(MatchedRevisionRepresenter.class, matchedRevisions)
     }
   }
 

--- a/api/api-materials-v2/src/test/groovy/com/thoughtworks/go/apiv2/materials/MaterialConfigControllerV2Test.groovy
+++ b/api/api-materials-v2/src/test/groovy/com/thoughtworks/go/apiv2/materials/MaterialConfigControllerV2Test.groovy
@@ -31,16 +31,14 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class MaterialConfigControllerV2Test implements SecurityServiceTrait, ControllerTrait<MaterialConfigControllerV2> {
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Mock
   private MaterialConfigService materialConfigService

--- a/api/api-materials-v2/src/test/groovy/com/thoughtworks/go/apiv2/materials/MaterialConfigControllerV2Test.groovy
+++ b/api/api-materials-v2/src/test/groovy/com/thoughtworks/go/apiv2/materials/MaterialConfigControllerV2Test.groovy
@@ -96,7 +96,7 @@ class MaterialConfigControllerV2Test implements SecurityServiceTrait, Controller
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(materialConfigs, MaterialConfigsRepresenter)
+          .hasBodyWithJsonObject(MaterialConfigsRepresenter, materialConfigs)
       }
     }
   }

--- a/api/api-materials-v2/src/test/groovy/com/thoughtworks/go/apiv2/materials/MaterialModificationsControllerV2Test.groovy
+++ b/api/api-materials-v2/src/test/groovy/com/thoughtworks/go/apiv2/materials/MaterialModificationsControllerV2Test.groovy
@@ -35,18 +35,16 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class MaterialModificationsControllerV2Test implements SecurityServiceTrait, ControllerTrait<MaterialModificationsControllerV2> {
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Mock
   private MaterialConfigService materialConfigService

--- a/api/api-materials-v2/src/test/groovy/com/thoughtworks/go/apiv2/materials/MaterialNotifyControllerV2Test.groovy
+++ b/api/api-materials-v2/src/test/groovy/com/thoughtworks/go/apiv2/materials/MaterialNotifyControllerV2Test.groovy
@@ -27,18 +27,16 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.verify
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class MaterialNotifyControllerV2Test implements SecurityServiceTrait, ControllerTrait<MaterialNotifyControllerV2> {
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Mock
   private MaterialUpdateService materialUpdateService

--- a/api/api-notification-filter-v2/src/test/groovy/com/thoughtworks/go/apiv2/notificationfilter/NotificationFilterControllerV2Test.groovy
+++ b/api/api-notification-filter-v2/src/test/groovy/com/thoughtworks/go/apiv2/notificationfilter/NotificationFilterControllerV2Test.groovy
@@ -33,13 +33,15 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class NotificationFilterControllerV2Test implements SecurityServiceTrait, ControllerTrait<NotificationFilterControllerV2> {
   @Mock
   private UserService userService
@@ -47,10 +49,6 @@ class NotificationFilterControllerV2Test implements SecurityServiceTrait, Contro
   @Mock
   private EntityHashingService entityHashingService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   NotificationFilterControllerV2 createControllerInstance() {

--- a/api/api-package-repository-v1/src/test/groovy/com/thoughtworks/go/apiv1/packagerepository/PackageRepositoryControllerV1Test.groovy
+++ b/api/api-package-repository-v1/src/test/groovy/com/thoughtworks/go/apiv1/packagerepository/PackageRepositoryControllerV1Test.groovy
@@ -163,7 +163,7 @@ class PackageRepositoryControllerV1Test implements SecurityServiceTrait, Control
         assertThatResponse()
           .isOk()
           .hasEtag('"etag"')
-          .hasBodyWithJsonObject(packageRepository, PackageRepositoryRepresenter)
+          .hasBodyWithJsonObject(PackageRepositoryRepresenter, packageRepository)
       }
     }
 

--- a/api/api-package-repository-v1/src/test/groovy/com/thoughtworks/go/apiv1/packagerepository/PackageRepositoryControllerV1Test.groovy
+++ b/api/api-package-repository-v1/src/test/groovy/com/thoughtworks/go/apiv1/packagerepository/PackageRepositoryControllerV1Test.groovy
@@ -34,13 +34,15 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.api.util.HaltApiMessages.etagDoesNotMatch
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PackageRepositoryControllerV1Test implements SecurityServiceTrait, ControllerTrait<PackageRepositoryControllerV1> {
 
   @Mock
@@ -49,10 +51,6 @@ class PackageRepositoryControllerV1Test implements SecurityServiceTrait, Control
   @Mock
   private EntityHashingService entityHashingService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   PackageRepositoryControllerV1 createControllerInstance() {

--- a/api/api-package-repository-v1/src/test/groovy/com/thoughtworks/go/apiv1/packagerepository/PackageRepositoryInternalControllerV1Test.groovy
+++ b/api/api-package-repository-v1/src/test/groovy/com/thoughtworks/go/apiv1/packagerepository/PackageRepositoryInternalControllerV1Test.groovy
@@ -35,13 +35,15 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.spark.Routes.SecurityAuthConfigAPI.VERIFY_CONNECTION
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PackageRepositoryInternalControllerV1Test implements SecurityServiceTrait, ControllerTrait<PackageRepositoryInternalControllerV1> {
   @Mock
   private PackageRepositoryService packageRepositoryService
@@ -49,10 +51,6 @@ class PackageRepositoryInternalControllerV1Test implements SecurityServiceTrait,
   @Mock
   private EntityHashingService entityHashingService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   PackageRepositoryInternalControllerV1 createControllerInstance() {

--- a/api/api-packages-v2/src/test/groovy/com/thoughtworks/go/apiv2/packages/PackagesControllerV2Test.groovy
+++ b/api/api-packages-v2/src/test/groovy/com/thoughtworks/go/apiv2/packages/PackagesControllerV2Test.groovy
@@ -39,14 +39,16 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static java.util.Collections.emptyList
 import static java.util.Collections.emptyMap
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PackagesControllerV2Test implements SecurityServiceTrait, ControllerTrait<PackagesControllerV2> {
   @Mock
   private EntityHashingService entityHashingService
@@ -54,10 +56,6 @@ class PackagesControllerV2Test implements SecurityServiceTrait, ControllerTrait<
   @Mock
   private PackageDefinitionService packageDefinitionService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   PackagesControllerV2 createControllerInstance() {

--- a/api/api-packages-v2/src/test/groovy/com/thoughtworks/go/apiv2/packages/PackagesControllerV2Test.groovy
+++ b/api/api-packages-v2/src/test/groovy/com/thoughtworks/go/apiv2/packages/PackagesControllerV2Test.groovy
@@ -185,7 +185,7 @@ class PackagesControllerV2Test implements SecurityServiceTrait, ControllerTrait<
         assertThatResponse()
           .isOk()
           .hasEtag('"etag"')
-          .hasBodyWithJsonObject(packageDefinition, PackageDefinitionRepresenter)
+          .hasBodyWithJsonObject(PackageDefinitionRepresenter, packageDefinition)
       }
     }
   }

--- a/api/api-packages-v2/src/test/groovy/com/thoughtworks/go/apiv2/packages/PackagesInternalControllerV2Test.groovy
+++ b/api/api-packages-v2/src/test/groovy/com/thoughtworks/go/apiv2/packages/PackagesInternalControllerV2Test.groovy
@@ -38,13 +38,15 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.spark.Routes.SecurityAuthConfigAPI.VERIFY_CONNECTION
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PackagesInternalControllerV2Test implements SecurityServiceTrait, ControllerTrait<PackagesInternalControllerV2> {
   @Mock
   private PackageDefinitionService packageDefinitionService
@@ -59,7 +61,6 @@ class PackagesInternalControllerV2Test implements SecurityServiceTrait, Controll
 
   @BeforeEach
   void setUp() {
-    initMocks(this)
     when(packageRepositoryService.getPackageRepository(any())).thenReturn(repo)
   }
 

--- a/api/api-permissions-v1/src/test/groovy/com/thoughtworks/go/apiv1/permissions/PermissionsControllerV1Test.groovy
+++ b/api/api-permissions-v1/src/test/groovy/com/thoughtworks/go/apiv1/permissions/PermissionsControllerV1Test.groovy
@@ -26,20 +26,18 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PermissionsControllerV1Test implements SecurityServiceTrait, ControllerTrait<PermissionsControllerV1> {
 
   @Mock
   PermissionsService permissionsService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   PermissionsControllerV1 createControllerInstance() {

--- a/api/api-pipeline-config-v11/src/test/groovy/com/thoughtworks/go/apiv11/pipelineconfig/PipelineConfigControllerV11Test.groovy
+++ b/api/api-pipeline-config-v11/src/test/groovy/com/thoughtworks/go/apiv11/pipelineconfig/PipelineConfigControllerV11Test.groovy
@@ -49,6 +49,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObject
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
@@ -57,15 +59,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PipelineConfigControllerV11Test implements SecurityServiceTrait, ControllerTrait<PipelineConfigControllerV11> {
   @Mock
   private FeatureToggleService featureToggleService;
 
   @BeforeEach
   void setUp() {
-    initMocks(this)
     Toggles.initializeWith(featureToggleService);
     when(featureToggleService.isToggleOn(Toggles.TEST_DRIVE)).thenReturn(false)
   }

--- a/api/api-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1Test.groovy
+++ b/api/api-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1Test.groovy
@@ -36,19 +36,17 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PipelineGroupsControllerV1Test implements SecurityServiceTrait, ControllerTrait<PipelineGroupsControllerV1> {
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Mock
   private PipelineConfigsService pipelineConfigsService

--- a/api/api-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1Test.groovy
+++ b/api/api-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1Test.groovy
@@ -100,7 +100,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
           .isOk()
           .hasEtag('"some-etag"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(expectedPipelineGroups, PipelineGroupsRepresenter)
+          .hasBodyWithJsonObject(PipelineGroupsRepresenter, expectedPipelineGroups)
       }
 
       @Test
@@ -158,7 +158,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
         verify(pipelineConfigsService).createGroup(any(), any(), any())
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject(pipelineGroup, PipelineGroupRepresenter)
+          .hasBodyWithJsonObject(PipelineGroupRepresenter, pipelineGroup)
       }
 
       @Test
@@ -251,7 +251,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject(group, PipelineGroupRepresenter)
+          .hasBodyWithJsonObject(PipelineGroupRepresenter, group)
           .hasEtag('"digest_for_group"')
       }
 
@@ -300,7 +300,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
           .isOk()
           .hasEtag('"digest_for_group"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(group, PipelineGroupRepresenter)
+          .hasBodyWithJsonObject(PipelineGroupRepresenter, group)
       }
     }
   }
@@ -355,7 +355,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject(group, PipelineGroupRepresenter)
+          .hasBodyWithJsonObject(PipelineGroupRepresenter, group)
       }
 
       @Test

--- a/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1Test.groovy
+++ b/api/api-pipeline-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineinstance/PipelineInstanceControllerV1Test.groovy
@@ -41,22 +41,20 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import java.util.stream.Stream
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PipelineInstanceControllerV1Test implements SecurityServiceTrait, ControllerTrait<PipelineInstanceControllerV1> {
   @Mock
   private PipelineHistoryService pipelineHistoryService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   PipelineInstanceControllerV1 createControllerInstance() {

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/PipelineOperationsControllerV1Test.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/PipelineOperationsControllerV1Test.groovy
@@ -57,12 +57,14 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.doAnswer
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PipelineOperationsControllerV1Test implements SecurityServiceTrait, ControllerTrait<PipelineOperationsControllerV1> {
   @Mock
   PipelineHistoryService pipelineHistoryService
@@ -72,11 +74,6 @@ class PipelineOperationsControllerV1Test implements SecurityServiceTrait, Contro
   PipelineUnlockApiService pipelineUnlockApiService
   @Mock
   PipelineTriggerService pipelineTriggerService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   PipelineOperationsControllerV1 createControllerInstance() {

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/PipelineOperationsControllerV1Test.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/PipelineOperationsControllerV1Test.groovy
@@ -338,7 +338,7 @@ class PipelineOperationsControllerV1Test implements SecurityServiceTrait, Contro
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(new TriggerOptions(variables, model), TriggerWithOptionsViewRepresenter.class)
+          .hasBodyWithJsonObject(TriggerWithOptionsViewRepresenter.class, new TriggerOptions(variables, model))
       }
 
       @Test

--- a/api/api-pipelines-as-code-internal-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelinesascodeinternal/PipelinesAsCodeInternalControllerV1Test.groovy
+++ b/api/api-pipelines-as-code-internal-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelinesascodeinternal/PipelinesAsCodeInternalControllerV1Test.groovy
@@ -27,11 +27,7 @@ import com.thoughtworks.go.config.materials.SubprocessExecutionContext
 import com.thoughtworks.go.config.update.CreatePipelineConfigCommand
 import com.thoughtworks.go.domain.materials.MaterialConfig
 import com.thoughtworks.go.plugin.access.configrepo.ConfigFileList
-import com.thoughtworks.go.server.service.ConfigRepoService
-import com.thoughtworks.go.server.service.EntityHashingService
-import com.thoughtworks.go.server.service.MaterialConfigConverter
-import com.thoughtworks.go.server.service.MaterialService
-import com.thoughtworks.go.server.service.PipelineConfigService
+import com.thoughtworks.go.server.service.*
 import com.thoughtworks.go.server.service.plugins.builder.DefaultPluginInfoFinder
 import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait
@@ -42,13 +38,15 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 import org.mockito.stubbing.Answer
 
 import static com.thoughtworks.go.plugin.access.configrepo.ExportedConfig.from
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PipelinesAsCodeInternalControllerV1Test implements SecurityServiceTrait, ControllerTrait<PipelinesAsCodeInternalControllerV1> {
 
   private static final String PLUGIN_ID = "test.config.plugin"
@@ -92,10 +90,6 @@ class PipelinesAsCodeInternalControllerV1Test implements SecurityServiceTrait, C
   @Mock
   EntityHashingService entityHashingService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   PipelinesAsCodeInternalControllerV1 createControllerInstance() {

--- a/api/api-plugin-images/src/test/groovy/com/thoughtworks/go/api/pluginimages/PluginImagesControllerTest.groovy
+++ b/api/api-plugin-images/src/test/groovy/com/thoughtworks/go/api/pluginimages/PluginImagesControllerTest.groovy
@@ -22,24 +22,21 @@ import com.thoughtworks.go.server.service.plugins.builder.DefaultPluginInfoFinde
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.SparkController
 import com.thoughtworks.go.spark.util.SecureRandom
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static java.nio.charset.StandardCharsets.UTF_8
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PluginImagesControllerTest implements ControllerTrait<SparkController> {
 
   @Mock
   DefaultPluginInfoFinder defaultPluginInfoFinder
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   PluginImagesController createControllerInstance() {

--- a/api/api-plugin-infos-v7/src/test/groovy/com/thoughtworks/go/apiv7/plugininfos/PluginInfosControllerV7Test.groovy
+++ b/api/api-plugin-infos-v7/src/test/groovy/com/thoughtworks/go/apiv7/plugininfos/PluginInfosControllerV7Test.groovy
@@ -36,13 +36,15 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.util.HaltApiMessages.notFoundMessage
 import static com.thoughtworks.go.helpers.PluginInfoMother.createAuthorizationPluginInfo
 import static com.thoughtworks.go.helpers.PluginInfoMother.createSCMPluginInfo
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PluginInfosControllerV7Test implements SecurityServiceTrait, ControllerTrait<PluginInfosControllerV7> {
   @Mock
   private DefaultPluginInfoFinder pluginInfoFinder
@@ -58,7 +60,6 @@ class PluginInfosControllerV7Test implements SecurityServiceTrait, ControllerTra
 
   @BeforeEach
   void setup() {
-    initMocks(this)
     Set extensions = ["authorization", "scm", "configrepo", "elastic-agent", "task", "package-repository", "notification", "analytics", "artifact"]
     when(extensionRegistry.allRegisteredExtensions()).thenReturn(extensions)
   }

--- a/api/api-plugin-infos-v7/src/test/groovy/com/thoughtworks/go/apiv7/plugininfos/PluginInfosControllerV7Test.groovy
+++ b/api/api-plugin-infos-v7/src/test/groovy/com/thoughtworks/go/apiv7/plugininfos/PluginInfosControllerV7Test.groovy
@@ -105,7 +105,7 @@ class PluginInfosControllerV7Test implements SecurityServiceTrait, ControllerTra
           .isOk()
           .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(pluginInfo, PluginInfoRepresenter)
+          .hasBodyWithJsonObject(PluginInfoRepresenter, pluginInfo)
       }
 
       @Test
@@ -139,7 +139,7 @@ class PluginInfosControllerV7Test implements SecurityServiceTrait, ControllerTra
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(pluginInfo, PluginInfoRepresenter)
+          .hasBodyWithJsonObject(PluginInfoRepresenter, pluginInfo)
       }
 
       @Test
@@ -231,7 +231,7 @@ class PluginInfosControllerV7Test implements SecurityServiceTrait, ControllerTra
           .isOk()
           .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(pluginInfos, PluginInfosRepresenter)
+          .hasBodyWithJsonObject(PluginInfosRepresenter, pluginInfos)
       }
 
       @Test
@@ -267,7 +267,7 @@ class PluginInfosControllerV7Test implements SecurityServiceTrait, ControllerTra
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(pluginInfos, PluginInfosRepresenter)
+          .hasBodyWithJsonObject(PluginInfosRepresenter, pluginInfos)
       }
 
 
@@ -322,7 +322,7 @@ class PluginInfosControllerV7Test implements SecurityServiceTrait, ControllerTra
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject(expectedPluginInfo, PluginInfosRepresenter)
+          .hasBodyWithJsonObject(PluginInfosRepresenter, expectedPluginInfo)
       }
 
       @Test

--- a/api/api-plugin-settings-v1/src/test/groovy/com/thoughtworks/go/apiv1/pluginsettings/PluginSettingsControllerV1Test.groovy
+++ b/api/api-plugin-settings-v1/src/test/groovy/com/thoughtworks/go/apiv1/pluginsettings/PluginSettingsControllerV1Test.groovy
@@ -41,12 +41,14 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.doAnswer
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PluginSettingsControllerV1Test implements SecurityServiceTrait, ControllerTrait<PluginSettingsControllerV1> {
   @Mock
   PluginService pluginService
@@ -54,10 +56,6 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
   @Mock
   EntityHashingService entityHashingService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   PluginSettingsControllerV1 createControllerInstance() {

--- a/api/api-plugin-settings-v1/src/test/groovy/com/thoughtworks/go/apiv1/pluginsettings/PluginSettingsControllerV1Test.groovy
+++ b/api/api-plugin-settings-v1/src/test/groovy/com/thoughtworks/go/apiv1/pluginsettings/PluginSettingsControllerV1Test.groovy
@@ -98,7 +98,7 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
           .isOk()
           .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(pluginSettings, PluginSettingsRepresenter)
+          .hasBodyWithJsonObject(PluginSettingsRepresenter, pluginSettings)
       }
 
       @Test
@@ -167,7 +167,7 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
           .isOk()
           .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(pluginSettings, PluginSettingsRepresenter)
+          .hasBodyWithJsonObject(PluginSettingsRepresenter, pluginSettings)
       }
 
       @Test
@@ -267,7 +267,7 @@ class PluginSettingsControllerV1Test implements SecurityServiceTrait, Controller
           .isOk()
           .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(pluginSettings, PluginSettingsRepresenter)
+          .hasBodyWithJsonObject(PluginSettingsRepresenter, pluginSettings)
       }
 
       @Test

--- a/api/api-roles-config-v3/src/test/groovy/com/thoughtworks/go/apiv3/rolesconfig/InternalRolesControllerV3Test.groovy
+++ b/api/api-roles-config-v3/src/test/groovy/com/thoughtworks/go/apiv3/rolesconfig/InternalRolesControllerV3Test.groovy
@@ -36,13 +36,15 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git
 import static java.util.Arrays.asList
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class InternalRolesControllerV3Test implements SecurityServiceTrait, ControllerTrait<InternalRolesControllerV3> {
   @Mock
   private RoleConfigService roleConfigService
@@ -55,10 +57,6 @@ class InternalRolesControllerV3Test implements SecurityServiceTrait, ControllerT
   @Mock
   private ClusterProfilesService clusterProfilesService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   InternalRolesControllerV3 createControllerInstance() {

--- a/api/api-roles-config-v3/src/test/groovy/com/thoughtworks/go/apiv3/rolesconfig/RolesControllerV3Test.groovy
+++ b/api/api-roles-config-v3/src/test/groovy/com/thoughtworks/go/apiv3/rolesconfig/RolesControllerV3Test.groovy
@@ -94,7 +94,7 @@ class RolesControllerV3Test implements SecurityServiceTrait, ControllerTrait<Rol
           .isOk()
           .hasEtag('"some-etag"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(expectedRoles, RolesRepresenter)
+          .hasBodyWithJsonObject(RolesRepresenter, expectedRoles)
       }
 
       @Test
@@ -110,7 +110,7 @@ class RolesControllerV3Test implements SecurityServiceTrait, ControllerTrait<Rol
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(new RolesConfig([pluginRoleConfig]), RolesRepresenter)
+          .hasBodyWithJsonObject(RolesRepresenter, new RolesConfig([pluginRoleConfig]))
       }
 
       @Test
@@ -185,7 +185,7 @@ class RolesControllerV3Test implements SecurityServiceTrait, ControllerTrait<Rol
           .isOk()
           .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(role, RoleRepresenter)
+          .hasBodyWithJsonObject(RoleRepresenter, role)
       }
 
       @Test
@@ -223,7 +223,7 @@ class RolesControllerV3Test implements SecurityServiceTrait, ControllerTrait<Rol
           .isOk()
           .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(role, RoleRepresenter)
+          .hasBodyWithJsonObject(RoleRepresenter, role)
       }
     }
   }
@@ -266,7 +266,7 @@ class RolesControllerV3Test implements SecurityServiceTrait, ControllerTrait<Rol
           .isOk()
           .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(role, RoleRepresenter)
+          .hasBodyWithJsonObject(RoleRepresenter, role)
       }
 
       @Test
@@ -401,7 +401,7 @@ class RolesControllerV3Test implements SecurityServiceTrait, ControllerTrait<Rol
           .isOk()
           .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(newRole, RoleRepresenter)
+          .hasBodyWithJsonObject(RoleRepresenter, newRole)
       }
     }
   }
@@ -468,7 +468,7 @@ class RolesControllerV3Test implements SecurityServiceTrait, ControllerTrait<Rol
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(new RolesConfig(role), RolesRepresenter.class)
+          .hasBodyWithJsonObject(RolesRepresenter.class, new RolesConfig(role))
       }
     }
   }

--- a/api/api-roles-config-v3/src/test/groovy/com/thoughtworks/go/apiv3/rolesconfig/RolesControllerV3Test.groovy
+++ b/api/api-roles-config-v3/src/test/groovy/com/thoughtworks/go/apiv3/rolesconfig/RolesControllerV3Test.groovy
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectWithoutLinks
@@ -40,14 +42,10 @@ import static com.thoughtworks.go.api.util.HaltApiMessages.etagDoesNotMatch
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class RolesControllerV3Test implements SecurityServiceTrait, ControllerTrait<RolesControllerV3> {
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Mock
   private RoleConfigService roleConfigService

--- a/api/api-scms-v4/src/test/groovy/com/thoughtworks/go/apiv4/scms/SCMControllerV4Test.groovy
+++ b/api/api-scms-v4/src/test/groovy/com/thoughtworks/go/apiv4/scms/SCMControllerV4Test.groovy
@@ -46,6 +46,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.util.HaltApiMessages.etagDoesNotMatch
 import static com.thoughtworks.go.api.util.HaltApiMessages.renameOfEntityIsNotSupportedMessage
@@ -56,8 +58,8 @@ import static java.util.Collections.emptyMap
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class SCMControllerV4Test implements SecurityServiceTrait, ControllerTrait<SCMControllerV4> {
   @Mock
   PluggableScmService scmService
@@ -65,10 +67,6 @@ class SCMControllerV4Test implements SecurityServiceTrait, ControllerTrait<SCMCo
   @Mock
   EntityHashingService entityHashingService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   SCMControllerV4 createControllerInstance() {

--- a/api/api-scms-v4/src/test/groovy/com/thoughtworks/go/apiv4/scms/SCMControllerV4Test.groovy
+++ b/api/api-scms-v4/src/test/groovy/com/thoughtworks/go/apiv4/scms/SCMControllerV4Test.groovy
@@ -115,7 +115,7 @@ class SCMControllerV4Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           .isOk()
           .hasEtag('"some-etag"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(scms, SCMsRepresenter)
+          .hasBodyWithJsonObject(SCMsRepresenter, scms)
       }
 
       @Test
@@ -179,7 +179,7 @@ class SCMControllerV4Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           .isOk()
           .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(scm, SCMRepresenter)
+          .hasBodyWithJsonObject(SCMRepresenter, scm)
       }
 
       @Test
@@ -225,7 +225,7 @@ class SCMControllerV4Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           .isOk()
           .hasEtag('"digest-new"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(scm, SCMRepresenter)
+          .hasBodyWithJsonObject(SCMRepresenter, scm)
       }
     }
   }
@@ -290,7 +290,7 @@ class SCMControllerV4Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           .isOk()
           .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(scm, SCMRepresenter)
+          .hasBodyWithJsonObject(SCMRepresenter, scm)
       }
 
 
@@ -525,7 +525,7 @@ class SCMControllerV4Test implements SecurityServiceTrait, ControllerTrait<SCMCo
           .isOk()
           .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(updatedSCM, SCMRepresenter)
+          .hasBodyWithJsonObject(SCMRepresenter, updatedSCM)
       }
 
       @Test

--- a/api/api-secret-configs-v3/src/test/groovy/com/thoughtworks/go/apiv3/secretconfigs/SecretConfigsControllerV3Test.groovy
+++ b/api/api-secret-configs-v3/src/test/groovy/com/thoughtworks/go/apiv3/secretconfigs/SecretConfigsControllerV3Test.groovy
@@ -108,7 +108,7 @@ class SecretConfigsControllerV3Test implements SecurityServiceTrait, ControllerT
           .isOk()
           .hasEtag('"ffff"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(expectedConfigs, SecretConfigsRepresenter)
+          .hasBodyWithJsonObject(SecretConfigsRepresenter, expectedConfigs)
       }
 
       @Test
@@ -139,7 +139,7 @@ class SecretConfigsControllerV3Test implements SecurityServiceTrait, ControllerT
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(expectedConfigs, SecretConfigsRepresenter)
+          .hasBodyWithJsonObject(SecretConfigsRepresenter, expectedConfigs)
       }
     }
   }
@@ -184,7 +184,7 @@ class SecretConfigsControllerV3Test implements SecurityServiceTrait, ControllerT
           .isOk()
           .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(expectedConfig, SecretConfigRepresenter)
+          .hasBodyWithJsonObject(SecretConfigRepresenter, expectedConfig)
       }
 
       @Test
@@ -232,7 +232,7 @@ class SecretConfigsControllerV3Test implements SecurityServiceTrait, ControllerT
           .isOk()
           .hasEtag('"digest-new"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(expectedConfig, SecretConfigRepresenter)
+          .hasBodyWithJsonObject(SecretConfigRepresenter, expectedConfig)
       }
     }
   }
@@ -309,7 +309,7 @@ class SecretConfigsControllerV3Test implements SecurityServiceTrait, ControllerT
           .isOk()
           .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(secretConfig, SecretConfigRepresenter)
+          .hasBodyWithJsonObject(SecretConfigRepresenter, secretConfig)
       }
 
 
@@ -469,7 +469,7 @@ class SecretConfigsControllerV3Test implements SecurityServiceTrait, ControllerT
           .isOk()
           .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(newSecretConfig, SecretConfigRepresenter)
+          .hasBodyWithJsonObject(SecretConfigRepresenter, newSecretConfig)
       }
 
       @Test

--- a/api/api-secret-configs-v3/src/test/groovy/com/thoughtworks/go/apiv3/secretconfigs/SecretConfigsControllerV3Test.groovy
+++ b/api/api-secret-configs-v3/src/test/groovy/com/thoughtworks/go/apiv3/secretconfigs/SecretConfigsControllerV3Test.groovy
@@ -20,7 +20,8 @@ import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.api.util.GsonTransformer
 import com.thoughtworks.go.apiv3.secretconfigs.representers.SecretConfigRepresenter
 import com.thoughtworks.go.apiv3.secretconfigs.representers.SecretConfigsRepresenter
-import com.thoughtworks.go.config.*
+import com.thoughtworks.go.config.SecretConfig
+import com.thoughtworks.go.config.SecretConfigs
 import com.thoughtworks.go.config.exceptions.EntityType
 import com.thoughtworks.go.config.rules.Allow
 import com.thoughtworks.go.config.rules.Deny
@@ -42,6 +43,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.apiv3.secretconfigs.representers.SecretConfigRepresenter.fromJSON
@@ -49,8 +52,8 @@ import static com.thoughtworks.go.apiv3.secretconfigs.representers.SecretConfigR
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class SecretConfigsControllerV3Test implements SecurityServiceTrait, ControllerTrait<SecretConfigsControllerV3> {
 
   @Mock
@@ -59,10 +62,6 @@ class SecretConfigsControllerV3Test implements SecurityServiceTrait, ControllerT
   @Mock
   EntityHashingService entityHashingService
 
-  @BeforeEach
-  void setup() {
-    initMocks(this)
-  }
 
   @Override
   SecretConfigsControllerV3 createControllerInstance() {

--- a/api/api-security-auth-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/securityauthconfig/SecurityAuthConfigControllerV2Test.groovy
+++ b/api/api-security-auth-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/securityauthconfig/SecurityAuthConfigControllerV2Test.groovy
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.util.HaltApiMessages.etagDoesNotMatch
 import static com.thoughtworks.go.api.util.HaltApiMessages.renameOfEntityIsNotSupportedMessage
@@ -46,8 +48,8 @@ import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.doAnswer
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, ControllerTrait<SecurityAuthConfigControllerV2> {
 
   @Mock
@@ -56,10 +58,6 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
   @Mock
   private EntityHashingService entityHashingService
 
-  @BeforeEach
-  void setup() {
-    initMocks(this)
-  }
 
   @Override
   SecurityAuthConfigControllerV2 createControllerInstance() {

--- a/api/api-security-auth-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/securityauthconfig/SecurityAuthConfigControllerV2Test.groovy
+++ b/api/api-security-auth-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/securityauthconfig/SecurityAuthConfigControllerV2Test.groovy
@@ -103,7 +103,7 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
           .isOk()
           .hasContentType(controller.mimeType)
           .hasEtag('"2ed2348f198e14381f2dd0e5a0e317f8a2287feb8807891a90ca9cd60248d45b"')
-          .hasBodyWithJsonObject(securityAuthConfigs, SecurityAuthConfigsRepresenter)
+          .hasBodyWithJsonObject(SecurityAuthConfigsRepresenter, securityAuthConfigs)
       }
     }
   }
@@ -145,7 +145,7 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
           .isOk()
           .hasEtag('"digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(securityAuthConfig, SecurityAuthConfigRepresenter)
+          .hasBodyWithJsonObject(SecurityAuthConfigRepresenter, securityAuthConfig)
       }
 
       @Test
@@ -185,7 +185,7 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
           .isOk()
           .hasEtag('"digest-new"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(securityAuthConfig, SecurityAuthConfigRepresenter)
+          .hasBodyWithJsonObject(SecurityAuthConfigRepresenter, securityAuthConfig)
       }
     }
   }
@@ -235,7 +235,7 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
           .isOk()
           .hasEtag('"some-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(new SecurityAuthConfig("file", "cd.go.authorization.file", create("Path", false, "/var/lib/pass.prop")), SecurityAuthConfigRepresenter)
+          .hasBodyWithJsonObject(SecurityAuthConfigRepresenter, new SecurityAuthConfig("file", "cd.go.authorization.file", create("Path", false, "/var/lib/pass.prop")))
       }
 
       @Test
@@ -361,7 +361,7 @@ class SecurityAuthConfigControllerV2Test implements SecurityServiceTrait, Contro
           .isOk()
           .hasEtag('"new-digest"')
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(updatedProfile, SecurityAuthConfigRepresenter)
+          .hasBodyWithJsonObject(SecurityAuthConfigRepresenter, updatedProfile)
       }
 
       @Test

--- a/api/api-security-auth-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/securityauthconfig/SecurityAuthConfigInternalControllerV2Test.groovy
+++ b/api/api-security-auth-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/securityauthconfig/SecurityAuthConfigInternalControllerV2Test.groovy
@@ -30,13 +30,15 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl
 import static com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother.create
 import static com.thoughtworks.go.spark.Routes.SecurityAuthConfigAPI.VERIFY_CONNECTION
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class SecurityAuthConfigInternalControllerV2Test implements SecurityServiceTrait, ControllerTrait<SecurityAuthConfigInternalControllerV2> {
 
   @Mock
@@ -45,10 +47,6 @@ class SecurityAuthConfigInternalControllerV2Test implements SecurityServiceTrait
   @Mock
   private EntityHashingService entityHashingService
 
-  @BeforeEach
-  void setup() {
-    initMocks(this)
-  }
 
   @Override
   SecurityAuthConfigInternalControllerV2 createControllerInstance() {

--- a/api/api-server-health-messages-v1/src/test/groovy/com/thoughtworks/go/apiv1/serverhealthmessages/ServerHealthMessagesControllerTest.groovy
+++ b/api/api-server-health-messages-v1/src/test/groovy/com/thoughtworks/go/apiv1/serverhealthmessages/ServerHealthMessagesControllerTest.groovy
@@ -67,7 +67,7 @@ class ServerHealthMessagesControllerTest implements SecurityServiceTrait, Contro
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonArray([state], ServerHealthMessagesRepresenter)
+          .hasBodyWithJsonArray(ServerHealthMessagesRepresenter, [state])
       }
 
       @Test

--- a/api/api-server-health-v1/src/test/groovy/com/thoughtworks/go/apiv1/serverhealth/ServerHealthControllerTest.groovy
+++ b/api/api-server-health-v1/src/test/groovy/com/thoughtworks/go/apiv1/serverhealth/ServerHealthControllerTest.groovy
@@ -20,19 +20,13 @@ import com.thoughtworks.go.spark.AllowAllUsersSecurity
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.Routes
 import com.thoughtworks.go.spark.SecurityServiceTrait
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
-import static org.mockito.MockitoAnnotations.initMocks
-
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ServerHealthControllerTest implements ControllerTrait<ServerHealthController>, SecurityServiceTrait {
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
-
   @Override
   ServerHealthController createControllerInstance() {
     return new ServerHealthController()

--- a/api/api-server-maintenance-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/servermaintenancemode/ServerMaintenanceModeControllerV1Test.groovy
+++ b/api/api-server-maintenance-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/servermaintenancemode/ServerMaintenanceModeControllerV1Test.groovy
@@ -42,6 +42,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import java.sql.Timestamp
 
@@ -49,8 +51,8 @@ import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.domain.PipelinePauseInfo.notPaused
 import static org.assertj.core.api.Assertions.assertThat
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ServerMaintenanceModeControllerV1Test implements SecurityServiceTrait, ControllerTrait<ServerMaintenanceModeControllerV1> {
   @Mock
   AgentService agentService
@@ -66,10 +68,6 @@ class ServerMaintenanceModeControllerV1Test implements SecurityServiceTrait, Con
 
   TestingClock testingClock = new TestingClock()
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   ServerMaintenanceModeControllerV1 createControllerInstance() {

--- a/api/api-server-maintenance-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/servermaintenancemode/representers/MaintenanceModeInfoRepresenterTest.groovy
+++ b/api/api-server-maintenance-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/servermaintenancemode/representers/MaintenanceModeInfoRepresenterTest.groovy
@@ -21,9 +21,10 @@ import com.thoughtworks.go.server.domain.ServerMaintenanceMode
 import com.thoughtworks.go.server.service.MaintenanceModeService
 import com.thoughtworks.go.util.SystemEnvironment
 import com.thoughtworks.go.util.TimeProvider
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import java.sql.Timestamp
 
@@ -32,13 +33,9 @@ import static com.thoughtworks.go.api.base.JsonOutputWriter.jsonDate
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class MaintenanceModeInfoRepresenterTest {
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Mock
   TimeProvider timeProvider

--- a/api/api-server-site-urls-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/serversiteurlsconfig/ServerSiteUrlsConfigControllerV1Test.groovy
+++ b/api/api-server-site-urls-config-v1/src/test/groovy/com/thoughtworks/go/apiv1/serversiteurlsconfig/ServerSiteUrlsConfigControllerV1Test.groovy
@@ -33,11 +33,13 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ServerSiteUrlsConfigControllerV1Test implements SecurityServiceTrait, ControllerTrait<ServerSiteUrlsConfigControllerV1> {
 
   @Mock
@@ -45,11 +47,6 @@ class ServerSiteUrlsConfigControllerV1Test implements SecurityServiceTrait, Cont
 
   @Mock
   EntityHashingService entityHashingService
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   ServerSiteUrlsConfigControllerV1 createControllerInstance() {

--- a/api/api-shared-v10/src/test/groovy/com/thoughtworks/go/apiv10/shared/representers/PipelineConfigRepresenterTest.groovy
+++ b/api/api-shared-v10/src/test/groovy/com/thoughtworks/go/apiv10/shared/representers/PipelineConfigRepresenterTest.groovy
@@ -32,10 +32,11 @@ import com.thoughtworks.go.helper.EnvironmentVariablesConfigMother
 import com.thoughtworks.go.helper.MaterialConfigsMother
 import com.thoughtworks.go.helper.StageConfigMother
 import com.thoughtworks.go.security.GoCipher
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl
 import static com.thoughtworks.go.api.base.JsonUtils.toObject
@@ -43,14 +44,10 @@ import static com.thoughtworks.go.helper.MaterialConfigsMother.git
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import static org.junit.jupiter.api.Assertions.*
 import static org.mockito.Mockito.mock
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PipelineConfigRepresenterTest {
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Mock
   private PasswordDeserializer passwordDeserializer

--- a/api/api-shared-v11/src/test/groovy/com/thoughtworks/go/apiv11/shared/representers/PipelineConfigRepresenterTest.groovy
+++ b/api/api-shared-v11/src/test/groovy/com/thoughtworks/go/apiv11/shared/representers/PipelineConfigRepresenterTest.groovy
@@ -32,10 +32,11 @@ import com.thoughtworks.go.helper.EnvironmentVariablesConfigMother
 import com.thoughtworks.go.helper.MaterialConfigsMother
 import com.thoughtworks.go.helper.StageConfigMother
 import com.thoughtworks.go.security.GoCipher
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl
 import static com.thoughtworks.go.api.base.JsonUtils.toObject
@@ -43,14 +44,10 @@ import static com.thoughtworks.go.helper.MaterialConfigsMother.git
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import static org.junit.jupiter.api.Assertions.*
 import static org.mockito.Mockito.mock
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PipelineConfigRepresenterTest {
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Mock
   private PasswordDeserializer passwordDeserializer

--- a/api/api-shared-v9/src/test/groovy/com/thoughtworks/go/apiv9/shared/representers/PipelineConfigRepresenterTest.groovy
+++ b/api/api-shared-v9/src/test/groovy/com/thoughtworks/go/apiv9/shared/representers/PipelineConfigRepresenterTest.groovy
@@ -32,10 +32,11 @@ import com.thoughtworks.go.helper.EnvironmentVariablesConfigMother
 import com.thoughtworks.go.helper.MaterialConfigsMother
 import com.thoughtworks.go.helper.StageConfigMother
 import com.thoughtworks.go.security.GoCipher
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl
 import static com.thoughtworks.go.api.base.JsonUtils.toObject
@@ -43,14 +44,10 @@ import static com.thoughtworks.go.helper.MaterialConfigsMother.git
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import static org.junit.jupiter.api.Assertions.*
 import static org.mockito.Mockito.mock
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PipelineConfigRepresenterTest {
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Mock
   private PasswordDeserializer passwordDeserializer

--- a/api/api-stage-instance-v2/src/test/groovy/com/thoughtworks/go/apiv2/stageinstance/StageInstanceControllerV2Test.groovy
+++ b/api/api-stage-instance-v2/src/test/groovy/com/thoughtworks/go/apiv2/stageinstance/StageInstanceControllerV2Test.groovy
@@ -406,7 +406,7 @@ class StageInstanceControllerV2Test implements SecurityServiceTrait, ControllerT
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject(getStageModel(), StageRepresenter)
+          .hasBodyWithJsonObject(StageRepresenter, getStageModel())
       }
 
       def getStageModel() {

--- a/api/api-stage-instance-v2/src/test/groovy/com/thoughtworks/go/apiv2/stageinstance/StageInstanceControllerV2Test.groovy
+++ b/api/api-stage-instance-v2/src/test/groovy/com/thoughtworks/go/apiv2/stageinstance/StageInstanceControllerV2Test.groovy
@@ -31,11 +31,7 @@ import com.thoughtworks.go.server.service.result.HttpOperationResult
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult
 import com.thoughtworks.go.serverhealth.HealthStateScope
 import com.thoughtworks.go.serverhealth.HealthStateType
-import com.thoughtworks.go.spark.ControllerTrait
-import com.thoughtworks.go.spark.DeprecatedApiTrait
-import com.thoughtworks.go.spark.PipelineAccessSecurity
-import com.thoughtworks.go.spark.PipelineGroupOperateUserSecurity
-import com.thoughtworks.go.spark.SecurityServiceTrait
+import com.thoughtworks.go.spark.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -44,14 +40,16 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import java.util.stream.Stream
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class StageInstanceControllerV2Test implements SecurityServiceTrait, ControllerTrait<StageInstanceControllerV2>, DeprecatedApiTrait {
 
   @Mock
@@ -60,10 +58,6 @@ class StageInstanceControllerV2Test implements SecurityServiceTrait, ControllerT
   @Mock
   private ScheduleService scheduleService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   StageInstanceControllerV2 createControllerInstance() {

--- a/api/api-stage-instance-v3/src/test/groovy/com/thoughtworks/go/apiv3/stageinstance/StageInstanceControllerV3Test.groovy
+++ b/api/api-stage-instance-v3/src/test/groovy/com/thoughtworks/go/apiv3/stageinstance/StageInstanceControllerV3Test.groovy
@@ -410,7 +410,7 @@ class StageInstanceControllerV3Test implements SecurityServiceTrait, ControllerT
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject(getStageModel(), StageRepresenter)
+          .hasBodyWithJsonObject(StageRepresenter, getStageModel())
       }
 
       def getStageModel() {

--- a/api/api-stage-instance-v3/src/test/groovy/com/thoughtworks/go/apiv3/stageinstance/StageInstanceControllerV3Test.groovy
+++ b/api/api-stage-instance-v3/src/test/groovy/com/thoughtworks/go/apiv3/stageinstance/StageInstanceControllerV3Test.groovy
@@ -43,6 +43,8 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import java.sql.Timestamp
 import java.util.stream.Stream
@@ -50,8 +52,8 @@ import java.util.stream.Stream
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class StageInstanceControllerV3Test implements SecurityServiceTrait, ControllerTrait<StageInstanceControllerV3> {
 
   @Mock
@@ -60,10 +62,6 @@ class StageInstanceControllerV3Test implements SecurityServiceTrait, ControllerT
   @Mock
   private ScheduleService scheduleService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   StageInstanceControllerV3 createControllerInstance() {

--- a/api/api-stage-operations-v2/src/test/groovy/com/thoughtworks/go/apiv2/stageoperations/StageOperationsControllerV2Test.groovy
+++ b/api/api-stage-operations-v2/src/test/groovy/com/thoughtworks/go/apiv2/stageoperations/StageOperationsControllerV2Test.groovy
@@ -33,12 +33,14 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class StageOperationsControllerV2Test implements SecurityServiceTrait, ControllerTrait<StageOperationsControllerV2> {
   @Mock
   ScheduleService scheduleService
@@ -52,10 +54,6 @@ class StageOperationsControllerV2Test implements SecurityServiceTrait, Controlle
   @Mock
   PipelineService pipelineService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   StageOperationsControllerV2 createControllerInstance() {

--- a/api/api-support/src/test/groovy/com/thoughtworks/go/api/support/ApiSupportControllerV1Test.groovy
+++ b/api/api-support/src/test/groovy/com/thoughtworks/go/api/support/ApiSupportControllerV1Test.groovy
@@ -15,33 +15,29 @@
  */
 package com.thoughtworks.go.api.support
 
-
 import com.thoughtworks.go.server.domain.Username
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult
 import com.thoughtworks.go.server.service.support.ServerStatusService
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.Routes
 import com.thoughtworks.go.spark.SecurityServiceTrait
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.doAnswer
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ApiSupportControllerV1Test implements SecurityServiceTrait, ControllerTrait<ApiSupportController> {
   @Mock
   private ServerStatusService serverStatusService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   ApiSupportController createControllerInstance() {

--- a/api/api-template-authorization-v1/src/test/groovy/com/thoughtworks/go/apiv1/templateauthorization/TemplateAuthorizationControllerV1Test.groovy
+++ b/api/api-template-authorization-v1/src/test/groovy/com/thoughtworks/go/apiv1/templateauthorization/TemplateAuthorizationControllerV1Test.groovy
@@ -32,17 +32,17 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectWithoutLinks
 import static com.thoughtworks.go.helper.PipelineTemplateConfigMother.createTemplate
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
-import static org.mockito.Mockito.doAnswer
-import static org.mockito.Mockito.doNothing
-import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
+import static org.mockito.Mockito.*
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class TemplateAuthorizationControllerV1Test implements SecurityServiceTrait, ControllerTrait<TemplateAuthorizationControllerV1> {
   @Mock
   EntityHashingService entityHashingService;
@@ -50,10 +50,6 @@ class TemplateAuthorizationControllerV1Test implements SecurityServiceTrait, Con
   @Mock
   TemplateConfigService templateConfigService;
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   TemplateAuthorizationControllerV1 createControllerInstance() {

--- a/api/api-template-config-v7/src/test/groovy/com/thoughtworks/go/apiv7/admin/templateconfig/TemplateConfigControllerV7Test.groovy
+++ b/api/api-template-config-v7/src/test/groovy/com/thoughtworks/go/apiv7/admin/templateconfig/TemplateConfigControllerV7Test.groovy
@@ -31,21 +31,22 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.helper.PipelineTemplateConfigMother.createTemplateWithParams
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class TemplateConfigControllerV7Test implements SecurityServiceTrait, ControllerTrait<TemplateConfigControllerV7> {
 
   private PipelineTemplateConfig template
 
   @BeforeEach
   void setUp() {
-    initMocks(this)
     template = new PipelineTemplateConfig(new CaseInsensitiveString('some-template'), new StageConfig(new CaseInsensitiveString('stage'), new JobConfigs(new JobConfig(new CaseInsensitiveString('job')))))
   }
 

--- a/api/api-template-config-v7/src/test/groovy/com/thoughtworks/go/apiv7/admin/templateconfig/TemplateConfigControllerV7Test.groovy
+++ b/api/api-template-config-v7/src/test/groovy/com/thoughtworks/go/apiv7/admin/templateconfig/TemplateConfigControllerV7Test.groovy
@@ -97,7 +97,7 @@ class TemplateConfigControllerV7Test implements SecurityServiceTrait, Controller
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject([templates], TemplatesConfigRepresenter)
+          .hasBodyWithJsonObject(TemplatesConfigRepresenter, [templates])
       }
     }
   }
@@ -139,7 +139,7 @@ class TemplateConfigControllerV7Test implements SecurityServiceTrait, Controller
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject(template, TemplateConfigRepresenter)
+          .hasBodyWithJsonObject(TemplateConfigRepresenter, template)
 
       }
 
@@ -281,7 +281,7 @@ class TemplateConfigControllerV7Test implements SecurityServiceTrait, Controller
 
         assertThatResponse()
         .isOk()
-        .hasBodyWithJsonObject(template, TemplateConfigRepresenter)
+        .hasBodyWithJsonObject(TemplateConfigRepresenter, template)
       }
 
       @Test
@@ -350,7 +350,7 @@ class TemplateConfigControllerV7Test implements SecurityServiceTrait, Controller
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject(template, TemplateConfigRepresenter)
+          .hasBodyWithJsonObject(TemplateConfigRepresenter, template)
       }
 
       @Test

--- a/api/api-user-search-v1/src/test/groovy/com/thoughtworks/go/apiv1/usersearch/UserSearchControllerV1Test.groovy
+++ b/api/api-user-search-v1/src/test/groovy/com/thoughtworks/go/apiv1/usersearch/UserSearchControllerV1Test.groovy
@@ -31,22 +31,20 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class UserSearchControllerV1Test implements SecurityServiceTrait, ControllerTrait<UserSearchControllerV1> {
 
   @Mock
   UserSearchService userSearchService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   UserSearchControllerV1 createControllerInstance() {

--- a/api/api-users-v3/src/test/groovy/com/thoughtworks/go/apiv3/users/UsersControllerV3Test.groovy
+++ b/api/api-users-v3/src/test/groovy/com/thoughtworks/go/apiv3/users/UsersControllerV3Test.groovy
@@ -93,7 +93,7 @@ class UsersControllerV3Test implements SecurityServiceTrait, ControllerTrait<Use
         def expectedUser = UserToRepresent.from(bobUser, securityService.isUserAdmin(bobUser.getUsername()), new RolesConfig())
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject([expectedUser], UsersRepresenter)
+          .hasBodyWithJsonObject(UsersRepresenter, [expectedUser])
       }
     }
   }
@@ -132,7 +132,7 @@ class UsersControllerV3Test implements SecurityServiceTrait, ControllerTrait<Use
 
         assertThatResponse()
           .isOk()
-          .hasBodyWithJsonObject(UserToRepresent.from(bobUser, false, new RolesConfig()), UserRepresenter)
+          .hasBodyWithJsonObject(UserRepresenter, UserToRepresent.from(bobUser, false, new RolesConfig()))
       }
     }
   }
@@ -177,7 +177,7 @@ class UsersControllerV3Test implements SecurityServiceTrait, ControllerTrait<Use
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(UserToRepresent.from(expectedUser, false, new RolesConfig()), UserRepresenter)
+          .hasBodyWithJsonObject(UserRepresenter, UserToRepresent.from(expectedUser, false, new RolesConfig()))
       }
     }
 
@@ -234,7 +234,7 @@ class UsersControllerV3Test implements SecurityServiceTrait, ControllerTrait<Use
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(UserToRepresent.from(new User(username), false, new RolesConfig()), UserRepresenter)
+          .hasBodyWithJsonObject(UserRepresenter, UserToRepresent.from(new User(username), false, new RolesConfig()))
       }
     }
 

--- a/api/api-users-v3/src/test/groovy/com/thoughtworks/go/apiv3/users/UsersControllerV3Test.groovy
+++ b/api/api-users-v3/src/test/groovy/com/thoughtworks/go/apiv3/users/UsersControllerV3Test.groovy
@@ -37,13 +37,15 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.doAnswer
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class UsersControllerV3Test implements SecurityServiceTrait, ControllerTrait<UsersControllerV3> {
   @Mock
   UserService userService
@@ -51,10 +53,6 @@ class UsersControllerV3Test implements SecurityServiceTrait, ControllerTrait<Use
   @Mock
   RoleConfigService roleConfigService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   UsersControllerV3 createControllerInstance() {

--- a/api/api-version-infos-v1/src/test/groovy/com/thoughtworks/go/apiv1/versioninfos/VersionInfosControllerV1Test.groovy
+++ b/api/api-version-infos-v1/src/test/groovy/com/thoughtworks/go/apiv1/versioninfos/VersionInfosControllerV1Test.groovy
@@ -30,10 +30,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class VersionInfosControllerV1Test implements SecurityServiceTrait, ControllerTrait<VersionInfosControllerV1> {
   @Mock
   private VersionInfoService versionInfoService
@@ -42,7 +44,6 @@ class VersionInfosControllerV1Test implements SecurityServiceTrait, ControllerTr
 
   @BeforeEach
   void setUp() {
-    initMocks(this)
     when(systemEnvironment.getUpdateServerUrl()).thenReturn("https://update.example.com/some/path")
   }
 

--- a/api/api-version-v1/src/test/groovy/com/thoughtworks/go/apiv1/version/VersionControllerV1Test.groovy
+++ b/api/api-version-v1/src/test/groovy/com/thoughtworks/go/apiv1/version/VersionControllerV1Test.groovy
@@ -21,9 +21,10 @@ import com.thoughtworks.go.spark.SecurityServiceTrait
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
-import static org.mockito.MockitoAnnotations.initMocks
-
+@MockitoSettings(strictness = Strictness.LENIENT)
 class VersionControllerV1Test implements SecurityServiceTrait, ControllerTrait<VersionControllerV1> {
 
   private CurrentGoCDVersion currentGoCDVersion
@@ -35,7 +36,6 @@ class VersionControllerV1Test implements SecurityServiceTrait, ControllerTrait<V
 
   @BeforeEach
   void setUp() {
-    initMocks(this)
     currentGoCDVersion = new CurrentGoCDVersion()
   }
 

--- a/api/api-version-v1/src/test/groovy/com/thoughtworks/go/apiv1/version/VersionControllerV1Test.groovy
+++ b/api/api-version-v1/src/test/groovy/com/thoughtworks/go/apiv1/version/VersionControllerV1Test.groovy
@@ -48,7 +48,7 @@ class VersionControllerV1Test implements SecurityServiceTrait, ControllerTrait<V
 
       assertThatResponse()
         .isOk()
-        .hasBodyWithJsonObject(currentGoCDVersion, VersionRepresenter)
+        .hasBodyWithJsonObject(VersionRepresenter, currentGoCDVersion)
 
     }
 

--- a/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/controller/PushWebhookControllerV1Test.groovy
+++ b/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/controller/PushWebhookControllerV1Test.groovy
@@ -30,14 +30,16 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.apiv1.webhook.controller.BaseWebhookController.PING_RESPONSE
 import static com.thoughtworks.go.apiv1.webhook.helpers.PostHelper.SECRET
 import static com.thoughtworks.go.util.Iters.first
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTrait<PushWebhookControllerV1> {
     @Mock
     private MaterialUpdateService materialUpdateService
@@ -46,7 +48,6 @@ class PushWebhookControllerV1Test implements SecurityServiceTrait, ControllerTra
 
     @BeforeEach
     void setUp() {
-        initMocks(this)
         when(serverConfigService.webhookSecret).thenReturn(SECRET)
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1165,13 +1165,11 @@ task newApi {
           import org.junit.jupiter.api.BeforeEach
           import org.junit.jupiter.api.Nested
           import org.junit.jupiter.api.Test
+          import org.mockito.junit.jupiter.MockitoSettings
+          import org.mockito.quality.Strictness
 
+          @MockitoSettings(strictness = Strictness.LENIENT)
           class ${controllerClassName}Test implements SecurityServiceTrait, ControllerTrait<${controllerClassName}> {
-
-            @BeforeEach
-            void setUp() {
-              initMocks(this)
-            }
 
             @Override
             ${controllerClassName} createControllerInstance() {

--- a/commandline/build.gradle
+++ b/commandline/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   implementation project(':util')
   implementation project(':config:config-api')
   annotationProcessor project.deps.lombok
+  compileOnly project.deps.jetBrainsAnnotations
 
   testImplementation project(':test:test-utils')
   testImplementation project.deps.junit5

--- a/commandline/src/main/java/com/thoughtworks/go/util/command/CommandLine.java
+++ b/commandline/src/main/java/com/thoughtworks/go/util/command/CommandLine.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.util.ProcessTag;
 import com.thoughtworks.go.util.ProcessWrapper;
 import com.thoughtworks.go.utils.CommandUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.TestOnly;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -209,9 +210,9 @@ public class CommandLine {
     }
 
     /**
-     * @deprecated this should not be used outside of this CommandLine(in production code), as using it directly can bypass smudging of sensitive data
-     * this is used only in tests
+     * This should not be used outside of this CommandLine(in production code), as using it directly can bypass smudging of sensitive data
      */
+    @TestOnly
     public ProcessWrapper execute(ConsoleOutputStreamConsumer outputStreamConsumer, EnvironmentVariableContext environmentVariableContext, ProcessTag processTag) {
         ProcessWrapper process = createProcess(environmentVariableContext, outputStreamConsumer, processTag, ERROR_STREAM_PREFIX_FOR_CMDS);
         process.typeInputToConsole(inputs);

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   api project.deps.springTx
   implementation project.deps.jodaTime
   annotationProcessor project.deps.lombok
+  compileOnly project.deps.jetBrainsAnnotations
 
   testImplementation project.deps.bouncyCastle
   testImplementation project.deps.bouncyCastlePkix

--- a/common/src/main/java/com/thoughtworks/go/domain/AgentInstance.java
+++ b/common/src/main/java/com/thoughtworks/go/domain/AgentInstance.java
@@ -29,6 +29,7 @@ import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TimeProvider;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.jetbrains.annotations.TestOnly;
 
 import java.util.Date;
 import java.util.List;
@@ -135,7 +136,7 @@ public class AgentInstance implements Comparable<AgentInstance> {
         agentRuntimeInfo.busy(agentBuildingInfo);
     }
 
-    //  Used only in tests
+    @TestOnly
     public void idle() {
         agentConfigStatus = Enabled;
         syncRuntimeStatus(Idle);

--- a/common/src/main/java/com/thoughtworks/go/domain/ArtifactMd5Checksums.java
+++ b/common/src/main/java/com/thoughtworks/go/domain/ArtifactMd5Checksums.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.domain;
 
+import org.jetbrains.annotations.TestOnly;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +56,7 @@ public class ArtifactMd5Checksums implements Serializable {
         }
     }
 
-    //Used only in tests
+    @TestOnly
     public ArtifactMd5Checksums(Properties checksumProperties) {
         this.checksumProperties = checksumProperties;
     }

--- a/common/src/main/java/com/thoughtworks/go/domain/FileHandler.java
+++ b/common/src/main/java/com/thoughtworks/go/domain/FileHandler.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -56,7 +57,7 @@ public class FileHandler implements FetchHandler {
         if (fileExist && artifact.isFile()) {
             String sha1 = FileUtil.sha1Digest(artifact);
             return format("%s/%s/%s/%s?sha1=%s", remoteHost, "remoting", "files", workingUrl,
-                    URLEncoder.encode(sha1, "UTF-8"));
+                    URLEncoder.encode(sha1, StandardCharsets.UTF_8));
         } else {
             return format("%s/%s/%s/%s", remoteHost, "remoting", "files", workingUrl);
         }

--- a/common/src/main/java/com/thoughtworks/go/presentation/pipelinehistory/StageInstanceModels.java
+++ b/common/src/main/java/com/thoughtworks/go/presentation/pipelinehistory/StageInstanceModels.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.StageConfig;
 import com.thoughtworks.go.domain.BaseCollection;
 import com.thoughtworks.go.domain.StageContainer;
+import org.jetbrains.annotations.TestOnly;
 
 import java.util.Date;
 
@@ -91,9 +92,9 @@ public class StageInstanceModels extends BaseCollection<StageInstanceModel> impl
     }
 
     /**
-     *
-     * @deprecated use add method. This is a test helper
+     * Use {@link #add(StageInstanceModel)} instead
      */
+    @TestOnly
     public void addStage(String name, JobHistory history) {
         add(new StageInstanceModel(name, "1", history));
     }

--- a/common/src/main/java/com/thoughtworks/go/serverhealth/ServerHealthService.java
+++ b/common/src/main/java/com/thoughtworks/go/serverhealth/ServerHealthService.java
@@ -100,7 +100,7 @@ public class ServerHealthService implements ApplicationContextAware {
         removeExpiredMessages();
     }
 
-    @Deprecated // Remove once we get rid of SpringJUnitTestRunner
+    @Deprecated(forRemoval = true) // Remove once we get rid of SpringJUnitTestRunner
     public void removeAllLogs() {
         serverHealth.clear();
     }

--- a/common/src/test/java/com/thoughtworks/go/util/DirectoryReaderTest.java
+++ b/common/src/test/java/com/thoughtworks/go/util/DirectoryReaderTest.java
@@ -15,21 +15,21 @@
  */
 package com.thoughtworks.go.util;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URLEncoder;
-import java.util.List;
-
 import com.thoughtworks.go.domain.DirectoryEntry;
 import com.thoughtworks.go.domain.FolderDirectoryEntry;
 import com.thoughtworks.go.domain.JobIdentifier;
-import static org.hamcrest.Matchers.is;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 
 public class DirectoryReaderTest {
@@ -45,7 +45,7 @@ public class DirectoryReaderTest {
     }
 
     @Test
-    public void shouldNotDieIfGivenBogusPath() throws Exception {
+    public void shouldNotDieIfGivenBogusPath() {
         DirectoryReader reader = new DirectoryReader(jobIdentifier);
         List<DirectoryEntry> entries = reader.listEntries(new File("totally bogus path!!!"), "");
         assertThat(entries.size(), is(0));
@@ -68,7 +68,7 @@ public class DirectoryReaderTest {
         assertThat(entries.get(0).getFileName(), is(filename));
         assertThat(entries.get(0).getUrl(),
                 is("/files/pipelineName/LATEST/stageName/LATEST/buildName" + folderRoot + "/"
-                        + URLEncoder.encode(filename)));
+                        + URLEncoder.encode(filename, StandardCharsets.UTF_8)));
     }
 
     @Test

--- a/config/config-api/build.gradle
+++ b/config/config-api/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   implementation project.deps.jodaTime
   providedAtPackageTime project.deps.bouncyCastle
   annotationProcessor project.deps.lombok
+  compileOnly project.deps.jetBrainsAnnotations
 
   testImplementation project(':test:test-utils')
   testImplementation project.deps.jaxen

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentPipelinesConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentPipelinesConfig.java
@@ -15,12 +15,13 @@
  */
 package com.thoughtworks.go.config;
 
+import com.thoughtworks.go.domain.BaseCollection;
+import com.thoughtworks.go.domain.ConfigErrors;
+import org.jetbrains.annotations.TestOnly;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import com.thoughtworks.go.domain.BaseCollection;
-import com.thoughtworks.go.domain.ConfigErrors;
 
 /**
  * @understands references to existing pipelines that are associated to an Environment
@@ -33,7 +34,7 @@ public class EnvironmentPipelinesConfig extends BaseCollection<EnvironmentPipeli
     public EnvironmentPipelinesConfig() {
     }
 
-    //used only in tests
+    @TestOnly
     public EnvironmentPipelinesConfig(CaseInsensitiveString... pipelineNames) {
         for (CaseInsensitiveString name : pipelineNames) {
             add(new EnvironmentPipelineConfig(name));

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PluginRoleUsersStore.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PluginRoleUsersStore.java
@@ -17,6 +17,7 @@ package com.thoughtworks.go.config;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
+import org.jetbrains.annotations.TestOnly;
 
 import java.util.*;
 
@@ -73,7 +74,7 @@ public class PluginRoleUsersStore {
         return new HashSet<>(roleToUsersMappings.keySet());
     }
 
-//    Used only in tests
+    @TestOnly
     public void clearAll() {
         roleToUsersMappings.clear();
     }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/ServerConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/ServerConfig.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.domain.SecureSiteUrl;
 import com.thoughtworks.go.domain.ServerSiteUrlConfig;
 import com.thoughtworks.go.domain.SiteUrl;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.TestOnly;
 
 import javax.annotation.PostConstruct;
 import java.util.Objects;
@@ -341,9 +342,7 @@ public class ServerConfig implements Validatable {
         return jobTimeout;
     }
 
-    /**
-     * @deprecated Used only in tests
-     */
+    @TestOnly
     public void setJobTimeout(String jobTimeout) {
         this.jobTimeout = jobTimeout;
     }

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/UnitTestReportGenerator.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/UnitTestReportGenerator.java
@@ -29,6 +29,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 
 public class UnitTestReportGenerator implements TestReportGenerator {
@@ -85,7 +86,7 @@ public class UnitTestReportGenerator implements TestReportGenerator {
     }
 
     public void merge(File[] testFiles, OutputStream outputStream) throws IOException {
-        try (PrintStream out = new PrintStream(outputStream, true, "UTF-8")) {
+        try (PrintStream out = new PrintStream(outputStream, true, StandardCharsets.UTF_8)) {
             out.println("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>");
             out.println("<all-results>");
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/util/pool/DigestObjectPools.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/util/pool/DigestObjectPools.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.util.pool;
 
 import org.apache.commons.codec.digest.MessageDigestAlgorithms;
+import org.jetbrains.annotations.TestOnly;
 
 import java.io.IOException;
 import java.security.MessageDigest;
@@ -92,9 +93,7 @@ public class DigestObjectPools {
         }
     }
 
-    /**
-     * @deprecated Used only in tests
-     */
+    @TestOnly
     void clearThreadLocals() {
         sha256DigestLocal.set(null);
         sha512DigestLocal.set(null);

--- a/config/config-server/build.gradle
+++ b/config/config-server/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   }
   implementation project.deps.slf4j
   implementation project.deps.cglib
+  compileOnly project.deps.jetBrainsAnnotations
   providedAtPackageTime(project.deps.bouncyCastle)
   testImplementation project(path: ':config:config-api', configuration: 'testOutput')
   testImplementation project(':test:test-utils')

--- a/config/config-server/src/main/java/com/thoughtworks/go/service/ConfigRepository.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/service/ConfigRepository.java
@@ -36,6 +36,7 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.treewalk.CanonicalTreeParser;
+import org.jetbrains.annotations.TestOnly;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -93,8 +94,7 @@ public class ConfigRepository {
         }
     }
 
-    @Deprecated
-        // used in test only
+    @TestOnly
     Git git() {
         return git;
     }

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/Modification.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/Modification.java
@@ -121,44 +121,26 @@ public class Modification extends PersistentObject implements Comparable, Serial
         this.additionalDataMap = JsonHelper.safeFromJson(this.additionalData, HashMap.class);
     }
 
-    /**
-     * @deprecated used only by material parsers and in test
-     */
     public void setUserName(String name) {
         this.userName = name;
     }
 
-    /**
-     * @deprecated used only by material parsers and in tests
-     */
     public void setEmailAddress(String email) {
         this.emailAddress = email;
     }
 
-    /**
-     * @deprecated used only by material parsers and in tests
-     */
     public void setComment(String comment) {
         this.comment = comment;
     }
 
-    /**
-     * @deprecated used only by material parsers and in tests
-     */
     public void setRevision(String revision) {
         this.revision = revision;
     }
 
-    /**
-     * @deprecated used only by material parsers and in tests
-     */
     public void setModifiedTime(Date modifiedTime) {
         this.modifiedTime = modifiedTime;
     }
 
-    /**
-     * @deprecated used only in tests
-     */
     public void setModifiedFiles(List<ModifiedFile> files) {
         this.files = files == null ? new LinkedHashSet<>() : new LinkedHashSet<>(files);
     }

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/dependency/DependencyMaterialRevision.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/dependency/DependencyMaterialRevision.java
@@ -15,15 +15,16 @@
  */
 package com.thoughtworks.go.domain.materials.dependency;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Map;
-
 import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.materials.Material;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.Revision;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.TestOnly;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Map;
 
 public class DependencyMaterialRevision implements Revision {
     private String pipelineName;
@@ -129,9 +130,7 @@ public class DependencyMaterialRevision implements Revision {
         return stageCounter;
     }
 
-    /**
-     * @deprecated used only in tests
-     */
+    @TestOnly
     public MaterialRevision convert(Material material, Date modifiedTime) {
         ArrayList<Modification> modifications = new ArrayList<>();
         modifications.add(new Modification(modifiedTime, getRevision(), getPipelineLabel(), null

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoMigrator.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoMigrator.java
@@ -21,6 +21,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public class ConfigRepoMigrator {
@@ -41,7 +42,7 @@ public class ConfigRepoMigrator {
     private Chainr getTransformerFor(int targetVersion) {
         try {
             String targetVersionFile = String.format("/config-repo/migrations/%s.json", targetVersion);
-            String transformJSON = IOUtils.toString(this.getClass().getResourceAsStream(targetVersionFile), "UTF-8");
+            String transformJSON = IOUtils.toString(this.getClass().getResourceAsStream(targetVersionFile), StandardCharsets.UTF_8);
             return Chainr.fromSpec(JsonUtils.jsonToList(transformJSON));
         } catch (Exception e) {
             throw new RuntimeException("Failed to migrate to version " + targetVersion, e);
@@ -51,7 +52,7 @@ public class ConfigRepoMigrator {
     private Map<String, Object> getContextMap(int targetVersion) {
         try {
             String contextFile = String.format("/config-repo/contexts/%s.json", targetVersion);
-            String contextJSON = IOUtils.toString(this.getClass().getResourceAsStream(contextFile), "UTF-8");
+            String contextJSON = IOUtils.toString(this.getClass().getResourceAsStream(contextFile), StandardCharsets.UTF_8);
             return JsonUtils.jsonToMap(contextJSON);
         } catch (Exception e) {
             LOGGER.debug(String.format("No context file present for target version '%s'.", targetVersion));

--- a/server/src/main/java/com/thoughtworks/go/domain/activity/JobStatusCache.java
+++ b/server/src/main/java/com/thoughtworks/go/domain/activity/JobStatusCache.java
@@ -15,21 +15,18 @@
  */
 package com.thoughtworks.go.domain.activity;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
 import com.thoughtworks.go.domain.JobConfigIdentifier;
 import com.thoughtworks.go.domain.JobInstance;
 import com.thoughtworks.go.domain.NullJobInstance;
 import com.thoughtworks.go.server.dao.StageDao;
 import com.thoughtworks.go.server.domain.JobStatusListener;
+import org.jetbrains.annotations.TestOnly;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * @understands jobs that are currently in progress
@@ -106,9 +103,7 @@ public class JobStatusCache implements JobStatusListener {
         return found;
     }
 
-    /**
-     * @Deprecated Only for tests
-     */
+    @TestOnly
     public void clear() {
         jobs.clear();
     }

--- a/server/src/main/java/com/thoughtworks/go/server/cache/GoCache.java
+++ b/server/src/main/java/com/thoughtworks/go/server/cache/GoCache.java
@@ -24,6 +24,7 @@ import net.sf.ehcache.config.CacheConfiguration;
 import net.sf.ehcache.event.CacheEventListener;
 import net.sf.ehcache.statistics.StatisticsGateway;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.TestOnly;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
@@ -52,9 +53,7 @@ public class GoCache {
     static class KeyList extends HashSet<String> {
     }
 
-    /**
-     * @deprecated only for tests
-     */
+    @TestOnly
     public GoCache(GoCache goCache) {
         this(goCache.ehCache, goCache.transactionSynchronizationManager);
     }

--- a/server/src/main/java/com/thoughtworks/go/server/dao/VersionInfoSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/VersionInfoSqlMapDao.java
@@ -19,6 +19,7 @@ import com.thoughtworks.go.domain.VersionInfo;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Restrictions;
+import org.jetbrains.annotations.TestOnly;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 import org.springframework.stereotype.Component;
@@ -57,7 +58,7 @@ public class VersionInfoSqlMapDao extends HibernateDaoSupport implements Version
                 .setCacheable(true).uniqueResult());
     }
 
-    // used only in tests
+    @TestOnly
     void deleteAll() {
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             @Override

--- a/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimeline.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimeline.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.server.persistence.PipelineRepository;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.util.ClonerFactory;
+import org.jetbrains.annotations.TestOnly;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,10 +65,7 @@ public class PipelineTimeline {
         maximumId = -1;
     }
 
-    /**
-     * @deprecated Used only in tests
-     */
-    @Deprecated
+    @TestOnly
     public Collection<PipelineTimelineEntry> getEntriesFor(String pipelineName) {
         naturalOrderLock.readLock().lock();
         try {
@@ -265,9 +263,9 @@ public class PipelineTimeline {
     }
 
     /**
-     * @deprecated No reason why you should use this apart from test tear down
+     * No reason why you should use this apart from test tear down
      */
-    @Deprecated
+    @TestOnly
     public void clearWhichIsEvilAndShouldNotBeUsedInRealWorld() {
         acquireAllWriteLocks();
         try {

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/providers/AccessTokenBasedPluginAuthenticationProvider.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/providers/AccessTokenBasedPluginAuthenticationProvider.java
@@ -30,6 +30,7 @@ import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.PluginRoleService;
 import com.thoughtworks.go.server.service.UserService;
 import com.thoughtworks.go.util.Clock;
+import org.jetbrains.annotations.TestOnly;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -93,8 +94,7 @@ public class AccessTokenBasedPluginAuthenticationProvider extends AbstractPlugin
         }
     }
 
-    //used only in tests
-    @Deprecated
+    @TestOnly
     public void setStore(AuthorizationMetadataStore store) {
         this.store = store;
     }

--- a/server/src/main/java/com/thoughtworks/go/server/persistence/AgentDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/persistence/AgentDao.java
@@ -26,6 +26,7 @@ import com.thoughtworks.go.server.util.UuidGenerator;
 import lombok.*;
 import org.hibernate.Query;
 import org.hibernate.SessionFactory;
+import org.jetbrains.annotations.TestOnly;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 import org.springframework.stereotype.Component;
@@ -310,9 +311,7 @@ public class AgentDao extends HibernateDaoSupport {
         });
     }
 
-    /**
-     * @deprecated Used only in tests
-     */
+    @TestOnly
     public void clearListeners() {
         this.agentEntityChangeListenerSet.clear();
     }

--- a/server/src/main/java/com/thoughtworks/go/server/presentation/models/ValueStreamMapPresentationModel.java
+++ b/server/src/main/java/com/thoughtworks/go/server/presentation/models/ValueStreamMapPresentationModel.java
@@ -17,6 +17,7 @@ package com.thoughtworks.go.server.presentation.models;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.domain.valuestreammap.Node;
+import org.jetbrains.annotations.TestOnly;
 
 import java.util.List;
 
@@ -43,7 +44,7 @@ public class ValueStreamMapPresentationModel {
         return nodeLevels;
     }
 
-    @Deprecated //Used only in tests
+    @TestOnly
     public Node findNode(CaseInsensitiveString nodeId) {
         for (List<Node> nodeLevel : nodeLevels) {
             for (Node node : nodeLevel) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/StageService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/StageService.java
@@ -52,6 +52,7 @@ import com.thoughtworks.go.server.util.Pagination;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.util.ClonerFactory;
+import org.jetbrains.annotations.TestOnly;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -521,10 +522,7 @@ public class StageService implements StageFinder {
         }
     }
 
-    /**
-     * @return Listeners
-     * @deprecated Used only in tests
-     */
+    @TestOnly
     List<StageStatusListener> getStageStatusListeners() {
         return stageStatusListeners;
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/materials/PackageRepositoryService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/materials/PackageRepositoryService.java
@@ -47,6 +47,7 @@ import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.TestOnly;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -187,7 +188,7 @@ public class PackageRepositoryService {
         }
     }
 
-    //Used only in tests
+    @TestOnly
     public void setPluginManager(PluginManager pluginManager) {
         this.pluginManager = pluginManager;
     }

--- a/server/src/main/java/com/thoughtworks/go/server/ui/controller/ResponseRedirector.java
+++ b/server/src/main/java/com/thoughtworks/go/server/ui/controller/ResponseRedirector.java
@@ -15,12 +15,13 @@
  */
 package com.thoughtworks.go.server.ui.controller;
 
-import java.util.Map;
-import java.net.URLEncoder;
+import org.springframework.web.servlet.View;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import org.springframework.web.servlet.View;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 public class ResponseRedirector implements View {
     private final String target;
@@ -46,7 +47,7 @@ public class ResponseRedirector implements View {
                     if (params.length() > 0) {
                         params += "&";
                     }
-                    params += key + "=" + URLEncoder.encode(value, "UTF-8");
+                    params += key + "=" + URLEncoder.encode(value, StandardCharsets.UTF_8);
                 }
             }
         }

--- a/server/src/main/java/com/thoughtworks/go/server/websocket/ConsoleLogSocket.java
+++ b/server/src/main/java/com/thoughtworks/go/server/websocket/ConsoleLogSocket.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -132,7 +133,7 @@ public class ConsoleLogSocket implements SocketEndpoint {
     }
 
     private long parseStartLine(UpgradeRequest request) {
-        Optional<NameValuePair> startLine = URLEncodedUtils.parse(request.getRequestURI(), "UTF-8").
+        Optional<NameValuePair> startLine = URLEncodedUtils.parse(request.getRequestURI(), StandardCharsets.UTF_8).
                 stream().
                 filter(pair -> "startLine".equals(pair.getName())).findFirst();
 

--- a/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
+++ b/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
@@ -98,7 +98,7 @@ public class GoConfigFileHelper {
         this.configFile = configFile.getAbsoluteFile();
         try {
             saveFullConfig(FileUtils.readFileToString(this.configFile, UTF_8), true);
-            this.originalXml = FileUtils.readFileToString(this.configFile, "UTF-8");
+            this.originalXml = FileUtils.readFileToString(this.configFile, UTF_8);
         } catch (Exception e) {
             throw bomb("Error reading config file", e);
         }

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/api/mocks/MockHttpServletResponseAssert.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/api/mocks/MockHttpServletResponseAssert.groovy
@@ -36,27 +36,11 @@ class MockHttpServletResponseAssert extends com.thoughtworks.go.http.mocks.MockH
     return this
   }
 
-  /**
-   * Use {@link #hasBodyWithJsonObject(java.lang.Class, java.lang.Object [])} instead
-   */
-  @Deprecated
-  MockHttpServletResponseAssert hasBodyWithJsonObject(Object expected, Class representer) throws UnsupportedEncodingException {
-    return hasBodyWithJsonObject(representer, expected)
-  }
-
   MockHttpServletResponseAssert hasBodyWithJsonObject(Class representer, Object... representerArgs) throws UnsupportedEncodingException {
     def expectedJson = toObjectString({ representer.toJSON(it, *representerArgs) })
 
     JsonFluentAssert.assertThatJson(actual.getContentAsString()).isEqualTo(expectedJson)
     return this
-  }
-
-  /**
-   * Use {@link #hasBodyWithJsonArray(java.lang.Class, java.lang.Object [])} instead
-   */
-  @Deprecated
-  MockHttpServletResponseAssert hasBodyWithJsonArray(Object expected, Class representer) throws UnsupportedEncodingException {
-    return hasBodyWithJsonArray(representer, expected)
   }
 
   MockHttpServletResponseAssert hasBodyWithJsonArray(Class representer, Object... representerArgs) throws UnsupportedEncodingException {

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/spring/RouteInformationProviderTest.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/spring/RouteInformationProviderTest.groovy
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 import spark.ExceptionHandler
 import spark.Filter
 import spark.Route
@@ -34,9 +36,9 @@ import javax.servlet.FilterConfig
 import static org.assertj.core.api.Assertions.assertThat
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 import static spark.Spark.*
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class RouteInformationProviderTest {
   @Mock
   Filter apiv11BeforeFilter1
@@ -85,7 +87,6 @@ class RouteInformationProviderTest {
 
   @BeforeEach
   void setUp() {
-    initMocks(this)
     routeInformationProvider = new RouteInformationProvider()
 
     controller1 = new SparkController() {

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/AccessTokensControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/AccessTokensControllerTest.groovy
@@ -28,10 +28,11 @@ import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 import spark.ModelAndView
 import spark.Request
 import spark.Response
@@ -39,8 +40,8 @@ import spark.Response
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AccessTokensControllerTest implements ControllerTrait<AccessTokensController>, SecurityServiceTrait {
   @Mock
   private AuthorizationExtensionCacheService authorizationExtensionCacheService
@@ -49,10 +50,6 @@ class AccessTokensControllerTest implements ControllerTrait<AccessTokensControll
   @Mock
   private Response response
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   AccessTokensController createControllerInstance() {

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/AnalyticsControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/AnalyticsControllerTest.groovy
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 import spark.ModelAndView
 import spark.Request
 import spark.Response
@@ -38,8 +40,8 @@ import spark.Response
 import static java.lang.String.format
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.*
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AnalyticsControllerTest implements ControllerTrait<AnalyticsController>, SecurityServiceTrait {
   private static final Gson GSON = new Gson()
 
@@ -277,8 +279,4 @@ class AnalyticsControllerTest implements ControllerTrait<AnalyticsController>, S
     }
   }
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 }

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ArtifactStoresControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ArtifactStoresControllerTest.groovy
@@ -20,13 +20,13 @@ import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.mocks.StubTemplateEngine
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 import spark.ModelAndView
 
-import static org.mockito.MockitoAnnotations.initMocks
-
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ArtifactStoresControllerTest implements ControllerTrait<ArtifactStoresController>, SecurityServiceTrait {
 
   @Nested
@@ -59,10 +59,6 @@ class ArtifactStoresControllerTest implements ControllerTrait<ArtifactStoresCont
     }
   }
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   ArtifactStoresController createControllerInstance() {

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/AuthConfigsControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/AuthConfigsControllerTest.groovy
@@ -19,11 +19,11 @@ import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
-import static org.mockito.MockitoAnnotations.initMocks
-
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AuthConfigsControllerTest implements ControllerTrait<AuthConfigsController>, SecurityServiceTrait {
 
   @Nested
@@ -43,10 +43,6 @@ class AuthConfigsControllerTest implements ControllerTrait<AuthConfigsController
     }
   }
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   AuthConfigsController createControllerInstance() {

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ClickyPipelineConfigControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ClickyPipelineConfigControllerTest.groovy
@@ -18,16 +18,16 @@ package com.thoughtworks.go.spark.spa
 
 import com.thoughtworks.go.config.CaseInsensitiveString
 import com.thoughtworks.go.server.service.AuthorizationExtensionCacheService
-import com.thoughtworks.go.server.service.GoConfigService
 import com.thoughtworks.go.server.service.SecurityAuthConfigService
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.GroupAdminUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 import spark.ModelAndView
 import spark.Request
 import spark.Response
@@ -35,8 +35,8 @@ import spark.Response
 import static org.assertj.core.api.Assertions.assertThat
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ClickyPipelineConfigControllerTest implements ControllerTrait<ClickyPipelineConfigController>, SecurityServiceTrait {
   @Mock
   private AuthorizationExtensionCacheService authorizationExtensionCacheService
@@ -45,10 +45,6 @@ class ClickyPipelineConfigControllerTest implements ControllerTrait<ClickyPipeli
   @Mock
   private Response response
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   ClickyPipelineConfigController createControllerInstance() {

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/CompareControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/CompareControllerTest.groovy
@@ -26,20 +26,18 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.ArgumentMatchers.*
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class CompareControllerTest implements ControllerTrait<CompareController>, SecurityServiceTrait {
   @Mock
   private PipelineService pipelineService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   CompareController createControllerInstance() {

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ElasticAgentConfigurationsControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ElasticAgentConfigurationsControllerTest.groovy
@@ -19,11 +19,11 @@ import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
-import static org.mockito.MockitoAnnotations.initMocks
-
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ElasticAgentConfigurationsControllerTest implements ControllerTrait<ElasticAgentConfigurationsController>, SecurityServiceTrait {
 
   @Override
@@ -48,10 +48,6 @@ class ElasticAgentConfigurationsControllerTest implements ControllerTrait<Elasti
     }
   }
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
 }
 

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/NewDashboardControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/NewDashboardControllerTest.groovy
@@ -17,7 +17,6 @@ package com.thoughtworks.go.spark.spa
 
 import com.thoughtworks.go.config.Authorization
 import com.thoughtworks.go.config.BasicPipelineConfigs
-import com.thoughtworks.go.config.PipelineConfigs
 import com.thoughtworks.go.domain.PipelineGroups
 import com.thoughtworks.go.server.service.PipelineConfigService
 import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService
@@ -29,11 +28,13 @@ import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class NewDashboardControllerTest implements ControllerTrait<NewDashboardController>, SecurityServiceTrait {
   PipelineConfigService pipelineConfigService = mock(PipelineConfigService.class)
 
@@ -106,9 +107,5 @@ class NewDashboardControllerTest implements ControllerTrait<NewDashboardControll
     }
   }
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
 }

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/NewEnvironmentsControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/NewEnvironmentsControllerTest.groovy
@@ -15,16 +15,15 @@
  */
 package com.thoughtworks.go.spark.spa
 
-
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
-import static org.mockito.MockitoAnnotations.initMocks
-
+@MockitoSettings(strictness = Strictness.LENIENT)
 class NewEnvironmentsControllerTest implements ControllerTrait<NewEnvironmentsController>, SecurityServiceTrait {
 
   @Override
@@ -49,10 +48,6 @@ class NewEnvironmentsControllerTest implements ControllerTrait<NewEnvironmentsCo
     }
   }
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
 }
 

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/PipelinesAsCodeControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/PipelinesAsCodeControllerTest.groovy
@@ -19,12 +19,13 @@ import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.spark.Routes.PipelineConfig.SPA_AS_CODE
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PipelinesAsCodeControllerTest implements ControllerTrait<PipelinesAsCodeController>, SecurityServiceTrait {
 
   @Nested
@@ -44,10 +45,6 @@ class PipelinesAsCodeControllerTest implements ControllerTrait<PipelinesAsCodeCo
     }
   }
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   PipelinesAsCodeController createControllerInstance() {

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/PipelinesControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/PipelinesControllerTest.groovy
@@ -19,12 +19,13 @@ import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.GroupAdminUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static com.thoughtworks.go.spark.Routes.PipelineConfig.SPA_CREATE
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PipelinesControllerTest implements ControllerTrait<PipelinesController>, SecurityServiceTrait {
 
   @Nested
@@ -44,10 +45,6 @@ class PipelinesControllerTest implements ControllerTrait<PipelinesController>, S
     }
   }
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   PipelinesController createControllerInstance() {

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/PluginsControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/PluginsControllerTest.groovy
@@ -19,11 +19,11 @@ import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.GroupAdminUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
-import static org.mockito.MockitoAnnotations.initMocks
-
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PluginsControllerTest implements ControllerTrait<PluginsController>, SecurityServiceTrait {
 
   @Override
@@ -47,11 +47,5 @@ class PluginsControllerTest implements ControllerTrait<PluginsController>, Secur
       }
     }
   }
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
-
 }
 

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/RolesControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/RolesControllerTest.groovy
@@ -19,11 +19,11 @@ import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
-import static org.mockito.MockitoAnnotations.initMocks
-
+@MockitoSettings(strictness = Strictness.LENIENT)
 class RolesControllerTest implements ControllerTrait<RolesController>, SecurityServiceTrait {
 
   @Nested
@@ -41,11 +41,6 @@ class RolesControllerTest implements ControllerTrait<RolesController>, SecurityS
         get(controller.controllerPath())
       }
     }
-  }
-
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
   }
 
   @Override

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ServerInfoControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ServerInfoControllerTest.groovy
@@ -22,15 +22,16 @@ import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 
 import static org.assertj.core.api.Assertions.assertThat
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ServerInfoControllerTest implements ControllerTrait<ServerInfoController>, SecurityServiceTrait {
   @Mock
   ArtifactsDirHolder artifactsDirHolder
@@ -60,10 +61,6 @@ class ServerInfoControllerTest implements ControllerTrait<ServerInfoController>,
     }
   }
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Test
   void 'should set appropriate meta information on view model'() {

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/StatusReportsControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/StatusReportsControllerTest.groovy
@@ -25,15 +25,16 @@ import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.mocks.StubTemplateEngine
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 import spark.ModelAndView
 
 import static org.mockito.Mockito.when
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class StatusReportsControllerTest implements ControllerTrait<StatusReportsController>, SecurityServiceTrait {
   @Mock
   ElasticAgentPluginService elasticAgentPluginService
@@ -41,10 +42,6 @@ class StatusReportsControllerTest implements ControllerTrait<StatusReportsContro
   @Mock
   JobInstanceService jobInstanceService
 
-  @BeforeEach
-  void setUp() {
-    initMocks(this)
-  }
 
   @Override
   StatusReportsController createControllerInstance() {

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/spring/FreemarkerTemplateEngineFactoryTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/spring/FreemarkerTemplateEngineFactoryTest.groovy
@@ -25,13 +25,15 @@ import com.thoughtworks.go.spark.spa.RolesController
 import freemarker.template.utility.StringUtil
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 import org.springframework.core.io.DefaultResourceLoader
 import spark.ModelAndView
 
 import static org.assertj.core.api.Assertions.assertThat
 import static org.mockito.Mockito.mock
-import static org.mockito.MockitoAnnotations.initMocks
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 class FreemarkerTemplateEngineFactoryTest {
 
   InitialContextProvider initialContextProvider
@@ -39,7 +41,6 @@ class FreemarkerTemplateEngineFactoryTest {
 
   @BeforeEach
   void setUp() {
-    initMocks(this)
     Toggles.initializeWith(mock(FeatureToggleService.class))
     initialContextProvider = new InitialContextProvider(mock(RailsAssetsService.class), mock(WebpackAssetsService), mock(SecurityService), mock(VersionInfoService), mock(DefaultPluginInfoFinder), mock(MaintenanceModeService), mock(ServerConfigService))
     engine = new FreemarkerTemplateEngineFactory(initialContextProvider, new DefaultResourceLoader(getClass().getClassLoader()), "classpath:velocity")


### PR DESCRIPTION
Compltes a few more clean-ups across test-related code

- removes deprecated usage of Mockito `initMocks`, replacing with JUnit extension approach, for consistency with rest of codebase
- replaces some deprecations with `@TestOnly` for clarity when reading code
- tidies some usages of Charsets to use the constants, rather than having to lookup by name every time