### PR TITLE
Experiement with using Gradle defaults for memory usage

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,3 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.workers.max=4
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx1g -XX:+UseCompressedOops -XX:-UseCompressedClassPointers


### PR DESCRIPTION
Return to Gradle Daemon defaults for JVM args.

- Reduce to 512MB JVM max memory ([docs note](https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:how_much_memory_does_the_daemon_use_and_can_i_give_it_more) this should be plenty)
- `-XX:+UseCompressedOops` is already enabled by default on modern JVMs
- `UseCompressedClassPointers` should be safe to have enabled on modern JVMs (currently force-disabled)

Trying to gradually increase reliability and simplicity of builds by reducing customisation. This change improved stability on #9818 builds where extra forked processes are required to deal with Gradle JVM version <> compile/test JVM version.