### PR TITLE
Correct message displayed when agents are stuck cancelling jobs

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/AgentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AgentService.java
@@ -64,9 +64,6 @@ import static com.thoughtworks.go.util.ExceptionUtils.bombIfNull;
 import static com.thoughtworks.go.util.TriState.TRUE;
 import static java.lang.String.format;
 import static java.time.Duration.between;
-import static java.time.LocalDateTime.now;
-import static java.time.LocalDateTime.ofInstant;
-import static java.time.ZoneId.systemDefault;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -307,9 +304,9 @@ public class AgentService implements DatabaseEntityChangeListener<Agent> {
     }
 
     private void addWarningForAgentsStuckInCancel() {
-        agentInstances.agentsStuckInCancel().stream().forEach(agentInstance -> {
+        agentInstances.agentsStuckInCancel().forEach(agentInstance -> {
             serverHealthService.update(warning(format("Agent `%s` is stuck in cancel.", agentInstance.getHostname()),
-                    format("Looks like agent is stuck in cancelling a job, the job was cancelled: %s (mins) back.", cancelledForMins(agentInstance.cancelledAt())),
+                    format("Looks like the agent is stuck cancelling a job, the job was cancelled %s minutes ago.", cancelledForMins(agentInstance.cancelledAt())),
                     HealthStateType.general(GLOBAL), Timeout.THIRTY_SECONDS));
         });
     }
@@ -324,7 +321,7 @@ public class AgentService implements DatabaseEntityChangeListener<Agent> {
     }
 
     private long cancelledForMins(Date cancelledAt) {
-        return between(now(), ofInstant(Instant.ofEpochMilli(cancelledAt.getTime()), systemDefault())).toMinutes();
+        return between(cancelledAt.toInstant(), Instant.now()).toMinutes();
     }
 
     public void building(String uuid, AgentBuildingInfo agentBuildingInfo) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/AgentServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/AgentServiceTest.java
@@ -51,6 +51,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 import static com.thoughtworks.go.CurrentGoCDVersion.docsUrl;
@@ -1506,7 +1508,7 @@ class AgentServiceTest {
             AgentInstance agentInstance = mock(AgentInstance.class);
 
             when(agentInstances.agentsStuckInCancel()).thenReturn(singletonList(agentInstance));
-            when(agentInstance.cancelledAt()).thenReturn(new Date());
+            when(agentInstance.cancelledAt()).thenReturn(new Date(Instant.now().minus(20, ChronoUnit.MINUTES).toEpochMilli()));
             when(agentInstance.getHostname()).thenReturn("test_agent");
 
             agentService.refresh();
@@ -1517,6 +1519,7 @@ class AgentServiceTest {
             ServerHealthState serverHealthState = argument.getValue();
             assertThat(serverHealthState.getMessage(), is("Agent `test_agent` is stuck in cancel."));
             assertThat(serverHealthState.getLogLevel(), is(HealthStateLevel.WARNING));
+            assertThat(serverHealthState.getDescription(), is("Looks like the agent is stuck cancelling a job, the job was cancelled 20 minutes ago."));
         }
     }
 


### PR DESCRIPTION
Fixes a minor bug in the message displayed when agents are stuck cancelling a job. Currently the message displays negative minutes which is confusing.
