### PR TITLE
Remove unnecessary feature flag added to disable material URL validation

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
@@ -392,7 +392,7 @@ public abstract class ScmMaterialConfig extends AbstractMaterialConfig implement
             return;
         }
 
-        if (System.getProperty("gocd.verify.url.correctness", "y").equalsIgnoreCase("y") && !url.isValidURLOrLocalPath()) {
+        if (!url.isValidURLOrLocalPath()) {
             errors().add(URL, "URL does not seem to be valid.");
         }
     }


### PR DESCRIPTION
This was added to resolve CVE-2021-43286 in https://github.com/gocd/gocd/commit/6fa9fb7a7c91e760f1adc2593acdd50f2d78676b but no issues have been raised with this or reports of needing to re-enable; so can be removed now.