### PR TITLE
Bump nokogiri from 1.11.5 to 1.12.5

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     minitest (5.14.4)
     multi_json (1.14.1)
     nio4r (2.5.7-java)
-    nokogiri (1.11.5-java)
+    nokogiri (1.12.5-java)
       racc (~> 1.4)
     phantomjs (2.1.1.0)
     pry (0.11.3-java)


### PR DESCRIPTION
Resolves CVE-2021-41098 / GHSA-2rr5-8q37-2w7h regarding disabling XXE by default on JRuby.

https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md#1125--2021-09-27