### PR TITLE
Remove xalan classloader hacks for TFS SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -667,11 +667,9 @@ subprojects {
     }
   }
 
-  project.configurations*.exclude(group: 'javax.xml.bind')
-  project.configurations*.exclude(group: 'junit')
-  project.configurations*.exclude(group: 'dom4j')
-  project.configurations*.exclude(group: 'xalan')
-  project.configurations*.exclude(group: 'xml-apis')
+  project.configurations*.exclude(group: 'javax.xml.bind') // Moved to jakarta.xml.bind
+  project.configurations*.exclude(group: 'junit') // Moved to org.junit
+  project.configurations*.exclude(group: 'dom4j') // Moved to org.dom4j
 }
 
 task allDependencies {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -106,7 +106,6 @@ final Map<String, String> libraries = [
   urlrewrite          : 'org.tuckey:urlrewritefilter:3.2.0',
   velocity            : 'org.apache.velocity:velocity:1.7',
   velocityToolsView   : 'velocity-tools:velocity-tools-view:1.4',
-  xalan               : 'xalan:xalan:2.7.2',
   xmlUnit             : 'org.xmlunit:xmlunit-assertj:2.9.0',
   ztExec              : 'org.zeroturnaround:zt-exec:1.12',
 ]

--- a/tfs-impl/tfs-impl-14/build.gradle
+++ b/tfs-impl/tfs-impl-14/build.gradle
@@ -25,8 +25,6 @@ dependencies {
   // https://github.com/Microsoft/team-explorer-everywhere/issues/268
   implementation files('tfssdk/lib/com.microsoft.tfs.sdk-14.118.0.jar')
 
-  // not an implementation dependency, but some classloader hell
-  implementation project.deps.xalan
   testImplementation project.deps.junit5
   testRuntimeOnly project.deps.junit5Engine
   testImplementation project.deps.hamcrest
@@ -43,9 +41,7 @@ task fatJar(type: Jar) {
   dependsOn jar
   from(jar.archiveFile) { into('lib/') }
 
-  from(project.configurations.compileClasspath.findAll {
-    it.absolutePath.contains('tfssdk') || it.absolutePath.contains('xalan') || it.absolutePath.contains('serializer')
-  }) {
+  from(project.configurations.compileClasspath.findAll { it.absolutePath.contains('tfssdk') }) {
     into 'lib/'
   }
 


### PR DESCRIPTION
Xalan and serializer seem to have been removed from the TFS SDK jar between the original release we were using when the workaround was added (14.0.3) and the current release (14.118). Seems unlikely these hacks are still required, and not sure what they might have been doing anyway :-)