### PR TITLE
Suppress H2 DB CVE-2021-42392 which is not exploitable

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -144,4 +144,15 @@
         <cve>CVE-2021-23463</cve>
     </suppress>
 
+    <suppress>
+        <notes><![CDATA[
+   The CVE as documented at https://github.com/h2database/h2database/security/advisories/GHSA-h376-j262-vhq6 and
+   https://jfrog.com/blog/the-jndi-strikes-back-unauthenticated-rce-in-h2-database-console/ only affects the H2 console
+   (not enabled on GoCD) and context-dependent use of JdbcUtils.getConnection (not possible from remote properties in GoCD)
+   so GoCD does not appear to be vulnerable to this problem.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.h2database/h2@.*$</packageUrl>
+        <cve>CVE-2021-42392</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
See the suppression comment - this defect does not appear to affect GoCD