### PR TITLE
Remove Alpine 3.11 agent builds

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -26,8 +26,7 @@ enum Distro implements DistroBehavior {
       def installSasl_Post_3_9 = ['apk add --no-cache libsasl']
 
       return [
-        new DistroVersion(version: '3.11', releaseName: '3.11', eolDate: parseDate('2021-11-01'), installPrerequisitesCommands: installSasl_Post_3_9, continueToBuild: true),
-        new DistroVersion(version: '3.12', releaseName: '3.12', eolDate: parseDate('2022-05-01'), installPrerequisitesCommands: installSasl_Post_3_9),
+        new DistroVersion(version: '3.12', releaseName: '3.12', eolDate: parseDate('2022-05-01'), installPrerequisitesCommands: installSasl_Post_3_9, continueToBuild: true),
         new DistroVersion(version: '3.13', releaseName: '3.13', eolDate: parseDate('2022-11-01'), installPrerequisitesCommands: installSasl_Post_3_9),
         new DistroVersion(version: '3.14', releaseName: '3.14', eolDate: parseDate('2023-05-01'), installPrerequisitesCommands: installSasl_Post_3_9),
       ]


### PR DESCRIPTION
Alpine 3.11 is EOL and no longer getting security patches.

Installer docker image builds now fail due to the EOL.