### PR TITLE
Bump dependency-check-gradle from 6.5.3 to 7.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,13 +28,12 @@ import java.util.stream.Collectors
 
 buildscript {
   repositories {
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
+    gradlePluginPortal()
+    mavenCentral()
   }
 
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:6.5.3'
+    classpath 'org.owasp:dependency-check-gradle:7.0.0'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.42.0'
     classpath 'gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1'
     classpath 'com.github.jk1:gradle-license-report:2.1'


### PR DESCRIPTION
Bumps dependency-check-gradle from 6.5.3 to 7.0.0.