### PR TITLE
Add empty dependency file in old location

### DIFF
--- a/server/webapp/WEB-INF/rails.new/package-lock.json
+++ b/server/webapp/WEB-INF/rails.new/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "dummy",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/server/webapp/WEB-INF/rails.new/package.json
+++ b/server/webapp/WEB-INF/rails.new/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dummy",
+  "version": "1.0.0",
+  "description": "dummy",
+  "license": "Apache-2.0",
+  "dependencies": {}
+}


### PR DESCRIPTION
GitHub dependency graph includes stale dependencies and misleading advisory for deps that don't exist. Temporarily added an empty package.json to clear these out, following https://github.com/dependabot/dependabot-core/issues/2041