### PR TITLE
Bump ChromeDriver from v98 to v99

### DIFF
--- a/server/jasmine.gradle
+++ b/server/jasmine.gradle
@@ -26,7 +26,7 @@ OperatingSystem currentOS = OperatingSystem.current()
 // Firefox/gecko: See https://github.com/mozilla/geckodriver/releases and review compatibility at
 //                https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html
 final Map<String, String> seleniumDrivers = [
-  chromedriver: '98.0.4758.102',
+  chromedriver: '99.0.4844.51',
   geckodriver: '0.30.0',
 ]
 


### PR DESCRIPTION
Matches Chrome bundled with windows OSS cookbook image v3.4.6
