### PR TITLE
Escape HTML in rendered error messages

### DIFF
--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/HtmlErrorPage.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/HtmlErrorPage.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.spark;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,7 +28,7 @@ public abstract class HtmlErrorPage {
 
     public static String errorPage(int code, String message) {
         return Holder.INSTANCE.replaceAll(buildRegex("status_code"), valueOf(code))
-                .replaceAll(buildRegex("error_message"), message);
+                .replaceAll(buildRegex("error_message"), StringEscapeUtils.escapeHtml4(message));
     }
 
     private static String buildRegex(final String value) {

--- a/spark/spark-base/src/test/java/com/thoughtworks/go/spark/HtmlErrorPageTest.java
+++ b/spark/spark-base/src/test/java/com/thoughtworks/go/spark/HtmlErrorPageTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.spark;
+
+import org.junit.jupiter.api.Test;
+
+import static com.thoughtworks.go.spark.HtmlErrorPage.errorPage;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HtmlErrorPageTest {
+
+    @Test
+    public void shouldReplaceStatusCodeAndMessage() {
+        assertThat(errorPage(404, "Error message"))
+                .contains("<h1>404</h1>")
+                .contains("<h2>Error message</h2>");
+    }
+
+    @Test
+    public void shouldEscapeHtmlInMessages() {
+        String htmlInMessage = "<img src=\"blah\"/>";
+        assertThat(errorPage(404, htmlInMessage))
+                .doesNotContain(htmlInMessage)
+                .contains("<h2>&lt;img src=&quot;blah&quot;/&gt;</h2>");
+    }
+}


### PR DESCRIPTION
Ensures anything inside an error message does not render as HTML on the error page.