### PR TITLE
Reinstate Gradle Daemon JVM arg defaults that were being accidentally overridden

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,11 @@ org.gradle.workers.max=4
 org.gradle.caching=true
 org.gradle.java.installations.auto-download=false
 
-# Workaround for issues with Java 17 and Groovy-generated dynamic proxies used by Grolifant on Groovy 3.0.9
+# add-opens is a workaround for issues with Java 17 and Groovy-generated dynamic proxies used by Grolifant on Groovy 3.0.9
 # https://issues.apache.org/jira/browse/GROOVY-10145 has the fix, but currently seems not backported to 3.x
 # This is seemingly only required by our use of Grolifant in DownloaderTask.groovy
-org.gradle.jvmargs=--add-opens=java.base/jdk.internal.module=ALL-UNNAMED
+#
+# The latter args other than the add open are Gradle defaults which are not applied if we add custom args
+# as noted in https://github.com/gradle/gradle/issues/19750. The defaults were taken from
+# https://github.com/gradle/gradle/blob/6ccf8a2cc74c8060992bd36189dec929143caed7/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java#L39
+org.gradle.jvmargs=--add-opens=java.base/jdk.internal.module=ALL-UNNAMED -Xmx512m -Xms256m -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError


### PR DESCRIPTION
According to https://github.com/gradle/gradle/issues/19750 as soon as we set the `--add-opens` here, we lost the constraints on JVM size and metaspace that Gradle normally sets. Oops. This possibly explains build instability (especially on Windows) and having to constrain our number of parallel workers in order to avoid our build containers exhausting memory and dying or getting killed by the container runtime.