### PR TITLE
Fix more Gradle 7 warnings on generated resources

### DIFF
--- a/development-utility/development-agent/build.gradle
+++ b/development-utility/development-agent/build.gradle
@@ -58,6 +58,10 @@ task generateResources(type: Copy) {
   }
 }
 
+processResources {
+  dependsOn generateResources
+}
+
 task prepare {
   dependsOn generateResources
 }

--- a/development-utility/development-server/build.gradle
+++ b/development-utility/development-server/build.gradle
@@ -74,6 +74,10 @@ task generateResources(type: Copy) {
   }
 }
 
+processResources {
+  dependsOn generateResources
+}
+
 task prepare {
   dependsOn generateResources
 }

--- a/test/test-utils/build.gradle
+++ b/test/test-utils/build.gradle
@@ -71,6 +71,10 @@ task generateResources(type: Copy) {
   }
 }
 
+processResources {
+  dependsOn generateResources
+}
+
 task prepare {
   dependsOn generateResources
 }


### PR DESCRIPTION
Add missing task dependencies to resolve warnings on Gradle 7. Missed these in #9738.