### PR TITLE
Revert "Bump testcontainers from 1.16.3 to 1.17.0"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -100,7 +100,7 @@ final Map<String, String> libraries = [
   springSecurity      : 'org.springframework.security:spring-security-config:4.2.20.RELEASE',
   springTestJunit5    : 'com.github.sbrannen:spring-test-junit5:1.5.0',
   systemStubs         : 'uk.org.webcompere:system-stubs-jupiter:1.2.0',
-  testcontainers      : 'org.testcontainers:testcontainers:1.17.0',
+  testcontainers      : 'org.testcontainers:testcontainers:1.16.3',
   tinybundles         : 'org.ops4j.pax.tinybundles:tinybundles:3.0.0',
   tokenBucket         : 'org.isomorphism:token-bucket:1.7',
   urlrewrite          : 'org.tuckey:urlrewritefilter:3.2.0',


### PR DESCRIPTION
Reverts gocd/gocd#10337

Seems to cause a weird `StackOverflowError` in some tests: https://build.gocd.org/go/tab/build/detail/build-linux/5980/build-non-server/2/FastTests-runInstance-1