### PR TITLE
Bump packaged JDK version from 17.0.2 to 17.0.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 # Configuration for https://github.com/asdf-vm/asdf as an alternative to jabba, rvm, nvm etc
-java temurin-17.0.2+8
+java temurin-17.0.3+7
 ruby jruby-9.3.4.0
 nodejs 16.14.2

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 import com.github.jk1.license.filter.LicenseBundleNormalizer
 import com.github.jk1.license.render.JsonReportRenderer
 import com.github.jk1.license.task.ReportTask
@@ -171,8 +172,8 @@ project.ext.packaging = [
   adoptOpenjdk: [
     featureVersion: 17,
     interimVersion: 0, // set to `null` for the first release
-    updateVersion : 2, // set to `null` for the first release
-    buildVersion  : 8
+    updateVersion : 3, // set to `null` for the first release
+    buildVersion  : 7
   ]
 ]
 


### PR DESCRIPTION
Roughly includes https://www.oracle.com/java/technologies/javase/17-0-3-bugfixes.html (Oracle list rather than OpenJDK list as seems easier to find)