### PR TITLE
Fix stalebot not marking dependabot PRs as stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,7 +6,7 @@ exemptLabels:
   - no stalebot
   - security
   - release blocker
-  - Waiting on dependency
+  - dependencies
 
 # Label to use when marking as stale
 staleLabel: "stale"


### PR DESCRIPTION
My bad; renamed the label that dependabot will use to be consistent across repos; and forgot to rename this config