### PR TITLE
Bump jruby from 9.3.3.0 to 9.3.4.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 # Configuration for https://github.com/asdf-vm/asdf as an alternative to jabba, rvm, nvm etc
 java temurin-17.0.2+8
-ruby jruby-9.3.3.0
+ruby jruby-9.3.4.0
 nodejs 16.14.1

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -73,7 +73,7 @@ final Map<String, String> libraries = [
   jgit                : 'org.eclipse.jgit:org.eclipse.jgit:6.1.0.202203080745-r',
   jodaTime            : 'joda-time:joda-time:2.10.14', // joda-time version has to be compatible with the jruby version
   jolt                : 'com.bazaarvoice.jolt:jolt-core:0.1.5',
-  jruby               : 'org.jruby:jruby-complete:9.3.3.0',
+  jruby               : 'org.jruby:jruby-complete:9.3.4.0',
   jsonUnit            : 'net.javacrumbs.json-unit:json-unit-fluent:2.32.0',
   jsontools           : 'com.sdicons.jsontools:jsontools-core:1.7',
   jsoup               : 'org.jsoup:jsoup:1.14.3',

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -249,7 +249,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.6.8p0 (jruby 9.3.3.0)
+   ruby 2.6.8p0 (jruby 9.3.4.0)
 
 BUNDLED WITH
    2.2.29


### PR DESCRIPTION
See https://www.jruby.org/2022/03/23/jruby-9-3-4-0.html

Looks relatively straightforward/minor.