### PR TITLE
Disable GPG signing on the config repository

### DIFF
--- a/config/config-server/src/main/java/com/thoughtworks/go/service/ConfigRepository.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/service/ConfigRepository.java
@@ -78,10 +78,14 @@ public class ConfigRepository {
         workingDir = this.systemEnvironment.getConfigRepoDir();
         File configRepoDir = new File(workingDir, ".git");
         gitRepo = new FileRepositoryBuilder().setGitDir(configRepoDir).build();
-        gitRepo.getConfig().setInt("gc", null, "auto", 0);
+        updateWithDefaults(gitRepo.getConfig());
         git = new Git(gitRepo);
     }
 
+    private void updateWithDefaults(StoredConfig config) {
+        config.setInt(ConfigConstants.CONFIG_GC_SECTION, null, ConfigConstants.CONFIG_KEY_AUTO, 0);
+        config.setBoolean(ConfigConstants.CONFIG_COMMIT_SECTION, null, ConfigConstants.CONFIG_KEY_GPGSIGN, false);
+    }
 
     public Repository getGitRepo() {
         return gitRepo;


### PR DESCRIPTION
There is no way GPG signing on the server config repo currently, as we do not configure JGit for GPG. If a user/host has GPG signing enabled at a global/user git level, even with GPG configured, this is insufficient to allow JGit to be able to sign commits. Currently I think we are better to force disable this on the config repository, overriding any global user config that might be inherited.

The alternative would be to disable reading the system/user git config but I'm not sure of the consequences of that so this seems lower surface area.

Fixes #10086
