### PR TITLE
Bump Gradle from 7.3 to 7.3.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=00b273629df4ce46e68df232161d5a7c4e495b9a029ce6e0420f071e21316867
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
+distributionSha256Sum=dd54e87b4d7aa8ff3c6afb0f7805aa121d4b70bca55b8c9b1b896eb103184582
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Includes log4shell resolution mitigations that will help us avoid accidentally introducing it in future.

See https://github.com/gradle/gradle/issues/19300 and https://github.com/gradle/gradle/issues/19300