### PR TITLE
Bump anticipated JavaEWAH version to match that from upgraded JGit

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -788,7 +788,7 @@ task verifyWar(type: VerifyJarTask) {
       ((project(':api').subprojects + project(':spark').subprojects).collect { eachProject -> eachProject.jar.archiveFile.get().asFile.name })
         + [
         "FastInfoset-1.2.15.jar",
-        "JavaEWAH-1.1.7.jar",
+        "JavaEWAH-1.1.12.jar",
         "activation-1.1.jar",
         "activemq-broker-${project.versions.activeMQ}.jar",
         "activemq-client-${project.versions.activeMQ}.jar",


### PR DESCRIPTION
#9687 changed the transitive JavaEWAH version that we should expect to be packaged (see https://projects.eclipse.org/projects/technology.jgit/releases/5.13.0 for dependency change)
