### PR TITLE
Revert "Bump logback-classic from 1.2.5 to 1.2.6"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -79,7 +79,7 @@ final Map<String, String> libraries = [
   jsoup               : 'org.jsoup:jsoup:1.14.2',
   junit5              : 'org.junit.jupiter:junit-jupiter-api:5.7.2',
   liquibase           : 'org.liquibase:liquibase-core:4.4.3',
-  logback             : 'ch.qos.logback:logback-classic:1.2.6',
+  logback             : 'ch.qos.logback:logback-classic:1.2.5',
   lombok              : 'org.projectlombok:lombok:1.18.20',
   mail                : 'com.sun.mail:mailapi:1.6.1',
   mockito             : 'org.mockito:mockito-core:3.12.4',


### PR DESCRIPTION
Reverts gocd/gocd#9684

Temporarily reverting as there is an unexpected transitive dependency weirdness going on in https://build.gocd.org/go/tab/build/detail/installers/2625/dist/2/dist due to https://github.com/qos-ch/logback/commit/db1a652ec99c880247a308ef2949808943d215b4

Probably needs to be sorted out in our Gradle configurations; suspect now the version matches between our own dependency and the transitive from logback, it is somehow getting excluded from the fatJar lib folder.