### PR TITLE
Fixes a memory leak in JMSMessageListenerAdapterTest

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -419,7 +419,7 @@ task fastUnitTest(type: Test) { thisTask ->
 
   mustRunAfter test
 
-  forkEvery 200
+  forkEvery 256
   maxHeapSize '2g'
 
   reports {


### PR DESCRIPTION
This class starts a thread in the background and doesn't provide a way to interrupt it, except in the real world when the consumer is closed and returns null messages. That doesn't happen with the mocks here unless we tell it to, by resetting them.

Without this happening, the invocation counts on the mocks just keep going on forever in the loop, after a couple of minutes there are 500,000 entries recorded by the mocks somehow :-)

![image](https://user-images.githubusercontent.com/29788154/152652367-4452bc9c-1a79-46f0-9320-8aca5e321afb.png)

There might also be issues with the daemon thread here for other tests, probably mitigated in integration tests by running each test class in its own Gradle worker process so the daemon thread will go away.
