### PR TITLE
Review dependency check CVEs / vulnerabilities

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -112,12 +112,37 @@
 
     <suppress>
         <notes><![CDATA[
+   This appears to be a false positive. Vulnerability is only reported against Spring `5.2.0` to `5.2.3` (not 4.3)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-webmvc@4\.3.*$</packageUrl>
+        <vulnerabilityName>CVE-2020-5397</vulnerabilityName>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
    From review of https://tanzu.vmware.com/security/cve-2021-22112 and the code of GoCD, GoCD does not appear to be
    subject to this defect, since it does not alter the security context in the manner required to elevate privileges
    in a small portion of the application and potentially be subject to this defect.
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-(core|web|config)@.*$</packageUrl>
         <cve>CVE-2021-22112</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   GoCD does not use bcrypt from Spring Security, so does not seem vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2022-22976
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-(core|web|config)@.*$</packageUrl>
+        <cve>CVE-2022-22976</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+      GoCD does not use RegexRequestMatchers from Spring Security with a value of '.' as required by https://nvd.nist.gov/vuln/detail/CVE-2022-22978
+      to be vulnerable to this issue.
+       ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-web@.*$</packageUrl>
+        <vulnerabilityName>CVE-2022-22978</vulnerabilityName>
     </suppress>
 
     <suppress>
@@ -132,11 +157,29 @@
 
     <suppress>
         <notes><![CDATA[
+   GoCD does not allow SpEL expressions to be supplied by users anywhere that can be found, so we do not seem to be
+   vulnerable to this issue.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-expression@.*$</packageUrl>
+        <vulnerabilityName>CVE-2022-22950</vulnerabilityName>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
    GoCD is not affected by this as we do not use disallowedFieldPatterns on DataBinders as required to trigger the issue
    as documented in https://spring.io/blog/2022/04/13/spring-framework-data-binding-rules-vulnerability-cve-2022-22968
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-.*@.*$</packageUrl>
         <vulnerabilityName>CVE-2022-22968</vulnerabilityName>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   GoCD is not vulnerable to the default as described at https://nvd.nist.gov/vuln/detail/CVE-2022-22970 as we do not
+   rely on data binding for dealing with MultipartFile or javax.servlet.Part objects into models.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-.*@.*$</packageUrl>
+        <vulnerabilityName>CVE-2022-22970</vulnerabilityName>
     </suppress>
 
     <suppress>

--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -203,6 +203,15 @@
 
     <suppress>
         <notes><![CDATA[
+   This is a false positive and not a vulnerability according to https://github.com/h2database/h2database/issues/3175#issuecomment-1142186324
+   - it's being reported against the wrong version from OSSINDEX.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.h2database/h2@.*$</packageUrl>
+        <vulnerabilityName>CVE-2018-14335</vulnerabilityName>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
    From review of https://nvd.nist.gov/vuln/detail/CVE-2021-23463 GoCD is not subject to this XXE vulnerability, because
    neither GoCD, Hibernate or MyBatis use JdbcResultSet.getSQLXML(). It seems this is unlikely to get a backport to
    H2 1.4.x which is a breaking change. See https://github.com/h2database/h2database/issues/3195 and

--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -120,14 +120,11 @@
         <cve>CVE-2021-22112</cve>
     </suppress>
 
-    <suppress until="2022-07-01Z">
+    <suppress>
         <notes><![CDATA[
    It is not believed that GoCD is directly vulnerable to the "SpringShell" attack since although we use WAR
    deployment, GoCD uses Jetty rather than Tomcat, and does not have the vulnerable classloader from Tomcat
    required to exploit the vulnerability.
-
-   Suppression will be time-limited for now to ensure it is reviewed based on new information until we can upgrade Spring.
-   See https://github.com/gocd/gocd/issues/10321#issuecomment-1085691072
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-.*@.*$</packageUrl>
         <vulnerabilityName>CVE-2022-22965</vulnerabilityName>

--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -185,7 +185,7 @@
         <vulnerabilityName>CWE-94: Improper Control of Generation of Code ('Code Injection')</vulnerabilityName>
     </suppress>
 
-    <suppress until="2022-06-01Z">
+    <suppress until="2022-08-01Z">
         <notes><![CDATA[
    Time-limited suppression for https://nvd.nist.gov/vuln/detail/CVE-2021-29425. GoCD is not vulnerable as the use of
    FilenameUtils.normalize does not "use the result to construct a path value" as required by the defect. Neither does

--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -48,7 +48,14 @@
         <vulnerabilityName>CVE-2010-1330</vulnerabilityName>
         <vulnerabilityName>CVE-2011-4838</vulnerabilityName>
     </suppress>
-
+    <suppress>
+        <notes><![CDATA[
+   Suppressing false positive - vulnerability is in Artemis, not the wider ActiveMQ, and NVD data has the wrong
+   affected versions anyway.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.activemq/activemq\-broker@.*$</packageUrl>
+        <vulnerabilityName>CVE-2015-3208</vulnerabilityName>
+    </suppress>
     <suppress>
         <notes><![CDATA[
    https://nvd.nist.gov/vuln/detail/CVE-2020-13697 as described only affects usage of "Nanolets" which is packaged


### PR DESCRIPTION
Suppress some more vulnerabilities raised by Dependency Check after review as to GoCD's exposure.