### PR TITLE
Fix OSX JVM default to run with packaged JRE

### DIFF
--- a/installers/osx.gradle
+++ b/installers/osx.gradle
@@ -65,14 +65,14 @@ def configureOSXZip(Zip zipTask, InstallerType installerType, Zip genericZipTask
     // dont include the wrapper.conf, and tanuki wrappers for OSes other than osx
     from(genericZipTree) {
       exclude "${installerType.baseName}-${project.goVersion}/wrapper-config/wrapper.conf"
-      exclude "${installerType.baseName}-${project.goVersion}/tanuki/wrapper-*"
-      exclude "${installerType.baseName}-${project.goVersion}/tanuki/libwrapper-*"
+      exclude "${installerType.baseName}-${project.goVersion}/wrapper/wrapper-*"
+      exclude "${installerType.baseName}-${project.goVersion}/wrapper/libwrapper-*"
       exclude "${installerType.baseName}-${project.goVersion}/bin/*.bat"
     }
 
     from(genericZipTree) {
-      include "${installerType.baseName}-${project.goVersion}/tanuki/wrapper-macosx-*"
-      include "${installerType.baseName}-${project.goVersion}/tanuki/libwrapper-macosx-*"
+      include "${installerType.baseName}-${project.goVersion}/wrapper/wrapper-macosx-*"
+      include "${installerType.baseName}-${project.goVersion}/wrapper/libwrapper-macosx-*"
     }
 
     // include the wrapper.conf, but replace the java command

--- a/installers/osx.gradle
+++ b/installers/osx.gradle
@@ -64,7 +64,7 @@ def configureOSXZip(Zip zipTask, InstallerType installerType, Zip genericZipTask
 
     // dont include the wrapper.conf, and tanuki wrappers for OSes other than osx
     from(genericZipTree) {
-      exclude "${installerType.baseName}-${project.goVersion}/config/wrapper.conf"
+      exclude "${installerType.baseName}-${project.goVersion}/wrapper-config/wrapper.conf"
       exclude "${installerType.baseName}-${project.goVersion}/tanuki/wrapper-*"
       exclude "${installerType.baseName}-${project.goVersion}/tanuki/libwrapper-*"
       exclude "${installerType.baseName}-${project.goVersion}/bin/*.bat"
@@ -77,7 +77,7 @@ def configureOSXZip(Zip zipTask, InstallerType installerType, Zip genericZipTask
 
     // include the wrapper.conf, but replace the java command
     from(genericZipTree) {
-      include "${installerType.baseName}-${project.goVersion}/config/wrapper.conf"
+      include "${installerType.baseName}-${project.goVersion}/wrapper-config/wrapper.conf"
       filter { String eachLine ->
         if (eachLine == 'wrapper.java.command=java') {
           eachLine = 'wrapper.java.command=jre/Contents/Home/bin/java'


### PR DESCRIPTION
Issue: #9914

The MacOS installers don't use the packaged JREs by default due to an issue updating the Tanuki wrappers.

(a side note is that to do so is actually quite painful since the binaries don't seem to be signed/notarised and thus MacOS requires a lot of opt-ins....)