### PR TITLE
Upgrade GoCD to run and build with Java 17

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 # Configuration for https://github.com/asdf-vm/asdf as an alternative to jabba, rvm, nvm etc
 java temurin-17.0.2+8
 ruby jruby-9.3.3.0
-nodejs 16.13.1
+nodejs 16.13.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 # Configuration for https://github.com/asdf-vm/asdf as an alternative to jabba, rvm, nvm etc
-java adoptopenjdk-15.0.2+7
+java temurin-17.0.1+12
 ruby jruby-9.3.3.0
 nodejs 16.13.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 # Configuration for https://github.com/asdf-vm/asdf as an alternative to jabba, rvm, nvm etc
-java temurin-17.0.1+12
+java temurin-17.0.2+8
 ruby jruby-9.3.3.0
 nodejs 16.13.1

--- a/build.gradle
+++ b/build.gradle
@@ -166,10 +166,10 @@ project.ext.compilerOptions = [
 
 project.ext.packaging = [
   adoptOpenjdk: [
-    featureVersion: 15,
+    featureVersion: 17,
     interimVersion: 0, // set to `null` for the first release
-    updateVersion : 2, // set to `null` for the first release
-    buildVersion  : 7
+    updateVersion : 1, // set to `null` for the first release
+    buildVersion  : 12
   ]
 ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -171,8 +171,8 @@ project.ext.packaging = [
   adoptOpenjdk: [
     featureVersion: 17,
     interimVersion: 0, // set to `null` for the first release
-    updateVersion : 1, // set to `null` for the first release
-    buildVersion  : 12
+    updateVersion : 2, // set to `null` for the first release
+    buildVersion  : 8
   ]
 ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-
 import com.github.jk1.license.filter.LicenseBundleNormalizer
 import com.github.jk1.license.render.JsonReportRenderer
 import com.github.jk1.license.task.ReportTask
+import com.thoughtworks.go.build.InstallerType
 import groovy.io.FileType
 import nl.javadude.gradle.plugins.license.License
 import org.apache.tools.ant.filters.FixCrLfFilter
@@ -156,8 +156,6 @@ rootProject.ext.distVersion = DIST_VERSION
 rootProject.ext.fullVersion = DIST_VERSION ? "${GO_VERSION}-${DIST_VERSION}" : GO_VERSION
 rootProject.ext.gitRevision = GIT_REVISION
 rootProject.ext.copyrightYear = Calendar.getInstance().get(Calendar.YEAR)
-
-project.ext.defaultJvmArgs = []
 
 project.ext.compilerOptions = [
   // source and target compatibility
@@ -535,7 +533,7 @@ subprojects {
     // fixup a tempdir that is predictable and we can clean it up later
     def tmpDir = project.file("${System.getProperty('java.io.tmpdir')}/gocd-tests/${new BigInteger(32, new SecureRandom()).toString(32)}")
     systemProperty 'java.io.tmpdir', tmpDir
-    jvmArgs += project.defaultJvmArgs
+    jvmArgs += testTask.project.name.startsWith("agent") ? InstallerType.agent.jvmModuleOpensArgs : InstallerType.server.jvmModuleOpensArgs
 
     doFirst {
       // workaround for https://github.com/unbroken-dome/gradle-testsets-plugin/issues/40

--- a/build.gradle
+++ b/build.gradle
@@ -160,8 +160,13 @@ rootProject.ext.copyrightYear = Calendar.getInstance().get(Calendar.YEAR)
 project.ext.defaultJvmArgs = []
 
 project.ext.compilerOptions = [
-  sourceCompatibility: 13,
-  targetCompatibility: 13,
+  // source and target compatibility
+  release: 13,
+]
+
+project.ext.toolchains = [
+  compilerVersion: 17,
+  testLauncherVersion: 17,
 ]
 
 project.ext.packaging = [
@@ -251,9 +256,9 @@ allprojects {
 
 idea {
   project {
-    jdkName = project.compilerOptions.targetCompatibility
-    targetBytecodeVersion = JavaVersion.toVersion(project.compilerOptions.targetCompatibility)
-    languageLevel = new IdeaLanguageLevel(project.compilerOptions.sourceCompatibility)
+    jdkName = project.toolchains.compilerVersion
+    targetBytecodeVersion = JavaVersion.toVersion(project.compilerOptions.release)
+    languageLevel = new IdeaLanguageLevel(project.compilerOptions.release)
   }
 }
 
@@ -400,8 +405,6 @@ subprojects {
       }
     }
 
-    sourceCompatibility = project.compilerOptions.sourceCompatibility
-    targetCompatibility = project.compilerOptions.targetCompatibility
     buildDir = "${projectDir}/target"
 
     configurations {
@@ -447,8 +450,8 @@ subprojects {
         'Go-Revision': project.gitRevision,
         'Implementation-Title': project.name,
         'Implementation-Version': project.version,
-        'Source-Compatibility': project.compilerOptions.sourceCompatibility,
-        'Target-Compatibility': project.compilerOptions.targetCompatibility
+        'Source-Compatibility': project.compilerOptions.release,
+        'Target-Compatibility': project.compilerOptions.release
       )
     }
 
@@ -488,6 +491,11 @@ subprojects {
     options.warnings = false
     options.encoding = "UTF-8"
     options.compilerArgs += '-Xlint:-deprecation'
+    options.release = project.compilerOptions.release
+
+    javaCompiler = javaToolchains.compilerFor {
+      languageVersion = JavaLanguageVersion.of(project.toolchains.compilerVersion)
+    }
   }
 
   project.afterEvaluate {
@@ -516,6 +524,10 @@ subprojects {
 //    outputs.upToDateWhen { false }
 
     testTask.useJUnitPlatform()
+    javaLauncher = javaToolchains.launcherFor {
+      languageVersion = JavaLanguageVersion.of(project.toolchains.testLauncherVersion)
+    }
+
     def allTestClasses
 
     maxParallelForks = project.hasProperty('maxParallelForks') ? project.maxParallelForks as int : 1

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/AdoptiumUrlHelper.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/AdoptiumUrlHelper.groovy
@@ -26,11 +26,12 @@ enum OperatingSystem {
   }
 }
 
-class AdoptOpenJDKUrlHelper {
+class AdoptiumUrlHelper {
   static String downloadURL(OperatingSystem operatingSystem, Integer featureVersion, Integer interimVersion, Integer updateVersion, Integer buildVersion) {
     String versionComponent = [featureVersion, interimVersion, updateVersion].findAll({ it != null }).join('.')
+    String featureSuffix = updateVersion == null ? '' : 'U'
 
-    "https://github.com/AdoptOpenJDK/openjdk${featureVersion}-binaries/releases/download/jdk-${versionComponent}%2B${buildVersion}/OpenJDK${featureVersion}U-jre_x64_${operatingSystem.name()}_hotspot_${versionComponent}_${buildVersion}.${operatingSystem.extension}"
+    "https://github.com/adoptium/temurin${featureVersion}-binaries/releases/download/jdk-${versionComponent}%2B${buildVersion}/OpenJDK${featureVersion}${featureSuffix}-jre_x64_${operatingSystem.name()}_hotspot_${versionComponent}_${buildVersion}.${operatingSystem.extension}"
   }
 
   static String sha256sumURL(OperatingSystem operatingSystem, Integer featureVersion, Integer interimVersion, Integer updateVersion, Integer buildVersion) {

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/AdoptiumUrlHelper.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/AdoptiumUrlHelper.groovy
@@ -16,22 +16,13 @@
 
 package com.thoughtworks.go.build
 
-enum OperatingSystem {
-  windows("zip"), linux("tar.gz"), mac("tar.gz")
-
-  final String extension
-
-  OperatingSystem(String extension) {
-    this.extension = extension
-  }
-}
 
 class AdoptiumUrlHelper {
   static String downloadURL(OperatingSystem operatingSystem, Integer featureVersion, Integer interimVersion, Integer updateVersion, Integer buildVersion) {
     String versionComponent = [featureVersion, interimVersion, updateVersion].findAll({ it != null }).join('.')
     String featureSuffix = updateVersion == null ? '' : 'U'
 
-    "https://github.com/adoptium/temurin${featureVersion}-binaries/releases/download/jdk-${versionComponent}%2B${buildVersion}/OpenJDK${featureVersion}${featureSuffix}-jre_x64_${operatingSystem.name()}_hotspot_${versionComponent}_${buildVersion}.${operatingSystem.extension}"
+    "https://github.com/adoptium/temurin${featureVersion}-binaries/releases/download/jdk-${versionComponent}%2B${buildVersion}/OpenJDK${featureVersion}${featureSuffix}-jre_x64_${operatingSystem.adoptiumAlias()}_hotspot_${versionComponent}_${buildVersion}.${operatingSystem.extension}"
   }
 
   static String sha256sumURL(OperatingSystem operatingSystem, Integer featureVersion, Integer interimVersion, Integer updateVersion, Integer buildVersion) {

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/DownloaderTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/DownloaderTask.groovy
@@ -16,7 +16,9 @@
 
 package com.thoughtworks.go.build
 
+import jdk.internal.module.Modules
 import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.ysb33r.grolifant.api.core.OperatingSystem
@@ -54,6 +56,19 @@ class DownloaderTask extends DefaultTask {
       @Override
       URI uriFromVersion(String version) {
         return url.toURI()
+      }
+
+      @Override
+      Provider<File> getDistributionRoot(String version) {
+        // Workaround for issues with Java 17 and Groovy-generated dynamic proxies used by Grolifant on Groovy 3.0.9
+        // Raised at https://gitlab.com/ysb33rOrg/grolifant/-/issues/82
+        // On Groovy side, https://issues.apache.org/jira/browse/GROOVY-10145 has a linked fix for Groovy 4, but
+        // currently seems not to be back-ported to 3.x
+
+        // Relies on gradle.properties setting to be able to do this opening dynamically
+        Modules.addOpensToAllUnnamed(artifactRootVerification.class.module, artifactRootVerification.class.packageName)
+
+        return super.getDistributionRoot(version)
       }
 
       @Override

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/ExecuteUnderRailsTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/ExecuteUnderRailsTask.groovy
@@ -67,8 +67,6 @@ class ExecuteUnderRailsTask extends JavaExec {
         environment += [CLASSPATH: project.jrubyJar().toString()]
       }
 
-      jvmArgs += project.defaultJvmArgs
-
       // flags to optimize jruby startup performance
       if (!disableJRubyOptimization) {
         jvmArgs += project.jrubyOptimizationJvmArgs

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerType.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerType.groovy
@@ -30,8 +30,8 @@ interface InstallerType {
   Map<String, String> getAdditionalEnvVars()
   Map<String, String> getAdditionalLinuxEnvVars()
 
+  List<String> getJvmModuleOpensArgs()
   List<String> getJvmArgs()
-
   List<String> getLinuxJvmArgs()
 
   boolean getAllowPassthrough()

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeAgent.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeAgent.groovy
@@ -47,11 +47,19 @@ class InstallerTypeAgent implements InstallerType {
     ]
   }
 
+  // Note that these apply to the launcher, but not necessarily the agent itself
+  @Override
+  List<String> getJvmModuleOpensArgs() {
+    []
+  }
+
+  // Note that these apply to the launcher, but not necessarily the agent itself
   @Override
   List<String> getJvmArgs() {
     []
   }
 
+  // Note that these apply to the launcher, but not the agent itself
   @Override
   List<String> getLinuxJvmArgs() {
     [

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeServer.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeServer.groovy
@@ -43,8 +43,16 @@ class InstallerTypeServer implements InstallerType {
   }
 
   @Override
-  List<String> getJvmArgs() {
+  List<String> getJvmModuleOpensArgs() {
     [
+      '--add-opens=java.base/java.lang=ALL-UNNAMED', // Required for Hibernate 3.6/Javassist proxying (at minimum, may be used for other things)
+      '--add-opens=java.base/java.util=ALL-UNNAMED', // Required at least for cloning GoConfig subclasses of java.util classes :(
+    ]
+  }
+
+  @Override
+  List<String> getJvmArgs() {
+    getJvmModuleOpensArgs() + [
       '-Xms512m',
       '-Xmx1024m',
       '-XX:MaxMetaspaceSize=400m',

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/OperatingSystem.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/OperatingSystem.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.build
+
+enum OperatingSystem {
+  windows("zip"), linux("tar.gz"), alpine_linux("tar.gz"), mac("tar.gz")
+
+  final String extension
+
+  OperatingSystem(String extension) {
+    this.extension = extension
+  }
+
+  String adoptiumAlias() {
+    name().replace('_', '-')
+  }
+}

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -16,11 +16,17 @@
 
 package com.thoughtworks.go.build.docker
 
+import com.thoughtworks.go.build.OperatingSystem
 import org.gradle.api.Project
 
 enum Distro implements DistroBehavior {
 
   alpine{
+    @Override
+    OperatingSystem getOperatingSystem() {
+      OperatingSystem.linux
+    }
+
     @Override
     List<DistroVersion> getSupportedVersions() {
       def installSasl_Post_3_9 = ['apk add --no-cache libsasl']
@@ -184,6 +190,11 @@ enum Distro implements DistroBehavior {
 
   docker{
     @Override
+    OperatingSystem getOperatingSystem() {
+      return alpine.getOperatingSystem()
+    }
+
+    @Override
     boolean isPrivilegedModeSupport() {
       return true
     }
@@ -211,7 +222,6 @@ enum Distro implements DistroBehavior {
     List<String> getInstallPrerequisitesCommands(DistroVersion distroVersion) {
       return alpine.getInstallPrerequisitesCommands(distroVersion)
     }
-
 
     @Override
     List<String> getInstallJavaCommands(Project project) {

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.build.docker
 
 import com.thoughtworks.go.build.AdoptiumUrlHelper
+import com.thoughtworks.go.build.OperatingSystem
 import org.gradle.api.Project
 
 trait DistroBehavior {
@@ -54,7 +55,7 @@ trait DistroBehavior {
 
   List<String> getInstallJavaCommands(Project project) {
     def downloadUrl = AdoptiumUrlHelper.downloadURL(
-      com.thoughtworks.go.build.OperatingSystem.linux,
+      getOperatingSystem(),
       project.packaging.adoptOpenjdk.featureVersion,
       project.packaging.adoptOpenjdk.interimVersion,
       project.packaging.adoptOpenjdk.updateVersion,
@@ -66,6 +67,10 @@ trait DistroBehavior {
       'tar -xf /tmp/jre.tar.gz -C /gocd-jre --strip 1',
       'rm -rf /tmp/jre.tar.gz'
     ]
+  }
+
+  OperatingSystem getOperatingSystem() {
+    OperatingSystem.linux
   }
 
   Map<String, String> getEnvironmentVariables(DistroVersion distroVersion) {

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
@@ -16,7 +16,7 @@
 
 package com.thoughtworks.go.build.docker
 
-import com.thoughtworks.go.build.AdoptOpenJDKUrlHelper
+import com.thoughtworks.go.build.AdoptiumUrlHelper
 import org.gradle.api.Project
 
 trait DistroBehavior {
@@ -53,7 +53,7 @@ trait DistroBehavior {
   }
 
   List<String> getInstallJavaCommands(Project project) {
-    def downloadUrl = AdoptOpenJDKUrlHelper.downloadURL(
+    def downloadUrl = AdoptiumUrlHelper.downloadURL(
       com.thoughtworks.go.build.OperatingSystem.linux,
       project.packaging.adoptOpenjdk.featureVersion,
       project.packaging.adoptOpenjdk.interimVersion,

--- a/config/config-server/src/main/java/com/thoughtworks/go/config/parser/GoConfigFieldLoader.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/config/parser/GoConfigFieldLoader.java
@@ -15,23 +15,19 @@
  */
 package com.thoughtworks.go.config.parser;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
-import java.util.Map;
-
-import com.thoughtworks.go.config.ConfigAttributeValue;
-import com.thoughtworks.go.config.ConfigCache;
-import com.thoughtworks.go.config.ConfigReferenceElement;
-import com.thoughtworks.go.config.ConfigSubtag;
-import com.thoughtworks.go.config.ConfigValue;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
 import com.thoughtworks.go.security.GoCipher;
 import org.jdom2.Attribute;
 import org.jdom2.Element;
 import org.springframework.beans.SimpleTypeConverter;
 import org.springframework.beans.TypeMismatchException;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.thoughtworks.go.config.ConfigCache.isAnnotationPresent;
 import static com.thoughtworks.go.config.parser.GoConfigAttributeLoader.attributeParser;
@@ -63,24 +59,28 @@ public class GoConfigFieldLoader<T> {
         this.field = field;
         this.configCache = configCache;
         this.configReferenceElements = configReferenceElements;
-        field.setAccessible(true);
         this.registry = registry;
     }
 
     public void parse() {
         if (isImplicitCollection()) {
+            field.setAccessible(true);
             Object val = GoConfigClassLoader.classParser(e, field.getType(), configCache, new GoCipher(), registry, configReferenceElements).parseImplicitCollection();
             setValue(val);
         } else if (isSubtag(field)) {
+            field.setAccessible(true);
             Object val = subtagParser(e, field, configCache, registry, configReferenceElements).parse();
             setValue(val);
         } else if (isAttribute(field)) {
+            field.setAccessible(true);
             Object val = attributeParser(e, field).parse(defaultValue());
             setValue(val);
         } else if (isConfigValue()) {
+            field.setAccessible(true);
             Object val = e.getText();
             setValue(val);
         } else if (isAnnotationPresent(field, ConfigReferenceElement.class)) {
+            field.setAccessible(true);
             ConfigReferenceElement referenceField = field.getAnnotation(ConfigReferenceElement.class);
             Attribute attribute = e.getAttribute(referenceField.referenceAttribute());
             if (attribute == null) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,8 @@ org.gradle.parallel=true
 org.gradle.workers.max=4
 org.gradle.caching=true
 org.gradle.java.installations.auto-download=false
+
+# Workaround for issues with Java 17 and Groovy-generated dynamic proxies used by Grolifant on Groovy 3.0.9
+# https://issues.apache.org/jira/browse/GROOVY-10145 has the fix, but currently seems not backported to 3.x
+# This is seemingly only required by our use of Grolifant in DownloaderTask.groovy
+org.gradle.jvmargs=--add-opens=java.base/jdk.internal.module=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.workers.max=4
 org.gradle.caching=true
+org.gradle.java.installations.auto-download=false

--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -15,7 +15,7 @@
  */
 
 
-import com.thoughtworks.go.build.AdoptOpenJDKUrlHelper
+import com.thoughtworks.go.build.AdoptiumUrlHelper
 import com.thoughtworks.go.build.DownloadFile
 import com.thoughtworks.go.build.InstallerType
 import groovy.json.JsonOutput
@@ -105,7 +105,7 @@ private File destFile(String url) {
 }
 
 task downloadLinuxJreChecksum(type: DownloadFile) {
-  def srcUrl = AdoptOpenJDKUrlHelper.sha256sumURL(
+  def srcUrl = AdoptiumUrlHelper.sha256sumURL(
     com.thoughtworks.go.build.OperatingSystem.linux,
     project.packaging.adoptOpenjdk.featureVersion,
     project.packaging.adoptOpenjdk.interimVersion,
@@ -119,7 +119,7 @@ task downloadLinuxJreChecksum(type: DownloadFile) {
 task downloadLinuxJre(type: DownloadFile) {
 
   dependsOn downloadLinuxJreChecksum
-  def srcUrl = AdoptOpenJDKUrlHelper.downloadURL(
+  def srcUrl = AdoptiumUrlHelper.downloadURL(
     com.thoughtworks.go.build.OperatingSystem.linux,
     project.packaging.adoptOpenjdk.featureVersion,
     project.packaging.adoptOpenjdk.interimVersion,

--- a/installers/osx.gradle
+++ b/installers/osx.gradle
@@ -1,4 +1,4 @@
-import com.thoughtworks.go.build.AdoptOpenJDKUrlHelper
+import com.thoughtworks.go.build.AdoptiumUrlHelper
 import com.thoughtworks.go.build.DownloadFile
 import com.thoughtworks.go.build.InstallerType
 import org.apache.commons.codec.digest.DigestUtils
@@ -24,7 +24,7 @@ private File destFile(String url) {
 }
 
 task downloadOsxJreChecksum(type: DownloadFile) {
-  def srcUrl = AdoptOpenJDKUrlHelper.sha256sumURL(
+  def srcUrl = AdoptiumUrlHelper.sha256sumURL(
     com.thoughtworks.go.build.OperatingSystem.mac,
     project.packaging.adoptOpenjdk.featureVersion,
     project.packaging.adoptOpenjdk.interimVersion,
@@ -37,7 +37,7 @@ task downloadOsxJreChecksum(type: DownloadFile) {
 
 task downloadOsxJre(type: DownloadFile) {
   dependsOn downloadOsxJreChecksum
-  def srcUrl = AdoptOpenJDKUrlHelper.downloadURL(
+  def srcUrl = AdoptiumUrlHelper.downloadURL(
     com.thoughtworks.go.build.OperatingSystem.mac,
     project.packaging.adoptOpenjdk.featureVersion,
     project.packaging.adoptOpenjdk.interimVersion,

--- a/installers/windows.gradle
+++ b/installers/windows.gradle
@@ -15,7 +15,7 @@
  */
 
 
-import com.thoughtworks.go.build.AdoptOpenJDKUrlHelper
+import com.thoughtworks.go.build.AdoptiumUrlHelper
 import com.thoughtworks.go.build.DownloadFile
 import com.thoughtworks.go.build.InstallerType
 import org.apache.commons.codec.digest.DigestUtils
@@ -26,7 +26,7 @@ private File destFile(String url) {
 }
 
 task downloadWindowsJreChecksum(type: DownloadFile) {
-  def srcUrl = AdoptOpenJDKUrlHelper.sha256sumURL(
+  def srcUrl = AdoptiumUrlHelper.sha256sumURL(
     com.thoughtworks.go.build.OperatingSystem.windows,
     project.packaging.adoptOpenjdk.featureVersion,
     project.packaging.adoptOpenjdk.interimVersion,
@@ -39,7 +39,7 @@ task downloadWindowsJreChecksum(type: DownloadFile) {
 
 task downloadWindowsJre(type: DownloadFile) {
   dependsOn downloadWindowsJreChecksum
-  def srcUrl = AdoptOpenJDKUrlHelper.downloadURL(
+  def srcUrl = AdoptiumUrlHelper.downloadURL(
     com.thoughtworks.go.build.OperatingSystem.windows,
     project.packaging.adoptOpenjdk.featureVersion,
     project.packaging.adoptOpenjdk.interimVersion,

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -419,8 +419,7 @@ task fastUnitTest(type: Test) { thisTask ->
 
   mustRunAfter test
 
-  forkEvery 256
-  minHeapSize '1g'
+  forkEvery 200
   maxHeapSize '2g'
 
   reports {

--- a/server/jasmine.gradle
+++ b/server/jasmine.gradle
@@ -75,8 +75,8 @@ def browser = { ->
   return 'firefox'
 }
 
-def browserExecutable = { String path->
-  def separator = "=".multiply(72)
+def browserExecutable = { String path ->
+  def separator = "=" * 72
   println "Browser versions"
   println(separator)
   switch(browser()) {
@@ -177,8 +177,12 @@ task jasmineOld(type: ExecuteUnderRailsTask) {
   ]
 
   args = ['-S', 'rails', 'jasmine:ci']
-  // setup max heap, this is typically required on windows.
-  jvmArgs('-Xmx2g')
+
+  jvmArgs += [
+          // Address JRuby: WARN FilenoUtil : Native subprocess control requires open access to the JDK IO subsystem
+          '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+          '--add-opens=java.base/java.io=ALL-UNNAMED'
+  ]
 
   doFirst {
     def additionalPaths = [

--- a/server/jasmine.gradle
+++ b/server/jasmine.gradle
@@ -176,13 +176,13 @@ task jasmineOld(type: ExecuteUnderRailsTask) {
     'BROWSER'            : browser(),
   ]
 
-  args = ['-S', 'rails', 'jasmine:ci']
-
   jvmArgs += [
           // Address JRuby: WARN FilenoUtil : Native subprocess control requires open access to the JDK IO subsystem
           '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
           '--add-opens=java.base/java.io=ALL-UNNAMED'
   ]
+  args = ['-S', 'rails', 'jasmine:ci']
+  maxHeapSize = '2g'
 
   doFirst {
     def additionalPaths = [

--- a/server/rails.gradle
+++ b/server/rails.gradle
@@ -111,20 +111,14 @@ task initializeRailsGems {
   inputs.files(project.configurations.jrubyGems)
   inputs.file("${project.railsRoot}/Gemfile")
   inputs.file("${project.railsRoot}/Gemfile.lock")
+  inputs.file("${project.railsRoot}/.bundle/config")
   inputs.properties([
     jrubyVersion: project.deps.jruby,
     bundledGemDir: project.bundledGemDir,
     railsRoot: project.railsRoot
   ])
 
-  def outputDirs = [
-    project.bundledGemDir,
-    "${project.railsRoot}/.bundle"
-  ]
-
-  outputDirs.each {
-    outputs.dir(it)
-  }
+  outputs.dir(project.bundledGemDir)
 
   doFirst {
     project.jrubyexec {

--- a/server/rails.gradle
+++ b/server/rails.gradle
@@ -288,10 +288,9 @@ task rspec(type: ExecuteUnderRailsTask) {
     'REPORTS_DIR': "${project.buildDir}/rspec-results"
   ]
 
-  maxHeapSize = '2g'
   jvmArgs += InstallerType.server.jvmModuleOpensArgs + ['-XX:+HeapDumpOnOutOfMemoryError', "-XX:HeapDumpPath=${project.buildDir}/heap-dumps"]
-
   args = ['-S', 'rspec', '--backtrace']
+  maxHeapSize = '2g'
 
   if (project.hasProperty('opts')) {
     args += Commandline.translateCommandline(project.property('opts')) as List<String>
@@ -317,10 +316,9 @@ task parallelRspec(type: ExecuteUnderRailsTask) {
     'REPORTS_DIR': "${project.buildDir}/rspec-results"
   ]
 
-  maxHeapSize = '2g'
   jvmArgs += InstallerType.server.jvmModuleOpensArgs + ['-XX:+HeapDumpOnOutOfMemoryError', "-XX:HeapDumpPath=${project.buildDir}/heap-dumps"]
-
   args = ['-S', 'rspec', '--backtrace']
+  maxHeapSize = '2g'
 
   if (project.hasProperty('opts')) {
     args += Commandline.translateCommandline(project.property('opts')) as List<String>

--- a/server/rails.gradle
+++ b/server/rails.gradle
@@ -15,6 +15,7 @@
  */
 
 import com.thoughtworks.go.build.ExecuteUnderRailsTask
+import com.thoughtworks.go.build.InstallerType
 import com.thoughtworks.go.build.YarnInstallTask
 import com.thoughtworks.go.build.YarnRunTask
 import groovy.text.SimpleTemplateEngine
@@ -293,8 +294,8 @@ task rspec(type: ExecuteUnderRailsTask) {
     'REPORTS_DIR': "${project.buildDir}/rspec-results"
   ]
 
-  maxHeapSize = '6g'
-  jvmArgs += ['-XX:+UseCompressedOops', '-XX:-UseCompressedClassPointers', '-XX:+HeapDumpOnOutOfMemoryError', "-XX:HeapDumpPath=${project.buildDir}/heap-dumps"]
+  maxHeapSize = '2g'
+  jvmArgs += InstallerType.server.jvmModuleOpensArgs + ['-XX:+HeapDumpOnOutOfMemoryError', "-XX:HeapDumpPath=${project.buildDir}/heap-dumps"]
 
   args = ['-S', 'rspec', '--backtrace']
 
@@ -322,8 +323,8 @@ task parallelRspec(type: ExecuteUnderRailsTask) {
     'REPORTS_DIR': "${project.buildDir}/rspec-results"
   ]
 
-  maxHeapSize = '6g'
-  jvmArgs += ['-XX:+UseCompressedOops', '-XX:-UseCompressedClassPointers', '-XX:+HeapDumpOnOutOfMemoryError', "-XX:HeapDumpPath=${project.buildDir}/heap-dumps"]
+  maxHeapSize = '2g'
+  jvmArgs += InstallerType.server.jvmModuleOpensArgs + ['-XX:+HeapDumpOnOutOfMemoryError', "-XX:HeapDumpPath=${project.buildDir}/heap-dumps"]
 
   args = ['-S', 'rspec', '--backtrace']
 

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -223,9 +223,8 @@ GEM
 
 PLATFORMS
   java
-  universal-java-11
-  universal-java-12
   universal-java-15
+  universal-java-17
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Fixes #9635, #9469

* Upgrades to Java 17
   * Since Gradle 6 was not compatible with Java 16+ when initially working on this, in order to decouple, introduces use of Gradle Java Toolchains to compile and test using a different JVM to that Gradle runs with (this is now moot, since the Gradle 7 upgrade was completed, but preserving ability to run tests with target JVM and Gradle with a newer JVM is possibly desirable)
   * Adds bare minimum `--add-opens` to open up internal JVM modules for reflection, that seems to be required in a number of places, including use of the deep object `cloner` (but not limited to this) and Hibernate 3.6/javassist
   * Avoids use of non-ideal`source`/`target` compatibility, preferring the `release` flag which ensures code doesn't depend on APIs from earlier JVMs it shouldn't.
* Switches Java builds to Eclipse Adoptium Temurin JRE builds
  * Adds ability to use an Alpine-specific Adoptium JRE, but not currently used due to issues with the Tanuki Service Wrapper on musl libc

Task list
* [X] Get pre-requisite JVM on build agents
* [X] Get tests passing
* [x] A lot of cleanups/TODOs/FIXMEs
* [x] Validate the various distributions
  * [X] Windows
  * [X] MacOS
  * [X] Linux (.deb via Ubuntu)
* [X] Factor out the `--add-opens` args so the tests for `agent` run with different set of args than `server` since they seem to require different packages to be open
* [X] Much more deep assessment of correctness of server and agent with the existing `--add-opens`. The current list was derived through trial and error.
  * [X] Review all the dodgy `setAccessible` reflection stuff throughout the code
    * There's a lot, but most of it seems to be via walking configuration, and params resolver stuff. I hope that this is OK with the existing opens. 
  * [X] Check the `SvnCommand` and such exception handling which sets exception internals. Is this used on agents?
    * The `smudgeException` code is only used when checking modifications on the server, it appears. So should be fine. 
  * [X] brute force through some more features "of interest" on server locally, and some relevant plugins?
* [ ] Consider changing compatibility back to Java 11 (previous LTS) rather than Java 13 which is not an LTS release.
* [X] Sanity check that 22.1.0 server can talk to 21.4.0 agent bootstrapper after server upgrade
* [X] Update developer docs to reflect need to `--add-opens` when running certain tests inside IDE
* [x] Rebase/squash

Before merge
* [x] Drop the final commit (that hacks the Gradle JDK version).
  * [x] Take a backup of build.gocd.org :-)
  * [x] Update the pipeline definition on `build.gocd.org` to `BUILD_ON_JDK=17`