### PR TITLE
Revert "Bump org.apache.felix.framework from 7.0.3 to 7.0.4"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -50,7 +50,7 @@ final Map<String, String> libraries = [
   dbunit              : 'org.dbunit:dbunit:2.7.3',
   dom4j               : 'org.dom4j:dom4j:2.1.3',
   ehcache             : 'net.sf.ehcache:ehcache:2.10.9.2',
-  felix               : 'org.apache.felix:org.apache.felix.framework:7.0.4',
+  felix               : 'org.apache.felix:org.apache.felix.framework:7.0.3',
   freemarker          : 'org.freemarker:freemarker:2.3.31',
   gradleDownload      : 'de.undercouch:gradle-download-task:5.1.0',
   grolifant           : 'org.ysb33r.gradle:grolifant70:1.3.3',


### PR DESCRIPTION
Reverts gocd/gocd#10460

Looks like change broke something on Windows, perhaps related to https://github.com/apache/felix-dev/pull/154