### PR TITLE
Bump bcprov-jdk15on from 1.68 to 1.69

### DIFF
--- a/agent-launcher/build.gradle
+++ b/agent-launcher/build.gradle
@@ -59,6 +59,7 @@ task verifyJar(type: VerifyJarTask) {
           "base-${project.version}.jar",
           "bcpkix-jdk15on-${project.versions.bouncyCastle}.jar",
           "bcprov-jdk15on-${project.versions.bouncyCastle}.jar",
+          "bcutil-jdk15on-${project.versions.bouncyCastle}.jar",
           "commons-codec-${project.versions.commonsCodec}.jar",
           "commons-io-${project.versions.commonsIO}.jar",
           "commons-lang3-${project.versions.commonsLang3}.jar",

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -133,6 +133,7 @@ task verifyJar(type: VerifyJarTask) {
       "base-${project.version}.jar",
       "bcpkix-jdk15on-${project.versions.bouncyCastle}.jar",
       "bcprov-jdk15on-${project.versions.bouncyCastle}.jar",
+      "bcutil-jdk15on-${project.versions.bouncyCastle}.jar",
       "checker-qual-3.12.0.jar",
       "cloning-${project.versions.cloning}.jar",
       "commandline-${project.version}.jar",

--- a/build.gradle
+++ b/build.gradle
@@ -400,7 +400,7 @@ subprojects {
     buildDir = "${projectDir}/target"
 
     configurations {
-      packagingOnly { transitive = false }
+      packagingOnly
       extractedAtTopLevel { transitive = false }
       fatJarConfig
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -32,7 +32,7 @@ final Map<String, String> libraries = [
   aspectj             : 'org.aspectj:aspectjrt:1.9.7',
   assertJ             : 'org.assertj:assertj-core:3.21.0',
   assertJ_DB          : 'org.assertj:assertj-db:2.0.2',
-  bouncyCastle        : 'org.bouncycastle:bcprov-jdk15on:1.68', // This version of BC is not compatible with the jruby-opensssl version, since we are not using jruby-opensssl going ahead with the upgrade.
+  bouncyCastle        : 'org.bouncycastle:bcprov-jdk15on:1.69', // This version of BC is not compatible with the jruby-opensssl version, since we are not using jruby-opensssl going ahead with the upgrade.
   bundler             : 'rubygems:bundler:2.1.1',
   cglib               : 'cglib:cglib:3.3.0',
   cloning             : 'io.github.kostaskougios:cloning:1.10.3',

--- a/server-launcher/build.gradle
+++ b/server-launcher/build.gradle
@@ -199,6 +199,7 @@ task verifyFatJar(type: VerifyJarTask) {
     "lib"         : [
       "bcpkix-jdk15on-${project.versions.bouncyCastle}.jar",
       "bcprov-jdk15on-${project.versions.bouncyCastle}.jar",
+      "bcutil-jdk15on-${project.versions.bouncyCastle}.jar",
       "commons-io-${project.versions.commonsIO}.jar",
       "commons-lang3-${project.versions.commonsLang3}.jar",
       "go-plugin-activator.jar",

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -239,7 +239,9 @@ dependencies {
   implementation project(':db-support:db-support-postgresql')
   implementation project(':db-support:db-support-mysql')
 
-  packagingOnly project(':base')
+  packagingOnly(project(':base')) {
+    transitive = false
+  }
   packagingOnly project.deps.servletApi
 
   copyOnly project(path: ':tfs-impl:tfs-impl-14', configuration: 'fatJarConfig')


### PR DESCRIPTION
Re-submit of #9579 which was reverted in #9605 since I wasn't sure of the implications at the time.

This now consistently includes the new bcutil jar alongside the existing provider and pkix jars across server, agent-launcher and agent, so this should be correct now. 

---
Bumps [bcprov-jdk15on](https://github.com/bcgit/bc-java) from 1.68 to 1.69.

<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://www.bouncycastle.org/releasenotes.html">bcprov-jdk15on's changelog</a>.</em></p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/bcgit/bc-java/commits">compare view</a></li>
</ul>
</details>
<br />
