### PR TITLE
Review dependency suppressions and upgrade OWASP dependency check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:7.1.0.1'
+    classpath 'org.owasp:dependency-check-gradle:7.1.1'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.42.0'
     classpath 'gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1'
     classpath 'com.github.jk1:gradle-license-report:2.1'

--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -18,12 +18,6 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes><![CDATA[
-   Suppressing false positive as GoCD internal mysql support JAR is not the same thing as MySQL.
-   ]]></notes>
-        <cpe>cpe:/a:mysql:mysql</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
    Suppressing false positive caused by OWASP Dependency Check thinking the shaded/packaged dirgra library is the same
    as the JRuby version. These are versioned independently and not the same thing.
    ]]></notes>

--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -141,7 +141,8 @@
       GoCD does not use RegexRequestMatchers from Spring Security with a value of '.' as required by https://nvd.nist.gov/vuln/detail/CVE-2022-22978
       to be vulnerable to this issue.
        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-web@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-(core|web|config)@.*$</packageUrl>
+        <cve>CVE-2022-22978</cve>
         <vulnerabilityName>CVE-2022-22978</vulnerabilityName>
     </suppress>
 

--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -120,6 +120,17 @@
 
     <suppress>
         <notes><![CDATA[
+   Spring WebMVC 4.3.x does not appear to be affected by https://tanzu.vmware.com/security/cve-2021-22060 based on review
+   of the patches made to `LogFormatUtils` in the fixed 5.2.19.RELEASE version: https://github.com/spring-projects/spring-framework/compare/v5.2.18.RELEASE...v5.2.19.RELEASE
+   This is because in Spring 4.3 all of these log statements are at TRACE level, which are very unlikely to be enabled
+   for a GoCD instance in production, and not in the default configuration
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-webmvc@4\.3.*$</packageUrl>
+        <vulnerabilityName>CVE-2021-22060</vulnerabilityName>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
    From review of https://tanzu.vmware.com/security/cve-2021-22112 and the code of GoCD, GoCD does not appear to be
    subject to this defect, since it does not alter the security context in the manner required to elevate privileges
    in a small portion of the application and potentially be subject to this defect.


### PR DESCRIPTION
- Review vulnerabilities to assess whether GoCD is affected, suppressing irrelevant ones that aren't mitigatable
- Bump OWASP dependency check
- Remove an old unnecessary suppression