### PR TITLE
Fix unstable integration test ordering

### DIFF
--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/StageServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/StageServiceTest.java
@@ -117,7 +117,7 @@ public class StageServiceTest {
 
     @AfterEach
     public void teardown() throws Exception {
-        configFileHelper.initializeConfigFile();
+        configFileHelper.onTearDown();
         SessionUtils.unsetCurrentUser();
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
@@ -140,7 +140,7 @@ public class CachedGoConfigIntegrationTest {
     @BeforeEach
     public void setUp() throws Exception {
         configHelper = new GoConfigFileHelper(DEFAULT_XML_WITH_2_AGENTS);
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         externalConfigRepo = TempDirUtils.createTempDirectoryIn(temporaryFolder, "config_repo").toFile();
         latestModification = setupExternalConfigRepo(externalConfigRepo);

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigRepoConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigRepoConfigDataSourceIntegrationTest.java
@@ -40,8 +40,8 @@ import java.io.IOException;
 
 import static com.thoughtworks.go.helper.ConfigFileFixture.DEFAULT_XML_WITH_2_AGENTS;
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {
@@ -73,7 +73,7 @@ public class GoConfigRepoConfigDataSourceIntegrationTest {
     @BeforeEach
     public void setUp(@TempDir File templateConfigRepo) throws Exception {
         GoConfigFileHelper configHelper = new GoConfigFileHelper(DEFAULT_XML_WITH_2_AGENTS);
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
 
         GoConfigRepoConfigDataSource repoConfigDataSource = new GoConfigRepoConfigDataSource(configWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
@@ -107,7 +107,7 @@ public class GoFileConfigDataSourceIntegrationTest {
         String absolutePath = new File(configDir, "cruise-config.xml").getAbsolutePath();
         systemEnvironment.setProperty(SystemEnvironment.CONFIG_FILE_PROPERTY, absolutePath);
         configHelper = new GoConfigFileHelper(DEFAULT_XML_WITH_2_AGENTS);
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url"), XmlPartialConfigProvider.providerName, "git-id");
         config.getRules().add(new Allow("refer", "*", "*"));

--- a/server/src/test-integration/java/com/thoughtworks/go/fixture/PipelineWithTwoStages.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/fixture/PipelineWithTwoStages.java
@@ -109,7 +109,7 @@ public class PipelineWithTwoStages implements PreCondition {
     }
 
     public void onSetUp() throws Exception {
-        configHelper.initializeConfigFile();
+        configHelper.onSetUp();
 
         addToSetup();
     }
@@ -130,8 +130,8 @@ public class PipelineWithTwoStages implements PreCondition {
 
     @Override
     public void onTearDown() throws Exception {
-        configHelper.initializeConfigFile();
         dbHelper.onTearDown();
+        configHelper.onTearDown();
     }
 
     protected Path tempDir() {

--- a/server/src/test-integration/java/com/thoughtworks/go/fixture/TwoPipelineGroups.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/fixture/TwoPipelineGroups.java
@@ -52,7 +52,7 @@ public class TwoPipelineGroups implements PreCondition {
     @Override
     public void onTearDown() throws Exception {
         if (isSetup) {
-            configHelper.initializeConfigFile();
+            configHelper.onTearDown();
             svnTestRepo.tearDown();
         }
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoaderIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoaderIntegrationTest.java
@@ -41,8 +41,8 @@ import java.io.File;
 import java.util.List;
 
 import static com.thoughtworks.go.helper.ConfigFileFixture.DEFAULT_XML_WITH_2_AGENTS;
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {
@@ -76,7 +76,7 @@ public class GoDashboardCurrentStateLoaderIntegrationTest {
         String absolutePath = new File(configDir, "cruise-config.xml").getAbsolutePath();
         systemEnvironment.setProperty(SystemEnvironment.CONFIG_FILE_PROPERTY, absolutePath);
         configHelper = new GoConfigFileHelper(DEFAULT_XML_WITH_2_AGENTS);
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
 
         goConfigService.forceNotifyListeners();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerIntegrationTest.java
@@ -101,8 +101,8 @@ public class ConfigMaterialUpdateListenerIntegrationTest {
         hgRepo = new HgTestRepo("testHgRepo", tempDir);
 
         dbHelper.onSetUp();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
 
         materialConfig = hg(hgRepo.projectRepositoryUrl(), null);
         ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(materialConfig, "gocd-xml", "gocd-id");
@@ -127,7 +127,7 @@ public class ConfigMaterialUpdateListenerIntegrationTest {
     @AfterEach
     public void teardown() throws Exception {
         diskSpaceSimulator.onTearDown();
-                dbHelper.onTearDown();
+        dbHelper.onTearDown();
         configHelper.onTearDown();
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/scheduling/PipelineScheduleQueueIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/scheduling/PipelineScheduleQueueIntegrationTest.java
@@ -96,9 +96,9 @@ public class PipelineScheduleQueueIntegrationTest {
     @BeforeEach
     public void setup(@TempDir Path tempDir) throws Exception {
         configFileEditor = new GoConfigFileHelper();
+        configFileEditor.usingCruiseConfigDao(goConfigDao);
         configFileEditor.onSetUp();
         dbHelper.onSetUp();
-        configFileEditor.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
         fixture = new PipelineWithTwoStages(materialRepository, transactionTemplate, tempDir);
         fixture.usingDbHelper(dbHelper).usingConfigHelper(configFileEditor).onSetUp();
         newCause = BuildCause.createWithEmptyModifications();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/AccessTokenServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/AccessTokenServiceIntegrationTest.java
@@ -76,7 +76,7 @@ public class AccessTokenServiceIntegrationTest {
                 "</security>");
 
         configHelper = new GoConfigFileHelper(content);
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         goConfigService.forceNotifyListeners();
     }
@@ -84,6 +84,7 @@ public class AccessTokenServiceIntegrationTest {
     @AfterEach
     public void tearDown() throws Exception {
         dbHelper.onTearDown();
+        configHelper.onTearDown();
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/AgentServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/AgentServiceIntegrationTest.java
@@ -35,7 +35,6 @@ import com.thoughtworks.go.listener.AgentStatusChangeListener;
 import com.thoughtworks.go.remote.AgentIdentifier;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.domain.AgentInstances;
-import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.messaging.SendEmailMessage;
 import com.thoughtworks.go.server.messaging.notifications.AgentStatusChangeNotifier;
 import com.thoughtworks.go.server.persistence.AgentDao;
@@ -115,8 +114,6 @@ public class AgentServiceIntegrationTest {
     private static final String UUID2 = "uuid2";
     private static final String UUID3 = "uuid3";
 
-    private static final Username USERNAME = new Username(new CaseInsensitiveString("admin"));
-
     private static final List<String> emptyStrList = emptyList();
 
     @BeforeEach
@@ -134,14 +131,13 @@ public class AgentServiceIntegrationTest {
     @AfterEach
     public void tearDown() throws Exception {
         new SystemEnvironment().setProperty("agent.connection.timeout", "300");
-        CONFIG_HELPER.usingCruiseConfigDao(goConfigDao);
-        CONFIG_HELPER.onTearDown();
+        dbHelper.onTearDown();
         cachedGoConfig.clearListeners();
         agentService.clearAll();
-        dbHelper.onTearDown();
+        CONFIG_HELPER.onTearDown();
     }
 
-    private AgentService getAgentService(AgentInstances agentInstances) {
+    private AgentService newAgentService(AgentInstances agentInstances) {
         return new AgentService(new SystemEnvironment(), agentInstances, agentDao,
                 new UuidGenerator(), serverHealthService, agentStatusChangeNotifier());
     }
@@ -238,7 +234,7 @@ public class AgentServiceIntegrationTest {
         AgentInstance denied = disabled();
 
         AgentInstances instances = new AgentInstances(new SystemEnvironment(), agentStatusChangeListener(), idle, pending, building, denied);
-        AgentService agentService = getAgentService(instances);
+        AgentService agentService = newAgentService(instances);
 
         AgentsViewModel agentViewModels = agentService.getRegisteredAgentsViewModel();
         assertThat(agentViewModels.size(), is(3));
@@ -248,7 +244,7 @@ public class AgentServiceIntegrationTest {
     @Test
     void getRegisteredAgentsViewModelShouldReturnEmptyRegisteredAgentsViewModelWhenThereAreNoRegisteredAgents() {
         AgentInstances agentInstances = new AgentInstances(new SystemEnvironment(), agentStatusChangeListener());
-        AgentService agentService = getAgentService(agentInstances);
+        AgentService agentService = newAgentService(agentInstances);
 
         AgentsViewModel agentViewModels = agentService.getRegisteredAgentsViewModel();
         assertThat(agentViewModels.size(), is(0));
@@ -544,7 +540,7 @@ public class AgentServiceIntegrationTest {
         @Test
         void shouldThrowExceptionWhenADuplicateAgentTriesToUpdateStatus() {
             AgentInstance buildingAgentInstance = building();
-            AgentService agentService = getAgentService(new AgentInstances(new SystemEnvironment(), agentStatusChangeListener(), buildingAgentInstance));
+            AgentService agentService = newAgentService(new AgentInstances(new SystemEnvironment(), agentStatusChangeListener(), buildingAgentInstance));
             AgentInstances agentInstances = agentService.findRegisteredAgents();
 
             String uuid = buildingAgentInstance.getAgent().getUuid();
@@ -609,7 +605,7 @@ public class AgentServiceIntegrationTest {
         @Test
         void shouldUpdateAgentStatus() {
             AgentInstance buildingAgentInstance = building();
-            AgentService agentService = getAgentService(new AgentInstances(new SystemEnvironment(), agentStatusChangeListener(), buildingAgentInstance));
+            AgentService agentService = newAgentService(new AgentInstances(new SystemEnvironment(), agentStatusChangeListener(), buildingAgentInstance));
             AgentInstances registeredAgentInstances = agentService.findRegisteredAgents();
 
             String uuid = buildingAgentInstance.getAgent().getUuid();
@@ -650,7 +646,7 @@ public class AgentServiceIntegrationTest {
             AgentInstance registeredAgent = disabled();
 
             AgentInstances instances = new AgentInstances(new SystemEnvironment(), agentStatusChangeListener(), pendingAgent);
-            AgentService agentService = getAgentService(instances);
+            AgentService agentService = newAgentService(instances);
 
             ArrayList<String> uuids = new ArrayList<>();
             uuids.add(pendingAgent.getUuid());
@@ -929,7 +925,7 @@ public class AgentServiceIntegrationTest {
 
             AgentInstances agentInstances = new AgentInstances(new SystemEnvironment(), agentStatusChangeListener(),
                     idleAgentInstance, pendingAgentInstance, buildingAgentInstance, deniedAgentInstance);
-            AgentService agentService = getAgentService(agentInstances);
+            AgentService agentService = newAgentService(agentInstances);
 
             assertThat(agentService.getAgentInstances().size(), is(4));
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceConfigRepoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceConfigRepoIntegrationTest.java
@@ -147,8 +147,8 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
         hgRepo = new HgTestRepo("testHgRepo", tempDir);
 
         dbHelper.onSetUp();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
 
         materialConfig = hgRepo.materialConfig();
         ConfigRepoConfig config = ConfigRepoConfig.createConfigRepoConfig(materialConfig, "gocd-xml", "gocd-id");
@@ -195,7 +195,7 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
     @AfterEach
     public void teardown() throws Exception {
         diskSpaceSimulator.onTearDown();
-                dbHelper.onTearDown();
+        dbHelper.onTearDown();
         pipelineScheduleQueue.clear();
         configHelper.onTearDown();
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceDependencyIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceDependencyIntegrationTest.java
@@ -36,7 +36,6 @@ import com.thoughtworks.go.domain.materials.svn.Subversion;
 import com.thoughtworks.go.domain.materials.svn.SvnCommand;
 import com.thoughtworks.go.helper.PipelineMother;
 import com.thoughtworks.go.helper.SvnTestRepo;
-import com.thoughtworks.go.helper.TestRepo;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.dao.PipelineDao;
 import com.thoughtworks.go.server.domain.PipelineTimeline;
@@ -189,8 +188,8 @@ public class BuildCauseProducerServiceDependencyIntegrationTest {
     @BeforeEach
     public void setup(@TempDir Path tempDir) throws Exception {
         dbHelper.onSetUp();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
         dependencyMaterialUpdateNotifier.disableUpdates();
 
         minglePipeline = new MinglePipeline();
@@ -229,7 +228,7 @@ public class BuildCauseProducerServiceDependencyIntegrationTest {
 
     @AfterEach
     public void teardown() throws Exception {
-                dbHelper.onTearDown();
+        dbHelper.onTearDown();
         pipelineScheduleQueue.clear();
         configHelper.onTearDown();
         dependencyMaterialUpdateNotifier.enableUpdates();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationHgTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationHgTest.java
@@ -84,8 +84,8 @@ public class BuildCauseProducerServiceIntegrationHgTest {
     @BeforeEach
     public void setup(@TempDir Path tempDir) throws Exception {
         dbHelper.onSetUp();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
         hgTestRepo = new HgTestRepo("hgTestRepo1", tempDir);
         hgMaterial = MaterialsMother.hgMaterial(hgTestRepo.projectRepositoryUrl());
         hgMaterial.setFilter(new Filter(new IgnoredFiles("helper/**/*.*")));
@@ -96,10 +96,10 @@ public class BuildCauseProducerServiceIntegrationHgTest {
 
     @AfterEach
     public void teardown() throws Exception {
-                dbHelper.onTearDown();
+        dbHelper.onTearDown();
         FileUtils.deleteQuietly(goConfigService.artifactsDir());
         FileUtils.deleteQuietly(workingFolder);
-                pipelineScheduleQueue.clear();
+        pipelineScheduleQueue.clear();
     }
 
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationSvnTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationSvnTest.java
@@ -24,7 +24,10 @@ import com.thoughtworks.go.config.materials.svn.SvnMaterial;
 import com.thoughtworks.go.domain.MaterialRevisions;
 import com.thoughtworks.go.domain.Pipeline;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
-import com.thoughtworks.go.helper.*;
+import com.thoughtworks.go.helper.MaterialsMother;
+import com.thoughtworks.go.helper.PipelineMother;
+import com.thoughtworks.go.helper.SvnTestRepo;
+import com.thoughtworks.go.helper.SvnTestRepoWithExternal;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.materials.MaterialDatabaseUpdater;
 import com.thoughtworks.go.server.scheduling.BuildCauseProducerService;
@@ -95,10 +98,10 @@ public class BuildCauseProducerServiceIntegrationSvnTest {
 
     @AfterEach
     public void teardown() throws Exception {
-                dbHelper.onTearDown();
+        dbHelper.onTearDown();
         FileUtils.deleteQuietly(goConfigService.artifactsDir());
         FileUtils.deleteQuietly(workingFolder);
-                pipelineScheduleQueue.clear();
+        pipelineScheduleQueue.clear();
         configHelper.onTearDown();
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
@@ -38,7 +38,10 @@ import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.domain.materials.Material;
 import com.thoughtworks.go.domain.materials.svn.Subversion;
 import com.thoughtworks.go.domain.materials.svn.SvnCommand;
-import com.thoughtworks.go.helper.*;
+import com.thoughtworks.go.helper.HgTestRepo;
+import com.thoughtworks.go.helper.PartialConfigMother;
+import com.thoughtworks.go.helper.PipelineMother;
+import com.thoughtworks.go.helper.SvnTestRepo;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.dao.PipelineDao;
 import com.thoughtworks.go.server.domain.PipelineTimeline;
@@ -158,8 +161,8 @@ public class BuildCauseProducerServiceIntegrationTest {
         svnRepository = new SvnTestRepo(tempDir);
 
         dbHelper.onSetUp();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
 
         repository = new SvnCommand(null, svnRepository.projectRepositoryUrl());
 
@@ -201,7 +204,7 @@ public class BuildCauseProducerServiceIntegrationTest {
     @AfterEach
     public void teardown() throws Exception {
         diskSpaceSimulator.onTearDown();
-                dbHelper.onTearDown();
+        dbHelper.onTearDown();
         pipelineScheduleQueue.clear();
         configHelper.onTearDown();
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceWithFlipModificationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceWithFlipModificationTest.java
@@ -34,7 +34,6 @@ import com.thoughtworks.go.domain.materials.svn.Subversion;
 import com.thoughtworks.go.domain.materials.svn.SvnCommand;
 import com.thoughtworks.go.helper.HgTestRepo;
 import com.thoughtworks.go.helper.SvnTestRepo;
-import com.thoughtworks.go.helper.TestRepo;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.dao.PipelineDao;
 import com.thoughtworks.go.server.domain.Username;
@@ -102,8 +101,8 @@ public class BuildCauseProducerServiceWithFlipModificationTest {
         configHelper = new GoConfigFileHelper();
 
         dbHelper.onSetUp();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
 
         svnRepository = new SvnTestRepo(tempDir);
         hgTestRepo = new HgTestRepo("testHgRepo", tempDir);
@@ -113,7 +112,7 @@ public class BuildCauseProducerServiceWithFlipModificationTest {
 
     @AfterEach
     public void teardown() throws Exception {
-                dbHelper.onTearDown();
+        dbHelper.onTearDown();
         FileUtils.deleteQuietly(goConfigService.artifactsDir());
         pipelineScheduleQueue.clear();
         configHelper.onTearDown();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ChangeMaterialsTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ChangeMaterialsTest.java
@@ -99,7 +99,6 @@ public class ChangeMaterialsTest {
         dbHelper.onSetUp();
         cruiseConfig = new GoConfigFileHelper().usingCruiseConfigDao(goConfigDao);
         cruiseConfig.onSetUp();
-        cruiseConfig.initializeConfigFile();
 
         hgTestRepo = new HgTestRepo(tempDir);
 
@@ -113,7 +112,6 @@ public class ChangeMaterialsTest {
 
     @AfterEach
     public void teardown() throws Exception {
-        cruiseConfig.initializeConfigFile();
         dbHelper.onTearDown();
         cruiseConfig.onTearDown();
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigRepoServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigRepoServiceIntegrationTest.java
@@ -41,9 +41,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -91,7 +91,7 @@ public class ConfigRepoServiceIntegrationTest {
         MaterialConfig repoMaterial = git("https://foo.git", "master");
         this.configRepo = ConfigRepoConfig.createConfigRepoConfig(repoMaterial, pluginId, repoId);
 
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
 
         goConfigService.forceNotifyListeners();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
@@ -84,7 +84,7 @@ public class ConfigSaveDeadlockDetectionIntegrationTest {
     @BeforeEach
     public void setup() throws Exception {
         configHelper = new GoConfigFileHelper(ConfigFileFixture.XML_WITH_SINGLE_ENVIRONMENT);
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         goConfigService.forceNotifyListeners();
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceIntegrationTest.java
@@ -21,8 +21,8 @@ import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.domain.ConfigElementForEdit;
-import com.thoughtworks.go.helper.PartialConfigMother;
 import com.thoughtworks.go.helper.AgentMother;
+import com.thoughtworks.go.helper.PartialConfigMother;
 import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.domain.Username;
@@ -38,11 +38,15 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.servlet.http.HttpServletResponse;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {
@@ -75,7 +79,7 @@ public class EnvironmentConfigServiceIntegrationTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
 
         goConfigService.forceNotifyListeners();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/FanInPerformanceTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/FanInPerformanceTest.java
@@ -45,8 +45,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {
@@ -78,7 +78,7 @@ public class FanInPerformanceTest {
     @BeforeEach
     public void setup() throws Exception {
         goCache.clear();
-        configHelper.usingCruiseConfigDao(goConfigFileDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigFileDao);
         configHelper.onSetUp();
         dbHelper.onSetUp();
         u = new ScheduleTestUtil(transactionTemplate, materialRepository, dbHelper, configHelper);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/GoConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/GoConfigServiceIntegrationTest.java
@@ -48,8 +48,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {
@@ -76,7 +76,7 @@ public class GoConfigServiceIntegrationTest {
     public void setup() throws Exception {
         configHelper = new GoConfigFileHelper();
         dbHelper.onSetUp();
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         goConfigService.forceNotifyListeners();
         setupMetadataForPlugin();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/GoDashboardServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/GoDashboardServiceIntegrationTest.java
@@ -49,9 +49,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {
@@ -98,7 +98,7 @@ public class GoDashboardServiceIntegrationTest {
     public void setup() throws Exception {
         configHelper = new GoConfigFileHelper();
         dbHelper.onSetUp();
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         goConfigService.forceNotifyListeners();
         u = new ScheduleTestUtil(transactionTemplate, materialRepository, dbHelper, configHelper);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PermissionsServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PermissionsServiceIntegrationTest.java
@@ -60,7 +60,7 @@ public class PermissionsServiceIntegrationTest {
     @BeforeEach
     public void setUp() throws Exception {
         configHelper = new GoConfigFileHelper();
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         goConfigService.forceNotifyListeners();
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
@@ -59,10 +59,10 @@ import java.util.UUID;
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
 import static com.thoughtworks.go.util.TestUtils.contains;
 import static java.util.Arrays.asList;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {
@@ -116,7 +116,7 @@ public class PipelineConfigServiceIntegrationTest {
         cachedGoPartials.clear();
         configHelper = new GoConfigFileHelper();
         dbHelper.onSetUp();
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         goConfigService.forceNotifyListeners();
         user = new Username(new CaseInsensitiveString("current"));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
@@ -49,8 +49,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
 import static com.thoughtworks.go.util.command.ProcessOutputStreamConsumer.inMemoryConsumer;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 @Disabled
 @ExtendWith(SpringExtension.class)
@@ -96,7 +96,7 @@ public class PipelineConfigServicePerformanceTest {
     public void setup() throws Exception {
         configHelper = new GoConfigFileHelper();
         dbHelper.onSetUp();
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         goConfigService.forceNotifyListeners();
         result = new HttpLocalizedOperationResult();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigsServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigsServiceIntegrationTest.java
@@ -43,8 +43,8 @@ import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {
@@ -74,7 +74,7 @@ public class PipelineConfigsServiceIntegrationTest {
         xml = goConfigMigration.upgradeIfNecessary(IOUtils.toString(getClass().getResourceAsStream("/data/config_with_pluggable_artifacts_store.xml"), UTF_8));
         setupMetadataForPlugin();
 
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         configHelper.writeXmlToConfigFile(xml);
         goConfigService.forceNotifyListeners();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineSchedulerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineSchedulerIntegrationTest.java
@@ -40,7 +40,10 @@ import com.thoughtworks.go.serverhealth.ServerHealthState;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.utils.Assertions;
 import com.thoughtworks.go.utils.Timeout;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -103,7 +106,7 @@ public class PipelineSchedulerIntegrationTest {
 
         dbHelper.onSetUp();
 
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         repository = new SvnCommand(null, testRepo.projectRepositoryUrl());
         configHelper.addPipeline(PIPELINE_MINGLE, DEV_STAGE, repository, "unit", "functional");
@@ -120,6 +123,7 @@ public class PipelineSchedulerIntegrationTest {
     public void tearDown() throws Exception {
         serverHealthService.removeAllLogs();
         pipelineScheduleQueue.clear();
+        dbHelper.onTearDown();
         configHelper.onTearDown();
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineStagesFeedServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineStagesFeedServiceIntegrationTest.java
@@ -29,8 +29,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {
@@ -51,7 +51,7 @@ public class PipelineStagesFeedServiceIntegrationTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         configHelper.addPipeline("cruise", "stage", "unit", "functional");
         configHelper.enableSecurity();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineTriggerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineTriggerServiceIntegrationTest.java
@@ -23,7 +23,6 @@ import com.thoughtworks.go.config.materials.svn.SvnMaterial;
 import com.thoughtworks.go.domain.EnvironmentVariable;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.helper.PipelineConfigMother;
-import com.thoughtworks.go.helper.TestRepo;
 import com.thoughtworks.go.security.CryptoException;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
@@ -53,7 +52,8 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {
@@ -127,7 +127,9 @@ public class PipelineTriggerServiceIntegrationTest {
 
     @AfterEach
     public void tearDown() throws Exception {
-                pipelineScheduleQueue.clear();
+        pipelineScheduleQueue.clear();
+        dbHelper.onTearDown();
+        configHelper.onTearDown();
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/RoleConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/RoleConfigServiceIntegrationTest.java
@@ -51,8 +51,8 @@ public class RoleConfigServiceIntegrationTest {
     @BeforeEach
     public void setUp() throws Exception {
         configFileHelper = new GoConfigFileHelper(ConfigFileFixture.CONFIG_WITH_ADMIN_AND_SECURITY_AUTH_CONFIG);
+        configFileHelper.usingCruiseConfigDao(goConfigDao);
         configFileHelper.onSetUp();
-        configFileHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
         goConfigService.forceNotifyListeners();
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceIntegrationTest.java
@@ -50,7 +50,10 @@ import com.thoughtworks.go.serverhealth.ServerHealthState;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.util.TimeProvider;
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
@@ -149,7 +152,7 @@ public class ScheduleServiceIntegrationTest {
     public void setup(@TempDir Path tempDir) throws Exception {
         configHelper = new GoConfigFileHelper();
         dbHelper.onSetUp();
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         pipelineFixture = new PipelineWithTwoStages(materialRepository, transactionTemplate, tempDir);
         pipelineFixture.usingConfigHelper(configHelper).usingDbHelper(dbHelper).onSetUp();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceRunOnAllAgentIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceRunOnAllAgentIntegrationTest.java
@@ -37,7 +37,10 @@ import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.serverhealth.ServerHealthState;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -99,7 +102,7 @@ public class ScheduleServiceRunOnAllAgentIntegrationTest {
     public void setup() throws Exception {
         CONFIG_HELPER = new GoConfigFileHelper();
         dbHelper.onSetUp();
-        CONFIG_HELPER.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        CONFIG_HELPER.usingCruiseConfigDao(goConfigDao);
         CONFIG_HELPER.onSetUp();
 
         repository = new SvnCommand(null, testRepo.projectRepositoryUrl());

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ServerConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ServerConfigServiceIntegrationTest.java
@@ -57,7 +57,7 @@ public class ServerConfigServiceIntegrationTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
 
         goConfigService.forceNotifyListeners();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/StageIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/StageIntegrationTest.java
@@ -74,9 +74,8 @@ public class StageIntegrationTest {
     @BeforeEach
     public void setUp(@TempDir Path tempDir) throws Exception {
         dbHelper.onSetUp();
-        CONFIG_HELPER.onSetUp();
         CONFIG_HELPER.usingCruiseConfigDao(goConfigDao);
-        CONFIG_HELPER.initializeConfigFile();
+        CONFIG_HELPER.onSetUp();
 
         TestRepo svnTestRepo = new SvnTestRepo(tempDir);
 
@@ -89,6 +88,7 @@ public class StageIntegrationTest {
     @AfterEach
     public void teardown() throws Exception {
         dbHelper.onTearDown();
+        CONFIG_HELPER.onTearDown();
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ValueStreamMapPerformanceTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ValueStreamMapPerformanceTest.java
@@ -78,9 +78,9 @@ public class ValueStreamMapPerformanceTest {
     @BeforeEach
     public void setup() throws Exception {
         configHelper = new GoConfigFileHelper();
-        dbHelper.onSetUp();
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
+        dbHelper.onSetUp();
         goConfigService.forceNotifyListeners();
         u = new ScheduleTestUtil(transactionTemplate, materialRepository, dbHelper, configHelper);
         graphGenerator = new GraphGenerator(configHelper, u);
@@ -88,8 +88,8 @@ public class ValueStreamMapPerformanceTest {
 
     @AfterEach
     public void tearDown() throws Exception {
-        configHelper.onTearDown();
         dbHelper.onTearDown();
+        configHelper.onTearDown();
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/materials/PackageDefinitionServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/materials/PackageDefinitionServiceIntegrationTest.java
@@ -36,9 +36,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {
@@ -68,7 +68,7 @@ public class PackageDefinitionServiceIntegrationTest {
         cachedGoPartials.clear();
         configHelper = new GoConfigFileHelper();
         dbHelper.onSetUp();
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         goConfigService.forceNotifyListeners();
         user = new Username(new CaseInsensitiveString("current"));
@@ -97,8 +97,8 @@ public class PackageDefinitionServiceIntegrationTest {
     @AfterEach
     public void tearDown() throws Exception {
         cachedGoPartials.clear();
-        configHelper.onTearDown();
         dbHelper.onTearDown();
+        configHelper.onTearDown();
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/materials/PackageRepositoryServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/materials/PackageRepositoryServiceIntegrationTest.java
@@ -41,9 +41,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(SpringExtension.class)
@@ -83,7 +83,7 @@ public class PackageRepositoryServiceIntegrationTest {
                 "</security>");
 
         configHelper = new GoConfigFileHelper(content);
-        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.usingCruiseConfigDao(goConfigDao);
         configHelper.onSetUp();
         goConfigService.forceNotifyListeners();
         service.setPluginManager(pluginManager);

--- a/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
+++ b/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
@@ -259,7 +259,6 @@ public class GoConfigFileHelper {
 
     public void onSetUp() throws IOException {
         initializeConfigFile();
-        goConfigDao.forceReload();
         writeConfigFile(load());
         originalConfigDir = sysEnv.getConfigDir();
         File configDir = configFile.getParentFile();
@@ -272,7 +271,9 @@ public class GoConfigFileHelper {
     }
 
     public void onTearDown() {
-        sysEnv.setProperty(SystemEnvironment.CONFIG_DIR_PROPERTY, originalConfigDir);
+        if (originalConfigDir != null) {
+            sysEnv.setProperty(SystemEnvironment.CONFIG_DIR_PROPERTY, originalConfigDir);
+        }
         FileUtils.deleteQuietly(configFile);
         try {
             saveFullConfig(originalXml, true);

--- a/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
+++ b/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.util;
 
+import com.google.common.base.Throwables;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
@@ -278,6 +279,7 @@ public class GoConfigFileHelper {
         try {
             saveFullConfig(originalXml, true);
         } catch (Exception e) {
+            Throwables.throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
Attempts to fix unstable integration tests by aligning the approach to setup and teardown the config files and related database configuration.

It seems when tests use/involve the fixtures for pipelines (`PipelineWithTwoStages` etc) which make changes to config in both database config file, they can leave the server configuration/context in a broken state which is not reset correctly for subsequent tests. In particular `PipelineScheduleServiceTest` fails repeatably if run after `JobAssignmentIntegrationTest` or after `AgentServiceIntegrationTest`, as do some other tests which expect jobs to be run (or not run) on all agents. These failures feel very random and cause a lot of broken pipeline runs.

In general
* prefer `configFileHelper.onSetup` to `initializeConfigFile` (the former already does the latter)
* avoid using `initializeConfigFile` in test teardowns. It's confusing when there is already an `onTearDown` which most tests use
* ordering of `dbHelper.onTearDown` and `configHelper.onTearDown` seems to be important in some cases (for some reason I don't fully understand). Align these (although it really would be better to have a way to enforce this).