### PR TITLE
Fix a couple of smaller Gradle 7 issues

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -84,6 +84,10 @@ task generateResources {
   }
 }
 
+processResources {
+  dependsOn generateResources
+}
+
 task prepare {
   dependsOn generateResources
 }

--- a/db-support/db-support-h2/build.gradle
+++ b/db-support/db-support-h2/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation project.deps.h2
     api project(':db-support:db-support-base')
 
+    testImplementation project(path: ':db-support:db-migration')
     testImplementation project(path: ':db-support:db-migration', configuration: 'testOutput')
 
     testImplementation project.deps.assertJ


### PR DESCRIPTION
Fixes two issues with Gradle 7 which can be done in a backwards compatible manner
- warning due to lack of explicit dependency between tasks when generating gocd version properties files
- `db-support:db-support-h2:compileTestJava` fails due to being unable to locate `DatabaseMigrator` class. Adding an explicit dependency on the main project seems to resolve this issue