### PR TITLE
Revert "Bump mockito-core from 4.5.1 to 4.6.0"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -81,7 +81,7 @@ final Map<String, String> libraries = [
   logback             : 'ch.qos.logback:logback-classic:1.2.11',
   lombok              : 'org.projectlombok:lombok:1.18.24',
   mail                : 'com.sun.mail:mailapi:2.0.1',
-  mockito             : 'org.mockito:mockito-core:4.6.0',
+  mockito             : 'org.mockito:mockito-core:4.5.1',
   mybatis             : 'org.mybatis:mybatis:3.5.10',
   mybatisSpring       : 'org.mybatis:mybatis-spring:2.0.7',
   mysql               : 'mysql:mysql-connector-java:8.0.29',


### PR DESCRIPTION
Reverts gocd/gocd#10477 - caused more Groovy-related problems, needs more investigation.

https://build.gocd.org/go/tab/build/detail/build-linux/6038/build-non-server/1/FastTests-runInstance-1

eg.

```
PushWebhookControllerV1Test > Payloads > accepts and notifies by scm names(String, Closure, String, String) > com.thoughtworks.go.apiv1.webhook.controller.PushWebhookControllerV1Test$Payloads.accepts and notifies by scm names(String, Closure, String, String)[4] FAILED
    java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because the return value of "org.mockito.invocation.Location.getSourceFile()" is null
        at org.mockito.internal.junit.DefaultStubbingLookupListener.potentialArgMismatches(DefaultStubbingLookupListener.java:81)
        at org.mockito.internal.junit.DefaultStubbingLookupListener.onStubbingLookup(DefaultStubbingLookupListener.java:52)
        at org.mockito.internal.listeners.StubbingLookupNotifier.notifyStubbedAnswerLookup(StubbingLookupNotifier.java:31)
        at org.mockito.internal.handler.MockHandlerImpl.handle(MockHandlerImpl.java:93)
        at org.mockito.internal.handler.NullResultGuardian.handle(NullResultGuardian.java:29)
        at org.mockito.internal.handler.InvocationNotifierHandler.handle(InvocationNotifierHandler.java:34)
        at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.doIntercept(MockMethodInterceptor.java:82)
        at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.doIntercept(MockMethodInterceptor.java:56)
        at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor$DispatcherDefaultingToRealMethod.interceptAbstract(MockMethodInterceptor.java:161)
        at org.mockito.codegen.FilterConfig$MockitoMock$XhsZmxIE.getInitParameter(Unknown Source)
        at spark.servlet.FilterTools.getFilterPath(FilterTools.java:63)
        at spark.servlet.SparkFilter.init(SparkFilter.java:72)
        at javax.servlet.Filter$init.call(Unknown Source)
        at com.thoughtworks.go.spark.ControllerTrait$Trait$Helper.getPrefilter(ControllerTrait.groovy:167)
        at jdk.internal.reflect.GeneratedMethodAccessor31.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:107)
        at org.codehaus.groovy.runtime.callsite.StaticMetaMethodSite$StaticMetaMethodSiteNoUnwrapNoCoerce.invoke(StaticMetaMethodSite.java:149)
        at org.codehaus.groovy.runtime.callsite.StaticMetaMethodSite.callStatic(StaticMetaMethodSite.java:100)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callStatic(AbstractCallSite.java:231)
        at com.thoughtworks.go.spark.ControllerTrait$Trait$Helper.sendRequest(ControllerTrait.groovy:153)
        at com.thoughtworks.go.spark.ControllerTrait$Trait$Helper$sendRequest$2.call(Unknown Source)
        at com.thoughtworks.go.apiv1.webhook.controller.PushWebhookControllerV1Test.sendRequest(PushWebhookControllerV1Test.groovy)
        at com.thoughtworks.go.spark.ControllerTrait$sendRequest$0.call(Unknown Source)
        at com.thoughtworks.go.spark.ControllerTrait$Trait$Helper.postWithApiHeader(ControllerTrait.groovy:103)
        at com.thoughtworks.go.spark.ControllerTrait$Trait$Helper$postWithApiHeader$1.call(Unknown Source)
        at com.thoughtworks.go.apiv1.webhook.controller.PushWebhookControllerV1Test.postWithApiHeader(PushWebhookControllerV1Test.groovy)
        at jdk.internal.reflect.GeneratedMethodAccessor60.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:107)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1268)
        at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.invokeMethodOnCurrentN(ScriptBytecodeAdapter.java:94)
        at com.thoughtworks.go.apiv1.webhook.controller.PushWebhookControllerV1Test.this$dist$invoke$1(PushWebhookControllerV1Test.groovy)
        at com.thoughtworks.go.apiv1.webhook.controller.PushWebhookControllerV1Test$Payloads.methodMissing(PushWebhookControllerV1Test.groovy)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:107)
        at groovy.lang.MetaClassImpl.invokeMissingMethod(MetaClassImpl.java:953)
        at groovy.lang.MetaClassImpl.invokePropertyOrMissing(MetaClassImpl.java:1347)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1270)
        at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.callCurrent(PogoMetaClassSite.java:61)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:203)
        at com.thoughtworks.go.apiv1.webhook.controller.PushWebhookControllerV1Test$Payloads.accepts and notifies by scm names(PushWebhookControllerV1Test.groovy:157)
```