### PR TITLE
nitpick: Make Linguist ignore more vendored stuff

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/.gitattributes
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/.gitattributes
@@ -1,0 +1,1 @@
+lib/** linguist-vendored

--- a/tfs-impl/tfs-impl-14/.gitattributes
+++ b/tfs-impl/tfs-impl-14/.gitattributes
@@ -1,0 +1,1 @@
+tfssdk/** linguist-vendored


### PR DESCRIPTION
The language stats have been bugging me :-) Github's linguist will only ignore vendored stuff in folders named appropriately, so is overcounting JavaScript and HTML and undercounting (as %) other stuff.

See https://github.com/github/linguist/blob/master/docs/overrides.md