### PR TITLE
Bump jruby from 9.2.9.0 to 9.2.20.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -74,7 +74,7 @@ final Map<String, String> libraries = [
   jgit                : 'org.eclipse.jgit:org.eclipse.jgit:6.0.0.202111291000-r',
   jodaTime            : 'joda-time:joda-time:2.10.13', // joda-time version has to be compatible with the jruby version
   jolt                : 'com.bazaarvoice.jolt:jolt-core:0.1.5',
-  jruby               : 'org.jruby:jruby-complete:9.2.9.0',
+  jruby               : 'org.jruby:jruby-complete:9.2.20.1',
   jsonUnit            : 'net.javacrumbs.json-unit:json-unit-fluent:2.28.0',
   jsontools           : 'com.sdicons.jsontools:jsontools-core:1.7',
   jsoup               : 'org.jsoup:jsoup:1.14.3',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -33,7 +33,7 @@ final Map<String, String> libraries = [
   assertJ             : 'org.assertj:assertj-core:3.21.0',
   assertJ_DB          : 'org.assertj:assertj-db:2.0.2',
   bouncyCastle        : 'org.bouncycastle:bcprov-jdk15on:1.70', // This version of BC is not compatible with the jruby-opensssl version, since we are not using jruby-opensssl going ahead with the upgrade.
-  bundler             : 'rubygems:bundler:2.2.32',
+  bundler             : 'rubygems:bundler:2.2.33',
   cglib               : 'cglib:cglib:3.3.0',
   cloning             : 'io.github.kostaskougios:cloning:1.10.3',
   commonsBeanUtils    : 'commons-beanutils:commons-beanutils:1.9.4',

--- a/server/lint.gradle
+++ b/server/lint.gradle
@@ -27,7 +27,7 @@ task scssLint {
     project.jrubyexec {
       workingDir = project.railsRoot
 
-      args = ['-S', 'bundle', 'exec', 'scss-lint', "--config", 'scss-lint.yml', inputDir]
+      args = ['-S', 'scss-lint', "--config", 'scss-lint.yml', inputDir]
       maxHeapSize = '1g'
     }
 

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.7'
+ruby '2.5.8'
 
 gem 'rails', '5.2.6'
 gem 'sass-rails', '5.1.0'

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -238,7 +238,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.5.7p0 (jruby 9.2.9.0)
+   ruby 2.5.8p0 (jruby 9.2.20.1)
 
 BUNDLED WITH
    2.2.32


### PR DESCRIPTION
https://www.jruby.org/2021/12/01/jruby-9-2-20-1.html

Includes RubyGems bump to 3.x which was done in https://www.jruby.org/2020/02/18/jruby-9-2-10-0.html

Minor workaround done to fix use of binaries via JRuby on Windows (used only for scss-lint, which is [deprecated and needs to be removed/replaced](https://github.com/sds/scss-lint))
  - RubyGems now generates binstubs with jruby.exe hardcoded which breaks used by `bundle exec` using the way we invoke JRuby (custom launch of JVM and jruby-complete jar). Previously the bin stubs/rubygems/bundler were able to get `RUBY` from env, and use our custom bash script. 
  - Raised https://github.com/jruby/jruby/issues/6960 for this change, but probably not important
  - Worked around by launching scss-lint directly without bundler which avoids needing to have one Jruby create another Jruby.