### PR TITLE
Bump ChromeDriver to 97 to match latest Chrome

### DIFF
--- a/server/jasmine.gradle
+++ b/server/jasmine.gradle
@@ -26,7 +26,7 @@ OperatingSystem currentOS = OperatingSystem.current()
 // Firefox/gecko: See https://github.com/mozilla/geckodriver/releases and review compatibility at
 //                https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html
 final Map<String, String> seleniumDrivers = [
-  chromedriver: '95.0.4638.54',
+  chromedriver: '97.0.4692.71',
   geckodriver: '0.30.0',
 ]
 


### PR DESCRIPTION
Sadly Chrome is auto-updating on our Windows build containers, causing us to have to chase versions when tasks are longish-lived. Need to find a way to disable auto-update possibly.

Works against https://github.com/gocd-contrib/gocd-oss-cookbooks/releases/tag/v3.3.1