### PR TITLE
Resolve Gradle 7 deprecation on use of `File` for `@Input`

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/BuildDockerImageTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/BuildDockerImageTask.groovy
@@ -38,7 +38,9 @@ class BuildDockerImageTask extends DefaultTask {
   @Input String tiniVersion
   @InputFile File artifactZip
   @Input ImageType imageType
-  @Input File outputDir // Not really a classic output dir from Gradle perspective, as multiple tasks share dir from parent with unique tarballs per distribution
+  // Not really a classic output dir from Gradle perspective, as multiple tasks share dir from parent with unique tarballs per distribution.
+  // We use a string for Gradle 7 compatibility, and because we don't want Gradle to consider the actual contents.
+  @Input String outputDir
   @Internal Closure templateHelper
   @Internal Closure verifyHelper
 


### PR DESCRIPTION
See https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/Input.html

- Seems to be fine to represent as a string directly
- Gets us a bit closer to #9604 