### PR TITLE
Add Docker builds against Alpine 3.16

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -33,6 +33,7 @@ enum Distro implements DistroBehavior {
         new DistroVersion(version: '3.13', releaseName: '3.13', eolDate: parseDate('2022-11-01'), continueToBuild: true),
         new DistroVersion(version: '3.14', releaseName: '3.14', eolDate: parseDate('2023-05-01')),
         new DistroVersion(version: '3.15', releaseName: '3.15', eolDate: parseDate('2023-11-01')),
+        new DistroVersion(version: '3.16', releaseName: '3.16', eolDate: parseDate('2024-05-01')),
       ]
     }
 

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -29,12 +29,10 @@ enum Distro implements DistroBehavior {
 
     @Override
     List<DistroVersion> getSupportedVersions() {
-      def installSasl_Post_3_9 = ['apk add --no-cache libsasl']
-
       return [
-        new DistroVersion(version: '3.13', releaseName: '3.13', eolDate: parseDate('2022-11-01'), installPrerequisitesCommands: installSasl_Post_3_9, continueToBuild: true),
-        new DistroVersion(version: '3.14', releaseName: '3.14', eolDate: parseDate('2023-05-01'), installPrerequisitesCommands: installSasl_Post_3_9),
-        new DistroVersion(version: '3.15', releaseName: '3.15', eolDate: parseDate('2023-11-01'), installPrerequisitesCommands: installSasl_Post_3_9),
+        new DistroVersion(version: '3.13', releaseName: '3.13', eolDate: parseDate('2022-11-01'), continueToBuild: true),
+        new DistroVersion(version: '3.14', releaseName: '3.14', eolDate: parseDate('2023-05-01')),
+        new DistroVersion(version: '3.15', releaseName: '3.15', eolDate: parseDate('2023-11-01')),
       ]
     }
 
@@ -202,7 +200,7 @@ enum Distro implements DistroBehavior {
     @Override
     List<DistroVersion> getSupportedVersions() {
       def installSasl = [
-              'apk add --no-cache libsasl sudo',
+              'apk add --no-cache sudo',
               // Workaround for https://github.com/docker-library/docker/commit/75e26edc9ea7fff4aa3212fafa5966f4d6b00022
               // which causes a clash with glibc, which is installed later for AdoptOpenJDK and will serve the same purpose
               'apk del --purge libc6-compat'

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -200,15 +200,8 @@ enum Distro implements DistroBehavior {
 
     @Override
     List<DistroVersion> getSupportedVersions() {
-      def installSasl = [
-              'apk add --no-cache sudo',
-              // Workaround for https://github.com/docker-library/docker/commit/75e26edc9ea7fff4aa3212fafa5966f4d6b00022
-              // which causes a clash with glibc, which is installed later for AdoptOpenJDK and will serve the same purpose
-              'apk del --purge libc6-compat'
-      ]
-
       return [
-        new DistroVersion(version: 'dind', releaseName: 'dind', eolDate: parseDate('2099-01-01'), installPrerequisitesCommands: installSasl)
+        new DistroVersion(version: 'dind', releaseName: 'dind', eolDate: parseDate('2099-01-01'))
       ]
     }
 
@@ -219,12 +212,22 @@ enum Distro implements DistroBehavior {
 
     @Override
     List<String> getInstallPrerequisitesCommands(DistroVersion distroVersion) {
-      return alpine.getInstallPrerequisitesCommands(distroVersion)
+      return alpine.getInstallPrerequisitesCommands(distroVersion) +
+        [
+          'apk add --no-cache sudo',
+        ]
     }
 
     @Override
     List<String> getInstallJavaCommands(Project project) {
-      return alpine.getInstallJavaCommands(project)
+      return [
+        // Workaround for https://github.com/docker-library/docker/commit/75e26edc9ea7fff4aa3212fafa5966f4d6b00022
+        // which causes a clash with glibc, which is installed later due to being needed for Tanuki Java Wrapper (and
+        // thus used by the particular Adoptium builds we are using Alpine Adoptium builds seemingly can't co-exist happily).
+        // We could avoid doing this once https://github.com/containerd/containerd/issues/5824 is fixed and makes its
+        // way to the relevant docker:dind image version.
+        'apk del --purge libc6-compat'
+      ] + alpine.getInstallJavaCommands(project)
     }
 
     @Override

--- a/settings-docker.gradle
+++ b/settings-docker.gradle
@@ -32,4 +32,4 @@ Distro.values().each { distro ->
 }
 
 include ":docker:gocd-server:${Distro.centos.projectName(Distro.centos.getVersion('8'))}"
-include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.15'))}"
+include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.16'))}"


### PR DESCRIPTION
https://alpinelinux.org/posts/Alpine-3.16.0-released.html

- Add builds of agents against `3.16`
- Switch gocd-server to build against `3.16`
- Some simplification of the Alpine-related `Dockerfile` scripting/templating to better convey intent