### PR TITLE
Reduce max heap size that unit tests run with to match integration tests

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -409,7 +409,7 @@ task fastUnitTest(type: Test) { thisTask ->
 
   forkEvery 256
   minHeapSize '1g'
-  maxHeapSize '4g'
+  maxHeapSize '2g'
 
   reports {
     html.enabled = true
@@ -441,8 +441,8 @@ task integrationTest(type: Test) { thisTask ->
   mustRunAfter test
 
   forkEvery System.properties.containsKey('idea.home.path') ? 0 : 1
-  minHeapSize '1024m'
-  maxHeapSize '2048m'
+  minHeapSize '1g'
+  maxHeapSize '2g'
 
   reports {
     html.enabled = true


### PR DESCRIPTION
Experiment to see whether this improves stability on the build server. 

Currently test forks are frequently getting killed due to using too much memory in the ECS containers they run within. I believe these have 6GB available, and since there can be multiple test processes running at the same time, and alongside other Gradle workers, 4G for a single one seems too much especially when the integration tests run with 2g maxHeapSize.

Will revert if this does not reliably improve things.