### PR TITLE
Migrate Centos 8 agent and server images to Centos Stream 8

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/BuildDockerImageTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/BuildDockerImageTask.groovy
@@ -113,7 +113,7 @@ class BuildDockerImageTask extends DefaultTask {
           // delete the parent image, to save space
           project.exec {
             workingDir = project.rootProject.projectDir
-            commandLine = ["docker", "rmi", "${distro.name()}:${distroVersion.releaseName}"]
+            commandLine = ["docker", "rmi", "${distro.getBaseImageLocation(distroVersion)}"]
           }
         }
       }

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -93,6 +93,11 @@ enum Distro implements DistroBehavior {
 
   centos{
     @Override
+    String getBaseImageRegistry(DistroVersion distroVersion) {
+      distroVersion.version >= "8" ? "quay.io/centos" : super.baseImageRegistry
+    }
+
+    @Override
     List<String> getInstallPrerequisitesCommands(DistroVersion distroVersion) {
       String git = gitPackage(distroVersion)
 
@@ -145,7 +150,7 @@ enum Distro implements DistroBehavior {
     List<DistroVersion> getSupportedVersions() {
       return [
         new DistroVersion(version: '7', releaseName: '7', eolDate: parseDate('2024-06-01')),
-        new DistroVersion(version: '8', releaseName: '8', eolDate: parseDate('2029-05-01'), installPrerequisitesCommands: ['yum install --assumeyes glibc-langpack-en'])
+        new DistroVersion(version: '8', releaseName: 'stream8', eolDate: parseDate('2024-05-31'), installPrerequisitesCommands: ['yum install --assumeyes glibc-langpack-en'])
       ]
     }
   },

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
@@ -25,6 +25,17 @@ trait DistroBehavior {
     return []
   }
 
+  abstract String name()
+
+  String getBaseImageRegistry(DistroVersion distroVersion) {
+    return "docker.io"
+  }
+
+
+  String getBaseImageLocation(DistroVersion distroVersion) {
+    "${getBaseImageRegistry(distroVersion)}/${name()}:${distroVersion.releaseName}"
+  }
+
   DistroVersion getVersion(String version) {
     return (supportedVersions.find { supportedVersion ->
       supportedVersion.version == version

--- a/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
@@ -33,10 +33,10 @@ RUN \
 RUN unzip /tmp/go-agent-${fullVersion}.zip -d /
 RUN mv /go-agent-${goVersion} /go-agent && chown -R ${r"${UID}"}:0 /go-agent && chmod -R g=u /go-agent
 
-FROM ${distro.name()}:${distroVersion.releaseName}
+FROM ${distro.getBaseImageLocation(distroVersion)}
 
 LABEL gocd.version="${goVersion}" \
-  description="GoCD agent based on ${distro.name()} version ${distroVersion.version}" \
+  description="GoCD agent based on ${distro.getBaseImageLocation(distroVersion)}" \
   maintainer="ThoughtWorks, Inc. <support@thoughtworks.com>" \
   url="https://www.gocd.org" \
   gocd.full.version="${fullVersion}" \

--- a/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
@@ -40,10 +40,10 @@ RUN mkdir -p /go-server/wrapper /go-server/bin && \
     mv /go-server-${goVersion}/wrapper/wrapper.jar /go-server/wrapper/ && \
     chown -R ${r"${UID}"}:0 /go-server && chmod -R g=u /go-server
 
-FROM ${distro.name()}:${distroVersion.releaseName}
+FROM ${distro.getBaseImageLocation(distroVersion)}
 
 LABEL gocd.version="${goVersion}" \
-  description="GoCD server based on ${distro.name()} version ${distroVersion.version}" \
+  description="GoCD server based on ${distro.getBaseImageLocation(distroVersion)}" \
   maintainer="ThoughtWorks, Inc. <support@thoughtworks.com>" \
   url="https://www.gocd.org" \
   gocd.full.version="${fullVersion}" \


### PR DESCRIPTION
The regular Centos 8 is EOL on 31 December 2021. The only further updates will come via Centos stream. 

Rather than distinct naming the images, this makes the lowest effort change to migrate to the new Centos Stream base images published by the team.

- Fixes #9940
- Introduces support to pull from different registries by distro and version. Not sure if this will have an impact on caching, as Docker cannot mirror from `quay.io` OOTB.
- Further discussion is needed on whether this is the best thing to do. Centos Stream will now be upstream of RHEL point releases, delivered in more "continuous delivery" style. Given GoCD releases relatively infrequently but rebuilds and sanity tests on latest images on every commit, I don't believe this is likely to be a major issue or will negatively harm its stability.

The base image as built by Centos seems to be much bigger on Centos Stream (231 MB vs 422 MB uncompressed), but it doesn't seem to make a huge difference to the end image size after GoCD is layered on top.

| Type | Before | After |
|------|-------|-------|
| Agent | 871 MB uncompressed | 920 MB uncompressed (+49 MB) |
| Server | 1.05 GB uncompressed | 1.10 GB uncompressed (+50 MB) |

Looking for comments on
- [x] There are currently no Docker Library official images yet for Centos Stream. This means they are not getting regularly rebuilt for updates and would rely on us `yum update`-ing them ourselves during our builds - thankfully [we do this already](https://github.com/gocd/gocd/blob/1dcd0b8b09e418222437865376608b92f8765c7a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy#L96-L100). By contrast there **are** [official Docker library images for Rocky Linux](https://hub.docker.com/_/rockylinux).
- [x] Generally are there concerns about use of Stream? If it is not a good idea, moving to Rocky or Alma Linux distros is an option, but is a bit more work to introduce a new distro and might be a bit weird as we'd have Centos 7 hanging around.
    - There are a few different opinions around the place. [This one](https://medium.com/swlh/centos-stream-why-its-awesome-5c45d944fb22) is more positive.
    - I had some generic comments [here](https://github.com/gocd/gocd/issues/9940#issuecomment-997160792).