### PR TITLE
Avoid logging massive stack traces when cookie is not set for agent

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/remote/BuildRepositoryRemoteImpl.java
+++ b/server/src/main/java/com/thoughtworks/go/remote/BuildRepositoryRemoteImpl.java
@@ -21,10 +21,7 @@ import com.thoughtworks.go.domain.JobResult;
 import com.thoughtworks.go.domain.JobState;
 import com.thoughtworks.go.server.messaging.JobStatusMessage;
 import com.thoughtworks.go.server.messaging.JobStatusTopic;
-import com.thoughtworks.go.server.service.AgentRuntimeInfo;
-import com.thoughtworks.go.server.service.AgentService;
-import com.thoughtworks.go.server.service.AgentWithDuplicateUUIDException;
-import com.thoughtworks.go.server.service.BuildRepositoryService;
+import com.thoughtworks.go.server.service.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,7 +50,7 @@ public class BuildRepositoryRemoteImpl {
             AgentInstance agentInstance = agentService.findAgentAndRefreshStatus(info.getUUId());
 
             return agentInstance.agentInstruction();
-        } catch (AgentWithDuplicateUUIDException agentException) {
+        } catch (AgentWithDuplicateUUIDException | AgentNoCookieSetException agentException) {
             throw wrappedException(agentException);
         } catch (Exception e) {
             LOGGER.error("Error occurred in {} ping.", info, e);


### PR DESCRIPTION
This is a common occurrence, especially with elastic agents. Better to treat it like AgentWithDuplicateUUIDException to avoid noise in the logs.

There doesn't seem any extra info in the stack trace and `ERROR` message not already contained in the `WARN` log or rest of the thread earlier.