### PR TITLE
Bump Tanuki Wrapper from 3.5.46 to 3.5.49

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -184,8 +184,8 @@ final Map<String, String> v = [
   ztExec              : versionOf(libraries.ztExec),
 
   // misc
-  tanuki              : '3.5.46-st',
-  tanukiSha256sum     : '27b1d3da6982bcdf1cc51f3bb99abb8763635ae4691e3fe36e310c818b3bbb42',
+  tanuki              : '3.5.49-st',
+  tanukiSha256sum     : '905fe5a9700559a93f5a49aa6acec95d896f4e9260c072e58ba55d24ab4db28b',
   tini                : '0.19.0',
 ]
 


### PR DESCRIPTION
Previous issue noted in #10152 has been addressed by Tanuki folks https://wrapper.tanukisoftware.com/doc/english/release-notes.html#3.5.49
