### PR TITLE
Downgrade Tanuki wrapper to 3.5.46 (as per last release)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -184,8 +184,8 @@ final Map<String, String> v = [
   ztExec              : versionOf(libraries.ztExec),
 
   // misc
-  tanuki              : '3.5.48-st',
-  tanukiSha256sum     : '7619e1d4320efcb7c2f5bafc36347993c3ff6417e2b8289e90c047033139c514',
+  tanuki              : '3.5.46-st',
+  tanukiSha256sum     : '27b1d3da6982bcdf1cc51f3bb99abb8763635ae4691e3fe36e310c818b3bbb42',
   tini                : '0.19.0',
 ]
 


### PR DESCRIPTION
Wrapper versions 3.5.47+ seem to have some funny behaviour in some cases where they spin in a tight CPU loop. Only observed this on build.gocd.org where there is a custom GoCD Server docker image, and supervisord is wrapping launch of the docker entrypoint and the tanuki wrapper, however it is replicable in that specific scenario on both 3.5.47 and 3.5.48. The problem goes away with a downgrade.

There may be a config oriented fix, but not sure right now. https://wrapper.tanukisoftware.com/doc/english/release-notes.html#3.5.47

This undoes #10033 for now.