### PR TITLE
Remove more dead code from removal of failures and properties job details tabs

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/presentation/models/JobStatusJsonPresentationModel.java
+++ b/server/src/main/java/com/thoughtworks/go/server/presentation/models/JobStatusJsonPresentationModel.java
@@ -124,16 +124,6 @@ public class JobStatusJsonPresentationModel {
         return instance.getId() == buildInstanceId;
     }
 
-    public String getTabToShow() {
-        String result = "";
-        if (instance.isPassed()) {
-            result = "#tab-artifacts";
-        } else if (instance.isFailed()) {
-            result = "#tab-failures";
-        }
-        return result;
-    }
-
     public String getBuildLocator() {
         return instance.buildLocator();
     }

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_build_detail.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_build_detail.scss
@@ -510,12 +510,6 @@ a.collapse-all {
   float: none;
 }
 
-.more {
-  padding: 0.5em;
-  color: #00000F;
-  text-decoration: underline;
-}
-
 /* build detail summary start */
 .build_detail_summary {
   margin-bottom: 1em;

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_build_detail_summary_jstemplate.vm
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_build_detail_summary_jstemplate.vm
@@ -37,7 +37,7 @@
     {/if}
   #end
 </li>
-  <li><span class="header">Completed on: </span><span id="build_completed_date">${% build.build_completed_date %}</span><a  href="#tab-properties" class ="more" target="_blank" onclick="new TabsManager('properties')">more...</a></li>
+  <li><span class="header">Completed on: </span><span id="build_completed_date">${% build.build_completed_date %}</span></li>
 <li><span class="header">Build cause: </span><span id="stage-${% build.id %}-buildCause">$esc.html($esc.html($presenter.buildCauseMessage))</span></li>
   {if build.current_status.toLowerCase() == 'passed' ||  build.current_status.toLowerCase() == 'failed'}
 <li><span class="header">Duration: </span><span>${% moment.duration(parseInt(build.current_build_duration), 's').humanizeForGoCD() %}</span></li>

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
@@ -42,8 +42,7 @@
                 <ul id="build-detail-summary" class="summary">
                   <li><span class="header">Scheduled on: </span><span id="build_scheduled_date">Loading...</span></li>
                   <li><span class="header">Agent: </span><span id="agent_name">Loading...</span></li>
-                  <li><span class="header">Completed on: </span><span id="build_completed_date">Loading...</span><a
-                    href="#tab-properties" class="more" onclick="new TabsManager('properties')">more...</a></li>
+                  <li><span class="header">Completed on: </span><span id="build_completed_date">Loading...</span></li>
                   <li><span class="header">Build cause: </span><span
                     id="stage-${presenter.id}-buildCause">$esc.html($presenter.buildCauseMessage)</span></li>
                   <li class="timer_area">

--- a/server/src/main/webapp/WEB-INF/vm/sidebar/_sidebar_build_list.vm
+++ b/server/src/main/webapp/WEB-INF/vm/sidebar/_sidebar_build_list.vm
@@ -42,7 +42,6 @@
                 <div class="time_ago" data="${listPresenter.scheduledTime}"></div>
 
                 </a>
-                <!-- should be ${listPresenter.tabToShow} -->
             </li>
             #end
         </ul>

--- a/server/src/test-fast/java/com/thoughtworks/go/server/presentation/models/JobStatusJsonPresentationModelTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/presentation/models/JobStatusJsonPresentationModelTest.java
@@ -32,18 +32,19 @@ import static com.thoughtworks.go.domain.JobResult.Passed;
 import static com.thoughtworks.go.helper.JobInstanceMother.*;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 public class JobStatusJsonPresentationModelTest {
 
-    @Test public void shouldShowBuildStatus() {
+    @Test
+    public void shouldShowBuildStatus() {
         JobInstance instance = assigned("test");
         instance.setId(12);
         instance.setAgentUuid("1234");
 
-        final Agent agent = new Agent("1234","localhost", "1234", "cookie");
+        final Agent agent = new Agent("1234", "localhost", "1234", "cookie");
 
         JobStatusJsonPresentationModel presenter = new JobStatusJsonPresentationModel(instance,
                 agent, mock(DurationBean.class));
@@ -57,7 +58,8 @@ public class JobStatusJsonPresentationModelTest {
                 "}");
     }
 
-    @Test public void shouldShowBuildStatusForCompleted() {
+    @Test
+    public void shouldShowBuildStatusForCompleted() {
         JobInstance instance = completed("test", Passed);
 
         JobStatusJsonPresentationModel presenter = new JobStatusJsonPresentationModel(instance);
@@ -69,7 +71,8 @@ public class JobStatusJsonPresentationModelTest {
                 "}");
     }
 
-    @Test public void shouldShowElapsedAndRemainingTimeForIncompleteBuild() throws Exception {
+    @Test
+    public void shouldShowElapsedAndRemainingTimeForIncompleteBuild() {
         JobInstance instance = building("test", new DateTime().minusSeconds(5).toDate());
 
         JobStatusJsonPresentationModel presenter = new JobStatusJsonPresentationModel(instance, mock(Agent.class),
@@ -85,7 +88,7 @@ public class JobStatusJsonPresentationModelTest {
     }
 
     @Test
-    public void shouldReturnNotYetAssignedIfAgentUuidIsNull() throws Exception {
+    public void shouldReturnNotYetAssignedIfAgentUuidIsNull() {
         JobInstance instance = building("Plan1");
         instance.setAgentUuid(null);
 
@@ -97,37 +100,20 @@ public class JobStatusJsonPresentationModelTest {
     }
 
     @Test
-    public void shouldReturnAgentHostname() throws Exception {
+    public void shouldReturnAgentHostname() {
         JobInstance instance = building("Plan1");
         instance.setAgentUuid("1234");
 
         JobStatusJsonPresentationModel presenter =
                 new JobStatusJsonPresentationModel(instance,
-                        new Agent("1234","localhost", "address", "cookie"), mock(DurationBean.class));
+                        new Agent("1234", "localhost", "address", "cookie"), mock(DurationBean.class));
         assertThatJson(new Gson().toJson(presenter.toJsonHash())).when(IGNORING_EXTRA_FIELDS).isEqualTo("{\n" +
                 "  \"agent\": \"localhost\"\n" +
                 "}");
     }
 
-    @Test public void shouldShowArtifactTabwhenBuildPassed() throws Exception {
-        JobInstance instance = JobInstanceMother.passed("plan1");
-        JobStatusJsonPresentationModel buildStatusJson = new JobStatusJsonPresentationModel(instance);
-        assertThat(buildStatusJson.getTabToShow(), is("#tab-artifacts"));
-    }
-
-    @Test public void shouldShowFailuresTabwhenBuildFailed() throws Exception {
-        JobInstance instance = JobInstanceMother.failed("plan1");
-        JobStatusJsonPresentationModel buildStatusJson = new JobStatusJsonPresentationModel(instance);
-        assertThat(buildStatusJson.getTabToShow(), is("#tab-failures"));
-    }
-
-    @Test public void shouldShowDefaultTabwhenBuildIsNeitherFailedNorPassed() throws Exception {
-        JobInstance instance = JobInstanceMother.cancelled("plan1");
-        JobStatusJsonPresentationModel buildStatusJson = new JobStatusJsonPresentationModel(instance);
-        assertThat(buildStatusJson.getTabToShow(), is(""));
-    }
-
-    @Test public void shouldEncodeBuildLocator() throws Exception {
+    @Test
+    public void shouldEncodeBuildLocator() {
         JobInstance instance = JobInstanceMother.completed("job-%", JobResult.Passed);
         instance.setIdentifier(new JobIdentifier("cruise-%", 1, "label-1", "dev-%", "1", "job-%", -1L));
 
@@ -137,7 +123,8 @@ public class JobStatusJsonPresentationModelTest {
         assertThat(JsonUtils.from(json).getString("buildLocator"), is("cruise-%25/1/dev-%25/1/job-%25"));
     }
 
-    @Test public void shouldIncludeBuildLocatorForDisplay() throws Exception {
+    @Test
+    public void shouldIncludeBuildLocatorForDisplay() {
         JobInstance instance = JobInstanceMother.completed("job-%", JobResult.Passed);
         instance.setIdentifier(new JobIdentifier("cruise-%", 1, "label-1", "dev-%", "1", "job-%", -1L));
 


### PR DESCRIPTION
These UI tabs do not exist on Job Details any longer so code referring to them should go
- for Properties for a long time (so the current "more..." link goes nowhere on Job Details and should be removed)
  - see #9988, #6887 
- the code in `JobStatusJsonPresentationModel` for `tabToShow` is unused, and not returned back to the UI, seemingly only used in tests.
  - This seems to date back to original open sourcing of GoCD so not sure why it's like this :-)
  - see #9662