### PR TITLE
Bump chromedriver from 87 to 95 (matching Windows agent version)

### DIFF
--- a/server/jasmine.gradle
+++ b/server/jasmine.gradle
@@ -22,9 +22,12 @@ import java.util.regex.Pattern
 
 OperatingSystem currentOS = OperatingSystem.current()
 
+// Chrome:        See https://chromedriver.chromium.org/downloads  Must match version of Chrome on build host
+// Firefox/gecko: See https://github.com/mozilla/geckodriver/releases and review compatibility at
+//                https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html
 final Map<String, String> seleniumDrivers = [
-  chromedriver: '87.0.4280.88',
-  geckodriver : '0.27.0',
+  chromedriver: '95.0.4638.54',
+  geckodriver: '0.30.0',
 ]
 
 def execute = { String path, String... argv ->


### PR DESCRIPTION
New build agent version in https://github.com/gocd-contrib/gocd-oss-cookbooks/compare/v3.1.0...v3.1.4 updates the Windows Chrome version to 95. Since chromedriver versions appear to need to match exactly, we need to update the driver versions we are using for testing.

Also bumps geckodriver from 0.27.0 to 0.30.0 (latest, no compatibility concerns)