### PR TITLE
Review potential Hibernate vulnerabilities

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -126,4 +126,23 @@
         <cve>CVE-2021-22112</cve>
     </suppress>
 
+    <suppress>
+        <notes><![CDATA[
+   From review of https://nvd.nist.gov/vuln/detail/CVE-2019-14900 and the fix on Hibernate 5.3 at https://github.com/hibernate/hibernate-orm/pull/3440/files
+   GoCD is not subject to this defect, since at time of writing we do not use literals on the Criteria API (it's also
+   unclear whether older Hibernate versions are subject to the same defect)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.hibernate/hibernate\-(core|ehcache)@.*$</packageUrl>
+        <cve>CVE-2019-14900</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   From review of https://nvd.nist.gov/vuln/detail/CVE-2020-25638 and https://bugzilla.redhat.com/show_bug.cgi?id=1881353
+   GoCD is not subject to this defect, because `hibernate.use_sql_comments` is left as the default (false) value.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.hibernate/hibernate\-(core|ehcache)@.*$</packageUrl>
+        <cve>CVE-2020-25638</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
These vulnerabilities do not appear to affect GoCD's usage as both are specific problems in the modern `Criteria` API (and unclear if they affect old Hibernate 3.6 version). It's non-trivial to upgrade Hibernate past these major versions at this stage.