### PR TITLE
Don't delete the source-controlled .bundle dir during clean

### DIFF
--- a/server/rails.gradle
+++ b/server/rails.gradle
@@ -167,7 +167,6 @@ task cleanRails(type: Delete) {
   doFirst {
     // these are purposely added as `doFirst` to avoid intellij from excluding these from the modules
     project.delete project.jrubyScriptsDir
-    project.delete "${project.railsRoot}/.bundle"
     project.delete project.bundledGemDir
   }
 }


### PR DESCRIPTION
The bundler config is now source controlled (in c77a7ed9) on recommendation from bundler team due to use of flags that need to persist across runs; so this shouldn't be deleted now.