### PR TITLE
Bump HttpClientMock from 1.0.4 to 1.10.0

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -60,7 +60,7 @@ final Map<String, String> libraries = [
   h2                  : 'com.h2database:h2:1.4.200',
   hamcrest            : 'org.hamcrest:hamcrest-core:2.2',
   hibernate           : 'org.hibernate:hibernate-ehcache:3.6.10.Final',
-  httpClientMock      : 'com.github.paweladamski:HttpClientMock:1.0.4',
+  httpClientMock      : 'com.github.paweladamski:HttpClientMock:1.10.0',
   jackson             : 'com.fasterxml.jackson.core:jackson-core:2.12.5',
   javaAssist          : 'javassist:javassist:3.12.1.GA',
   javaxAnnotation     : 'javax.annotation:javax.annotation-api:1.3.2',


### PR DESCRIPTION
HttpClientMock 2.x is only compatible with Apache Http Client 5+ so this is the latest we can go.