### PR TITLE
Fix Gradle 7 cross-project test dependencies

### DIFF
--- a/db-support/db-support-mysql/build.gradle
+++ b/db-support/db-support-mysql/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 
     annotationProcessor project.deps.lombok
 
+    testImplementation project(path: ':db-support:db-migration')
     testImplementation project(path: ':db-support:db-migration', configuration: 'testOutput')
 
     testImplementation project.deps.testcontainersJunit

--- a/db-support/db-support-postgresql/build.gradle
+++ b/db-support/db-support-postgresql/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 
     annotationProcessor project.deps.lombok
 
+    testImplementation project(path: ':db-support:db-migration')
     testImplementation project(path: ':db-support:db-migration', configuration: 'testOutput')
 
     testImplementation project.deps.testcontainersJunit

--- a/spark/spark-base/build.gradle
+++ b/spark/spark-base/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   }
 
   testImplementation localGroovy()
+  testImplementation project(path: ':jetty9')
   testImplementation project(path: ':jetty9', configuration: 'testOutput')
 
   testImplementation project.deps.bouncyCastle


### PR DESCRIPTION
Add explicit dependencies to normal project/compile/artifact output where required in tests.

Similar to #9738, these seem to be required to work correctly on Gradle 7 (and backward compatible with Gradle 6).

Currently the lack of these dependencies causes runtime classpath issues. They could be declared as `testRuntimeOnly` but this seemed more consistent for now.