### PR TITLE
Bump Chrome driver to 98

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/ExecuteUnderRailsTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/ExecuteUnderRailsTask.groovy
@@ -99,7 +99,7 @@ class ExecuteUnderRailsTask extends JavaExec {
   }
 
   static dumpTaskCommand(JavaExecSpec execSpec) {
-    println "[${execSpec.workingDir}]\$ ${execSpec.executable} ${execSpec.allJvmArgs.join(' ')} ${execSpec.mainClass.get()} ${execSpec.args.join(' ')}"
+    println "[${execSpec.workingDir}]\$ java ${execSpec.allJvmArgs.join(' ')} ${execSpec.mainClass.get()} ${execSpec.args.join(' ')}"
   }
 
   static void debugEnvironment(JavaExecSpec javaExecSpec, Map<String, Object> originalEnv) {

--- a/server/jasmine.gradle
+++ b/server/jasmine.gradle
@@ -26,7 +26,7 @@ OperatingSystem currentOS = OperatingSystem.current()
 // Firefox/gecko: See https://github.com/mozilla/geckodriver/releases and review compatibility at
 //                https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html
 final Map<String, String> seleniumDrivers = [
-  chromedriver: '97.0.4692.71',
+  chromedriver: '98.0.4758.80',
   geckodriver: '0.30.0',
 ]
 


### PR DESCRIPTION
Upgrade to version that matches the packaged browser on our machines.

Also fixes a logging nitpick on JavaExec rails tasks