### PR TITLE
Update material userName/password in sync with one another when constructing BuildWork

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/domain/materials/AbstractMaterialTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/AbstractMaterialTest.java
@@ -18,6 +18,8 @@ package com.thoughtworks.go.domain.materials;
 import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.materials.AbstractMaterial;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
+import com.thoughtworks.go.config.materials.svn.SvnMaterial;
+import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
 import com.thoughtworks.go.domain.MaterialInstance;
 import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.util.command.ConsoleOutputStreamConsumer;
@@ -30,7 +32,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 public class AbstractMaterialTest {
 
@@ -206,5 +208,28 @@ public class AbstractMaterialTest {
         assertThatCode(() -> material.checkConnection(executionContext))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("'checkConnection' cannot be performed on material of type name");
+    }
+
+    @Test
+    public void updateConfigShouldIgnoreNonPasswordAwareConfig() {
+        MaterialConfig config = mock(MaterialConfig.class);
+        SvnMaterial passwordAwareMaterial = new SvnMaterial("url", "username", "password", false);
+        passwordAwareMaterial.updateFromConfig(config);
+        verifyNoInteractions(config);
+    }
+
+    @Test
+    public void updateConfigShouldTakeUserPassFromPasswordAwareConfig() {
+        SvnMaterialConfig config = mock(SvnMaterialConfig.class);
+        when(config.getUserName()).thenReturn("newUsername");
+        when(config.getPassword()).thenReturn("newPassword");
+        SvnMaterial passwordAwareMaterial = new SvnMaterial("url", "username", "password", false);
+        passwordAwareMaterial.updateFromConfig(config);
+
+        assertThat(passwordAwareMaterial.getUserName()).isEqualTo("newUsername");
+        assertThat(passwordAwareMaterial.getPassword()).isEqualTo("newPassword");
+
+        verify(config).getUserName();
+        verify(config).getPassword();
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/AbstractMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/AbstractMaterialConfig.java
@@ -121,8 +121,8 @@ public abstract class AbstractMaterialConfig implements MaterialConfig, ParamsAt
     public String getTruncatedDisplayName() {
         String displayName = getDisplayName();
         if (displayName.length() > TRUNCATED_NAME_MAX_LENGTH) {
-            StringBuffer buffer = new StringBuffer();
-            buffer.append(displayName.substring(0, TRUNCATED_NAME_MAX_LENGTH / 2));
+            StringBuilder buffer = new StringBuilder();
+            buffer.append(displayName, 0, TRUNCATED_NAME_MAX_LENGTH / 2);
             buffer.append("...");
             buffer.append(displayName.substring(displayName.length() - TRUNCATED_NAME_MAX_LENGTH / 2));
             displayName = buffer.toString();

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/PasswordAwareMaterial.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/PasswordAwareMaterial.java
@@ -16,6 +16,8 @@
 package com.thoughtworks.go.config.materials;
 
 public interface PasswordAwareMaterial {
+    void setUserName(String userName);
+    String getUserName();
     void setPassword(String password);
     String getPassword();
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/materials/TestingMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/materials/TestingMaterialConfig.java
@@ -17,17 +17,10 @@ package com.thoughtworks.go.domain.materials;
 
 import com.thoughtworks.go.config.ValidationContext;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
-import org.joda.time.DateTime;
 
-import java.util.Date;
 import java.util.Map;
 
-public class TestingMaterialConfig extends ScmMaterialConfig {
-    public static final Date TWO_DAYS_AGO_CHECKIN = new DateTime().minusDays(2).toDate();
-
-    public static final String MOD_TYPE = "svn";
-    public static final String MOD_REVISION = "98";
-
+public class TestingMaterialConfig extends ScmMaterialConfig{
     private static final String TYPE = "TestingMaterial";
 
     private String url;

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/AbstractMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/AbstractMaterial.java
@@ -226,6 +226,7 @@ public abstract class AbstractMaterial extends PersistentObject implements Mater
     public void updateFromConfig(MaterialConfig materialConfig) {
         if (materialConfig instanceof PasswordAwareMaterial) {
             PasswordAwareMaterial passwordConfig = (PasswordAwareMaterial) materialConfig;
+            ((PasswordAwareMaterial) this).setUserName(passwordConfig.getUserName());
             ((PasswordAwareMaterial) this).setPassword(passwordConfig.getPassword());
         }
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ScheduledPipelineLoaderTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ScheduledPipelineLoaderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.materials.PasswordAwareMaterial;
+import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
+import com.thoughtworks.go.domain.Pipeline;
+import com.thoughtworks.go.helper.MaterialConfigsMother;
+import com.thoughtworks.go.server.dao.PipelineSqlMapDao;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import static com.thoughtworks.go.helper.ConfigFileFixture.configWith;
+import static com.thoughtworks.go.helper.GoConfigMother.createPipelineConfigWithMaterialConfig;
+import static com.thoughtworks.go.helper.PipelineMother.preparing;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@MockitoSettings
+class ScheduledPipelineLoaderTest {
+
+    @Mock
+    private PipelineSqlMapDao pipelineDao;
+    @Mock
+    private GoConfigService goConfigService;
+    @InjectMocks
+    private MaterialExpansionService materialExpansionService;
+
+    private ScheduledPipelineLoader loader;
+
+    @BeforeEach
+    public void setUp() {
+        loader = new ScheduledPipelineLoader(pipelineDao, goConfigService, null, null, null, materialExpansionService, null);
+    }
+
+    @Test
+    public void materialUserPassShouldBeTakenFromConfigOnLoad() {
+
+        // De-duplication of materials may lead to the triggering material having different credentials to the
+        // configured material specific to this pipeline.
+        GitMaterialConfig triggeredMaterial = MaterialConfigsMother.git("https://url", "userNameFromTrigger", null);
+        GitMaterialConfig configuredMaterial = MaterialConfigsMother.git("https://url", "userFromConfig", "passFromConfig");
+
+        assertThat(triggeredMaterial.getUserName()).isNotEqualTo(configuredMaterial.getUserName());
+        assertThat(triggeredMaterial.getPassword()).isNotEqualTo(configuredMaterial.getPassword());
+
+        when(pipelineDao.pipelineWithMaterialsAndModsByBuildId(1))
+                .thenReturn(preparing(createPipelineConfigWithMaterialConfig(triggeredMaterial)));
+
+        when(goConfigService.getCurrentConfig())
+                .thenReturn(configWith(createPipelineConfigWithMaterialConfig(configuredMaterial)));
+
+        Pipeline loadedPipeline = loader.pipelineWithPasswordAwareBuildCauseByBuildId(1);
+
+        assertThat(loadedPipeline.getMaterialRevisions())
+                .singleElement()
+                .satisfies(rev -> assertThat(rev.getMaterial().config())
+                        .isInstanceOfSatisfying(PasswordAwareMaterial.class, mat -> {
+                            assertThat(mat.getUserName()).isEqualTo("userFromConfig");
+                            assertThat(mat.getPassword()).isEqualTo("passFromConfig");
+                        }));
+    }
+}


### PR DESCRIPTION
- fixes #8986
- fixes #9153

When loading a triggered run from the DB to construct buildWork, the userName from the material is, for some reason persisted. However the password is not and is dynamically loaded from the GoConfig based on the pipeline name and fingerprint. So when determining the correct password to use for construction of `BuildWork` to dispatch to the agent, it will use the one from the `MaterialConfig` attached to the pipeline, not the de-duplicated material used for triggering.

If the pipeline is configured with a different username for the same url/branch in two different pipelines, the password will be updated but not the userName, leaving them out of sync. For some source control targets this doesn't seem to matter when using tokens (e.g GitHub) but others require the username to match that whom generated the token, and  others still support legacy username/password.

In any case, the entire credential needs to be updated together to ensure that it is consistent, rather than assuming that the persisted `userName` is the same one corresponding to the `password`.

The other alternative would be to review the persisted material revisions to see whether the material usernames should be persisted with the correct one relevant to the material attached to each scheduled pipeline, but in any case, updating username/pass together seems to be the correct thing to do to me.

Testing
- [x] Replicated with unit-ish test on `ScheduledPipelineLoader`, the source of the problem
- [x] Characterisation unit tests added for location of the direct change/fix
- [x] Replicated and tested fix locally with Git via Github (two accounts with different usernames and tokens, by checking the username/token combinations are accurate with all combinations)
