### PR TITLE
Bump gocd-filebased-authentication-plugin to 2.1.1-137

### DIFF
--- a/tw-go-plugins/build.gradle
+++ b/tw-go-plugins/build.gradle
@@ -34,9 +34,9 @@ def dependencies = [
   new GithubArtifact(
     user: 'gocd',
     repo: 'gocd-filebased-authentication-plugin',
-    tagName: 'v2.1.0-123',
-    asset: 'gocd-filebased-authentication-plugin-2.1.0-123.jar',
-    checksum: '8a873b1466c9f1f8a46cec4bac1431be4fcb27f3871dcfb699d61a0adc45e626'
+    tagName: 'v2.1.1-137',
+    asset: 'gocd-filebased-authentication-plugin-2.1.1-137.jar',
+    checksum: '24ac7e9340a5aad52f07e6e8d992ca2e2844889618eb970011d73f7f33263f24'
   ),
   new GithubArtifact(
     user: 'gocd',


### PR DESCRIPTION
Improves help for users on paths to use. See https://github.com/gocd/gocd-filebased-authentication-plugin/releases/tag/v2.1.1-137

Fixes https://github.com/gocd/docs.go.cd/issues/658 (along with a docs update)