### PR TITLE
Bump file-based-secret-plugin version to 1.1.0-80

### DIFF
--- a/tw-go-plugins/build.gradle
+++ b/tw-go-plugins/build.gradle
@@ -62,9 +62,9 @@ def dependencies = [
   new GithubArtifact(
     user: 'gocd',
     repo: 'gocd-file-based-secrets-plugin',
-    tagName: 'v1.0.0-33',
-    asset: 'gocd-file-based-secrets-plugin-1.0.0-33.jar',
-    checksum: '66207eb56aa9e3df6dbe587b1fd55f681cb3bce61865fae72b824e12a8bf08ff'
+    tagName: 'v1.1.0-80',
+    asset: 'gocd-file-based-secrets-plugin-1.1.0-80.jar',
+    checksum: '41611dcceff2cb3c1923baac051a7993f055b3876edb3b3956282e47e0c2e359'
   )
 ]
 


### PR DESCRIPTION
https://github.com/gocd/gocd-file-based-secrets-plugin/releases/tag/v1.1.0-80

Starting to bump bundled plugins gradually, as some of them have nested dependencies which have reported CVEs against them.

No functional change, but this is the first time I have done this, so let's see how we go with a simple-ish one.