### PR TITLE
Bump ruby (mainly dev) dependencies

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile
@@ -22,7 +22,7 @@ group :development, :test do
   gem 'jasmine_selenium_runner'
 
   # make sure to `System.setProperty("jruby.runtime.arguments", "--debug")` before opening up pry
-  gem 'pry-debugger-jruby'
+  gem 'pry-debugger-jruby', platforms: :jruby
 end
 
 group :test do

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile
@@ -1,6 +1,4 @@
 source 'https://rubygems.org'
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
 ruby '2.5.8'
 
 gem 'rails', '5.2.6'

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile
@@ -15,7 +15,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 group :development, :test do
   # we use `jasmine` gem + `selenium-webdriver` for the `jasmine:ci` task
   # this task will run jasmine in a browser, driven by selenium
-  gem 'jasmine', '3.7.0' # 3.8 has issues on JRuby due to webrick being added
+  gem 'jasmine'
   gem 'jasmine-jquery-rails'
   gem 'jasmine_selenium_runner'
 
@@ -29,11 +29,6 @@ group :test do
   gem 'rspec-instafail', require: false
   gem 'rspec_junit_formatter'
   gem 'rails-controller-testing'
-
-  # Lock i18n version during tests to workaround issue with use of refinements within i18n under JRuby.
-  # Should be fixed in JRuby 9.2.15.0+ - try removing then.
-  # See https://github.com/jruby/jruby/issues/6547 and https://github.com/ruby-i18n/i18n/issues/555
-  gem 'i18n', '1.8.7', platform: :jruby
 end
 
 group :development do

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -89,19 +89,19 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
-    method_source (0.9.2)
+    method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.14.4)
     nio4r (2.5.8-java)
     nokogiri (1.12.5-java)
       racc (~> 1.4)
     phantomjs (2.1.1.0)
-    pry (0.12.2-java)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
+    pry (0.14.1-java)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
       spoon (~> 0.0)
-    pry-debugger-jruby (1.2.2-java)
-      pry (>= 0.10, < 0.13)
+    pry-debugger-jruby (2.1.0-java)
+      pry (>= 0.13, < 0.15)
       ruby-debug-base (>= 0.10.4, < 0.12)
     public_suffix (4.0.6)
     racc (1.6.0-java)
@@ -242,4 +242,4 @@ RUBY VERSION
    ruby 2.5.8p0 (jruby 9.2.20.1)
 
 BUNDLED WITH
-   2.2.32
+   2.2.33

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     dynamic_form (1.1.4)
     erubi (1.10.0)
     ffi (1.15.4-java)

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -220,8 +220,7 @@ DEPENDENCIES
   bundler-audit
   capybara
   dynamic_form
-  i18n (= 1.8.7)
-  jasmine (= 3.7.0)
+  jasmine
   jasmine-jquery-rails
   jasmine_selenium_runner
   js-routes

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
-    brakeman (5.1.2)
+    brakeman (5.2.0)
     builder (3.2.4)
     bundler-audit (0.8.0)
       bundler (>= 1.2.0, < 3)

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -68,14 +68,15 @@ GEM
     ffi (1.15.4-java)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    i18n (1.8.7)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    jasmine (3.7.0)
-      jasmine-core (~> 3.7.0)
+    jasmine (3.10.0)
+      jasmine-core (~> 3.10.0)
       phantomjs
-      rack (>= 1.2.1)
+      rack (>= 2.1.4)
       rake
-    jasmine-core (3.7.1)
+      webrick
+    jasmine-core (3.10.1)
     jasmine-jquery-rails (2.0.3)
     jasmine_selenium_runner (3.0.0)
       jasmine (~> 3.0)
@@ -203,6 +204,7 @@ GEM
       thread_safe (~> 0.1)
     tzinfo-data (1.2021.5)
       tzinfo (>= 1.0.0)
+    webrick (1.7.0)
     websocket-driver (0.7.3-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
- Corrects Gemfile so dependabot should be able to parse it
- Removes some locked dependencies that are no longer necessary to lock after #9855 
- Minor bumps to dev/test dependendencies