### PR TITLE
Revert "Bump dependency-check-gradle from 6.3.2 to 6.4.1"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:6.4.1'
+    classpath 'org.owasp:dependency-check-gradle:6.3.2'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.39.0'
     classpath 'gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0'
     classpath 'com.github.jk1:gradle-license-report:1.17'


### PR DESCRIPTION
Reverts gocd/gocd#9759 due to https://github.com/jeremylong/DependencyCheck/issues/3726