### PR TITLE
Add Ubuntu 22.04 'Jammy Jellyfish' Docker images

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -182,7 +182,8 @@ enum Distro implements DistroBehavior {
     List<DistroVersion> getSupportedVersions() {
       return [
         new DistroVersion(version: '18.04', releaseName: 'bionic', eolDate: parseDate('2023-04-01')),
-        new DistroVersion(version: '20.04', releaseName: 'focal', eolDate: parseDate('2030-04-01'))
+        new DistroVersion(version: '20.04', releaseName: 'focal', eolDate: parseDate('2030-04-01')),
+        new DistroVersion(version: '22.04', releaseName: 'jammy', eolDate: parseDate('2032-04-01')),
       ]
     }
   },


### PR DESCRIPTION
Released 21 Apr 2022: https://endoflife.date/ubuntu