### PR TITLE
Revert "Remove unused AdminService"

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/AdminService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AdminService.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.validation.GoConfigValidity;
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Service
+public class AdminService {
+    private final GoConfigService goConfigService;
+
+    @Autowired
+    public AdminService(GoConfigService goConfigService) {
+        this.goConfigService = goConfigService;
+    }
+
+
+    public Map<String, Object> configurationJsonForSourceXml() {
+        Map<String, Object> json = new LinkedHashMap<>();
+        Map<String, Object> configJson = new LinkedHashMap<>();
+        GoConfigService.XmlPartialSaver saver = goConfigService.fileSaver(false);
+        configJson.put("location", goConfigService.fileLocation());
+        configJson.put("content", saver.asXml());
+        configJson.put("md5", saver.getMd5());
+        json.put("config", configJson);
+        return json;
+    }
+
+    public GoConfigValidity updateConfig(Map attributes, HttpLocalizedOperationResult result) {
+        GoConfigValidity validity;
+        String configXml = (String) attributes.get("content");
+        String configMd5 = (String) attributes.get("md5");
+        GoConfigService.XmlPartialSaver fileSaver = goConfigService.fileSaver(false);
+        validity = fileSaver.saveXml(configXml, configMd5);
+        if (!validity.isValid()) {
+            result.badRequest("Save failed, see errors below");
+        }
+        return validity;
+    }
+}

--- a/server/src/main/webapp/WEB-INF/rails/spec/support/java_spec_imports.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/support/java_spec_imports.rb
@@ -46,6 +46,7 @@ module JavaSpecImports
   java_import com.thoughtworks.go.util.GoConfigFileHelper unless defined? GoConfigFileHelper
   java_import com.thoughtworks.go.util.ReflectionUtil unless defined? ReflectionUtil
   java_import com.thoughtworks.go.server.service.UserService unless defined? UserService
+  java_import com.thoughtworks.go.server.service.AdminService unless defined? AdminService
   java_import com.thoughtworks.go.presentation.TriStateSelection unless defined? TriStateSelection
   java_import com.thoughtworks.go.server.domain.Username unless defined? Username
   java_import com.thoughtworks.go.config.materials.AbstractMaterial unless defined? AbstractMaterial

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/AdminServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/AdminServiceTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.validation.GoConfigValidity;
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+public class AdminServiceTest {
+    private GoConfigService goConfigService;
+    private AdminService adminService;
+    private String fileLocation = "file location";
+
+    @BeforeEach
+    public void setup() throws Exception {
+        goConfigService = mock(GoConfigService.class);
+
+        adminService = new AdminService(goConfigService);
+    }
+
+    @Test
+    public void shouldGenerateConfigurationJson() throws Exception {
+        GoConfigService.XmlPartialSaver fileSaver = mock(GoConfigService.XmlPartialSaver.class);
+        when(fileSaver.asXml()).thenReturn("xml content");
+        when(fileSaver.getMd5()).thenReturn("md5 value");
+        when(goConfigService.fileSaver(false)).thenReturn(fileSaver);
+        when(goConfigService.fileLocation()).thenReturn(fileLocation);
+
+        final Map<String, Object> json = adminService.configurationJsonForSourceXml();
+
+        Map<String, String> config = (Map<String, String>) json.get("config");
+        assertThat(config, hasEntry("location", fileLocation));
+        assertThat(config, hasEntry("content", "xml content"));
+        assertThat(config, hasEntry("md5", "md5 value"));
+    }
+
+    @Test
+    public void shouldUpdateConfig() throws Exception {
+        HashMap attributes = new HashMap();
+        String content = "config_xml";
+        attributes.put("content", content);
+        String md5 = "config_md5";
+        attributes.put("md5", md5);
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        GoConfigService.XmlPartialSaver fileSaver = mock(GoConfigService.XmlPartialSaver.class);
+        when(fileSaver.saveXml(content, md5)).thenReturn(GoConfigValidity.valid());
+        when(goConfigService.fileSaver(false)).thenReturn(fileSaver);
+
+        adminService.updateConfig(attributes, result);
+
+        assertThat(result.isSuccessful(), is(true));
+        verify(fileSaver).saveXml(content, md5);
+        verify(goConfigService).fileSaver(false);
+    }
+
+
+    @Test
+    public void shouldReturnInvalidIfConfigIsNotSaved() throws Exception {
+        HashMap attributes = new HashMap();
+        String content = "invalid_config_xml";
+        attributes.put("content", content);
+        String md5 = "config_md5";
+        attributes.put("md5", md5);
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        GoConfigService.XmlPartialSaver fileSaver = mock(GoConfigService.XmlPartialSaver.class);
+        GoConfigValidity validity = GoConfigValidity.invalid("Wrong config xml");
+        when(fileSaver.saveXml(content, md5)).thenReturn(validity);
+        when(goConfigService.fileSaver(false)).thenReturn(fileSaver);
+
+        GoConfigValidity actual = adminService.updateConfig(attributes, result);
+
+        assertThat(result.isSuccessful(), is(false));
+        GoConfigValidity.InvalidGoConfig invalidGoConfig = (GoConfigValidity.InvalidGoConfig) actual;
+        assertThat(invalidGoConfig.isValid(), is(false));
+        assertThat(invalidGoConfig.errorMessage(), is("Wrong config xml"));
+
+        verify(fileSaver).saveXml(content, md5);
+        verify(goConfigService).fileSaver(false);
+    }
+}


### PR DESCRIPTION
Reverts gocd/gocd#10191

Seems this is used somewhere in ruby-lang, and for some reason my global search failed to find it. Restoring.