### PR TITLE
Use consistent approach to clone cruise config in tests

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BasicCruiseConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BasicCruiseConfig.java
@@ -63,7 +63,7 @@ public class BasicCruiseConfig implements CruiseConfig {
     /**
      * Enumeration of classes somewhere within the config hierarchy that should not be cloned
      */
-    static final Class<?>[] DO_NOT_CLONE_CLASSES = List.of(
+    public static final Class<?>[] DO_NOT_CLONE_CLASSES = List.of(
             AllPipelineConfigs.class,
             AllTemplatesWithAssociatedPipelines.class,
             PipelineNameToConfigMap.class,

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/BasicCruiseConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/BasicCruiseConfigTest.java
@@ -323,7 +323,7 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
                 new ConfigurationProperty(new ConfigurationKey("k3"), new ConfigurationValue("pub_v3"))));
         jobConfig.artifactTypeConfigs().add(artifactConfig);
 
-        BasicCruiseConfig preprocessed = GO_CONFIG_CLONER.deepClone(cruiseConfig);
+        BasicCruiseConfig preprocessed = GoConfigMother.deepClone(cruiseConfig);
         new ConfigParamPreprocessor().process(preprocessed);
         cruiseConfig.encryptSecureProperties(preprocessed);
 
@@ -355,7 +355,7 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
 
         cruiseConfig.server().security().getRoles().add(pluginRole);
 
-        BasicCruiseConfig preprocessed = GO_CONFIG_CLONER.deepClone(cruiseConfig);
+        BasicCruiseConfig preprocessed = GoConfigMother.deepClone(cruiseConfig);
         new ConfigParamPreprocessor().process(preprocessed);
         cruiseConfig.encryptSecureProperties(preprocessed);
 
@@ -387,7 +387,7 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
 
         cruiseConfig.getElasticConfig().getProfiles().add(elasticProfile);
 
-        BasicCruiseConfig preprocessed = GO_CONFIG_CLONER.deepClone(cruiseConfig);
+        BasicCruiseConfig preprocessed = GoConfigMother.deepClone(cruiseConfig);
         new ConfigParamPreprocessor().process(preprocessed);
         cruiseConfig.encryptSecureProperties(preprocessed);
 
@@ -411,7 +411,7 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
 
         resetCipher.setupAESCipherFile();
         BasicCruiseConfig config = setupPipelines();
-        BasicCruiseConfig preprocessed = GO_CONFIG_CLONER.deepClone(config);
+        BasicCruiseConfig preprocessed = GoConfigMother.deepClone(config);
         new ConfigParamPreprocessor().process(preprocessed);
         config.encryptSecureProperties(preprocessed);
         PipelineConfig ancestor = config.pipelineConfigByName(new CaseInsensitiveString("ancestor"));

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/CruiseConfigTestBase.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/CruiseConfigTestBase.java
@@ -15,7 +15,6 @@
  */
 package com.thoughtworks.go.config;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.materials.PackageMaterialConfig;
 import com.thoughtworks.go.config.materials.PluggableSCMMaterialConfig;
@@ -40,7 +39,6 @@ import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.domain.scm.SCMMother;
 import com.thoughtworks.go.helper.*;
 import com.thoughtworks.go.security.GoCipher;
-import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.FunctionalUtils;
 import com.thoughtworks.go.util.ReflectionUtil;
 import com.thoughtworks.go.util.command.UrlArgument;
@@ -66,14 +64,6 @@ public abstract class CruiseConfigTestBase implements FunctionalUtils {
     protected abstract CruiseConfig createCruiseConfig(BasicPipelineConfigs pipelineConfigs);
 
     protected abstract BasicCruiseConfig createCruiseConfig();
-
-    protected static final Cloner GO_CONFIG_CLONER = cloner();
-
-    private static Cloner cloner() {
-        Cloner instance = ClonerFactory.instance();
-        instance.nullInsteadOfClone(BasicCruiseConfig.DO_NOT_CLONE_CLASSES);
-        return instance;
-    }
 
     protected PartialConfig createPartial() {
         return PartialConfigMother.withPipelineInGroup("remote-pipe-1", "remote_group");

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/MergeCruiseConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/MergeCruiseConfigTest.java
@@ -356,7 +356,7 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
         PartialConfig partialConfig = PartialConfigMother.withPipelineInGroup("pipeline-1", "g2");
         partialConfig.setOrigin(new RepoConfigOrigin());
         CruiseConfig config = new BasicCruiseConfig(mainCruiseConfig, partialConfig);
-        CruiseConfig cloned = GO_CONFIG_CLONER.deepClone(config);
+        CruiseConfig cloned = GoConfigMother.deepClone(config);
 
         List<ConfigErrors> allErrors = cloned.validateAfterPreprocess();
         assertThat(allErrors.size(), is(2));

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigValidationTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigValidationTest.java
@@ -25,7 +25,6 @@ import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.packagerepository.PackageDefinitionMother;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.helper.MaterialConfigsMother;
-import com.thoughtworks.go.util.ClonerFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -378,7 +377,7 @@ class PipelineConfigValidationTest {
         p3.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("p2"), new CaseInsensitiveString("stage")));
 
         PipelineConfig p1 = cruiseConfig.getPipelineConfigByName(new CaseInsensitiveString(pipelineName));
-        p1 = ClonerFactory.instance().deepClone(p1); // Do not remove cloning else it changes the underlying cache object defeating the purpose of the test.
+        p1 = GoConfigMother.deepClone(p1); // Do not remove cloning else it changes the underlying cache object defeating the purpose of the test.
         p1.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("p3"), new CaseInsensitiveString("stage")));
         p1.validateTree(PipelineConfigSaveValidationContext.forChain(true, cruiseConfig.getGroups().first().getGroup(), cruiseConfig, p1));
         assertThat(p1.materialConfigs().errors().isEmpty()).isFalse();

--- a/config/config-api/src/test/java/com/thoughtworks/go/helper/GoConfigMother.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/helper/GoConfigMother.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.helper;
 
+import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
@@ -34,6 +35,7 @@ import com.thoughtworks.go.plugin.access.packagematerial.PackageConfiguration;
 import com.thoughtworks.go.plugin.access.packagematerial.PackageConfigurations;
 import com.thoughtworks.go.plugin.access.packagematerial.RepositoryMetadataStore;
 import com.thoughtworks.go.security.GoCipher;
+import com.thoughtworks.go.util.ClonerFactory;
 
 import java.io.File;
 import java.util.Arrays;
@@ -44,6 +46,19 @@ import static com.thoughtworks.go.helper.MaterialConfigsMother.svn;
 import static java.util.Arrays.asList;
 
 public class GoConfigMother {
+    public static final Cloner CLONER = cloner();
+
+    private static Cloner cloner() {
+        // Recreated here, because we deliberately not have access to the `GoConfigCloner` from the API
+        Cloner instance = ClonerFactory.instance();
+        instance.nullInsteadOfClone(BasicCruiseConfig.DO_NOT_CLONE_CLASSES);
+        return instance;
+    }
+
+    public static <T> T deepClone(T config) {
+        return CLONER.deepClone(config);
+    }
+
     public Role createRole(String roleName, String... users) {
         return new RoleConfig(new CaseInsensitiveString(roleName), toRoleUsers(users));
     }

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/GoConfigParallelGraphWalkerTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/GoConfigParallelGraphWalkerTest.java
@@ -21,21 +21,20 @@ import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.helper.JobConfigMother;
 import com.thoughtworks.go.helper.MaterialConfigsMother;
 import com.thoughtworks.go.helper.PipelineConfigMother;
-import com.thoughtworks.go.util.ClonerFactory;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class GoConfigParallelGraphWalkerTest {
 
     @Test
     public void shouldWalkCruiseConfigObjectsParallelly() {
         CruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("bad pipeline name");
-        CruiseConfig rawCruiseConfig = ClonerFactory.instance().deepClone(cruiseConfig);
+        CruiseConfig rawCruiseConfig = GoConfigMother.deepClone(cruiseConfig);
         MagicalGoConfigXmlLoader.validate(cruiseConfig);
         cruiseConfig.copyErrorsTo(rawCruiseConfig);
         assertThat(rawCruiseConfig.pipelineConfigByName(new CaseInsensitiveString("bad pipeline name")).errors(),
@@ -52,7 +51,7 @@ public class GoConfigParallelGraphWalkerTest {
         pipelineWithTemplate.setTemplateName(new CaseInsensitiveString("template-1"));
         cruiseConfig.getGroups().get(0).add(pipelineWithTemplate);
 
-        CruiseConfig rawCruiseConfig = ClonerFactory.instance().deepClone(cruiseConfig);
+        CruiseConfig rawCruiseConfig = GoConfigMother.deepClone(cruiseConfig);
         MagicalGoConfigXmlLoader.validate(cruiseConfig);
         cruiseConfig.copyErrorsTo(rawCruiseConfig);
         assertThat(rawCruiseConfig.pipelineConfigByName(new CaseInsensitiveString("pipeline-with-template")).errors().isEmpty(), is(true));
@@ -71,7 +70,7 @@ public class GoConfigParallelGraphWalkerTest {
         pipelineWithTemplate.setTemplateName(new CaseInsensitiveString("invalid template name"));
         cruiseConfig.getGroups().get(0).add(pipelineWithTemplate);
 
-        CruiseConfig rawCruiseConfig = ClonerFactory.instance().deepClone(cruiseConfig);
+        CruiseConfig rawCruiseConfig = GoConfigMother.deepClone(cruiseConfig);
         MagicalGoConfigXmlLoader.validate(cruiseConfig);
         cruiseConfig.copyErrorsTo(rawCruiseConfig);
 
@@ -119,7 +118,7 @@ public class GoConfigParallelGraphWalkerTest {
         PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig("pipeline", MaterialConfigsMother.defaultMaterialConfigs(), new JobConfigs(JobConfigMother.createJobConfigWithJobNameAndEmptyResources()));
         pipelineConfig.setVariables(new EnvironmentVariablesConfig(asList(new EnvironmentVariableConfig("name", "value"))));
 
-        PipelineConfig pipelineWithErrors = ClonerFactory.instance().deepClone(pipelineConfig);
+        PipelineConfig pipelineWithErrors = GoConfigMother.deepClone(pipelineConfig);
         pipelineWithErrors.getVariables().get(0).addError("name", "error on environment variable");
         pipelineWithErrors.first().addError("name", "error on stage");
         pipelineWithErrors.first().getJobs().first().addError("name", "error on job");

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filters/InvalidateAuthenticationOnSecurityConfigChangeFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filters/InvalidateAuthenticationOnSecurityConfigChangeFilterTest.java
@@ -29,7 +29,6 @@ import com.thoughtworks.go.server.security.userdetail.GoUserPrinciple;
 import com.thoughtworks.go.server.service.AuthorizationExtensionCacheService;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.PluginRoleService;
-import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TestingClock;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,7 +85,7 @@ class InvalidateAuthenticationOnSecurityConfigChangeFilterTest {
         filter = new InvalidateAuthenticationOnSecurityConfigChangeFilter(goConfigService, clock, cacheService, pluginRoleService);
         filter.initialize();
         filter.onPluginRoleChange();
-        filter.onConfigChange(ClonerFactory.instance().deepClone(cruiseConfig));
+        filter.onConfigChange(GoConfigMother.deepClone(cruiseConfig));
         reset(cacheService);
     }
 
@@ -119,7 +118,7 @@ class InvalidateAuthenticationOnSecurityConfigChangeFilterTest {
 
         clock.addSeconds(1);
         cruiseConfig.addEnvironment("Foo");
-        filter.onConfigChange(ClonerFactory.instance().deepClone(cruiseConfig));
+        filter.onConfigChange(GoConfigMother.deepClone(cruiseConfig));
 
         response.reset();
         filter.doFilter(request, response, filterChain);
@@ -145,7 +144,7 @@ class InvalidateAuthenticationOnSecurityConfigChangeFilterTest {
 
         clock.addSeconds(1);
         GoConfigMother.addUserAsSuperAdmin(cruiseConfig, "bob");
-        filter.onConfigChange(ClonerFactory.instance().deepClone(cruiseConfig));
+        filter.onConfigChange(GoConfigMother.deepClone(cruiseConfig));
 
         response.reset();
         filter.doFilter(request, response, filterChain);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
@@ -23,12 +23,12 @@ import com.thoughtworks.go.config.merge.MergeEnvironmentConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.config.update.ConfigUpdateCheckFailedException;
 import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.listener.EntityConfigChangedListener;
 import com.thoughtworks.go.presentation.environment.EnvironmentPipelineModel;
 import com.thoughtworks.go.server.domain.AgentInstances;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
-import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -113,7 +113,7 @@ class EnvironmentConfigServiceTest {
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         BasicEnvironmentConfig env = (BasicEnvironmentConfig) environmentConfigService.getEnvironmentConfig(uat).getLocal();
         cruiseConfig.addEnvironment(env);
-        BasicEnvironmentConfig expectedToEdit = ClonerFactory.instance().deepClone(env);
+        BasicEnvironmentConfig expectedToEdit = GoConfigMother.deepClone(env);
 
         when(mockGoConfigService.getConfigForEditing()).thenReturn(cruiseConfig);
 
@@ -140,7 +140,7 @@ class EnvironmentConfigServiceTest {
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         BasicEnvironmentConfig env = (BasicEnvironmentConfig) environmentConfigService.getEnvironmentConfig(uat).getLocal();
         cruiseConfig.addEnvironment(env);
-        List<BasicEnvironmentConfig> expectedToEdit = singletonList(ClonerFactory.instance().deepClone(env));
+        List<BasicEnvironmentConfig> expectedToEdit = singletonList(GoConfigMother.deepClone(env));
 
         when(mockGoConfigService.getConfigForEditing()).thenReturn(cruiseConfig);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
@@ -20,12 +20,12 @@ import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
 import com.thoughtworks.go.config.pluggabletask.PluggableTask;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
+import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.helper.JobConfigMother;
 import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.presentation.CanDeleteResult;
 import com.thoughtworks.go.server.service.tasks.PluggableTaskService;
-import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.ReflectionUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,8 +37,8 @@ import java.util.UUID;
 import static com.thoughtworks.go.helper.EnvironmentConfigMother.environment;
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
 import static com.thoughtworks.go.helper.PipelineConfigMother.createGroup;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.*;
 
 public class PipelineConfigServiceTest {
@@ -143,7 +143,7 @@ public class PipelineConfigServiceTest {
 
     @Test
     public void pipelineCountShouldIncludeConfigRepoPipelinesAsWell() {
-        CruiseConfig mergedCruiseConfig = ClonerFactory.instance().deepClone(cruiseConfig);
+        CruiseConfig mergedCruiseConfig = GoConfigMother.deepClone(cruiseConfig);
         ReflectionUtil.setField(mergedCruiseConfig, "allPipelineConfigs", null);
         mergedCruiseConfig.addPipeline("default", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
         when(goConfigService.cruiseConfig()).thenReturn(mergedCruiseConfig);
@@ -155,7 +155,7 @@ public class PipelineConfigServiceTest {
 
     @Test
     public void shouldGetAllViewableMergePipelineConfigs() throws Exception {
-        CruiseConfig mergedCruiseConfig = ClonerFactory.instance().deepClone(cruiseConfig);
+        CruiseConfig mergedCruiseConfig = GoConfigMother.deepClone(cruiseConfig);
         ReflectionUtil.setField(mergedCruiseConfig, "allPipelineConfigs", null);
         mergedCruiseConfig.addPipeline("group1", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
         mergedCruiseConfig.addPipeline("group2", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
@@ -180,7 +180,7 @@ public class PipelineConfigServiceTest {
 
     @Test
     public void shouldGetAllViewableGroups() throws Exception {
-        CruiseConfig cruiseConfig = ClonerFactory.instance().deepClone(this.cruiseConfig);
+        CruiseConfig cruiseConfig = GoConfigMother.deepClone(this.cruiseConfig);
         ReflectionUtil.setField(cruiseConfig, "allPipelineConfigs", null);
         cruiseConfig.addPipeline("group1", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));
         cruiseConfig.addPipeline("group2", PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString()));

--- a/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
@@ -880,7 +880,7 @@ public class CachedGoConfigIntegrationTest {
         String remoteDownstream = "remote-downstream";
         setupExternalConfigRepoWithDependencyMaterialOnPipelineInMainXml(upstream, remoteDownstream);
 
-        PartialConfig partialWithStageRenamed = ClonerFactory.instance().deepClone(cachedGoPartials.lastValidPartials().get(0));
+        PartialConfig partialWithStageRenamed = GoConfigMother.deepClone(cachedGoPartials.lastValidPartials().get(0));
         PipelineConfig pipelineInRemoteConfigRepo = partialWithStageRenamed.getGroups().get(0).getPipelines().get(0);
         pipelineInRemoteConfigRepo.materialConfigs().getDependencyMaterial().setStageName(new CaseInsensitiveString("new_name"));
         partialWithStageRenamed.setOrigin(new RepoConfigOrigin(configRepo, "r2"));
@@ -932,7 +932,7 @@ public class CachedGoConfigIntegrationTest {
         cachedGoPartials.clear();
         PartialConfig invalidPartial = PartialConfigMother.invalidPartial("invalid", new RepoConfigOrigin(configRepo, "revision1"));
         partialConfigService.onSuccessPartialConfig(configRepo, invalidPartial);
-        CruiseConfig updatedConfig = ClonerFactory.instance().deepClone(goConfigService.getConfigForEditing());
+        CruiseConfig updatedConfig = GoConfigMother.deepClone(goConfigService.getConfigForEditing());
         updatedConfig.server().setJobTimeout("10");
         String updatedXml = goFileConfigDataSource.configAsXml(updatedConfig, false);
         FileUtils.writeStringToFile(new File(goConfigDao.fileLocation()), updatedXml, UTF_8);
@@ -1059,7 +1059,7 @@ public class CachedGoConfigIntegrationTest {
         assertThat(cachedGoPartials.lastValidPartials().contains(validPartial)).isTrue();
         assertThat(cachedGoPartials.lastKnownPartials().contains(validPartial)).isTrue();
 
-        CruiseConfig config = ClonerFactory.instance().deepClone(cachedGoConfig.loadForEditing());
+        CruiseConfig config = GoConfigMother.deepClone(cachedGoConfig.loadForEditing());
 
         config.addEnvironment(UUID.randomUUID().toString());
 
@@ -1087,7 +1087,7 @@ public class CachedGoConfigIntegrationTest {
         assertThat(cachedGoPartials.lastValidPartials().isEmpty()).isTrue();
         assertThat(cachedGoPartials.lastKnownPartials().contains(invalidPartial)).isTrue();
 
-        CruiseConfig config = ClonerFactory.instance().deepClone(cachedGoConfig.loadForEditing());
+        CruiseConfig config = GoConfigMother.deepClone(cachedGoConfig.loadForEditing());
 
         config.addEnvironment(UUID.randomUUID().toString());
 
@@ -1117,7 +1117,7 @@ public class CachedGoConfigIntegrationTest {
         assertThat(cachedGoPartials.lastValidPartials().contains(validPartial)).isTrue();
         assertThat(cachedGoPartials.lastKnownPartials().contains(invalidPartial)).isTrue();
 
-        CruiseConfig config = ClonerFactory.instance().deepClone(cachedGoConfig.loadForEditing());
+        CruiseConfig config = GoConfigMother.deepClone(cachedGoConfig.loadForEditing());
 
         config.addEnvironment(UUID.randomUUID().toString());
 
@@ -1141,7 +1141,7 @@ public class CachedGoConfigIntegrationTest {
         setupExternalConfigRepoWithDependencyMaterialOnPipelineInMainXml("upstream", "downstream");
         String gitShaBeforeSave = configRepository.getCurrentRevCommit().getName();
         CruiseConfig originalConfig = cachedGoConfig.loadForEditing();
-        CruiseConfig editedConfig = ClonerFactory.instance().deepClone(originalConfig);
+        CruiseConfig editedConfig = GoConfigMother.deepClone(originalConfig);
 
         editedConfig.getGroups().remove(editedConfig.findGroup("default"));
 
@@ -1172,7 +1172,7 @@ public class CachedGoConfigIntegrationTest {
         assertThat(cachedGoPartials.lastValidPartials().isEmpty()).isTrue();
 
         CruiseConfig originalConfig = cachedGoConfig.loadForEditing();
-        CruiseConfig editedConfig = ClonerFactory.instance().deepClone(originalConfig);
+        CruiseConfig editedConfig = GoConfigMother.deepClone(originalConfig);
 
         editedConfig.addPipeline("default", upstream);
         ConfigSaveState state = cachedGoConfig.writeFullConfigWithLock(new FullConfigUpdateCommand(editedConfig, goConfigService.configFileMd5()));

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
@@ -605,7 +605,7 @@ public class GoFileConfigDataSourceIntegrationTest {
 
     private void updateConfigOnFileSystem(UpdateConfig updateConfig) throws Exception {
         String cruiseConfigFile = systemEnvironment.getCruiseConfigFile();
-        CruiseConfig updatedConfig = ClonerFactory.instance().deepClone(goConfigService.getConfigForEditing());
+        CruiseConfig updatedConfig = GoConfigMother.deepClone(goConfigService.getConfigForEditing());
         updateConfig.update(updatedConfig);
         File configFile = new File(cruiseConfigFile);
         FileOutputStream outputStream = new FileOutputStream(configFile);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
@@ -15,7 +15,6 @@
  */
 package com.thoughtworks.go.server.persistence;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.GoConfigDao;
@@ -38,7 +37,6 @@ import com.thoughtworks.go.server.service.InstanceFactory;
 import com.thoughtworks.go.server.service.ScheduleTestUtil;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
-import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.util.TimeProvider;
 import org.joda.time.DateTime;
@@ -92,7 +90,6 @@ public class PipelineRepositoryIntegrationTest {
 
     private GoConfigFileHelper configHelper = new GoConfigFileHelper();
     private static final String PIPELINE_NAME = "pipeline";
-    public static final Cloner CLONER = ClonerFactory.instance();
 
     @BeforeEach
     public void setup() throws Exception {
@@ -141,7 +138,7 @@ public class PipelineRepositoryIntegrationTest {
         assertThat(flyweightsRevs.get(0).revision, is("g2"));
         assertThat(flyweightsRevs.get(1).revision, is("g1"));
 
-        MaterialConfigs materials = CLONER.deepClone(p.config.materialConfigs());
+        MaterialConfigs materials = configHelper.deepClone(p.config.materialConfigs());
         Collections.reverse(materials);
         configHelper.setMaterialConfigForPipeline("P", materials.toArray(new MaterialConfig[0]));
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/AutoTriggerDependencyResolutionTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/AutoTriggerDependencyResolutionTest.java
@@ -15,7 +15,6 @@
  */
 package com.thoughtworks.go.server.service;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.GoConfigDao;
@@ -41,7 +40,6 @@ import com.thoughtworks.go.server.materials.MaterialChecker;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.service.dd.MaxBackTrackLimitReachedException;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
-import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.jupiter.api.AfterEach;
@@ -72,7 +70,6 @@ import static org.mockito.Mockito.when;
 })
 public class AutoTriggerDependencyResolutionTest {
     public static final String STAGE_NAME = "s";
-    public static final Cloner CLONER = ClonerFactory.instance();
     @Autowired
     private DatabaseAccessHelper dbHelper;
     @Autowired
@@ -224,7 +221,7 @@ public class AutoTriggerDependencyResolutionTest {
                 if (nth-- > 0) {
                     continue;
                 }
-                return CLONER.deepClone(mat);
+                return configHelper.deepClone(mat);
             }
         }
         throw new RuntimeException("You don't have this material configured");

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
@@ -57,7 +57,10 @@ import com.thoughtworks.go.util.*;
 import com.thoughtworks.go.utils.SerializationTester;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -292,7 +295,7 @@ public class BuildAssignmentServiceIntegrationTest {
         buildAssignmentService.onTimer();
 
         PipelineConfig originalPipelineConfig = configHelper.getCachedGoConfig().currentConfig().getPipelineConfigByName(new CaseInsensitiveString(fixture.pipelineName));
-        PipelineConfig pipelineConfig = ClonerFactory.instance().deepClone(originalPipelineConfig);
+        PipelineConfig pipelineConfig = configHelper.deepClone(originalPipelineConfig);
         String md5 = entityHashingService.hashForEntity(originalPipelineConfig, fixture.groupName);
         StageConfig devStage = pipelineConfig.findBy(new CaseInsensitiveString(fixture.devStage));
         pipelineConfig.remove(devStage);
@@ -319,7 +322,7 @@ public class BuildAssignmentServiceIntegrationTest {
         buildAssignmentService.onTimer();
 
         PipelineConfig originalPipelineConfig = configHelper.getCachedGoConfig().currentConfig().getPipelineConfigByName(new CaseInsensitiveString(fixture.pipelineName));
-        PipelineConfig pipelineConfig = ClonerFactory.instance().deepClone(originalPipelineConfig);
+        PipelineConfig pipelineConfig = configHelper.deepClone(originalPipelineConfig);
         String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(pipelineConfig);
         String md5 = entityHashingService.hashForEntity(originalPipelineConfig, fixture.groupName);
         StageConfig devStage = pipelineConfig.findBy(new CaseInsensitiveString(fixture.devStage));
@@ -349,7 +352,7 @@ public class BuildAssignmentServiceIntegrationTest {
 
         buildAssignmentService.onTimer();
 
-        PipelineConfig pipelineConfig = ClonerFactory.instance().deepClone(configHelper.getCachedGoConfig().currentConfig().getPipelineConfigByName(new CaseInsensitiveString(fixture.pipelineName)));
+        PipelineConfig pipelineConfig = configHelper.deepClone(configHelper.getCachedGoConfig().currentConfig().getPipelineConfigByName(new CaseInsensitiveString(fixture.pipelineName)));
 
         pipelineConfigService.deletePipelineConfig(loserUser, pipelineConfig, new HttpLocalizedOperationResult());
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
@@ -28,7 +28,6 @@ import com.thoughtworks.go.helper.PartialConfigMother;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.server.service.support.ServerStatusService;
-import com.thoughtworks.go.util.ClonerFactory;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
@@ -242,7 +241,7 @@ public class ConfigSaveDeadlockDetectionIntegrationTest {
             public void run() {
                 try {
                     CruiseConfig cruiseConfig = cachedGoConfig.loadForEditing();
-                    CruiseConfig cruiseConfig1 = ClonerFactory.instance().deepClone(cruiseConfig);
+                    CruiseConfig cruiseConfig1 = configHelper.deepClone(cruiseConfig);
                     cruiseConfig1.addEnvironment(UUID.randomUUID().toString());
 
                     goConfigDao.updateFullConfig(new FullConfigUpdateCommand(cruiseConfig1, cruiseConfig.getMd5()));

--- a/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
+++ b/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
@@ -60,10 +60,11 @@ import static org.mockito.Mockito.mock;
  */
 public class GoConfigFileHelper {
 
+    private static final GoConfigCloner CLONER = new GoConfigCloner();
     private final File configFile;
     private final String originalXml;
 
-    public GoConfigMother goConfigMother = new GoConfigMother();
+    private GoConfigMother goConfigMother = new GoConfigMother();
     private File passwordFile = null;
     private GoConfigDao goConfigDao;
     private CachedGoConfig cachedGoConfig;
@@ -108,6 +109,10 @@ public class GoConfigFileHelper {
 
     public GoConfigFileHelper(String xml) {
         this(xml, createTestingDao());
+    }
+
+    public <T> T deepClone(T config) {
+        return CLONER.deepClone(config);
     }
 
     /**
@@ -531,7 +536,7 @@ public class GoConfigFileHelper {
     public CruiseConfig load() {
         try {
             goConfigDao.forceReload();
-            return new GoConfigCloner().deepClone(goConfigDao.loadForEditing());
+            return deepClone(goConfigDao.loadForEditing());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -540,7 +545,7 @@ public class GoConfigFileHelper {
     public CruiseConfig loadForEdit() {
         try {
             goConfigDao.forceReload();
-            CruiseConfig cruiseConfig = new GoConfigCloner().deepClone(goConfigDao.loadForEditing());
+            CruiseConfig cruiseConfig = deepClone(goConfigDao.loadForEditing());
             cruiseConfig.initializeServer();
             return cruiseConfig;
         } catch (Exception e) {


### PR DESCRIPTION
As a follow-up to #9854 this tries to clone config consistently across tests, with the same nulling of cached fields in the configured cloning. While this isn't required right now, there is special logic that seems like a recipe for weird test failures or issues on Java 16/17 with reflection on private fields.. 

This isn't bullet-proof, as there are actually a number of cloner instances used in different parts of the production code that seem to clone different sub-parts of the config, so some of the changes here may not be perfect. Intent is to ensure tests use the same optimizations and "nulling of cached values" as the production code to avoid issues later.