### PR TITLE
Build the gocd-server on Alpine 3.14 by default

### DIFF
--- a/settings-docker.gradle
+++ b/settings-docker.gradle
@@ -32,4 +32,4 @@ Distro.values().each { distro ->
 }
 
 include ":docker:gocd-server:${Distro.centos.projectName(Distro.centos.getVersion('8'))}"
-include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.13'))}"
+include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.14'))}"


### PR DESCRIPTION
Default was moved from `3.11` -> `3.13` in GoCD `21.3.0` when we started agent builds on `3.14`. `3.14` has been out since May 2021 so this should be stable for use with GoCD server.