### PR TITLE
Bump bundler and tweak JRuby bin stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -284,7 +284,6 @@ server/target/
 server/test-repo/
 server/testdata/test-agent.jar
 server/tfs-impl-14.jar
-server/src/main/webapp/WEB-INF/rails/.bundle/
 server/src/main/webapp/WEB-INF/rails/db/config.git/
 server/src/main/webapp/WEB-INF/rails/logs/
 server/src/main/webapp/WEB-INF/rails/node_modules/

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -33,7 +33,7 @@ final Map<String, String> libraries = [
   assertJ             : 'org.assertj:assertj-core:3.21.0',
   assertJ_DB          : 'org.assertj:assertj-db:2.0.2',
   bouncyCastle        : 'org.bouncycastle:bcprov-jdk15on:1.70', // This version of BC is not compatible with the jruby-opensssl version, since we are not using jruby-opensssl going ahead with the upgrade.
-  bundler             : 'rubygems:bundler:2.1.1',
+  bundler             : 'rubygems:bundler:2.2.32',
   cglib               : 'cglib:cglib:3.3.0',
   cloning             : 'io.github.kostaskougios:cloning:1.10.3',
   commonsBeanUtils    : 'commons-beanutils:commons-beanutils:1.9.4',

--- a/server/rails.gradle
+++ b/server/rails.gradle
@@ -136,7 +136,7 @@ task initializeRailsGems {
 
     project.jrubyexec {
       workingDir = project.railsRoot
-      args = ['-S', 'bundle', 'install', '--path', 'gems', '--clean', '--jobs', '4']
+      args = ['-S', 'bundle', 'install']
       maxHeapSize = '1g'
     }
   }

--- a/server/script-templates/jruby
+++ b/server/script-templates/jruby
@@ -32,6 +32,6 @@ exec "${javaExecutable}" \\
 <% print systemProperties.collect { entry -> "  '-D${entry}'" }.join(" \\\n") %> \\
   "\${jvm_args[@]}" \\
   -cp \\
-  \${combined_classpath}:${classpath.join(':')} \\
+  "\${combined_classpath}:${classpath.join(':')}" \\
   ${mainClassName} \\
   "\${argv[@]}"

--- a/server/script-templates/jruby.bat
+++ b/server/script-templates/jruby.bat
@@ -1,13 +1,13 @@
 @echo off
 
-<% print environment.collect { entry -> """set ${entry.key}=${entry.value}""" }.join("\n") %>
+<% print environment.collect { entry -> """set ${entry.key}=\"${entry.value}\"""" }.join("\n") %>
 rem add jruby and rubygem binstubs to PATH
-set PATH=${additionalJRubyPaths.join(File.pathSeparator)};%PATH%
+set PATH="${additionalJRubyPaths.join(File.pathSeparator)};%PATH%"
 
 "${javaExecutable}" ^
 <% print jvmArgs.collect { entry -> $/  "${entry}"/$ }.join(" ^\n") %> ^
 <% print systemProperties.collect { entry -> $/  "-D${entry}"/$ }.join(" ^\n") %> ^
   -cp ^
-  ${jrubyJar};${classpath.join(';')} ^
+  "${jrubyJar};${classpath.join(';')}" ^
   ${mainClassName} ^
   %*

--- a/server/src/main/webapp/WEB-INF/rails/.bundle/config
+++ b/server/src/main/webapp/WEB-INF/rails/.bundle/config
@@ -1,0 +1,4 @@
+---
+BUNDLE_PATH: "gems"
+BUNDLE_JOBS: "4"
+BUNDLE_CLEAN: "true"

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    marcel (1.0.1)
+    marcel (1.0.2)
     method_source (0.9.2)
     mini_mime (1.1.2)
     minitest (5.14.4)
@@ -241,4 +241,4 @@ RUBY VERSION
    ruby 2.5.7p0 (jruby 9.2.9.0)
 
 BUNDLED WITH
-   2.1.1
+   2.2.32


### PR DESCRIPTION
- Bump bundler from 2.1.1 to 2.2.32
- Tweak the generated JRuby scripts to improve handling of spaces in paths, especially on Windows (discovered while working on #9855)
- Bump marcel from 1.0.1 to 1.0.2 (to validate bundle update)