### PR TITLE
Fix compatibility with JDK 11.0.15 and 17.0.3 by increasing the XPath Expression Operation limit

### DIFF
--- a/config/config-server/src/main/java/com/thoughtworks/go/config/GoConfigMigration.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/config/GoConfigMigration.java
@@ -48,6 +48,7 @@ import static com.thoughtworks.go.util.XmlUtils.buildXmlDocument;
 @Component
 public class GoConfigMigration {
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(GoConfigMigration.class.getName());
+    private static final int XPATH_EXPRESSION_OPERATION_LIMIT = 200;
     private final String schemaVersion = "schemaVersion";
     private final TimeProvider timeProvider;
     private final ConfigElementImplementationRegistry registry;
@@ -140,7 +141,9 @@ public class GoConfigMigration {
 
     private Transformer transformer(String xsltName, InputStream xslt) {
         try {
-            return TransformerFactory.newInstance().newTransformer(new StreamSource(xslt));
+            TransformerFactory factory = TransformerFactory.newInstance();
+            factory.setAttribute("jdk.xml.xpathExprOpLimit", XPATH_EXPRESSION_OPERATION_LIMIT);
+            return factory.newTransformer(new StreamSource(xslt));
         } catch (TransformerConfigurationException tce) {
             throw bomb("Couldn't parse XSL template " + xsltName, tce);
         }


### PR DESCRIPTION
In JDK 17.0.3 and 11.0.15 there are new limits of 100 ops on XPath expressions, likely for security/DoS reasons. Our expressions in config migration in places have more than this, so we need to increase the limit for compatibility.

See https://www.oracle.com/java/technologies/javase/11-0-15-relnotes.html and https://www.oracle.com/java/technologies/javase/17-0-3-relnotes.html

Running tests with specific patch releases of JDK 11.0.15 or 17.0.3 reveals this issue.

```
BuildAssignmentServiceIntegrationTest > shouldNotScheduleJobsDuringServerMaintenanceMode() FAILED
    java.lang.RuntimeException: Couldn't parse XSL template file:/Users/chad/Projects/community/gocd/gocd/config/config-server/target/libs/config-server-22.2.0-14177.jar!/upgrades/22.xsl
        at com.thoughtworks.go.util.ExceptionUtils.bomb(ExceptionUtils.java:41)
        at com.thoughtworks.go.config.GoConfigMigration.transformer(GoConfigMigration.java:145)
        at com.thoughtworks.go.config.GoConfigMigration.upgrade(GoConfigMigration.java:117)
        at com.thoughtworks.go.config.GoConfigMigration.upgrade(GoConfigMigration.java:98)
        at com.thoughtworks.go.config.GoConfigMigration.upgrade(GoConfigMigration.java:89)
        at com.thoughtworks.go.config.GoConfigMigration.upgradeIfNecessary(GoConfigMigration.java:74)
        at com.thoughtworks.go.config.ConfigMigrator.migrate(ConfigMigrator.java:42)
        at com.thoughtworks.go.config.ConfigMigrator.migrate(ConfigMigrator.java:54)
        at com.thoughtworks.go.util.GoConfigFileHelper.initializeConfigFile(GoConfigFileHelper.java:276)
        at com.thoughtworks.go.util.GoConfigFileHelper.<init>(GoConfigFileHelper.java:92)
        at com.thoughtworks.go.util.GoConfigFileHelper.<init>(GoConfigFileHelper.java:111)
        at com.thoughtworks.go.util.GoConfigFileHelper.<init>(GoConfigFileHelper.java:75)
        at com.thoughtworks.go.server.service.BuildAssignmentServiceIntegrationTest.setUp(BuildAssignmentServiceIntegrationTest.java:176)

        Caused by:
        javax.xml.transform.TransformerConfigurationException: JAXP0801002: the compiler encountered an XPath expression containing '108' operators that exceeds the '100' limit set by 'FEATURE_SECURE_PROCESSING'.
            at java.xml/com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl.newTemplates(TransformerFactoryImpl.java:1079)
            at java.xml/com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl.newTransformer(TransformerFactoryImpl.java:834)
            at com.thoughtworks.go.config.GoConfigMigration.transformer(GoConfigMigration.java:143)
            ... 11 more
```