### PR TITLE
Perform minor test cleanups

### DIFF
--- a/api/api-config-repos-v4/src/test/groovy/com/thoughtworks/go/apiv4/configrepos/ConfigReposControllerV4Test.groovy
+++ b/api/api-config-repos-v4/src/test/groovy/com/thoughtworks/go/apiv4/configrepos/ConfigReposControllerV4Test.groovy
@@ -52,7 +52,6 @@ import static com.thoughtworks.go.helper.MaterialConfigsMother.hg
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
-import static org.mockito.internal.verification.VerificationModeFactory.times
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ConfigReposControllerV4Test implements SecurityServiceTrait, ControllerTrait<ConfigReposControllerV4> {

--- a/common/src/test/java/com/thoughtworks/go/domain/TestArtifactPlanTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/TestArtifactPlanTest.java
@@ -22,7 +22,6 @@ import org.apache.commons.io.FilenameUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.internal.verification.Times;
 
 import java.io.File;
 import java.io.IOException;
@@ -82,7 +81,7 @@ public class TestArtifactPlanTest {
 
         verify(mockArtifactPublisher).upload(first, "logs/report");
         verify(mockArtifactPublisher).upload(second, "logs/test/a/b");
-        verify(mockArtifactPublisher, new Times(2)).upload(any(File.class), eq("testoutput"));
+        verify(mockArtifactPublisher, times(2)).upload(any(File.class), eq("testoutput"));
     }
 
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerFactoryTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerFactoryTest.java
@@ -19,12 +19,10 @@ import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.internal.verification.Times;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class ConfigMaterialUpdateListenerFactoryTest {
@@ -45,6 +43,6 @@ public class ConfigMaterialUpdateListenerFactoryTest {
                 null, null, null, null, null);
         factory.init();
 
-        verify(configMaterialPostUpdateQueue, new Times(numberOfConfigMaterialPostUpdateListeners)).addListener(any(ConfigMaterialUpdateListener.class));
+        verify(configMaterialPostUpdateQueue, times(numberOfConfigMaterialPostUpdateListeners)).addListener(any(ConfigMaterialUpdateListener.class));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialUpdateListenerFactoryTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialUpdateListenerFactoryTest.java
@@ -28,12 +28,10 @@ import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.internal.verification.Times;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class MaterialUpdateListenerFactoryTest {
@@ -71,7 +69,7 @@ public class MaterialUpdateListenerFactoryTest {
                 dependencyMaterialQueue, maintenanceModeService, configMaterialPostUpdateQueue, goConfigService);
         factory.init();
 
-        verify(queue, new Times(NUMBER_OF_CONSUMERS)).addListener(any(GoMessageListener.class));
+        verify(queue, times(NUMBER_OF_CONSUMERS)).addListener(any(GoMessageListener.class));
     }
 
     @Test
@@ -85,7 +83,7 @@ public class MaterialUpdateListenerFactoryTest {
                 dependencyMaterialQueue, maintenanceModeService, configMaterialPostUpdateQueue, goConfigService);
         factory.init();
 
-        verify(configQueue, new Times(NUMBER_OF_CONFIG_CONSUMERS)).addListener(any(GoMessageListener.class));
+        verify(configQueue, times(NUMBER_OF_CONFIG_CONSUMERS)).addListener(any(GoMessageListener.class));
     }
 
     @Test
@@ -101,6 +99,6 @@ public class MaterialUpdateListenerFactoryTest {
                 dependencyMaterialQueue, maintenanceModeService, configMaterialPostUpdateQueue, goConfigService);
         factory.init();
 
-        verify(dependencyMaterialQueue, new Times(noOfDependencyMaterialCheckListeners)).addListener(any(GoMessageListener.class));
+        verify(dependencyMaterialQueue, times(noOfDependencyMaterialCheckListeners)).addListener(any(GoMessageListener.class));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSchedulerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSchedulerTest.java
@@ -39,14 +39,13 @@ import com.thoughtworks.go.serverhealth.ServerHealthService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.internal.verification.NoMoreInteractions;
 
 import java.util.*;
 
 import static com.thoughtworks.go.helper.GoConfigMother.configWithPipelines;
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.*;
 
 public class PipelineSchedulerTest {
@@ -122,7 +121,7 @@ public class PipelineSchedulerTest {
         final HashMap<String, String> revisions = new HashMap<>();
         scheduler.manualProduceBuildCauseAndSave("blahPipeline", Username.ANONYMOUS, new ScheduleOptions(revisions, Collections.singletonMap("blahVariable", "blahValue"), new HashMap<>()), operationResult);
         //noinspection unchecked
-        verify(buildCauseProducerService, new NoMoreInteractions()).manualSchedulePipeline(any(Username.class), any(CaseInsensitiveString.class), any(ScheduleOptions.class), any(OperationResult.class));
+        verifyNoMoreInteractions(buildCauseProducerService);
         verify(operationResult).notFound("Variable 'blahVariable' has not been configured for pipeline 'blahPipeline'", "Variable 'blahVariable' has not been configured for pipeline 'blahPipeline'",
                 HealthStateType.general(HealthStateScope.forPipeline("blahPipeline")));
     }

--- a/test/http-mocks/src/main/java/com/thoughtworks/go/http/mocks/MockHttpServletRequestAssert.java
+++ b/test/http-mocks/src/main/java/com/thoughtworks/go/http/mocks/MockHttpServletRequestAssert.java
@@ -17,9 +17,9 @@
 package com.thoughtworks.go.http.mocks;
 
 import org.assertj.core.api.AbstractObjectAssert;
-import org.assertj.core.util.Objects;
 
 import javax.servlet.http.HttpSession;
+import java.util.Objects;
 
 public class MockHttpServletRequestAssert<SELF extends MockHttpServletRequestAssert<SELF>> extends AbstractObjectAssert<SELF, MockHttpServletRequest> {
 
@@ -40,7 +40,7 @@ public class MockHttpServletRequestAssert<SELF extends MockHttpServletRequestAss
 
     public SELF hasSessionAttribute(String name, Object expectedAttributeValue) {
         final Object actualAttributeValue = getSession().getAttribute(name);
-        if (!Objects.areEqual(expectedAttributeValue, actualAttributeValue)) {
+        if (!Objects.deepEquals(expectedAttributeValue, actualAttributeValue)) {
             failWithMessage("Expected session to contain attribute <%s>: <%s>, but found <%s>: <%s>", name, expectedAttributeValue, name, actualAttributeValue);
         }
         return myself;

--- a/test/http-mocks/src/main/java/com/thoughtworks/go/http/mocks/MockHttpServletResponseAssert.java
+++ b/test/http-mocks/src/main/java/com/thoughtworks/go/http/mocks/MockHttpServletResponseAssert.java
@@ -23,13 +23,13 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.error.ShouldContainCharSequence;
 import org.assertj.core.internal.Failures;
-import org.assertj.core.util.Objects;
 import org.hamcrest.text.MatchesPattern;
 import org.springframework.util.InvalidMimeTypeException;
 import org.springframework.util.MimeType;
 
 import javax.servlet.http.Cookie;
 import java.io.UnsupportedEncodingException;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import static javax.servlet.http.HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE;
@@ -74,7 +74,7 @@ public class MockHttpServletResponseAssert<SELF extends MockHttpServletResponseA
     public SELF hasHeader(String headerName, String expectedHeader) {
         String actualHeader = actual.getHeader(headerName);
 
-        if (!Objects.areEqual(actualHeader, expectedHeader)) {
+        if (!Objects.deepEquals(actualHeader, expectedHeader)) {
             failWithMessage("Expected header '%s: %s', but was '%s: %s'", headerName, expectedHeader, headerName, actualHeader);
         }
         return myself;
@@ -112,7 +112,7 @@ public class MockHttpServletResponseAssert<SELF extends MockHttpServletResponseA
     }
 
     public SELF hasBody(byte[] expected) {
-        if (!Objects.areEqual(actual.getContentAsByteArray(), expected)) {
+        if (!Objects.deepEquals(actual.getContentAsByteArray(), expected)) {
             this.as("body");
             throw Failures.instance().failure(info, shouldBeEqual(actual.getContentAsByteArray(), expected, info.representation()));
         }
@@ -120,7 +120,7 @@ public class MockHttpServletResponseAssert<SELF extends MockHttpServletResponseA
     }
 
     public SELF hasBody(String expected) throws UnsupportedEncodingException {
-        if (!Objects.areEqual(actual.getContentAsString(), expected)) {
+        if (!Objects.deepEquals(actual.getContentAsString(), expected)) {
             this.as("body");
             throw Failures.instance().failure(info, shouldBeEqual(actual.getContentAsString(), expected, info.representation()));
         }


### PR DESCRIPTION
- removes some linger use of internal classes from libraries
- removes use of some deprecated methods from AssertJ