### PR TITLE
Fix expectations for Guava transitive dependency versions

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -147,7 +147,7 @@ task verifyJar(type: VerifyJarTask) {
       "db-${project.version}.jar",
       "dom4j-${project.versions.dom4j}.jar",
       "domain-${project.version}.jar",
-      "error_prone_annotations-2.7.1.jar",
+      "error_prone_annotations-2.11.0.jar",
       "failureaccess-1.0.1.jar",
       "go-plugin-access-${project.version}.jar",
       "go-plugin-activator.jar",

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -838,7 +838,7 @@ task verifyWar(type: VerifyJarTask) {
         "dom4j-${project.versions.dom4j}.jar",
         "domain-${project.version}.jar",
         "ehcache-${project.versions.ehcache}.jar",
-        "error_prone_annotations-2.7.1.jar",
+        "error_prone_annotations-2.11.0.jar",
         "failureaccess-1.0.1.jar",
         "freemarker-${project.versions.freemarker}.jar",
         "geronimo-j2ee-management_1.1_spec-1.0.1.jar",


### PR DESCRIPTION
Guava 31.1 increased this transitive dependency version - corrects an issue from #10231 
