### PR TITLE
Reduce internal JVM reflection in preparation for Java 16/17 upgrade

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -128,6 +128,7 @@ task verifyJar(type: VerifyJarTask) {
       "FastInfoset-1.2.15.jar",
       "agent-${project.version}-classes.jar",
       "agent-common-${project.version}.jar",
+      "animal-sniffer-annotations-1.9.jar",
       "ant-${project.versions.apacheAnt}.jar",
       "base-${project.version}.jar",
       "bcpkix-jdk15on-${project.versions.bouncyCastle}.jar",

--- a/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
@@ -64,7 +64,6 @@ public class GoConstants {
     public static final long MEGA_BYTE = 1024 * 1024;
     public static final long GIGA_BYTE = MEGABYTES_IN_GIGABYTE * MEGA_BYTE;
     public static final String USE_COMPRESSED_JAVASCRIPT = "rails.use.compressed.js";
-    public static final String I18N_CACHE_LIFE = "cruise.i18n.cache.life";
     public static final String GO_URL_CONTEXT = "/go";
     public static final String REGULAR_MULTIPART_FILENAME = "file";
     public static final String CHECKSUM_MULTIPART_FILENAME = "file_checksum";

--- a/common/src/main/java/com/thoughtworks/go/remote/Serialization.java
+++ b/common/src/main/java/com/thoughtworks/go/remote/Serialization.java
@@ -168,11 +168,18 @@ public class Serialization {
         }
     }
 
-    private static class FileAdapter implements JsonDeserializer<File> {
+    private static class FileAdapter implements JsonSerializer<File>, JsonDeserializer<File> {
         @Override
         public File deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
             String path = json.getAsJsonObject().get("path").getAsString();
             return new File(separatorsToSystem(path));
+        }
+
+        @Override
+        public JsonElement serialize(File src, Type typeOfSrc, JsonSerializationContext context) {
+            JsonObject serialized = new JsonObject();
+            serialized.add("path", new JsonPrimitive(src.getPath()));
+            return serialized;
         }
     }
 

--- a/common/src/test/java/com/thoughtworks/go/util/FileUtilTest.java
+++ b/common/src/test/java/com/thoughtworks/go/util/FileUtilTest.java
@@ -32,6 +32,7 @@ import static com.thoughtworks.go.util.FileUtil.isSubdirectoryOf;
 import static com.thoughtworks.go.util.FileUtilTest.FilePathMatcher.assertPath;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 public class FileUtilTest {
@@ -52,13 +53,13 @@ public class FileUtilTest {
     }
 
     @Test
-    void shouldUseSpeficiedFolderIfAbsolute() {
+    void shouldUseSpecifiedFolderIfAbsolute() {
         final File absolutePath = new File("zx").getAbsoluteFile();
         assertThat(FileUtil.applyBaseDirIfRelative(new File("xyz"), absolutePath)).isEqualTo(absolutePath);
     }
 
     @Test
-    void shouldUseSpeficiedFolderIfBaseDirIsEmpty() throws Exception {
+    void shouldUseSpecifiedFolderIfBaseDirIsEmpty() throws Exception {
         assertThat(FileUtil.applyBaseDirIfRelative(new File(""), new File("zx"))).isEqualTo(new File("zx"));
     }
 
@@ -144,12 +145,10 @@ public class FileUtilTest {
         assertThat(FileUtil.getCanonicalPath(folder)).isEqualTo(folder.getCanonicalPath());
         File spyFile = spy(new File("/xyz/non-existent-file"));
         IOException canonicalPathException = new IOException("Failed to build the canonical path");
-        when(spyFile.getCanonicalPath()).thenThrow(canonicalPathException);
-        try {
-            FileUtil.getCanonicalPath(spyFile);
-        } catch (RuntimeException e) {
-            assertThat(e.getCause()).isEqualTo(canonicalPathException);
-        }
+        doThrow(canonicalPathException).when(spyFile).getCanonicalPath();
+        assertThatThrownBy(() -> FileUtil.getCanonicalPath(spyFile))
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasCause(canonicalPathException);
     }
 
     @Test

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BasicCruiseConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BasicCruiseConfig.java
@@ -59,6 +59,18 @@ import static java.util.stream.Collectors.toMap;
  */
 @ConfigTag("cruise")
 public class BasicCruiseConfig implements CruiseConfig {
+
+    /**
+     * Enumeration of classes somewhere within the config hierarchy that should not be cloned
+     */
+    static final Class<?>[] DO_NOT_CLONE_CLASSES = List.of(
+            AllPipelineConfigs.class,
+            AllTemplatesWithAssociatedPipelines.class,
+            PipelineNameToConfigMap.class,
+            CachedPluggableArtifactConfigs.class,
+            CachedFetchPluggableArtifactTasks.class
+    ).toArray(Class[]::new);
+
     @ConfigSubtag
     @SkipParameterResolution
     private ServerConfig serverConfig = new ServerConfig();

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/IgnoredFiles.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/IgnoredFiles.java
@@ -25,6 +25,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 @ConfigTag(value = "ignore")
@@ -33,9 +34,8 @@ public class IgnoredFiles implements Serializable, Validatable {
     private String pattern;
     private String processedPattern;
     private ConfigErrors configErrors = new ConfigErrors();
-    private final Pattern punctuationRegex = Pattern.compile("\\p{Punct}");
+    private static final Pattern PUNCTUATION_REGEX = Pattern.compile("\\p{Punct}");
 
-    public static final String PATTERN = "pattern";
     public IgnoredFiles() {
     }
 
@@ -52,7 +52,7 @@ public class IgnoredFiles implements Serializable, Validatable {
             return false;
         }
         IgnoredFiles ignore = (IgnoredFiles) o;
-        return !(pattern != null ? !pattern.equals(ignore.pattern) : ignore.pattern != null);
+        return Objects.equals(pattern, ignore.pattern);
     }
 
     @Override
@@ -88,11 +88,11 @@ public class IgnoredFiles implements Serializable, Validatable {
 
     private String escape(String pattern) {
         StringBuilder result = new StringBuilder();
-        for(char c : pattern.toCharArray()){
-            if( c != '*' && punctuationRegex.matcher(String.valueOf(c)).matches()){
+        for (char c : pattern.toCharArray()) {
+            if (c != '*' && PUNCTUATION_REGEX.matcher(String.valueOf(c)).matches()) {
                 result.append("\\").append(c);
-            }else{
-                result.append(String.valueOf(c));
+            } else {
+                result.append(c);
             }
         }
         return result.toString();

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/BasicCruiseConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/BasicCruiseConfigTest.java
@@ -47,7 +47,6 @@ import com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo;
 import com.thoughtworks.go.security.CryptoException;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.security.ResetCipher;
-import com.thoughtworks.go.util.ClonerFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,8 +60,8 @@ import java.util.Map;
 import static com.thoughtworks.go.helper.MaterialConfigsMother.*;
 import static com.thoughtworks.go.helper.PipelineConfigMother.*;
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -324,7 +323,7 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
                 new ConfigurationProperty(new ConfigurationKey("k3"), new ConfigurationValue("pub_v3"))));
         jobConfig.artifactTypeConfigs().add(artifactConfig);
 
-        BasicCruiseConfig preprocessed = ClonerFactory.instance().deepClone(cruiseConfig);
+        BasicCruiseConfig preprocessed = GO_CONFIG_CLONER.deepClone(cruiseConfig);
         new ConfigParamPreprocessor().process(preprocessed);
         cruiseConfig.encryptSecureProperties(preprocessed);
 
@@ -356,7 +355,7 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
 
         cruiseConfig.server().security().getRoles().add(pluginRole);
 
-        BasicCruiseConfig preprocessed = ClonerFactory.instance().deepClone(cruiseConfig);
+        BasicCruiseConfig preprocessed = GO_CONFIG_CLONER.deepClone(cruiseConfig);
         new ConfigParamPreprocessor().process(preprocessed);
         cruiseConfig.encryptSecureProperties(preprocessed);
 
@@ -388,7 +387,7 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
 
         cruiseConfig.getElasticConfig().getProfiles().add(elasticProfile);
 
-        BasicCruiseConfig preprocessed = ClonerFactory.instance().deepClone(cruiseConfig);
+        BasicCruiseConfig preprocessed = GO_CONFIG_CLONER.deepClone(cruiseConfig);
         new ConfigParamPreprocessor().process(preprocessed);
         cruiseConfig.encryptSecureProperties(preprocessed);
 
@@ -412,7 +411,7 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
 
         resetCipher.setupAESCipherFile();
         BasicCruiseConfig config = setupPipelines();
-        BasicCruiseConfig preprocessed = ClonerFactory.instance().deepClone(config);
+        BasicCruiseConfig preprocessed = GO_CONFIG_CLONER.deepClone(config);
         new ConfigParamPreprocessor().process(preprocessed);
         config.encryptSecureProperties(preprocessed);
         PipelineConfig ancestor = config.pipelineConfigByName(new CaseInsensitiveString("ancestor"));

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/CruiseConfigTestBase.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/CruiseConfigTestBase.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.config;
 
+import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.materials.PackageMaterialConfig;
 import com.thoughtworks.go.config.materials.PluggableSCMMaterialConfig;
@@ -39,6 +40,7 @@ import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.domain.scm.SCMMother;
 import com.thoughtworks.go.helper.*;
 import com.thoughtworks.go.security.GoCipher;
+import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.FunctionalUtils;
 import com.thoughtworks.go.util.ReflectionUtil;
 import com.thoughtworks.go.util.command.UrlArgument;
@@ -51,7 +53,8 @@ import static com.thoughtworks.go.helper.MaterialConfigsMother.*;
 import static com.thoughtworks.go.helper.PipelineConfigMother.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.*;
 
@@ -63,6 +66,14 @@ public abstract class CruiseConfigTestBase implements FunctionalUtils {
     protected abstract CruiseConfig createCruiseConfig(BasicPipelineConfigs pipelineConfigs);
 
     protected abstract BasicCruiseConfig createCruiseConfig();
+
+    protected static final Cloner GO_CONFIG_CLONER = cloner();
+
+    private static Cloner cloner() {
+        Cloner instance = ClonerFactory.instance();
+        instance.nullInsteadOfClone(BasicCruiseConfig.DO_NOT_CLONE_CLASSES);
+        return instance;
+    }
 
     protected PartialConfig createPartial() {
         return PartialConfigMother.withPipelineInGroup("remote-pipe-1", "remote_group");

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/MergeCruiseConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/MergeCruiseConfigTest.java
@@ -15,7 +15,6 @@
  */
 package com.thoughtworks.go.config;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
 import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.config.merge.MergePipelineConfigs;
@@ -25,7 +24,6 @@ import com.thoughtworks.go.domain.config.Configuration;
 import com.thoughtworks.go.domain.config.PluginConfiguration;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.helper.*;
-import com.thoughtworks.go.util.ClonerFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -358,8 +356,7 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
         PartialConfig partialConfig = PartialConfigMother.withPipelineInGroup("pipeline-1", "g2");
         partialConfig.setOrigin(new RepoConfigOrigin());
         CruiseConfig config = new BasicCruiseConfig(mainCruiseConfig, partialConfig);
-        Cloner CLONER = ClonerFactory.instance();
-        CruiseConfig cloned = CLONER.deepClone(config);
+        CruiseConfig cloned = GO_CONFIG_CLONER.deepClone(config);
 
         List<ConfigErrors> allErrors = cloned.validateAfterPreprocess();
         assertThat(allErrors.size(), is(2));

--- a/config/config-server/src/main/java/com/thoughtworks/go/config/GoConfigCloner.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/config/GoConfigCloner.java
@@ -16,9 +16,6 @@
 package com.thoughtworks.go.config;
 
 import com.rits.cloning.Cloner;
-import com.thoughtworks.go.config.BasicCruiseConfig.AllPipelineConfigs;
-import com.thoughtworks.go.config.BasicCruiseConfig.AllTemplatesWithAssociatedPipelines;
-import com.thoughtworks.go.config.BasicCruiseConfig.PipelineNameToConfigMap;
 import com.thoughtworks.go.util.ClonerFactory;
 
 // Cloner to handle nullification of specific classes in config objects.
@@ -32,11 +29,7 @@ import com.thoughtworks.go.util.ClonerFactory;
 // This is one place to mark all the classes to be ignored during clone.
 public class GoConfigCloner extends Cloner {
     public GoConfigCloner() {
-        nullInsteadOfClone(AllPipelineConfigs.class,
-                AllTemplatesWithAssociatedPipelines.class,
-                PipelineNameToConfigMap.class,
-                CachedPluggableArtifactConfigs.class,
-                CachedFetchPluggableArtifactTasks.class);
+        nullInsteadOfClone(BasicCruiseConfig.DO_NOT_CLONE_CLASSES);
         ClonerFactory.applyFixes(this);
     }
 }

--- a/config/config-server/src/test/java/com/thoughtworks/go/service/ConfigRepositoryTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/service/ConfigRepositoryTest.java
@@ -36,12 +36,8 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -344,6 +340,22 @@ public class ConfigRepositoryTest {
 
         assertThat(configRepo.git().getRepository().getBranch(), is("master"));
         assertThat(configRepo.git().branchList().call().size(), is(1));
+    }
+
+    @Test
+    void shouldCleanButIgnoreMasterResetIfRepoExistsButNoMasterBranch() throws Exception {
+        // Start with an empty repo
+        assertThat(configRepo.git().getRepository().getDirectory().exists(), is(true));
+
+        ConfigRepository configRepository = new ConfigRepository(systemEnvironment);
+        configRepository.initialize();
+
+        assertThat(configRepo.git().getRepository().getBranch(), is("master"));
+        assertThat(configRepo.git().branchList().call(), hasSize(0));
+
+        // Ensure we can still use the config repo
+        configRepository.checkin(goConfigRevision("v1", "md5-1"));
+        assertThat(configRepo.git().branchList().call(), hasSize(1));
     }
 
     @Test

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -52,7 +52,7 @@ final Map<String, String> libraries = [
   dbunit              : 'org.dbunit:dbunit:2.7.2',
   dom4j               : 'dom4j:dom4j:1.6.1',
   ehcache             : 'net.sf.ehcache:ehcache:2.10.9.2',
-  felix               : 'org.apache.felix:org.apache.felix.framework:5.6.12',
+  felix               : 'org.apache.felix:org.apache.felix.framework:7.0.1',
   freemarker          : 'org.freemarker:freemarker:2.3.31',
   gradleDownload      : 'de.undercouch:gradle-download-task:4.1.2',
   grolifant           : 'org.ysb33r.gradle:grolifant60:1.3.2',

--- a/development-utility/development-server/src/main/java/com/thoughtworks/go/server/DevelopmentServer.java
+++ b/development-utility/development-server/src/main/java/com/thoughtworks/go/server/DevelopmentServer.java
@@ -56,7 +56,6 @@ public class DevelopmentServer {
         systemEnvironment.set(SystemEnvironment.DEFAULT_PLUGINS_ZIP, "/plugins.zip");
         systemEnvironment.set(SystemEnvironment.PLUGIN_ACTIVATOR_JAR_PATH, "go-plugin-activator.jar");
         systemEnvironment.set(SystemEnvironment.FAIL_STARTUP_ON_DATA_ERROR, true);
-        systemEnvironment.setProperty(GoConstants.I18N_CACHE_LIFE, "0"); //0 means reload when stale
         systemEnvironment.set(SystemEnvironment.GO_SERVER_MODE, "development");
         setupPeriodicGC(systemEnvironment);
         assertPluginsZipExists();

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -167,7 +167,6 @@ project.ext.rails.testPluginsWorkDir = project.file("${project.rails.testPlugins
 
 project.ext.railsSystemProperties = [
   'always.reload.config.file'                    : true,
-  'cruise.i18n.cache.life'                       : 0,
   'cruise.config.dir'                            : project.rails.testConfigDir,
   'plugins.go.provided.path'                     : project.rails.testBundledPluginsDir,
   'plugins.external.provided.path'               : project.rails.testExternalPluginsDir,

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -795,6 +795,7 @@ task verifyWar(type: VerifyJarTask) {
         "activemq-broker-${project.versions.activeMQ}.jar",
         "activemq-client-${project.versions.activeMQ}.jar",
         "activemq-openwire-legacy-${project.versions.activeMQ}.jar",
+        "animal-sniffer-annotations-1.9.jar",
         "ant-${project.versions.apacheAnt}.jar",
         "antlr-2.7.6.jar",
         "aopalliance-1.0.jar",

--- a/server/src/main/resources/cruise.properties
+++ b/server/src/main/resources/cruise.properties
@@ -34,8 +34,6 @@ cruise.disk.space.check.interval=5000
 cruise.agent.service.refresh.interval=5000
 gocd.accesstoken.lastused.update.interval=60000
 
-cruise.i18n.cache.life=-1
-
 cruise.material.modifications.cache.limit=5000
 cruise.cache.elements.limit=100000
 cruise.cache.is.eternal=true

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filterchains/ArtifactSizeEnforcementFilterChainTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filterchains/ArtifactSizeEnforcementFilterChainTest.java
@@ -21,7 +21,6 @@ import com.thoughtworks.go.http.mocks.MockHttpServletRequest;
 import com.thoughtworks.go.http.mocks.MockHttpServletResponse;
 import com.thoughtworks.go.server.newsecurity.filters.ArtifactSizeEnforcementFilter;
 import com.thoughtworks.go.server.service.ArtifactsDirHolder;
-import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -37,24 +36,16 @@ import static com.thoughtworks.go.server.newsecurity.filterchains.DenyGoCDAccess
 import static org.mockito.Mockito.*;
 
 class ArtifactSizeEnforcementFilterChainTest {
-
-    private File artifactsDir;
-
-    private MockHttpServletRequest request;
-    private MockHttpServletResponse response;
+    private MockHttpServletResponse response = new MockHttpServletResponse();
     private ArtifactSizeEnforcementFilterChain filter;
     private FilterChain filterChain;
 
     @BeforeEach
     void setUp() {
-        artifactsDir = spy(new File("."));
+        File artifactsDir = mock(File.class);
         when(artifactsDir.getUsableSpace()).thenReturn(FileSize.valueOf("1GB").getSize());
-        GoConfigService goConfigService = mock(GoConfigService.class);
-        when(goConfigService.artifactsDir()).thenReturn(artifactsDir);
-
-        response = new MockHttpServletResponse();
-        ArtifactsDirHolder artifactsDirHolder = new ArtifactsDirHolder(null, goConfigService);
-        artifactsDirHolder.initialize();
+        ArtifactsDirHolder artifactsDirHolder = mock(ArtifactsDirHolder.class);
+        when(artifactsDirHolder.getArtifactsDir()).thenReturn(artifactsDir);
         filter = new ArtifactSizeEnforcementFilterChain(new ArtifactSizeEnforcementFilter(artifactsDirHolder, new SystemEnvironment()));
         filterChain = mock(FilterChain.class);
     }
@@ -62,7 +53,7 @@ class ArtifactSizeEnforcementFilterChainTest {
     @ParameterizedTest
     @ValueSource(strings = {"/files/bar/foo.zip", "/remoting/files/bar/foo.zip"})
     void shouldDoNothingWhenNoArtifactSizeHeaderPresent(String path) throws IOException, ServletException {
-        request = HttpRequestBuilder.POST(path).build();
+        MockHttpServletRequest request = HttpRequestBuilder.POST(path).build();
         filter.doFilter(request, response, filterChain);
 
         assertThat(response)
@@ -74,7 +65,7 @@ class ArtifactSizeEnforcementFilterChainTest {
     @ParameterizedTest
     @ValueSource(strings = {"/files/bar/foo.zip", "/remoting/files/bar/foo.zip"})
     void shouldAllowIfEnoughDiskSpaceIsAvailable(String path) throws IOException, ServletException {
-        request = HttpRequestBuilder.POST(path).withHeader("X-GO-ARTIFACT-SIZE", FileSize.valueOf("100MB").getSize()).build();
+        MockHttpServletRequest request = HttpRequestBuilder.POST(path).withHeader("X-GO-ARTIFACT-SIZE", FileSize.valueOf("100MB").getSize()).build();
 
         filter.doFilter(request, response, filterChain);
 
@@ -86,7 +77,7 @@ class ArtifactSizeEnforcementFilterChainTest {
     @ParameterizedTest
     @ValueSource(strings = {"/files/bar/foo.zip", "/remoting/files/bar/foo.zip"})
     void shouldDisallowIfNotEnoughDiskSpaceIsAvailable(String path) throws IOException, ServletException {
-        request = HttpRequestBuilder.POST(path).withHeader("X-GO-ARTIFACT-SIZE", FileSize.valueOf("600MB").getSize()).build();
+        MockHttpServletRequest request = HttpRequestBuilder.POST(path).withHeader("X-GO-ARTIFACT-SIZE", FileSize.valueOf("600MB").getSize()).build();
 
         filter.doFilter(request, response, filterChain);
 

--- a/server/src/test-integration/resources/test.properties
+++ b/server/src/test-integration/resources/test.properties
@@ -30,7 +30,6 @@ cruise.disk.space.check.interval=5000
 cruise.agent.service.refresh.interval=5000
 gocd.accesstoken.lastused.update.interval=60000
 
-cruise.i18n.cache.life=-1
 
 cruise.material.modifications.cache.limit=200
 cruise.cache.elements.limit=100000

--- a/util/src/main/java/com/thoughtworks/go/util/ClonerFactory.java
+++ b/util/src/main/java/com/thoughtworks/go/util/ClonerFactory.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.util;
 import com.rits.cloning.Cloner;
 import com.rits.cloning.IDeepCloner;
 
+import java.io.File;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
@@ -54,6 +55,7 @@ public class ClonerFactory {
             cloner.registerFastCloner(Date.class, (t, _1, _2) -> new Date(((Date)t).getTime()));
             cloner.registerFastCloner(java.sql.Date.class, (t, _1, _2) -> new java.sql.Date(((java.sql.Date)t).getTime()));
             cloner.registerFastCloner(Timestamp.class, ClonerFactory::cloneTimestamp);
+            cloner.registerFastCloner(File.class, (t, _1, _2) -> new File(((File)t).getPath()));
             return cloner;
         }
     }

--- a/util/src/test/java/com/thoughtworks/go/util/ClonerFactoryTest.java
+++ b/util/src/test/java/com/thoughtworks/go/util/ClonerFactoryTest.java
@@ -20,6 +20,7 @@ import com.rits.cloning.Cloner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
@@ -123,6 +124,14 @@ class ClonerFactoryTest {
         assertThat(dupe)
                 .isExactlyInstanceOf(Timestamp.class)
                 .isEqualTo(date);
+    }
+
+    @Test
+    void cloneFile() {
+        File file = new File("hello/world");
+        assertThat(cloner.deepClone(file))
+                .isExactlyInstanceOf(File.class)
+                .isEqualTo(file);
     }
 
 }


### PR DESCRIPTION
This PR makes a number of tweaks relevant (but not coupled to) Java 16/17 upgrade, being worked on in #9818.

Changes made
- Bump apache felix from `5.6.12` to `7.0.1`. Seems to have no implications for ability to load plugins on server/agent and entirely backward compatible as far as I can see.
- Server can now recover on start if it failed after config repo creation, but before checking in initial config (relevant when server fails to start due to a missing `--add-open` in Java 16/17 (see #9818)
- Change JSON serialization, object cloning & a couple of tests to avoid relying on reflection to internals of `java.io.File`
- Avoid unnecessary reflection/serialization of `java.util.regex.Pattern` within `IgnoredFiles`
- Change tests to avoid unnecessary internal usage of `java.util.concurrent.*` during `CruiseConfig` cloning by re-using same approach as the server

Other minor changes
- removes unused property from old internationalization code