### PR TITLE
Bump yum repo poller plugin to latest patched version

### DIFF
--- a/tw-go-plugins/build.gradle
+++ b/tw-go-plugins/build.gradle
@@ -41,9 +41,9 @@ def dependencies = [
   new GithubArtifact(
     user: 'gocd',
     repo: 'gocd-yum-repository-poller-plugin',
-    tagName: 'v2.0.5-37',
-    asset: 'gocd-yum-repo-plugin-2.0.5-37.jar',
-    checksum: '7518b4f2d63e69591bf83780f3eba96183a68d0e8fe1e8feb38797df0a4b448f'
+    tagName: 'v2.0.5-92',
+    asset: 'gocd-yum-repo-plugin-2.0.5-92.jar',
+    checksum: '1e8accc81660cb2e49c4c1c423a8a4471fbf6ec0f0d56f86ffecaa666ccf9bf3'
   ),
   new GithubArtifact(
     user: 'tomzo',


### PR DESCRIPTION
https://github.com/gocd/gocd-yum-repository-poller-plugin/releases/tag/v2.0.5-92

Hasn't been released for a while - no functional changes, but keeps the included dependencies patched.