### PR TITLE
Drop source/target compatibility back to Java 11 LTS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,7 @@ rootProject.ext.copyrightYear = Calendar.getInstance().get(Calendar.YEAR)
 
 project.ext.compilerOptions = [
   // source and target compatibility
-  release: 13,
+  release: 11,
 ]
 
 project.ext.toolchains = [


### PR DESCRIPTION
This was increased to Java 13 in GoCD 21.2.0 in commit d72a92d53b1406fce1a0c96558b904493bf657ab - this change decreases it back because requiring versions of the JDK that are not LTS, and are out of even active security patching is not so friendly given the current maintenance support for GoCD. Furthermore, some JVM versions such as Java 16 and 17 made changes that were somewhat time consuming to ensure compatibility with, especially due to some of the older libraries/frameworks GoCD is still packaged with. We were left in the state for the last 10 months where there was no supported and fully patched Java version that GoCD would run with (Java 13/14/15 were all EOL, 16/17 weren't compatible)

Furthermore this can cause some challenges for plugins because the go-plugin-api jar also this version (maybe we should version it separately?) and that makes it messy for folks to build a GoCD plugin against the latest API jar, but running against an LTS Java version without knowing all the details about which server version used which target Java version, and whether changing the plugin API version matters.

We can announce a new policy later if necessary, and look at whether we should run certain tests against 2 LTS versions (we don't seem to actually run tests except with the target packaged Java version currently)

Tasks
 - [ ] Post-release: Update commentary on [www.gocd.org](https://www.gocd.org/download)
 - [ ] Check for other places the minimum Java version is documented. docs.gocd.org?