### PR TITLE
Use stable JRuby Gradle plugin (v2.0.2) with Gradle 7.0 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.39.0'
     classpath 'gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0'
     classpath 'com.github.jk1:gradle-license-report:1.17'
-    classpath "com.github.jruby-gradle:jruby-gradle-core-plugin:2.1.0-alpha.2"
+    classpath "com.github.jruby-gradle:jruby-gradle-core-plugin:2.0.2"
   }
 }
 

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/DownloaderTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/DownloaderTask.groovy
@@ -18,6 +18,7 @@ package com.thoughtworks.go.build
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.ysb33r.grolifant.api.core.OperatingSystem
 import org.ysb33r.grolifant.api.core.ProjectOperations
@@ -33,6 +34,13 @@ class DownloaderTask extends DefaultTask {
   @Input
   String packageVersion
 
+  @Internal
+  protected final ProjectOperations projectOperations
+
+  DownloaderTask() {
+    projectOperations = ProjectOperations.create(project)
+  }
+
   @TaskAction
   void perform() {
     AbstractDistributionInstaller installer = createInstaller()
@@ -43,7 +51,7 @@ class DownloaderTask extends DefaultTask {
   }
 
   private AbstractDistributionInstaller createInstaller() {
-    new AbstractDistributionInstaller(packageName, "download/${packageName}/${packageVersion}", ProjectOperations.find(project)) {
+    new AbstractDistributionInstaller(packageName, "download/${packageName}/${packageVersion}", projectOperations) {
 
       @Override
       URI uriFromVersion(String version) {


### PR DESCRIPTION
Previously dependabot suggested bumping 2.0 alpha -> 2.1 alpha in #9376, however it'd be better to use the stable versions as `2.1.0-*` hasn't been pushed since late 2020.