### PR TITLE
Build the GoCD Server default image on Alpine 3.13

### DIFF
--- a/settings-docker.gradle
+++ b/settings-docker.gradle
@@ -32,4 +32,4 @@ Distro.values().each { distro ->
 }
 
 include ":docker:gocd-server:${Distro.centos.projectName(Distro.centos.getVersion('8'))}"
-include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.11'))}"
+include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.13'))}"


### PR DESCRIPTION
Currently it is using Alpine `3.11` which is EOL in 10 days.

* Scanned with Snyk, no vulnerabilities at time of writing. The `3.11` image (rebuilt at time of writing) has one vulnerability in openssh https://snyk.io/vuln/SNYK-ALPINE311-OPENSSH-1728380
* Tested running the image and using the server locally, interacting with an agent etc.

Haven't yet bumped to Alpine `3.14` since we don't have a (non-DIND) agent building on this version yet; and I don't believe I have permissions to create the required individual GH repository just yet.