### PR TITLE
Remove stray ;

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/general_options_tab.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/general_options_tab.tsx
@@ -29,7 +29,7 @@ export class GeneralOptionsTabContent extends TabContent<PipelineConfig> {
   }
 
   getPipelineSchedulingCheckBox(entity: PipelineConfig, templateConfig: TemplateConfig) {
-    let additionalHelpText: string = ";";
+    let additionalHelpText: string = "";
     if (entity.isUsingTemplate()) {
       additionalHelpText = ` Since this pipeline is based on '${entity.template()}' template, automatic/manual behaviour of the pipeline is determined by the template's first stage.`;
     }


### PR DESCRIPTION
Previously, the help text on the General tab of a Pipeline showed:
`If unchecked, this pipeline will only schedule in response to a Manual/API/Timer trigger. Unchecking this box is the same as making the first stage manual.;`

Now it will be:
`If unchecked, this pipeline will only schedule in response to a Manual/API/Timer trigger. Unchecking this box is the same as making the first stage manual.`