### PR TITLE
Remove unused agent/server keystore properties

### DIFF
--- a/app-server/src/main/java/com/thoughtworks/go/server/AppServer.java
+++ b/app-server/src/main/java/com/thoughtworks/go/server/AppServer.java
@@ -19,11 +19,9 @@ import com.thoughtworks.go.util.SystemEnvironment;
 
 public abstract class AppServer {
     protected SystemEnvironment systemEnvironment;
-    protected String password;
 
-    public AppServer(SystemEnvironment systemEnvironment, String password) {
+    public AppServer(SystemEnvironment systemEnvironment) {
         this.systemEnvironment = systemEnvironment;
-        this.password = password;
     }
 
     abstract void addExtraJarsToClasspath(String extraClasspath);

--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -162,8 +162,6 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<Boolean> GO_API_WITH_SAFE_MODE = new GoBooleanSystemProperty("go.api.with.safe.mode", true);
     public static GoSystemProperty<Integer> MAX_PENDING_AGENTS_ALLOWED = new GoIntSystemProperty("max.pending.agents.allowed", 100);
     public static GoSystemProperty<Boolean> CHECK_AND_REMOVE_DUPLICATE_MODIFICATIONS = new GoBooleanSystemProperty("go.modifications.removeDuplicates", true);
-    public static GoSystemProperty<String> GO_AGENT_KEYSTORE_PASSWORD = new GoStringSystemProperty("go.agent.keystore.password", "agent5s0repa55w0rd");
-    public static GoSystemProperty<String> GO_SERVER_KEYSTORE_PASSWORD = new GoStringSystemProperty("go.server.keystore.password", "serverKeystorepa55w0rd");
     public static final GoSystemProperty<Boolean> GO_DIAGNOSTICS_MODE = new GoBooleanSystemProperty("go.diagnostics.mode", false);
 
     public static GoIntSystemProperty DEPENDENCY_MATERIAL_UPDATE_LISTENERS = new GoIntSystemProperty("dependency.material.check.threads", 3);
@@ -670,14 +668,6 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public boolean isApiSafeModeEnabled() {
         return GO_API_WITH_SAFE_MODE.getValue();
-    }
-
-    public String getAgentKeyStorePassword() {
-        return get(SystemEnvironment.GO_AGENT_KEYSTORE_PASSWORD);
-    }
-
-    public String getServerKeyStorePassword() {
-        return get(SystemEnvironment.GO_SERVER_KEYSTORE_PASSWORD);
     }
 
     public int sessionTimeoutInSeconds() {

--- a/jetty9/src/main/java/com/thoughtworks/go/server/Jetty9Server.java
+++ b/jetty9/src/main/java/com/thoughtworks/go/server/Jetty9Server.java
@@ -57,12 +57,12 @@ public class Jetty9Server extends AppServer {
     private static final Logger LOG = LoggerFactory.getLogger(Jetty9Server.class);
     private final DeploymentManager deploymentManager;
 
-    public Jetty9Server(SystemEnvironment systemEnvironment, String password) {
-        this(systemEnvironment, password, new Server(), new DeploymentManager());
+    public Jetty9Server(SystemEnvironment systemEnvironment) {
+        this(systemEnvironment, new Server(), new DeploymentManager());
     }
 
-    Jetty9Server(SystemEnvironment systemEnvironment, String password, Server server, DeploymentManager deploymentManager) {
-        super(systemEnvironment, password);
+    Jetty9Server(SystemEnvironment systemEnvironment, Server server, DeploymentManager deploymentManager) {
+        super(systemEnvironment);
         systemEnvironment.set(SystemEnvironment.JETTY_XML_FILE_NAME, JETTY_XML);
         this.server = server;
         this.deploymentManager = deploymentManager;

--- a/jetty9/src/test/java/com/thoughtworks/go/server/Jetty9ServerTest.java
+++ b/jetty9/src/test/java/com/thoughtworks/go/server/Jetty9ServerTest.java
@@ -111,7 +111,7 @@ public class Jetty9ServerTest {
         when(systemEnvironment.sessionCookieMaxAgeInSeconds()).thenReturn(5678);
 
         when(sslSocketFactory.getSupportedCipherSuites()).thenReturn(new String[]{});
-        jetty9Server = new Jetty9Server(systemEnvironment, "pwd", server, deploymentManager);
+        jetty9Server = new Jetty9Server(systemEnvironment, server, deploymentManager);
         ReflectionUtil.setStaticField(Jetty9Server.class, "JETTY_XML_LOCATION_IN_JAR", "config");
     }
 

--- a/jetty9/src/test/java/com/thoughtworks/go/server/util/GoPlainSocketConnectorTest.java
+++ b/jetty9/src/test/java/com/thoughtworks/go/server/util/GoPlainSocketConnectorTest.java
@@ -40,7 +40,7 @@ public class GoPlainSocketConnectorTest {
         when(systemEnvironment.get(SystemEnvironment.RESPONSE_BUFFER_SIZE)).thenReturn(100);
         when(systemEnvironment.get(SystemEnvironment.IDLE_TIMEOUT)).thenReturn(200);
         when(systemEnvironment.getListenHost()).thenReturn("foo");
-        Jetty9Server server = new Jetty9Server(systemEnvironment, null);
+        Jetty9Server server = new Jetty9Server(systemEnvironment);
 
         connector = (ServerConnector) new GoPlainSocketConnector(server, systemEnvironment).getConnector();
 

--- a/server/src/main/java/com/thoughtworks/go/server/GoServer.java
+++ b/server/src/main/java/com/thoughtworks/go/server/GoServer.java
@@ -34,7 +34,7 @@ public class GoServer {
 
     private static final Logger LOG = LoggerFactory.getLogger(GoServer.class);
 
-    private SystemEnvironment systemEnvironment;
+    private final SystemEnvironment systemEnvironment;
     private AppServer server;
     protected SubprocessLogger subprocessLogger;
 
@@ -69,8 +69,8 @@ public class GoServer {
     }
 
     AppServer configureServer() throws Exception {
-        Constructor<?> constructor = Class.forName(systemEnvironment.get(SystemEnvironment.APP_SERVER)).getConstructor(SystemEnvironment.class, String.class);
-        AppServer server = ((AppServer) constructor.newInstance(systemEnvironment, systemEnvironment.getServerKeyStorePassword()));
+        Constructor<?> constructor = Class.forName(systemEnvironment.get(SystemEnvironment.APP_SERVER)).getConstructor(SystemEnvironment.class);
+        AppServer server = ((AppServer) constructor.newInstance(systemEnvironment));
         server.configure();
         logMessageIfUsingAddons();
         server.setSessionConfig();

--- a/server/src/test-fast/java/com/thoughtworks/go/server/AppServerStub.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/AppServerStub.java
@@ -18,14 +18,15 @@ package com.thoughtworks.go.server;
 import com.thoughtworks.go.util.SystemEnvironment;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class AppServerStub extends AppServer {
 
-    public HashMap<String, Object> calls = new HashMap<>();
-    public HashMap<String, String> initparams = new HashMap<>();
+    public final Map<String, Object> calls = new HashMap<>();
+    public final Map<String, String> initParams = new HashMap<>();
 
-    public AppServerStub(SystemEnvironment systemEnvironment, String password) {
-        super(systemEnvironment, password);
+    public AppServerStub(SystemEnvironment systemEnvironment) {
+        super(systemEnvironment);
     }
 
     @Override
@@ -40,7 +41,7 @@ public class AppServerStub extends AppServer {
 
     @Override
     void setInitParameter(String name, String value) {
-        initparams.put(name, value);
+        initParams.put(name, value);
     }
 
     @Override
@@ -50,17 +51,17 @@ public class AppServerStub extends AppServer {
     }
 
     @Override
-    void configure() throws Exception {
+    void configure() {
         calls.put("configure", true);
     }
 
     @Override
-    void start() throws Exception {
+    void start() {
         calls.put("start", true);
     }
 
     @Override
-    void stop() throws Exception {
+    void stop() {
         calls.put("stop", true);
 
     }


### PR DESCRIPTION
Support for TLS configuration of GoCD itself was removed in GoCD 20.6.0, along with the need to set keystore passwords via the previous mechanisms, so these can be removed.
