### PR TITLE
Add specific fast cloners for `Date`s and `Timestamps`

### DIFF
--- a/util/src/main/java/com/thoughtworks/go/util/ClonerFactory.java
+++ b/util/src/main/java/com/thoughtworks/go/util/ClonerFactory.java
@@ -17,8 +17,12 @@
 package com.thoughtworks.go.util;
 
 import com.rits.cloning.Cloner;
+import com.rits.cloning.IDeepCloner;
 
+import java.sql.Timestamp;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -47,10 +51,18 @@ public class ClonerFactory {
         private static Cloner create(final Cloner cloner) {
             cloner.registerFastCloner(LIST_1_2.getClass(), (t, _1, _2) -> List.of(((List<?>) t).toArray()));
             cloner.registerFastCloner(SET_1_2.getClass(), (t, _1, _2) -> Set.of(((Set<?>) t).toArray()));
-
+            cloner.registerFastCloner(Date.class, (t, _1, _2) -> new Date(((Date)t).getTime()));
+            cloner.registerFastCloner(java.sql.Date.class, (t, _1, _2) -> new java.sql.Date(((java.sql.Date)t).getTime()));
+            cloner.registerFastCloner(Timestamp.class, ClonerFactory::cloneTimestamp);
             return cloner;
         }
+    }
 
+    private static Timestamp cloneTimestamp(Object t, IDeepCloner cloner, Map<Object, Object> cloners) {
+        Timestamp original = (Timestamp) t;
+        Timestamp clone = new Timestamp(original.getTime());
+        clone.setNanos(original.getNanos());
+        return clone;
     }
 
     public static Cloner instance() {

--- a/util/src/test/java/com/thoughtworks/go/util/ClonerFactoryTest.java
+++ b/util/src/test/java/com/thoughtworks/go/util/ClonerFactoryTest.java
@@ -20,10 +20,14 @@ import com.rits.cloning.Cloner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Timestamp;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ClonerFactoryTest {
     private Cloner cloner;
@@ -91,6 +95,34 @@ class ClonerFactoryTest {
 
         assertEquals(5, dupe.size());
         assertEquals(set, dupe);
+    }
+
+    @Test
+    void cloneDate() {
+        Date date = new Date();
+        Date dupe = cloner.deepClone(date);
+        assertThat(dupe)
+                .isExactlyInstanceOf(Date.class)
+                .isEqualTo(date);
+    }
+
+    @Test
+    void cloneSqlDate() {
+        Date date = new java.sql.Date(System.currentTimeMillis());
+        Date dupe = cloner.deepClone(date);
+        assertThat(dupe)
+                .isExactlyInstanceOf(java.sql.Date.class)
+                .isEqualTo(date);
+    }
+
+    @Test
+    void cloneTimestamp() {
+        Timestamp date = new Timestamp(System.currentTimeMillis());
+        date.setNanos(1);
+        Timestamp dupe = cloner.deepClone(date);
+        assertThat(dupe)
+                .isExactlyInstanceOf(Timestamp.class)
+                .isEqualTo(date);
     }
 
 }


### PR DESCRIPTION
Currently there are both `Date` and `Timestamp` objects deep within the structures that are cloned on pipelines.

While currently it works fine, it is relying on a deep field-by-field clone and reflection into private JVM classes. For `Date` and `Timestamp` this requires access to `sun.util.calendar`'s `BaseCalendar` which has a lazily set field inside `java.util.Date`. 

Such reflection is brittle, and discouraged heavily on Java 16/17. This change reduces need to open access to private Java module APIs for cloning these particular object structures by using a simpler cloning mechanism.

Reduces dependencies for upgrade in #9818.