### PR TITLE
Avoid future mini-css-extract-plugin problems by going back to v1

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -59,7 +59,7 @@
     "@types/license-checker": "^25.0.1",
     "@types/lodash": "^4.14.178",
     "@types/lru-cache": "^5.1.0",
-    "@types/mini-css-extract-plugin": "^2.4.0",
+    "@types/mini-css-extract-plugin": "^1",
     "@types/mithril": "2.0.8",
     "@types/node": "^16.11.21",
     "@types/optimize-css-assets-webpack-plugin": "^5.0.5",

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -1157,10 +1157,10 @@
   resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
   integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
 
-"@types/mini-css-extract-plugin@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@types/mini-css-extract-plugin/-/mini-css-extract-plugin-2.4.0.tgz#b2b1b7afc41fee384e164da8e732301bcbdf4579"
-  integrity sha512-1Pq4i+2+c8jncxfX5k7BzPIEoyrq+n7L319zMxiLUH4RlWTGcQJjemtMftLQnoTt21oHhZE0PjXd2W1xM1m4Hg==
+"@types/mini-css-extract-plugin@^1":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@types/mini-css-extract-plugin/-/mini-css-extract-plugin-1.4.3.tgz#4907ee3953fecd199fab24ef056dabef51ff19a2"
+  integrity sha512-jyOSVaF4ie2jUGr1uohqeyDrp7ktRthdFxDKzTgbPZtl0QI5geEopW7UKD/DEfn0XgV1KEq/RnZlUmnrEAWbmg==
   dependencies:
     "@types/node" "*"
     tapable "^2.2.0"


### PR DESCRIPTION
v2 now includes its own types so it's not relevant to use the @types v2 definitions. When we upgrade to v2, we will just remove the types dependencies entirely.

Effectively reverts #9795 to ensure the types don't go out of sync with the dependency. We are still using v1 of the plugin, so it reduces issues like these to use the correct types version.