### PR TITLE
Normalize client-sent headers to strong ETags

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/model/personalization_vm_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/model/personalization_vm_spec.js
@@ -162,7 +162,7 @@ describe("Personalization View Model", () => {
       jasmine.Ajax.stubRequest(SparkRoutes.pipelineSelectionPath(), undefined, 'GET').andReturn({
         responseText:    JSON.stringify({filters: [{ name:"New", type: "whitelist", pipelines: ["a"] }]}),
         responseHeaders: {
-          ETag:           `"1234567"`,
+          ETag:           `W/"1234567"`,
           'Content-Type': 'application/vnd.go.cd.v1+json'
         },
         status:          200

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/api_request_builder.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/api_request_builder.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {CaseInsensitiveMap} from "helpers/collections";
+import {mrequest} from "helpers/mrequest";
 import _ from "lodash";
 import m from "mithril";
 
@@ -78,7 +79,7 @@ export class ApiResult<T> {
   }
 
   getEtag(): string | null {
-    return this.header("etag") || null;
+    return mrequest.normalizeEtag(this.header("etag"));
   }
 
   getRedirectUrl(): string {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/mrequest.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/mrequest.ts
@@ -16,6 +16,7 @@
 
 import * as CONSTANTS from "helpers/constants";
 import $ from "jquery";
+import _ from "lodash";
 
 const setHeaders = (xhr: JQuery.jqXHR, version: string) => {
   xhr.setRequestHeader("Content-Type", "application/json");
@@ -60,10 +61,17 @@ export const mrequest = {
     }
   },
 
+  normalizeEtag(value: string | undefined | null) {
+    return _.isNil(value) ? null : value
+      .replace(/^W\//, "")
+      .replace(/"/g, "")
+      .replace(/--(gzip|deflate)$/, "");
+  },
+
   unwrapMessageOrEntity: (type: any, originalEtag: string) => (data: any, xhr: JQuery.jqXHR) => {
     if (xhr.status === 200) {
       const entity = type.fromJSON(data);
-      entity.etag(xhr.getResponseHeader("ETag"));
+      entity.etag(mrequest.normalizeEtag(xhr.getResponseHeader("ETag")));
       return entity;
     }
     if (xhr.status === 422 && !!data.data) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spec/mrequest_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/spec/mrequest_spec.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {mrequest} from "../mrequest";
+
+describe("mrequest", () => {
+
+  describe("normalizeEtag", () => {
+
+    it("should normalize nullish tags to null", () => {
+      expect(mrequest.normalizeEtag(undefined)).toBe(null);
+      expect(mrequest.normalizeEtag(null)).toBe(null);
+    });
+
+    it("should normalize tags with quotes to ones without", () => {
+      expect(mrequest.normalizeEtag('"hello"')).toBe("hello");
+      expect(mrequest.normalizeEtag("hello")).toBe("hello");
+    });
+
+    it("should normalize weak etags to strong", () => {
+      expect(mrequest.normalizeEtag('W/"hello"')).toBe("hello");
+    });
+
+    it("should normalize etags with Jetty compression suffixes", () => {
+      expect(mrequest.normalizeEtag("hello--gzip")).toBe("hello");
+      expect(mrequest.normalizeEtag("hello--deflate")).toBe("hello");
+      expect(mrequest.normalizeEtag('"hello--gzip"')).toBe("hello");
+      expect(mrequest.normalizeEtag('"hello--deflate"')).toBe("hello");
+      expect(mrequest.normalizeEtag('W/"hello--gzip"')).toBe("hello");
+      expect(mrequest.normalizeEtag('W/"hello--deflate"')).toBe("hello");
+    });
+  });
+});

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/mixins/crud_mixins.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/mixins/crud_mixins.js
@@ -186,7 +186,7 @@ CrudMixins.Refresh = function (options) {
 
       const didFulfill = (data, _textStatus, jqXHR) => {
         const entity = type.fromJSON(data);
-        entity.etag(jqXHR.getResponseHeader('ETag'));
+        entity.etag(mrequest.normalizeEtag(jqXHR.getResponseHeader('ETag')));
         deferred.resolve(entity);
       };
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/new_dashboard.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/new_dashboard.js
@@ -21,7 +21,7 @@ import {Dashboard} from "models/dashboard/dashboard";
 import {DashboardWidget} from "views/dashboard/dashboard_widget";
 import {AjaxPoller} from "helpers/ajax_poller";
 import {PageLoadError} from "views/shared/page_load_error";
-import {PersonalizationVM as PersonalizeVM} from "views/dashboard/models/personalization_vm";
+import {parseNormalizedEtagFrom, PersonalizationVM as PersonalizeVM} from "views/dashboard/models/personalization_vm";
 import {PluginInfos} from "../models/shared/plugin_infos";
 
 $(() => {
@@ -124,13 +124,9 @@ $(() => {
     dashboard.message(message);
   }
 
-  function parseEtag(req) {
-    return (req.getResponseHeader("ETag") || "").replace(/"/g, "").replace(/--(gzip|deflate)$/, "");
-  }
-
   function createRepeater() {
     const onsuccess = (data, _textStatus, jqXHR) => {
-      const etag = parseEtag(jqXHR);
+      const etag = parseNormalizedEtagFrom(jqXHR);
 
       if (jqXHR.status === 304) {
         return;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/models/personalization_vm.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/models/personalization_vm.js
@@ -38,7 +38,7 @@ export function PersonalizationVM(currentView) {
   function fetchPersonalization() {
     return Personalization.get(checksum()).then((personalization, xhr) => {
       if (304 !== xhr.status) {
-        checksum(parseEtag(xhr));
+        checksum(parseNormalizedEtagFrom(xhr));
 
         names(personalization.names());
         model(personalization);
@@ -93,7 +93,7 @@ export function PersonalizationVM(currentView) {
     return Personalization.getPipelines(pipelinesChecksum()).then((data, _textStatus, xhr) => {
       if (304 !== xhr.status) {
         model().pipelineGroups(data.pipelines);
-        pipelinesChecksum(parseEtag(xhr));
+        pipelinesChecksum(parseNormalizedEtagFrom(xhr));
       }
     });
   };
@@ -161,8 +161,8 @@ export function PersonalizationVM(currentView) {
   };
 }
 
-function parseEtag(req) {
-  return (req.getResponseHeader("ETag") || "").replace(/"/g, "").replace(/--(gzip|deflate)$/, "");
+export function parseNormalizedEtagFrom(req) {
+  return (req.getResponseHeader("ETag") || "").replace(/^W\//, "").replace(/"/g, "").replace(/--(gzip|deflate)$/, "");
 }
 
 /** Case-insensitive functions */


### PR DESCRIPTION
Fixes #9964, #9405, https://github.com/gocd-contrib/email-notifier/issues/46

**Background**
Currently GoCD always sets strong ETags in response headers as noted in #6278. Putting aside whether this is wise or not (as opposed to setting weak etags), we use these etags both to determine whether a resource is modified or whether there has been a race condition update in `If-None-Match` and `If-Match` headers respectively. 

https://datatracker.ietf.org/doc/html/rfc7232#section-3.1 says that when comparing to the `If-Match` header (for updates, basically) we should use "strong comparison" which effectively means the a weak etag validator is not considered equal to the strong etag validator with the same content. While accepting these RFCs were written with the intention of more old-school webserver file uploads _rather than REST APIs_, the requirement to do this is a problem because some caching proxies (e.g CloudFlare) have features to minify and re-compress JSON responses for optimization and [convert our strong etag to a weak etag](https://support.cloudflare.com/hc/en-us/articles/218505467-Using-ETag-Headers-with-Cloudflare). This minification can be disabled and strong etags kept in tact, however it doesn't seem this should be a requirement for GoCD use and there have been a number of tickets raised over the years. All have been linked to Cloudflare, although I imagine even a reverse proxy like NGINX may do the same thing.

This conversion to weak etags before client return causes updates of these resources to fail, which is confusing and not desirable.

**Addressing the issue**
Technically we already compare etags in a slightly "non-strong" way because the server ignores `--gzip` and `--deflate` suffixes that Jetty can add when compressing responses already. e.g the below (there are also some [hacks in JS client side code](https://github.com/gocd/gocd/blob/2daf703480f3d33cf5f06eeb0efd218bf2f031ae/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/models/personalization_vm.js#L164-L166) to remove the some suffixes, maybe due to legacy Rails APIs since replaced, but ignoring these for now) 

https://github.com/gocd/gocd/blob/2daf703480f3d33cf5f06eeb0efd218bf2f031ae/api/api-base/src/main/java/com/thoughtworks/go/api/ControllerMethods.java#L54-L62

It also doesn't really make sense to compare objects "byte-by-byte" when considering API responses which do not really have a canonical octal/binary representation.

In any case, it seems to express the intent more clearly to have our UI JS _normalize the ETags it sends back in headers to strong ETags_, which is what this change does.

**Alternative Fix**
Alternative would be to change the matching on the server side to allow a weak etag to match a strong etag in the normalization logic in `ControllerMethods` location above, which would be a much simpler change.

However this seems to go against the spirit of the spec, although it is possible I am misreading it. When you read the description [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests#weak_validation) it reads as if the server should do a weak validation if the client puts a weak validator in the header, but [the spec reads differently](https://datatracker.ietf.org/doc/html/rfc7232#section-3.1) as if any weak validator ever sent in an `If-Match` header will never match when doing "Strong Comparison" as it requires. I'm not sure how people implement this in practice.

The downside of the approach taken in this PR is that use of the GoCD APIs via other client code will likely have similar issues, and have to normalize their own ETags in PUT calls made to the API.