### PR TITLE
Downgrade Commons IO to fix issues cleaning working dirs

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -156,4 +156,21 @@
         <cve>CVE-2022-23221</cve>
     </suppress>
 
+    <suppress until="2022-05-01Z">
+        <notes><![CDATA[
+   Time-limited suppression for https://nvd.nist.gov/vuln/detail/CVE-2021-29425. GoCD is not vulnerable as the use of
+   FilenameUtils.normalize does not "use the result to construct a path value" as required by the defect. Neither does
+   any of GoCD's libraries use this functionality.
+
+   This was fixed in Commons IO 2.7 and GoCD originally upgraded to 2.11.0, however unfortunately all later versions
+   have some regressions as noted in https://github.com/gocd/gocd/issues/9397 https://github.com/gocd/gocd/pull/9517
+   and https://github.com/gocd/gocd/issues/9927
+
+   While the last issue appears to be fixed by Commons IO 2.12 (not yet released) there are other regressions in 2.12
+   master due to ongoing work and it feels the path to stability might take some time.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/commons\-io/commons\-io@.*$</packageUrl>
+        <cve>CVE-2021-29425</cve>
+    </suppress>
+
 </suppressions>

--- a/common/src/main/java/com/thoughtworks/go/remote/work/BuildWork.java
+++ b/common/src/main/java/com/thoughtworks/go/remote/work/BuildWork.java
@@ -91,7 +91,7 @@ public class BuildWork implements Work {
         try {
             goPublisher.reportErrorMessage(messageOf(e), e);
         } catch (Exception reportException) {
-            LOGGER.error("Unable to report error message - %s.", messageOf(e), reportException);
+            LOGGER.error("Unable to report error message - {}.", messageOf(e), reportException);
         }
         reportCompletion(JobResult.Failed);
     }
@@ -270,10 +270,10 @@ public class BuildWork implements Work {
     private void createWorkingDirectoryIfNotExist(File buildWorkingDirectory) {
         if (assignment.shouldCleanWorkingDir() && buildWorkingDirectory.exists()) {
             try {
-                FileUtils.cleanDirectory(buildWorkingDirectory);
                 goPublisher.consumeLineWithPrefix("Cleaning working directory \"" + buildWorkingDirectory.getAbsolutePath() + "\" since stage is configured to clean working directory");
+                FileUtils.cleanDirectory(buildWorkingDirectory);
             } catch (IOException e) {
-                bomb("Clean working directory is set to true. Unable to clean working directory for agent: " + buildWorkingDirectory.getAbsolutePath() + ", with error: " + e.getMessage());
+                bomb("Clean working directory is set to true. Unable to clean working directory for agent: " + buildWorkingDirectory.getAbsolutePath() + ", with error: " + e.getMessage(), e);
             }
         }
         if (!buildWorkingDirectory.exists()) {

--- a/common/src/test/java/com/thoughtworks/go/config/GuidServiceTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/GuidServiceTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 public class GuidServiceTest extends IdFileServiceTestBase {
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         idFileService = new GuidService();
 
         idFileService.store(DATA);

--- a/common/src/test/java/com/thoughtworks/go/config/TokenServiceTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/TokenServiceTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 public class TokenServiceTest extends IdFileServiceTestBase {
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         idFileService = new TokenService();
 
         idFileService.store(DATA);

--- a/common/src/test/java/com/thoughtworks/go/util/SystemEnvironmentTest.java
+++ b/common/src/test/java/com/thoughtworks/go/util/SystemEnvironmentTest.java
@@ -16,30 +16,35 @@
 package com.thoughtworks.go.util;
 
 import ch.qos.logback.classic.Level;
-import com.rits.cloning.Cloner;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import java.io.File;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(SystemStubsExtension.class)
 class SystemEnvironmentTest {
-    private static final Cloner CLONER = ClonerFactory.instance();
-    private Properties original;
+
+    @SystemStub
+    SystemProperties systemProperties;
+
     private SystemEnvironment systemEnvironment;
 
     @BeforeEach
     void before() {
-        original = CLONER.deepClone(System.getProperties());
         systemEnvironment = new SystemEnvironment();
+        systemEnvironment.clearProperty("any");
     }
 
     @AfterEach
     void after() {
-        System.setProperties(original);
         new SystemEnvironment().reset(SystemEnvironment.ENABLE_CONFIG_MERGE_FEATURE);
     }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -44,7 +44,7 @@ final Map<String, String> libraries = [
   commonsDbcp         : 'org.apache.commons:commons-dbcp2:2.9.0',
   commonsDigester     : 'commons-digester:commons-digester:2.1',
   commonsFileUpload   : 'commons-fileupload:commons-fileupload:1.4',
-  commonsIO           : 'commons-io:commons-io:2.11.0',
+  commonsIO           : 'commons-io:commons-io:2.6',
   commonsLang         : 'commons-lang:commons-lang:2.6',
   commonsLang3        : 'org.apache.commons:commons-lang3:3.12.0',
   commonsPool         : 'org.apache.commons:commons-pool2:2.11.1',


### PR DESCRIPTION
Fixes #9927 (and undoes #9517 while adding tests for the issues it introduced)

- 2.7 -> 2.8.0 has bugs affecting deletion of read-only files as noted in https://github.com/gocd/gocd/issues/9397#issuecomment-880813088
- 2.9.0 -> 2.11.0 fixes the above, but introduces #9927 / https://issues.apache.org/jira/projects/IO/issues/IO-751
- 2.12.0 is not yet released, but is subject to apache/commons-io#324 at time of writing and seems like it will take time to stabilise (this was the fix in #10067)

The only known issue with `2.6` is CVE-2021-29425 as noted in #9397, however after further review it does not affect GoCD's usage of the library. Added a time-limited OWASP Suppression for now - hopefully Commons IO 2.12 is released and stable by then.

There doesn't seem to be anything obvious in the changelogs for 2.7 -> 2.11.0 that we might be relying on in terms of fixes for reported issues. Additionally the JVM 16/17 fix noted in the changelog isn't relevant to GoCD.