### PR TITLE
Exclude generated JS routes from linting

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/config/plugins.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/config/plugins.ts
@@ -36,6 +36,7 @@ export function plugins(configOptions: ConfigOptions): webpack.Plugin[] {
   const plugins = [
     new ESLintPlugin({
       extensions: ["js", "msx"],
+      exclude: ["node_modules", "webpack/gen"],
       failOnWarning: true,
       threads: true
     }),


### PR DESCRIPTION
On Windows these get generated by Ruby with CRLF endings which webpack doesn't like. This excludes them like the old eslint-loader code did, and like the `yarn` tasks do.