### PR TITLE
Avoid unnecessary full re-installs of Yarn dependencies & unnecessary yarn task re-runs

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/YarnInstallTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/YarnInstallTask.groovy
@@ -17,7 +17,10 @@
 package com.thoughtworks.go.build
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 import org.gradle.internal.os.OperatingSystem
 
@@ -39,10 +42,9 @@ class YarnInstallTask extends DefaultTask {
     }
   }
 
-  @InputDirectory
-  @PathSensitive(value = PathSensitivity.ABSOLUTE)
-  File getWorkingDir() {
-    return workingDir
+  @Input // not an @InputFile/InputDirectory, because we don't care about the contents of the workingDir itself
+  String getWorkingDir() {
+    return workingDir.toString()
   }
 
   @OutputDirectory

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/YarnRunTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/YarnRunTask.groovy
@@ -41,10 +41,9 @@ class YarnRunTask extends DefaultTask {
     })
   }
 
-  @InputDirectory
-  @PathSensitive(value = PathSensitivity.ABSOLUTE)
-  File getWorkingDir() {
-    return workingDir
+  @Input // not an @InputFile/InputDirectory, because we don't care about the contents of the workingDir itself
+  String getWorkingDir() {
+    return workingDir.toString()
   }
 
   @Input


### PR DESCRIPTION
Speeds up the local dev process by fixing the Gradle results caching of Yarn installs.

In #8557 the working directory was redeclared as type `@InputDirectory` to address some Gradle 7 compatibility issues with annotating properties correctly. The problem is that using this type causes Gradle to observe the contents of this directory and assess whether it has changed between runs in order to decide whether the task is stale and needs to be re-run. https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/InputDirectory.html

Since this folder has many other files other than `node_modules`, `package.json`, `yarn.lock` etc, it basically always considers the task `outOfDate` which currently causes the code as written to wipe `node_modules` and do an unnecessary full reinstall and re-link, which is **very** slow.

Changing these types back to regular input strings will cause it to only consider them out of date if the path itself changes, which reverts to the behaviour before #8557, while still being Gradle 7 compliant in terms of annotating inputs correctly.