### PR TITLE
Simplify Docker image build by using official curl images

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
@@ -17,19 +17,14 @@
 # Please file any issues or PRs at https://github.com/gocd/gocd
 ###############################################################################################
 
-FROM alpine:latest as gocd-agent-unzip
-
+FROM curlimages/curl:latest as gocd-agent-unzip
+USER root
 ARG UID=1000
-
 <#if useFromArtifact >
 COPY go-agent-${fullVersion}.zip /tmp/go-agent-${fullVersion}.zip
 <#else>
-RUN \
-  apk --no-cache upgrade && \
-  apk add --no-cache curl && \
-  curl --fail --location --silent --show-error "https://download.gocd.org/binaries/${fullVersion}/generic/go-agent-${fullVersion}.zip" > /tmp/go-agent-${fullVersion}.zip
+RUN curl --fail --location --silent --show-error "https://download.gocd.org/binaries/${fullVersion}/generic/go-agent-${fullVersion}.zip" > /tmp/go-agent-${fullVersion}.zip
 </#if>
-
 RUN unzip /tmp/go-agent-${fullVersion}.zip -d /
 RUN mv /go-agent-${goVersion} /go-agent && chown -R ${r"${UID}"}:0 /go-agent && chmod -R g=u /go-agent
 
@@ -83,7 +78,7 @@ RUN \
 ADD docker-entrypoint.sh /
 
 
-COPY --from=gocd-agent-unzip /go-agent /go-agent
+COPY --from=gocd-agent-unzip /tmp/go-agent /go-agent
 # ensure that logs are printed to console output
 COPY --chown=go:root agent-bootstrapper-logback-include.xml agent-launcher-logback-include.xml agent-logback-include.xml /go-agent/config/
 <#if distro.name() == "docker">

--- a/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
@@ -17,15 +17,13 @@
 # Please file any issues or PRs at https://github.com/gocd/gocd
 ###############################################################################################
 
-FROM alpine:latest as gocd-server-unzip
+FROM curlimages/curl:latest as gocd-server-unzip
+USER root
 ARG UID=1000
 <#if useFromArtifact >
 COPY go-server-${fullVersion}.zip /tmp/go-server-${fullVersion}.zip
 <#else>
-RUN \
-  apk --no-cache upgrade && \
-  apk add --no-cache curl && \
-  curl --fail --location --silent --show-error "https://download.gocd.org/binaries/${fullVersion}/generic/go-server-${fullVersion}.zip" > /tmp/go-server-${fullVersion}.zip
+RUN curl --fail --location --silent --show-error "https://download.gocd.org/binaries/${fullVersion}/generic/go-server-${fullVersion}.zip" > /tmp/go-server-${fullVersion}.zip
 </#if>
 RUN unzip /tmp/go-server-${fullVersion}.zip -d /
 RUN mkdir -p /go-server/wrapper /go-server/bin && \


### PR DESCRIPTION
The official images are based on Alpine anyway, and this removes a minor bit of complexity from the Dockerfiles.