### PR TITLE
Allow Mockito/ByteBuddy to self-attach to VM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -536,6 +536,7 @@ subprojects {
     // fixup a tempdir that is predictable and we can clean it up later
     def tmpDir = project.file("${System.getProperty('java.io.tmpdir')}/gocd-tests/${new BigInteger(32, new SecureRandom()).toString(32)}")
     systemProperty 'java.io.tmpdir', tmpDir
+    systemProperty 'jdk.attach.allowAttachSelf', 'true'
     jvmArgs += testTask.project.name.startsWith("agent") ? InstallerType.agent.jvmModuleOpensArgs : InstallerType.server.jvmModuleOpensArgs
 
     doFirst {


### PR DESCRIPTION
Currently ByteBuddy/Mockito-inline seems to fail on Windows within a docker container when trying to attach to the VM. Let's try the suggestion from https://github.com/raphw/byte-buddy/issues/612#issuecomment-463618016 and https://github.com/raphw/byte-buddy/blob/b69acb3212ab914ca2bb84d0c9f9951ee0678e26/byte-buddy-agent/src/main/java/net/bytebuddy/agent/ByteBuddyAgent.java#L644-L645
