### PR TITLE
Temporarily add empty dependency file in old location

### DIFF
--- a/server/webapp/WEB-INF/rails.new/Gemfile
+++ b/server/webapp/WEB-INF/rails.new/Gemfile
@@ -1,0 +1,1 @@
+source "https://rubygems.org"

--- a/server/webapp/WEB-INF/rails.new/Gemfile.lock
+++ b/server/webapp/WEB-INF/rails.new/Gemfile.lock
@@ -1,0 +1,11 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+
+BUNDLED WITH
+   2.2.24


### PR DESCRIPTION
GitHub dependency graph includes stale dependencies and misleading advisory for deps that don't exist. Temporarily added an empty Gemfile to clear these out, following https://github.com/dependabot/dependabot-core/issues/2041
