### PR TITLE
Suppress OWASP dependency check FP on Eclipse Angus Mail SMTP

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -251,4 +251,12 @@
         <cve>CVE-2021-29425</cve>
     </suppress>
 
+    <suppress>
+        <notes><![CDATA[
+   The Eclipse Angus Mail SMTP component is not the Eclipse IDE :-)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.angus/smtp@.*$</packageUrl>
+        <cpe>cpe:/a:eclipse:eclipse_ide</cpe>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
Follow-up to #10499 to suppress a false positive match to Eclipse IDE now appearing in the OWASP dependency check reports.
