### PR TITLE
Add bundler to dependabot (along with scripts)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,31 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 99
 - package-ecosystem: npm
   directory: "/server/src/main/webapp/WEB-INF/rails"
   schedule:
     interval: weekly
     day: friday
-  open-pull-requests-limit: 99
+  commit-message:
+    prefix-development: dev
+- package-ecosystem: bundler
+  directory: "/server/src/main/webapp/WEB-INF/rails"
+  commit-message:
+    prefix-development: dev
+  schedule:
+    interval: weekly
+    day: friday
+- package-ecosystem: npm
+  directory: "/scripts"
+  commit-message:
+    prefix: dev-scripts
+  schedule:
+    interval: weekly
+    day: friday
+- package-ecosystem: bundler
+  directory: "/scripts"
+  schedule:
+    interval: weekly
+    day: friday
+  commit-message:
+    prefix: dev-scripts


### PR DESCRIPTION
There may have been a reason to exclude this originally; perhaps the intention to get rid of Ruby/Rails code; however we still have it and it is bundled with the server, so we should probably try our best to keep it updated and patched where appropriate.
