### PR TITLE
Remove unnecessary/confusing migration of SSL port

### DIFF
--- a/installers/linux/shared/partials/_go-server-config-migration.sh.erb
+++ b/installers/linux/shared/partials/_go-server-config-migration.sh.erb
@@ -56,13 +56,6 @@
                 fi
             fi
 
-            if [ ! -z "${GO_SERVER_SSL_PORT}" ]; then
-                # non default port
-                if [ "${GO_SERVER_SSL_PORT}" != "8154" ]; then
-                  MIGRATED_SERVER_JVM_ARGS="${MIGRATED_SERVER_JVM_ARGS}${MIGRATED_SERVER_JVM_ARGS:+ }-Dcruise.server.ssl.port=${GO_SERVER_SSL_PORT}"
-                fi
-            fi
-
             if [ ! -z "${GO_SERVER_SYSTEM_PROPERTIES}" ]; then
                 MIGRATED_SERVER_JVM_ARGS="${MIGRATED_SERVER_JVM_ARGS}${MIGRATED_SERVER_JVM_ARGS:+ }${GO_SERVER_SYSTEM_PROPERTIES}"
             fi


### PR DESCRIPTION
SSL/TLS configuration was removed from GoCD two years ago, so this chunk is necessary.