### PR TITLE
Support push webhooks with multiple changes

### DIFF
--- a/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/controller/BaseWebhookController.java
+++ b/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/controller/BaseWebhookController.java
@@ -27,6 +27,10 @@ import spark.Response;
 public abstract class BaseWebhookController extends ApiController implements SparkSpringController, WebhookValidation {
     public static final String PING_RESPONSE = "pong";
 
+    public static final String SUCCESS_RESPONSE = "OK!";
+
+    public static final String NO_MATCHING_MATERIALS_RESPONSE = "No matching materials!";
+
     protected BaseWebhookController(ApiVersion apiVersion) {
         super(apiVersion);
     }
@@ -37,7 +41,7 @@ public abstract class BaseWebhookController extends ApiController implements Spa
     }
 
     protected String success(final Response response) {
-        return accepted(response, "OK!");
+        return accepted(response, SUCCESS_RESPONSE);
     }
 
     protected String acknowledge(final Response response) {

--- a/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/request/payload/push/BitbucketPush.java
+++ b/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/request/payload/push/BitbucketPush.java
@@ -21,6 +21,10 @@ import com.thoughtworks.go.apiv1.webhook.request.json.BitbucketRepository;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static java.util.stream.Collectors.toCollection;
 
 @SuppressWarnings({"MismatchedQueryAndUpdateOfCollection", "unused", "RedundantSuppression"})
 public class BitbucketPush implements PushPayload {
@@ -29,13 +33,12 @@ public class BitbucketPush implements PushPayload {
     private BitbucketRepository repository;
 
     @Override
-    public String branch() {
+    public Set<String> branches() {
         return this.push.changes.stream()
                 .filter(change -> change.newCommit != null)
                 .filter(change -> StringUtils.equalsIgnoreCase(change.newCommit.type, "branch"))
                 .map(change -> change.newCommit.name)
-                .findFirst()
-                .orElse(""); // if pushing a tag, this might be blank
+                .collect(toCollection(TreeSet::new)); // if pushing a tag, this might be empty
     }
 
     @Override

--- a/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/request/payload/push/GitHubPush.java
+++ b/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/request/payload/push/GitHubPush.java
@@ -18,6 +18,9 @@ package com.thoughtworks.go.apiv1.webhook.request.payload.push;
 
 import com.thoughtworks.go.apiv1.webhook.request.json.GitHubRepository;
 
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
 import static org.apache.commons.lang3.StringUtils.removeStart;
 
 @SuppressWarnings({"unused", "RedundantSuppression"})
@@ -27,8 +30,8 @@ public class GitHubPush implements PushPayload {
     private GitHubRepository repository;
 
     @Override
-    public String branch() {
-        return ref.startsWith("refs/heads/") ? removeStart(ref, "refs/heads/") : "";
+    public Set<String> branches() {
+        return ref.startsWith("refs/heads/") ? Set.of(removeStart(ref, "refs/heads/")) : emptySet();
     }
 
     @Override

--- a/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/request/payload/push/GitLabPush.java
+++ b/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/request/payload/push/GitLabPush.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableSet;
+import static org.apache.commons.collections4.SetUtils.emptySet;
 import static org.apache.commons.collections4.SetUtils.union;
 import static org.apache.commons.lang3.StringUtils.removeStart;
 
@@ -32,8 +33,8 @@ public class GitLabPush implements PushPayload {
     private GitLabProject project;
 
     @Override
-    public String branch() {
-        return ref.startsWith("refs/heads/") ? removeStart(ref, "refs/heads/") : "";
+    public Set<String> branches() {
+        return ref.startsWith("refs/heads/") ? Set.of(removeStart(ref, "refs/heads/")) : emptySet();
     }
 
     @Override

--- a/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/request/payload/push/HostedBitbucketPush.java
+++ b/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/request/payload/push/HostedBitbucketPush.java
@@ -22,9 +22,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toCollection;
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 
 @SuppressWarnings({"MismatchedQueryAndUpdateOfCollection", "unused", "RedundantSuppression"})
@@ -34,13 +36,12 @@ public class HostedBitbucketPush implements PushPayload {
     private HostedBitbucketRepository repository;
 
     @Override
-    public String branch() {
+    public Set<String> branches() {
         return this.changes.stream()
                 .filter(change -> change.ref != null)
                 .filter(change -> equalsIgnoreCase(change.ref.type, "branch"))
                 .map(change -> change.ref.displayId)
-                .findFirst()
-                .orElse(""); // if pushing a tag, this might be blank
+                .collect(toCollection(TreeSet::new)); // if pushing a tag, this might be empty
     }
 
     @Override

--- a/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/request/payload/push/PushPayload.java
+++ b/api/api-webhook-v1/src/main/java/com/thoughtworks/go/apiv1/webhook/request/payload/push/PushPayload.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import static java.lang.String.format;
 
 public interface PushPayload extends Payload {
-    String branch();
+    Set<String> branches();
 
     default Set<String> repoUrls() {
         return possibleUrls(hostname(), fullName());
@@ -62,7 +62,7 @@ public interface PushPayload extends Payload {
         return format("%s[%s][%s]",
                 getClass().getSimpleName(),
                 fullName(),
-                branch()
+                String.join(", ", branches())
         );
     }
 }

--- a/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/helpers/Fixtures.groovy
+++ b/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/helpers/Fixtures.groovy
@@ -112,6 +112,16 @@ class Fixtures {
             }
         }
 
+        static class PushMultipleChanges implements ArgumentsProvider, PostHelper.Mixin {
+            @Override
+            Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+                return Stream.of(
+                        Arguments.of(Notify.BITBUCKET, { String s -> withBitbucket(s) }, "/bitbucket-push-multiple-changes.json", first(Bitbucket.PUSH)),
+                        Arguments.of(Notify.HOSTED_BITBUCKET, { String s -> withHostedBitbucket(s) }, "/hosted-bitbucket-push-multiple-changes.json", first(HostedBitbucket.PUSH))
+                )
+            }
+        }
+
         static class Ping implements ArgumentsProvider, PostHelper.Mixin {
             @Override
             Stream<? extends Arguments> provideArguments(ExtensionContext context) {

--- a/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/GitHubRequestTest.java
+++ b/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/GitHubRequestTest.java
@@ -47,7 +47,7 @@ class GitHubRequestTest implements WithMockRequests {
     }
 
     private void assertPayload(GitHubPush payload) {
-        assertEquals("release", payload.branch());
+        assertEquals(Set.of("release"), payload.branches());
         assertEquals("gocd/spaceship", payload.fullName());
         assertEquals("github.com", payload.hostname());
     }

--- a/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/GitLabRequestTest.java
+++ b/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/GitLabRequestTest.java
@@ -21,6 +21,8 @@ import com.thoughtworks.go.apiv1.webhook.request.payload.push.GitLabPush;
 import com.thoughtworks.go.junit5.FileSource;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class GitLabRequestTest implements WithMockRequests {
@@ -32,7 +34,7 @@ class GitLabRequestTest implements WithMockRequests {
     }
 
     private void assertPayload(GitLabPush payload) {
-        assertEquals("release", payload.branch());
+        assertEquals(Set.of("release"), payload.branches());
         assertEquals("gocd/spaceship", payload.fullName());
         assertEquals("gitlab.example.com", payload.hostname());
     }

--- a/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/HostedBitbucketRequestTest.java
+++ b/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/HostedBitbucketRequestTest.java
@@ -21,17 +21,26 @@ import com.thoughtworks.go.apiv1.webhook.request.payload.push.HostedBitbucketPus
 import com.thoughtworks.go.junit5.FileSource;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class HostedBitbucketRequestTest implements WithMockRequests {
     @ParameterizedTest
     @FileSource(files = "/hosted-bitbucket-push.json")
     void parsePayload(String body) {
-        assertPayload(hostedBitbucket().body(body).build().parsePayload(HostedBitbucketPush.class));
+        assertPayload(Set.of("release"), hostedBitbucket().body(body).build().parsePayload(HostedBitbucketPush.class));
     }
 
-    private void assertPayload(HostedBitbucketPush payload) {
-        assertEquals("release", payload.branch());
+    @ParameterizedTest
+    @FileSource(files = "/hosted-bitbucket-push-multiple-changes.json")
+    void parsePayloadWithMultipleChanges(String body) {
+        assertPayload(Set.of("release/1.0", "release/2.0", "release/3.0"),
+                hostedBitbucket().body(body).build().parsePayload(HostedBitbucketPush.class));
+    }
+
+    private void assertPayload(Set<String> expectedBranches, HostedBitbucketPush payload) {
+        assertEquals(expectedBranches, payload.branches());
         assertEquals("gocd/spaceship", payload.fullName());
         assertEquals("bitbucket-server", payload.hostname());
         assertEquals("git", payload.scmType());

--- a/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/payload/push/BitbucketPushTest.java
+++ b/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/payload/push/BitbucketPushTest.java
@@ -30,7 +30,7 @@ class BitbucketPushTest {
     void deserializes(String json) {
         final BitbucketPush payload = GsonTransformer.getInstance().fromJson(json, BitbucketPush.class);
 
-        assertEquals("release", payload.branch());
+        assertEquals(Set.of("release"), payload.branches());
         assertEquals("gocd/spaceship", payload.fullName());
         assertEquals("bitbucket.org", payload.hostname());
         assertEquals("git", payload.scmType());

--- a/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/payload/push/GitHubPushTest.java
+++ b/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/payload/push/GitHubPushTest.java
@@ -30,7 +30,7 @@ class GitHubPushTest {
     void deserializes(String json) {
         final GitHubPush payload = GsonTransformer.getInstance().fromJson(json, GitHubPush.class);
 
-        assertEquals("release", payload.branch());
+        assertEquals(Set.of("release"), payload.branches());
         assertEquals("gocd/spaceship", payload.fullName());
         assertEquals("github.com", payload.hostname());
     }

--- a/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/payload/push/GitLabPushTest.java
+++ b/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/payload/push/GitLabPushTest.java
@@ -30,7 +30,7 @@ class GitLabPushTest {
     void deserializes(String json) {
         final GitLabPush payload = GsonTransformer.getInstance().fromJson(json, GitLabPush.class);
 
-        assertEquals("release", payload.branch());
+        assertEquals(Set.of("release"), payload.branches());
         assertEquals("gocd/spaceship", payload.fullName());
         assertEquals("gitlab.example.com", payload.hostname());
     }

--- a/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/payload/push/HostedBitbucketPushTest.java
+++ b/api/api-webhook-v1/src/test/groovy/com/thoughtworks/go/apiv1/webhook/request/payload/push/HostedBitbucketPushTest.java
@@ -30,7 +30,7 @@ class HostedBitbucketPushTest {
     void deserializes(String json) {
         final HostedBitbucketPush payload = GsonTransformer.getInstance().fromJson(json, HostedBitbucketPush.class);
 
-        assertEquals("release", payload.branch());
+        assertEquals(Set.of("release"), payload.branches());
         assertEquals("gocd/spaceship", payload.fullName());
         assertEquals("bitbucket-server", payload.hostname());
         assertEquals("git", payload.scmType());

--- a/api/api-webhook-v1/src/test/resources/bitbucket-push-multiple-changes.json
+++ b/api/api-webhook-v1/src/test/resources/bitbucket-push-multiple-changes.json
@@ -1,0 +1,33 @@
+{
+  "push": {
+    "changes": [
+      {
+        "new": {
+          "name": "release/1.0",
+          "type": "branch"
+        }
+      },
+      {
+        "new": {
+          "name": "release/2.0",
+          "type": "branch"
+        }
+      },
+      {
+        "new": {
+          "name": "release/3.0",
+          "type": "branch"
+        }
+      }
+    ]
+  },
+  "repository": {
+    "scm": "git",
+    "full_name": "gocd/spaceship",
+    "links": {
+      "html": {
+        "href": "https://bitbucket.org/gocd/spaceship"
+      }
+    }
+  }
+}

--- a/api/api-webhook-v1/src/test/resources/hosted-bitbucket-push-multiple-changes.json
+++ b/api/api-webhook-v1/src/test/resources/hosted-bitbucket-push-multiple-changes.json
@@ -1,0 +1,51 @@
+{
+  "changes": [
+    {
+      "ref": {
+        "displayId": "release/1.0",
+        "id": "refs/heads/release/1.0",
+        "type": "BRANCH"
+      }
+    },
+    {
+      "ref": {
+        "displayId": "release/2.0",
+        "id": "refs/heads/release/2.0",
+        "type": "BRANCH"
+      }
+    },
+    {
+      "ref": {
+        "displayId": "release/3.0",
+        "id": "refs/heads/release/3.0",
+        "type": "BRANCH"
+      }
+    }
+  ],
+  "eventKey": "repo:refs_changed",
+  "repository": {
+    "slug": "spaceship",
+    "project": {
+      "key": "GOCD"
+    },
+    "links": {
+      "clone": [
+        {
+          "href": "ssh://git@bitbucket-server/gocd/spaceship.git",
+          "name": "ssh"
+        },
+        {
+          "href": "http://user:pass@bitbucket-server/scm/gocd/spaceship.git",
+          "name": "http"
+        }
+      ],
+      "self": [
+        {
+          "href": "http://bitbucket-server/projects/GOCD/repos/spaceship/browse"
+        }
+      ]
+    },
+    "scmId": "git",
+    "name": "Foo"
+  }
+}


### PR DESCRIPTION
The push webhook controller can now handle payloads with multiple
changes to different branches. The controller triggers a material update
for each branch.

Currently, only hosted Bitbucket has webhooks with multiple changes.
Cloud Bitbucket has a pending feature request for the same.
This commit already handles cloud bitbucket as well.
Github and Gitlab do not support multiple changes.

For observability purposes, the controller returns a combined response message
with the material update result for each branch.

For backwards compatibility, it still returns the old response
message without branch when the webhook only contains a single branch.

Example response messages:

Single branch (as before):
* "OK!"
* "No matching materials!"

Multiple branches (new):
* "release/1.0: OK!, release/2.0: OK!"
* "release/1.0: No matching materials!, release/2.0: OK!"

Implements #10071
