### PR TITLE
Replace deprecated `StringEscapeUtils` usage

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/StringUtil.java
+++ b/base/src/main/java/com/thoughtworks/go/util/StringUtil.java
@@ -15,29 +15,14 @@
  */
 package com.thoughtworks.go.util;
 
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public final class StringUtil {
-    private static final String DELIMITER = "_";
-    private static final String DELIMITER_MATCHER = DELIMITER;
-    private static final String DELIMITER_ESCAPE_SEQ = DELIMITER + DELIMITER;
-
     private StringUtil() {
-    }
-
-    public static String quoteJavascriptString(String s) {
-        return "\"" + StringEscapeUtils.escapeJava(s) + "\"";
-    }
-
-    public static String joinSentences(String... strings) {
-        return Arrays.stream(strings).map(String::trim).map(s -> s.endsWith(".") ? s : s + ".").collect(Collectors.joining(" "));
     }
 
     public static String matchPattern(String regEx, String s) {
@@ -72,20 +57,6 @@ public final class StringUtil {
             strings[i] = string.toLowerCase();
         }
         return StringUtils.join(strings, " ");
-    }
-
-    public static String escapeAndJoinStrings(Object... items) {
-        StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < items.length; i++) {
-            Object item = items[i];
-            if (item != null) {
-                builder.append(item.toString().replaceAll(DELIMITER_MATCHER, DELIMITER_ESCAPE_SEQ));
-            }
-            if (i + 1 < items.length) {
-                builder.append(DELIMITER);
-            }
-        }
-        return builder.toString();
     }
 
     public static String joinForDisplay(final Collection<?> objects) {

--- a/base/src/test/java/com/thoughtworks/go/util/StringUtilTest.java
+++ b/base/src/test/java/com/thoughtworks/go/util/StringUtilTest.java
@@ -18,14 +18,11 @@ package com.thoughtworks.go.util;
 import org.junit.jupiter.api.Test;
 
 import static com.thoughtworks.go.util.StringUtil.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class StringUtilTest {
-    @Test public void shouldQuoteJavascriptString() throws Exception {
-        assertThat(StringUtil.quoteJavascriptString("a b \\c \"d"), is("\"a b \\\\c \\\"d\""));
-    }
 
     @Test public void shouldFindSimpleRegExMatch() throws Exception {
         String url = "http://java.sun.com:80/docs/books/tutorial/essential/regex/test_harness.html";
@@ -38,21 +35,6 @@ public class StringUtilTest {
         assertThat(humanize("camelCase"), is("camel case"));
         assertThat(humanize("camel"), is("camel"));
         assertThat(humanize("camelCaseForALongString"), is("camel case for a long string"));
-    }
-
-    @Test
-    public void shouldJoinWithCharEscaped() {
-        assertThat(escapeAndJoinStrings("foo", "bar", "baz", "hi_bye"), is("foo_bar_baz_hi__bye"));
-    }
-
-    @Test
-    public void shouldJoinWithNullsRepresentedAsBlankStrings() {
-        assertThat(escapeAndJoinStrings("foo", null, "hi_bye", null, null), is("foo__hi__bye__"));
-    }
-
-    @Test
-    public void shouldJoinSentences() {
-        assertThat(joinSentences("foo.", "bar", "baz. "), is("foo. bar. baz."));
     }
 
     @Test

--- a/common/src/main/java/com/thoughtworks/go/serverhealth/ServerHealthState.java
+++ b/common/src/main/java/com/thoughtworks/go/serverhealth/ServerHealthState.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bombIfNull;
-import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
+import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
 
 public class ServerHealthState {
     private final HealthStateLevel healthStateLevel;

--- a/config/config-api/build.gradle
+++ b/config/config-api/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
   implementation project.deps.commonsCodec
   implementation project.deps.commonsCollections4
+  implementation project.deps.commonsText
   api(project.deps.quartz) {
     transitive = false
   }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/HttpException.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/HttpException.java
@@ -20,7 +20,7 @@ import org.springframework.http.HttpStatus;
 import java.util.Objects;
 
 import static java.lang.String.format;
-import static org.apache.commons.lang3.StringEscapeUtils.escapeXml11;
+import static org.apache.commons.text.StringEscapeUtils.escapeXml11;
 
 public abstract class HttpException extends RuntimeException {
     private final HttpStatus status;

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/DefaultCommentRenderer.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/DefaultCommentRenderer.java
@@ -15,8 +15,8 @@
  */
 package com.thoughtworks.go.domain;
 
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/domain/DefaultCommentRendererTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/domain/DefaultCommentRendererTest.java
@@ -15,12 +15,12 @@
  */
 package com.thoughtworks.go.domain;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 
 public class DefaultCommentRendererTest {
 

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   implementation project(':plugin-infra:plugin-metadata-store')
   implementation project.deps.javaxAnnotation
   implementation project.deps.commonsCollections4
+  implementation project.deps.commonsText
   implementation project.deps.cloning
   implementation project.deps.jdom
   implementation project.deps.jodaTime

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/mercurial/HgModificationSplitter.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/mercurial/HgModificationSplitter.java
@@ -15,24 +15,25 @@
  */
 package com.thoughtworks.go.domain.materials.mercurial;
 
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.Date;
-import java.io.StringReader;
-import java.io.File;
-import java.text.ParseException;
-
 import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.domain.materials.Modifications;
 import com.thoughtworks.go.domain.materials.ModifiedAction;
 import com.thoughtworks.go.domain.materials.Revision;
-import com.thoughtworks.go.domain.materials.Modifications;
-import com.thoughtworks.go.util.command.ConsoleResult;
 import com.thoughtworks.go.util.DateUtils;
 import com.thoughtworks.go.util.ExceptionUtils;
-import org.jdom2.input.SAXBuilder;
+import com.thoughtworks.go.util.command.ConsoleResult;
+import org.apache.commons.text.StringEscapeUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import org.jdom2.input.SAXBuilder;
+
+import java.io.File;
+import java.io.StringReader;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
 
 public class HgModificationSplitter {
 
@@ -70,8 +71,8 @@ public class HgModificationSplitter {
 
     private Modification parseChangeset(Element changeset) {
         Date modifiedTime = DateUtils.parseRFC822(changeset.getChildText("date"));
-        String author = org.apache.commons.lang3.StringEscapeUtils.unescapeXml(changeset.getChildText("author"));
-        String comment = org.apache.commons.lang3.StringEscapeUtils.unescapeXml(changeset.getChildText("desc"));
+        String author = StringEscapeUtils.unescapeXml(changeset.getChildText("author"));
+        String comment = StringEscapeUtils.unescapeXml(changeset.getChildText("desc"));
         String revision = changeset.getChildText("node");
         Modification modification = new Modification(author, comment, null, modifiedTime, revision);
 

--- a/server/src/main/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdater.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdater.java
@@ -43,7 +43,7 @@ import org.springframework.transaction.TransactionStatus;
 import java.io.File;
 import java.util.List;
 
-import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
+import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
 
 /**
  * @understands how to update materials on the database from the real SCMs

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/helpers/ServerUnavailabilityResponse.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/helpers/ServerUnavailabilityResponse.java
@@ -16,7 +16,7 @@
 package com.thoughtworks.go.server.newsecurity.filters.helpers;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/handlers/renderer/XMLErrorMessageRenderer.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/handlers/renderer/XMLErrorMessageRenderer.java
@@ -16,7 +16,7 @@
 package com.thoughtworks.go.server.newsecurity.handlers.renderer;
 
 import com.thoughtworks.go.server.newsecurity.models.ContentTypeAwareResponse;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.springframework.http.MediaType;
 
 public class XMLErrorMessageRenderer extends ContentTypeAwareResponse {
@@ -28,7 +28,7 @@ public class XMLErrorMessageRenderer extends ContentTypeAwareResponse {
     public String getFormattedMessage(String message) {
         return new StringBuilder()
                 .append("<access-denied>\n")
-                .append("  <message>").append(StringEscapeUtils.escapeXml(message)).append("</message>\n")
+                .append("  <message>").append(StringEscapeUtils.escapeXml11(message)).append("</message>\n")
                 .append("</access-denied>\n")
                 .toString();
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/presentation/models/MaterialRevisionsJsonBuilderTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/presentation/models/MaterialRevisionsJsonBuilderTest.java
@@ -37,9 +37,9 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
-import static org.hamcrest.Matchers.is;
+import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class MaterialRevisionsJsonBuilderTest {
     private MaterialRevisions materialRevisions;


### PR DESCRIPTION
Replaces references from commonsLang3 to commonsText as suggested in the deprecation warning.

Also removed some unused/dead util code only referred to in tests.