### PR TITLE
Upgrade dom4j from 1.6.1 to 2.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,9 @@
  */
 
 
-import com.github.jk1.license.task.ReportTask
 import com.github.jk1.license.filter.LicenseBundleNormalizer
 import com.github.jk1.license.render.JsonReportRenderer
+import com.github.jk1.license.task.ReportTask
 import groovy.io.FileType
 import nl.javadude.gradle.plugins.license.License
 import org.apache.tools.ant.filters.FixCrLfFilter
@@ -647,6 +647,7 @@ subprojects {
   }
 
   project.configurations*.exclude(group: 'junit')
+  project.configurations*.exclude(group: 'dom4j')
   project.configurations*.exclude(group: 'xalan')
   project.configurations*.exclude(group: 'xml-apis')
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -23,7 +23,10 @@ dependencies {
   api project(':util')
   api project(':domain')
   api project(':plugin-infra:go-plugin-access')
-  api project.deps.dom4j
+  api(project.deps.dom4j) {
+    // workaround for dom4j Gradle metadata optional dependency issues (https://github.com/dom4j/dom4j/issues/99)
+    transitive = false
+  }
   api project.deps.apacheHttpMime
   api project.deps.commonsCollections4
   api project.deps.commonsText

--- a/config/config-server/build.gradle
+++ b/config/config-server/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   }
   implementation project.deps.slf4j
   implementation project.deps.cglib
+  implementation project.deps.jaxen
   compileOnly project.deps.jetBrainsAnnotations
   providedAtPackageTime(project.deps.bouncyCastle)
   testImplementation project(path: ':config:config-api', configuration: 'testOutput')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -50,7 +50,7 @@ final Map<String, String> libraries = [
   commonsPool         : 'org.apache.commons:commons-pool2:2.11.1',
   commonsText         : 'org.apache.commons:commons-text:1.9',
   dbunit              : 'org.dbunit:dbunit:2.7.2',
-  dom4j               : 'dom4j:dom4j:1.6.1',
+  dom4j               : 'org.dom4j:dom4j:2.1.3',
   ehcache             : 'net.sf.ehcache:ehcache:2.10.9.2',
   felix               : 'org.apache.felix:org.apache.felix.framework:7.0.3',
   freemarker          : 'org.freemarker:freemarker:2.3.31',

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -297,11 +297,6 @@ dependencies {
   implementation project.deps.mailSmtp
   implementation project.deps.objenesis
 
-  // needed by jdom2 for some XPATH stuff
-  implementation(project.deps.jaxen) {
-    exclude(module: 'xom')
-    exclude(module: 'jdom')
-  }
   implementation project.deps.slf4j
   implementation(project.deps.jgitServer) {
     exclude(module: 'jsch')
@@ -966,19 +961,6 @@ task licenseReportAggregate {
           // License is automatically detected as 0BSD by gradle-license-report, but appears to actually be BSD-3-Clause in nature
           moduleLicense   : 'BSD-3-Clause',
           moduleLicenseUrl: "https://spdx.org/licenses/BSD-3-Clause.html"
-        ]
-      ]
-    ],
-    [
-      moduleName    : 'dom4j:dom4j',
-      moduleVersion : '1.6.1',
-      moduleUrls    : [
-        "https://dom4j.github.io/"
-      ],
-      moduleLicenses: [
-        [
-          moduleLicense   : 'dom4j BSD license',
-          moduleLicenseUrl: "https://github.com/dom4j/dom4j/blob/dom4j_1_6_1/LICENSE.txt"
         ]
       ]
     ],

--- a/server/src/main/java/com/thoughtworks/go/server/domain/xml/FeedEntriesRepresenter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/xml/FeedEntriesRepresenter.java
@@ -69,7 +69,7 @@ public class FeedEntriesRepresenter implements XmlRepresentable {
             .textNode("id", entryUrl);
 
         if (feed.isManuallyTriggered()) {
-            builder.node("go:author", childBuilder -> childBuilder.cdataNode("go:name", feed.getApprovedBy()));
+            builder.node("go", "author", childBuilder -> childBuilder.cdataNode("go", "name", feed.getApprovedBy()));
         }
 
         feed.getAuthors().forEach(author -> {
@@ -82,7 +82,7 @@ public class FeedEntriesRepresenter implements XmlRepresentable {
         });
 
         if (isNotBlank(feed.getCancelledBy())) {
-            builder.node("cancelledBy", child -> child.cdataNode("go:name", feed.getCancelledBy()));
+            builder.node("cancelledBy", child -> child.cdataNode("go", "name", feed.getCancelledBy()));
         }
 
         String stageTitle = identifier.getStageName() + " Stage Detail";

--- a/server/src/main/java/com/thoughtworks/go/server/domain/xml/builder/AbstractBuilder.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/xml/builder/AbstractBuilder.java
@@ -50,6 +50,11 @@ public abstract class AbstractBuilder<T, SELF> {
         return mySelf;
     }
 
+    public SELF cdataNode(String prefix, String name, String CDATA) {
+        current().add(withNamespace(prefix,  name).addCDATA(CDATA));
+        return mySelf;
+    }
+
     public SELF link(String href, String rel) {
         current().add(getLink(href, rel));
         return mySelf;
@@ -57,13 +62,20 @@ public abstract class AbstractBuilder<T, SELF> {
 
     public SELF link(String href, String rel, String title, String type) {
         current().add(getLink(href, rel)
-            .addAttribute("title", title)
-            .addAttribute("type", type));
+                .addAttribute("title", title)
+                .addAttribute("type", type));
         return mySelf;
     }
 
     public SELF node(String name, Consumer<ElementBuilder> consumer) {
         DOMElement element = withNamespace(name);
+        current().add(element);
+        consumer.accept(new ElementBuilder(element));
+        return mySelf;
+    }
+
+    public SELF node(String prefix, String name, Consumer<ElementBuilder> consumer) {
+        DOMElement element = withNamespace(prefix, name);
         current().add(element);
         consumer.accept(new ElementBuilder(element));
         return mySelf;
@@ -95,14 +107,18 @@ public abstract class AbstractBuilder<T, SELF> {
 
     private Element getLink(String href, String rel) {
         return withNamespace("link")
-            .addAttribute("rel", rel)
-            .addAttribute("href", href);
+                .addAttribute("rel", rel)
+                .addAttribute("href", href);
     }
 
     private DOMElement withNamespace(String name) {
         DOMElement element = new DOMElement(name);
         getDefaultNameSpace().ifPresent(element::setNamespace);
         return element;
+    }
+
+    private DOMElement withNamespace(String prefix, String name) {
+        return new DOMElement(name, current().getNamespaceForPrefix(prefix));
     }
 
     private Optional<Namespace> getDefaultNameSpace() {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/JUnitReportGenerator.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/JUnitReportGenerator.java
@@ -24,6 +24,7 @@ import org.dom4j.io.SAXReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -31,14 +32,18 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class JUnitReportGenerator {
 
     public static void main(String[] args) throws Exception {
-        Document doc = new SAXReader().read(new FileInputStream(new File("/home/cruise/sample_junit.xml")));
+        Document doc = new SAXReader().read(new FileInputStream("/home/cruise/sample_junit.xml"));
         Element suite = (Element) doc.selectSingleNode("//testsuite");
         Element rootElement = doc.getRootElement();
         for (int i = 0; i < 50000; i++) {
             Element copy = suite.createCopy();
             setAttr(i, copy, "name");
             setAttr(i, copy, "hostname");
-            List<Element> elements = copy.selectNodes(".//testcase");
+            List<Element> elements = copy.selectNodes(".//testcase")
+                    .stream()
+                    .filter(Element.class::isInstance)
+                    .map(Element.class::cast)
+                    .collect(Collectors.toList());
             for (Element element : elements) {
                 setAttr(i, element, "classname");
                 setAttr(i, element, "name");

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/FeedEntriesRepresenterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/xml/FeedEntriesRepresenterTest.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.domain.feed.FeedEntries;
 import com.thoughtworks.go.domain.feed.stage.StageFeedEntry;
 import com.thoughtworks.go.junit5.FileSource;
 import com.thoughtworks.go.util.DateUtils;
+import com.thoughtworks.go.util.GoConstants;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.dom4j.Document;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -76,6 +77,6 @@ public class FeedEntriesRepresenterTest {
     private static StageFeedEntry cancelled() {
         Date date = DateUtils.parseISO8601("2019-12-31T07:28:30+05:30");
         StageIdentifier identifier = new StageIdentifier("up42", 2, "integration-tests", "100");
-        return new StageFeedEntry(1L, 1L, identifier, 123L, date, StageResult.Cancelled, "", "Bob", "Admin");
+        return new StageFeedEntry(1L, 1L, identifier, 123L, date, StageResult.Cancelled, GoConstants.APPROVAL_MANUAL, "Bob", "Admin");
     }
 }

--- a/server/src/test-fast/resources/feeds/stages-with-entries.xml
+++ b/server/src/test-fast/resources/feeds/stages-with-entries.xml
@@ -12,6 +12,9 @@
         <title><![CDATA[up42(2) stage integration-tests(100) Cancelled]]></title>
         <updated>2019-12-31T01:58:30Z</updated>
         <id>https://go-server/go/pipelines/up42/2/integration-tests/100</id>
+        <go:author xmlns:go="http://www.thoughtworks-studios.com/ns/go">
+            <go:name><![CDATA[Bob]]></go:name>
+        </go:author>
         <author>
             <name><![CDATA[bob]]></name>
             <email>bob@gocd.org</email>


### PR DESCRIPTION
Despite not being flagged on OWASP Dependency Check reports, DOM4J 1.6.1 may be subject to https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-1000632 - it's not 100% clear that this **only** affects DOM4J 2.x and folks such as Hibernate upgraded it as a result: https://hibernate.atlassian.net/browse/HHH-12964

Additionally, `1.6.1` is very EOL and un-patched.

Should be OK on the basis that
- It seems fully compatible at runtime (except possibly some stricter validation of QNames in https://github.com/dom4j/dom4j/issues/48)
- Our old Hibernate 3.6 version depends on it, but was upgraded in hibernate/hibernate-orm#2533 (albeit on Hibernate 5) with no other code changes to Hibernate, it seems
- [Release notes](https://github.com/dom4j/dom4j/releases) don't mention any serious breaking changes other than Java source code compatibility changes, and compile time generics https://github.com/dom4j/dom4j/releases/tag/version-2.0.0

To make this work
- Fixed compile time generics changes in test utility
- Fixed incorrect use of Dom4j in FeedEntriesRepresenter which now fails QName validation. Test validated before and after upgrade to produce identical XML.
- Improved the jaxen dependency modelling. This is needed for JDOM2, not DOM4j; and seemingly only within some config-api validation for the server.