### PR TITLE
Fix Jasmine tests of old JS code on Windows

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/ExecuteUnderRailsTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/ExecuteUnderRailsTask.groovy
@@ -23,6 +23,8 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.process.JavaExecSpec
 
+import static com.thoughtworks.go.build.OperatingSystemHelper.normalizeEnvironmentPath
+
 class ExecuteUnderRailsTask extends JavaExec {
   private static final OperatingSystem CURRENT_OS = OperatingSystem.current()
   private Map<String, Object> originalEnv
@@ -50,11 +52,7 @@ class ExecuteUnderRailsTask extends JavaExec {
 
   static void setup(Project project, JavaExecSpec execSpec, boolean disableJRubyOptimization) {
     execSpec.with {
-      if(CURRENT_OS.isWindows()) {
-        // because windows PATH variable is case-insensitive, so we force it to be `PATH` instead of `Path` or whatever else
-        def pathVariableName = environment.keySet().find { eachKey -> eachKey.toUpperCase().equals("PATH")}
-        environment['PATH'] = environment.remove(pathVariableName)
-      }
+      normalizeEnvironmentPath(environment)
       environment['PATH'] = (project.additionalJRubyPaths + [environment['PATH']]).join(File.pathSeparator)
 
       classpath(project.jrubyJar())

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/OperatingSystem.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/OperatingSystem.groovy
@@ -29,3 +29,18 @@ enum OperatingSystem {
     name().replace('_', '-')
   }
 }
+
+class OperatingSystemHelper {
+  private static final org.gradle.internal.os.OperatingSystem CURRENT_OS = org.gradle.internal.os.OperatingSystem.current()
+
+  static Map<String, Object> normalizeEnvironmentPath(Map<String, Object> environment) {
+    if (CURRENT_OS.isWindows()) {
+      // because windows PATH variable is case-insensitive, so we force it to be `PATH` instead of `Path` or whatever else
+      def pathVariableName = environment.keySet().find { eachKey -> eachKey.toUpperCase().equals("PATH")}
+      if (pathVariableName != null) {
+        environment['PATH'] = environment.remove(pathVariableName)
+      }
+    }
+    return environment
+  }
+}

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/YarnRunTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/YarnRunTask.groovy
@@ -23,6 +23,8 @@ import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.process.ExecSpec
 
+import static com.thoughtworks.go.build.OperatingSystemHelper.normalizeEnvironmentPath
+
 @CacheableTask
 class YarnRunTask extends DefaultTask {
   private File workingDir
@@ -62,8 +64,9 @@ class YarnRunTask extends DefaultTask {
   Map<String, Object> getEnvironment() {
     if (environment == null) {
       this.setEnvironment(System.getenv())
+      normalizeEnvironmentPath(environment)
     }
-    return environment;
+    return environment
   }
 
   @SkipWhenEmpty
@@ -113,7 +116,7 @@ class YarnRunTask extends DefaultTask {
       }
 
       project.exec { ExecSpec execSpec ->
-        execSpec.environment = environment
+        execSpec.environment = this.getEnvironment()
         execSpec.environment("FORCE_COLOR", "true")
         execSpec.standardOutput = System.out
         execSpec.errorOutput = System.err

--- a/server/rails.gradle
+++ b/server/rails.gradle
@@ -124,6 +124,10 @@ task initializeRailsGems {
       workingDir = project.railsRoot
       args = ['-S', 'bundle', 'install']
       maxHeapSize = '1g'
+
+      // Workaround JDK 17.0.3 issue https://bugs.openjdk.java.net/browse/JDK-8285445 on Windows. See https://github.com/jruby/jruby/issues/7182
+      // Should be able to be removed after OpenJDK 17.0.4 (July 2022)
+      jvmArgs += '-Djdk.io.File.enableADS=true'
     }
   }
 }
@@ -213,6 +217,10 @@ task compileAssetsRailsTest(type: ExecuteUnderRailsTask) {
 
   args = ['-S', 'rake', '--trace', 'assets:clobber', "assets:precompile"]
 
+  // Workaround JDK 17.0.3 issue https://bugs.openjdk.java.net/browse/JDK-8285445 on Windows. See https://github.com/jruby/jruby/issues/7182
+  // Should be able to be removed after OpenJDK 17.0.4 (July 2022)
+  jvmArgs += '-Djdk.io.File.enableADS=true'
+
   doFirst {
     delete "${project.railsRoot}/tmp"
     delete publicAssetsDir
@@ -240,6 +248,10 @@ task compileAssetsRailsProd(type: ExecuteUnderRailsTask) {
   )
 
   args = ['-S', 'rake', '--trace', 'assets:clobber', 'assets:precompile']
+
+  // Workaround JDK 17.0.3 issue https://bugs.openjdk.java.net/browse/JDK-8285445 on Windows. See https://github.com/jruby/jruby/issues/7182
+  // Should be able to be removed after OpenJDK 17.0.4 (July 2022)
+  jvmArgs += '-Djdk.io.File.enableADS=true'
 
   doFirst {
     delete "${project.railsRoot}/tmp"

--- a/server/src/main/webapp/WEB-INF/rails/spec/javascripts/support/jasmine-browser-runner+1.0.0.patch
+++ b/server/src/main/webapp/WEB-INF/rails/spec/javascripts/support/jasmine-browser-runner+1.0.0.patch
@@ -1,15 +1,11 @@
 diff --git a/node_modules/jasmine-browser-runner/lib/runner.js b/node_modules/jasmine-browser-runner/lib/runner.js
-index cf4f385..62af587 100644
+index cf4f385..9b6ba55 100644
 --- a/node_modules/jasmine-browser-runner/lib/runner.js
 +++ b/node_modules/jasmine-browser-runner/lib/runner.js
-@@ -14,8 +14,19 @@ function getBatch(driver) {
-       "try { JSON.stringify(expectation.actual); } catch (e) { expectation.actual = '<circular actual>'; }\n" +
-       '}\n' +
-       '}\n' +
--      'return results;'
-+      'return JSON.parse(JSON.parse(JSON.stringify(results)));'
-   );
-+// Above line contains a patch/workaround for serialization bugs with FF/geckodriver - relating to
+@@ -1,6 +1,19 @@
+ const querystring = require('querystring');
+ 
++// Below contains a patch/workaround for serialization bugs with FF/geckodriver - relating to
 +// https://github.com/mozilla/geckodriver/issues/914
 +// https://github.com/mozilla/geckodriver/issues/792
 +//
@@ -20,6 +16,21 @@ index cf4f385..62af587 100644
 +//
 +// Similar patch was used on previous Ruby Jasmine runner:
 +// https://github.com/gocd/gocd/blob/2daf703480f3d33cf5f06eeb0efd218bf2f031ae/server/src/main/webapp/WEB-INF/rails/lib/extensions/jasmine_rails_spec_helper.rb#L17-L50
+ function getBatch(driver) {
++  return driver.getCapabilities().then(function(c) {
++
+   return driver.executeScript(
+     'var results = batchReporter.getBatch();\n' +
+       'for (var i = 0; i < results.length; i++) {\n' +
+@@ -14,8 +27,10 @@ function getBatch(driver) {
+       "try { JSON.stringify(expectation.actual); } catch (e) { expectation.actual = '<circular actual>'; }\n" +
+       '}\n' +
+       '}\n' +
+-      'return results;'
++      (c.getBrowserName() !== 'firefox' ? 'return results;' : 'return JSON.parse(JSON.parse(JSON.stringify(results)));')
+   );
++
++  });
  }
  
  function proxyToReporters(batch, reporters) {


### PR DESCRIPTION
Corrects issues with #10476 when running on Windows 
- PATH for driver not being passed through to Yarn properly/consistently due to case insensitivity of env vars on Windows
- Hack to workaround Prototype.js being applied incorrectly to Chrome (or other non-Firefox browsers)
- Unrelated issue running JRuby RubyGem installs on Windows with JDK `11.0.15`, `17.0.3` etc that will only be fixed in the next release. 