### PR TITLE
Build server image on Alpine 3.15 by default

### DIFF
--- a/settings-docker.gradle
+++ b/settings-docker.gradle
@@ -32,4 +32,4 @@ Distro.values().each { distro ->
 }
 
 include ":docker:gocd-server:${Distro.centos.projectName(Distro.centos.getVersion('8'))}"
-include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.14'))}"
+include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.15'))}"


### PR DESCRIPTION
This has been out for over a month now, and seems stable, so let's plan for this for the default version for next release.