### PR TITLE
Bump tini from 0.18.0 to 0.19.0

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -183,7 +183,7 @@ final Map<String, String> v = [
 
   // misc
   tanuki              : '3.5.41',
-  tini                : '0.18.0',
+  tini                : '0.19.0',
   velocityToolsView   : '1.4',
 ]
 

--- a/installers/tanuki.gradle
+++ b/installers/tanuki.gradle
@@ -22,7 +22,7 @@ private File destFile(String url) {
 }
 
 task downloadTanukiDeltaPack(type: DownloadFile) {
-  def srcUrl = System.getenv("TANKUK_WRAPPER_URL") ?: "https://nexus.gocd.io/repository/s3-mirrors/local/tanuki/wrapper-delta-pack-${project.versions.tanuki}-st.tar.gz"
+  def srcUrl = System.getenv("TANUKI_WRAPPER_URL") ?: "https://nexus.gocd.io/repository/s3-mirrors/local/tanuki/wrapper-delta-pack-${project.versions.tanuki}-st.tar.gz"
   src srcUrl
   dest destFile(srcUrl)
   checksum '18625b1d009e0973fe066d12ab6ea3b956d7a25d9220966d763de601df28e3a5'

--- a/installers/windows.gradle
+++ b/installers/windows.gradle
@@ -70,9 +70,9 @@ def configureWindowsFilesystem(Task windowsInstallerTask, InstallerType installe
 
         // dont include the wrapper.conf, and tanuki wrappers for OSes other than windows
         from(genericZipTree) {
+          exclude "${installerType.baseName}-${project.goVersion}/wrapper-config/wrapper.conf"
           exclude "${installerType.baseName}-${project.goVersion}/wrapper/wrapper-*"
           exclude "${installerType.baseName}-${project.goVersion}/wrapper/libwrapper-*"
-          exclude "${installerType.baseName}-${project.goVersion}/wrapper-config/wrapper.conf"
           exclude "${installerType.baseName}-${project.goVersion}/bin/*"
         }
 


### PR DESCRIPTION
No major functional differences but good to be on latest version.

https://github.com/krallin/tini/releases/tag/v0.19.0