### PR TITLE
Switch to Debian "slim" variants as agent base image

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -164,10 +164,10 @@ enum Distro implements DistroBehavior {
     @Override
     List<DistroVersion> getSupportedVersions() {
       return [
-        new DistroVersion(version: '9', releaseName: 'stretch', eolDate: parseDate('2022-06-30')),
+        new DistroVersion(version: '9', releaseName: 'stretch-slim', eolDate: parseDate('2022-06-30')),
         // No EOL-LTS specified for buster release. Checkout https://wiki.debian.org/DebianReleases for more info
-        new DistroVersion(version: '10', releaseName: 'buster', eolDate: parseDate('2024-06-01')),
-        new DistroVersion(version: '11', releaseName: 'bullseye', eolDate: parseDate('2026-08-15')),
+        new DistroVersion(version: '10', releaseName: 'buster-slim', eolDate: parseDate('2024-06-01')),
+        new DistroVersion(version: '11', releaseName: 'bullseye-slim', eolDate: parseDate('2026-08-15')),
       ]
     }
   },


### PR DESCRIPTION
As noted in #9873, there doesn't seem to be any major reason to include all the documentation and locales from the non-slim variants.

See https://github.com/debuerreotype/debuerreotype/blob/master/scripts/.slimify-includes and https://github.com/debuerreotype/debuerreotype/blob/master/scripts/.slimify-excludes for the differences from the full versions.

Seeking input on whether there are additional concerns with this.