### PR TITLE
Change GoCD to no longer force links to open in new windows/tabs

### DIFF
--- a/server/src/main/resources/server_in_maintenance_mode.html
+++ b/server/src/main/resources/server_in_maintenance_mode.html
@@ -75,7 +75,7 @@
       <div class="message">
         <span id="message_text"/>
         &nbsp;
-        <a target="_blank" href="%docsBaseUrl%/advanced_usage/maintenance_mode.html">Learn more..</a>
+        <a target="_blank" href="%docsBaseUrl%/advanced_usage/maintenance_mode.html">Learn More</a>
       </div>
     </div>
   </div>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/spec/version_updater_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/spec/version_updater_spec.ts
@@ -263,7 +263,7 @@ describe("VersionUpdater", () => {
       expect(notifications[0].message).toBe("A new version of GoCD - 18.7.0-1234 is available.");
       expect(notifications[0].type).toBe("UpdateCheck");
       expect(notifications[0].link).toBe("https://www.gocd.org/download/");
-      expect(notifications[0].linkText).toBe("Learn more ...");
+      expect(notifications[0].linkText).toBe("Learn More");
       expect(notifications[0].read).toBe(false);
       expect(notifications[0].id).not.toBeUndefined();
     });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/version_updater.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/version_updater.ts
@@ -93,7 +93,7 @@ export class VersionUpdater {
     VersionUpdater.markUpdateDone();
     const latestVersionNumber = await VersionUpdater.get();
     if (latestVersionNumber !== undefined) {
-      SystemNotifications.notifyNewMessage("UpdateCheck", `A new version of GoCD - ${latestVersionNumber} is available.`, "https://www.gocd.org/download/", "Learn more ...");
+      SystemNotifications.notifyNewMessage("UpdateCheck", `A new version of GoCD - ${latestVersionNumber} is available.`, "https://www.gocd.org/download/", "Learn More");
     }
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/link/spec/index_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/link/spec/index_spec.tsx
@@ -40,7 +40,7 @@ describe("Link", () => {
   });
 
   it("should show external link icon when specified", () => {
-    helper.mount(() => <Link target="_blank" href="docs.gocd.org" externalLinkIcon={true}/>);
+    helper.mount(() => <Link href="docs.gocd.org" target="_blank" externalLinkIcon={true}/>);
     const anchor = helper.q("a");
     expect(anchor).toHaveClass(styles.externalIcon);
   });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/job_agent_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/job_agent_widget.tsx
@@ -41,7 +41,7 @@ export class JobAgentWidget extends MithrilComponent<Attrs, State> {
       const agentDetailsPageLink = `/go/agents/${job.agent_uuid}/job_run_history`;
       const agent: Agent | undefined = agents().getAgent(job.agent_uuid);
       const agentForDisplay = agent ? agent.hostname : job.agent_uuid;
-      return <Link title={agentForDisplay} href={agentDetailsPageLink} target={"_blank"}>{agentForDisplay}</Link>;
+      return <Link title={agentForDisplay} href={agentDetailsPageLink}>{agentForDisplay}</Link>;
     };
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/jobs_list_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/jobs_list_widget.tsx
@@ -20,6 +20,7 @@ import * as Icons from "views/components/icons";
 import {MithrilComponent} from "../../../jsx/mithril-component";
 import {Agents} from "../../../models/agents/agents";
 import {CheckboxField} from "../../components/forms/input_fields";
+import {Link} from "../../components/link";
 import * as styles from "./index.scss";
 import {JobAgentWidget} from "./job_agent_widget";
 import {JobProgressBarWidget} from "./job_progress_bar_widget";
@@ -68,7 +69,9 @@ export class JobsListWidget extends MithrilComponent<Attrs, State> {
           <span title={job.name} className={styles.jobName}>{job.name}</span>
         </div>
         <div class={styles.consoleLogIconCell}  data-test-id={`console-log-icon-for-${job.name}`}>
-          <Icons.ConsoleLog title="Go to Job Console Log" onclick={() => window.open(jobDetailsPageLink)} target={"_blank"} iconOnly={true}/>
+          <Link href={jobDetailsPageLink}>
+            <Icons.ConsoleLog title="Go to Job Console Log" iconOnly={true}/>
+          </Link>
         </div>
         <div class={styles.stateCell} data-test-id={`state-for-${job.name}`}>
           <JobStateWidget job={job}/>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/stage_overview_header_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/spec/stage_overview_header_spec.tsx
@@ -152,9 +152,10 @@ describe('Stage Overview Header', () => {
 
   it('should render link to stage details page', () => {
     const expectedLink = `/go/pipelines/up42/20/up42_stage/1`;
-    const link = helper.q('a');
+    const linkContainer = helper.byTestId('stage-details-page-link');
+    expect(linkContainer).toBeInDOM();
 
-    expect(helper.byTestId('stage-details-page-link')).toBeInDOM();
+    const link = helper.q('a', linkContainer);
     expect(link).toContainText('Go to Stage Details Page');
     expect((link as any).href.indexOf(expectedLink)).not.toBe(-1);
   });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/stage_overview_header.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/stage_overview_header.tsx
@@ -107,7 +107,9 @@ export class StageHeaderWidget extends MithrilComponent<StageHeaderAttrs, StageH
     let stageSettings: m.Child;
     if (vnode.attrs.canAdminister) {
       stageSettings = (<div className={styles.stageSettings}>
-        <Icons.Settings iconOnly={true} data-test-url={stageSettingsUrl} onclick={() => window.open(stageSettingsUrl)}/>
+        <Link href={stageSettingsUrl}>
+          <Icons.Settings iconOnly={true} data-test-url={stageSettingsUrl}/>
+        </Link>
       </div>);
     } else {
       const disabledEditMessage = `You dont have permissions to edit the stage.`;
@@ -204,7 +206,7 @@ export class StageHeaderWidget extends MithrilComponent<StageHeaderAttrs, StageH
         </div>
         <div data-test-id="stage-details-page-link" class={styles.stageDetailsPageLink}>
           {dummyContainer}
-          <Link href={stageDetailsPageLink} externalLinkIcon={true} target={"_blank"}>Go to Stage Details Page</Link>
+          <Link href={stageDetailsPageLink}>Go to Stage Details Page</Link>
         </div>
       </div>
     </div>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/access_tokens/access_tokens_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/access_tokens/access_tokens_widget.tsx
@@ -70,7 +70,7 @@ export class AccessTokensWidgetForCurrentUser extends MithrilViewComponent<Attrs
     return <ul data-test-id="access-token-info">
       <li>Click on "Generate Token" to create new personal access token.</li>
       <li>A Generated token can be used to access the GoCD API.
-        <Link href={docsUrl('configuration/access_tokens.html')} externalLinkIcon={true}> Learn More</Link>
+        <Link href={docsUrl('configuration/access_tokens.html')} target="_blank" externalLinkIcon={true}> Learn More</Link>
       </li>
     </ul>;
   }
@@ -163,7 +163,7 @@ export class AccessTokensWidgetForAdmin extends MithrilViewComponent<AdminAttrs>
       <li>Navigate to <a href="/go/access_tokens">Personal Access Tokens</a>.</li>
       <li>Click on "Generate Token" to create new personal access token.</li>
       <li>The generated token can be used to access the GoCD API.
-        <Link href={docsUrl('configuration/access_tokens.html')} externalLinkIcon={true}> Learn More</Link>
+        <Link href={docsUrl('configuration/access_tokens.html')} target="_blank" externalLinkIcon={true}> Learn More</Link>
       </li>
     </ul>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/admin_pipelines_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/admin_pipelines_widget.tsx
@@ -205,10 +205,10 @@ export class PipelineGroupsWidget extends MithrilViewComponent<Attrs> {
   public static helpTextWhenEmpty() {
     return <ul data-test-id="pipelines-help-text">
       <li>Only GoCD system administrators are allowed to create a pipeline group.
-        <Link href={docsUrl("configuration/pipelines.html")} externalLinkIcon={true}> Learn More</Link>
+        <Link href={docsUrl("configuration/pipelines.html")} target="_blank" externalLinkIcon={true}> Learn More</Link>
       </li>
       <li>A GoCD Administrator can authorize users and roles to be administrators for pipeline groups.
-        <Link href={docsUrl("configuration/delegating_group_administration.html")} externalLinkIcon={true}> Learn More</Link>
+        <Link href={docsUrl("configuration/delegating_group_administration.html")} target="_blank" externalLinkIcon={true}> Learn More</Link>
       </li>
     </ul>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_templates/admin_templates_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_templates/admin_templates_widget.tsx
@@ -187,7 +187,7 @@ export class AdminTemplatesWidget extends MithrilViewComponent<Attrs> {
     return <ul>
       <li>Templating helps to create reusable workflows and makes managing large number of pipelines easier.</li>
       <li>GoCD Administrators can enable any GoCD user to edit a template by making them a template administrator.
-        <Link href={docsUrl("configuration/pipeline_templates.html")} externalLinkIcon={true}> Learn More</Link>
+        <Link href={docsUrl("configuration/pipeline_templates.html")} target="_blank" externalLinkIcon={true}> Learn More</Link>
       </li>
     </ul>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/agent-job-run-history/agent_job_run_history_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/agent-job-run-history/agent_job_run_history_widget.tsx
@@ -52,9 +52,7 @@ export class AgentJobRunHistoryWidget extends MithrilComponent<Attrs, State> {
       const stageName    = jobHistoryItem.stage_name;
       const jobName      = jobHistoryItem.job_name;
 
-      const jobNameLink = <Link
-        href={`/go/tab/build/detail/${pipelineName}/${jobHistoryItem.pipeline_counter}/${stageName}/${jobHistoryItem.stage_counter}/${jobName}`}
-        target="_blank">
+      const jobNameLink = <Link href={`/go/tab/build/detail/${pipelineName}/${jobHistoryItem.pipeline_counter}/${stageName}/${jobHistoryItem.stage_counter}/${jobName}`}>
         {jobName}
       </Link>;
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/agents.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/agents.tsx
@@ -128,7 +128,7 @@ export class AgentsPage extends Page<null, State> {
   helpText(): m.Children {
     return <span>
       GoCD Agents are the workers in the GoCD ecosystem. Agents pick up jobs which are assigned to them, execute the tasks in the job and report the status of the job to the GoCD Server.
-      <Link href={docsUrl("introduction/concepts_in_go.html#agent")} externalLinkIcon={true}> Learn More</Link>
+      <Link href={docsUrl("introduction/concepts_in_go.html#agent")} target="_blank" externalLinkIcon={true}> Learn More</Link>
     </span>;
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs/auth_configs_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/auth_configs/auth_configs_widget.tsx
@@ -43,7 +43,7 @@ export class AuthConfigsWidget extends MithrilViewComponent<Attrs> {
       </li>
       <li>GoCD can be setup to use multiple authorization configurations at the same time.</li>
       <li>An auth configuration can be used to setup user authorization. You can read more about authorization in
-        GoCD from <Link target="_blank" href={docsUrl("configuration/dev_authentication.html")}>here</Link>.
+        GoCD from <Link href={docsUrl("configuration/dev_authentication.html")} target="_blank" externalLinkIcon={true}>here</Link>.
       </li>
     </ul>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tab_handler.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tab_handler.tsx
@@ -137,7 +137,7 @@ export abstract class TabHandler<T> extends Page<null, T> {
       const entity = (this.getEntity() as PipelineConfig);
       if (entity.origin().isDefinedInConfigRepo()) {
         const message = <div>
-          Can not edit pipeline '{entity.name()}' as it is defined in <a href={`/go/admin/config_repos#!${entity.origin().id()}`} target="_blank">{entity.origin().id()}</a> Config Repository!
+          Can not edit pipeline '{entity.name()}' as it is defined in <a href={`/go/admin/config_repos#!${entity.origin().id()}`}>{entity.origin().id()}</a> Config Repository!
         </div>;
 
         configRepoPipelineMessage = <FlashMessage message={message} type={MessageType.warning}/>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/widgets/job_editor_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/widgets/job_editor_widget.tsx
@@ -72,7 +72,7 @@ export class JobEditor extends MithrilViewComponent<Attrs> {
       <TextField label={["Elastic profile id", <Help content={
         [
           "Elastic Profile that this job requires to run. ",
-          <Link target="_blank" href={"/go/admin/elastic_agent_configurations"}>Click here</Link>,
+          <Link href={"/go/admin/elastic_agent_configurations"}>Click here</Link>,
           " to see and manage all elastic profiles."]}/>
       ]}
                  dataTestId={"elastic-profile-id-input"}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare.tsx
@@ -109,7 +109,7 @@ export class ComparePage extends Page<null, State> {
     return <div>
       GoCD allows the comparison between any two builds of a pipeline and displays the changes happened between the two. The information included in
       the view are code check-ins, upstream pipelines info, mainly revision and instance and story/defect numbers (when linked to a tracking tool).
-      <Link href={docsUrl('advanced_usage/compare_pipelines.html')} externalLinkIcon={true}> Learn More</Link>
+      <Link href={docsUrl('advanced_usage/compare_pipelines.html')} target="_blank" externalLinkIcon={true}> Learn More</Link>
     </div>;
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
@@ -310,7 +310,7 @@ export class ConfigReposWidget extends MithrilViewComponent<CollectionAttrs> {
       <li>GoCD can utilize the pipeline definitions stored in an external source code repository (either in your application’s repository, or in a
         separate repository).
       </li>
-      <li>You can read more about config repositories from <Link target="_blank" href={docsUrl('advanced_usage/pipelines_as_code.html')}>here</Link>.
+      <li>You can read more about config repositories from <Link href={docsUrl('advanced_usage/pipelines_as_code.html')} target="_blank" externalLinkIcon={true}>here</Link>.
       </li>
     </ul>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agents.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agents.tsx
@@ -357,7 +357,7 @@ export class ElasticAgentsPage extends Page<null, State> {
         image (ami, container image), size of the CPU/memory/disk, network settings among other things.
       </li>
       <li>You can read more about elastic agent configurations from
-        <Link target="_blank" href={docsUrl("configuration/elastic_agents.html")}> here</Link>.
+        <Link href={docsUrl("configuration/elastic_agents.html")} target="_blank" externalLinkIcon={true}>here</Link>.
       </li>
     </ul>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/maintenance_mode_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/maintenance_mode_widget.tsx
@@ -67,7 +67,7 @@ export class MaintenanceModeWidget extends MithrilViewComponent<Attrs> {
           When put into maintenance mode, it is safe to restart or upgrade the GoCD server without having any running
           jobs reschedule when the server is back up.
           &nbsp;
-          <Link target="_blank" href={docsUrl("/advanced_usage/maintenance_mode.html")}>Learn more..</Link>
+          <Link href={docsUrl("/advanced_usage/maintenance_mode.html")} target="_blank" externalLinkIcon={true}>Learn More</Link>
         </p>
 
         <div class={styles.maintenanceModeInfo}>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/spec/maintenance_mode_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/spec/maintenance_mode_widget_spec.tsx
@@ -43,7 +43,7 @@ describe("Maintenance Mode Widget", () => {
 
   it("should add a link to the maintenance mode documentation", () => {
     const expectedLink = docsUrl("/advanced_usage/maintenance_mode.html");
-    const expectedText = "Learn more..";
+    const expectedText = "Learn More";
 
     expect((helper.q("a") as HTMLAnchorElement).href).toBe(expectedLink);
     expect(helper.q("a").innerText).toBe(expectedText);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/materials_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/materials_widget.tsx
@@ -36,9 +36,9 @@ export class MaterialsWidget extends MithrilViewComponent<MaterialsAttrs> {
     if (vnode.attrs.materials().length === 0) {
       return <div>
         <FlashMessage type={MessageType.info}>
-          Either no pipelines have been set up or you are not authorized to view the same.&nbsp;
+          Either no pipelines have been set up or you are not authorized to view the same.
           <Link href={docsUrl("configuration/dev_authorization.html#specifying-permissions-for-pipeline-groups")} target="_blank"
-                externalLinkIcon={true}>Learn More</Link>
+                externalLinkIcon={true}> Learn More</Link>
         </FlashMessage>
         <div data-test-id="materials-help" class={styles.help}>
           {MaterialsWidget.helpText()}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/modal.tsx
@@ -254,7 +254,7 @@ export class ShowUsagesModal extends Modal {
                        .map((pipeline: string, index) => {
                          return [
                            <span>{pipeline}</span>,
-                           <Link href={SparkRoutes.pipelineEditPath('pipelines', pipeline, 'materials')} target={"_blank"}
+                           <Link href={SparkRoutes.pipelineEditPath('pipelines', pipeline, 'materials')}
                                  dataTestId={`material-link-${index}`}>View/Edit Material</Link>
                          ];
                        }));

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/config_repo_link.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/config_repo_link.tsx
@@ -29,7 +29,7 @@ export class ConfigRepoLink extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs>) {
     return <span data-test-id={vnode.attrs.dataTestId} className={styles.configRepoLink}>
                                       (Config Repository:
-                                      <Link target="_blank" href={SparkRoutes.ConfigRepoViewPath(vnode.attrs.configRepoId)}>
+                                      <Link href={SparkRoutes.ConfigRepoViewPath(vnode.attrs.configRepoId)}>
                                         {vnode.attrs.configRepoId}
                                       </Link>
                                       )

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_pipelines_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/edit_pipelines_modal.tsx
@@ -110,7 +110,7 @@ export class UnavailablePipelinesBecauseOfOtherEnvironmentWidget extends Mithril
             const environmentWithOrigin = vnode.attrs.pipelinesVM.environments.findEnvironmentForPipeline(pipeline.name());
             const environmentLink       = <span data-test-id={`pipeline-list-item-for-${pipeline.name()}`} class={styles.configRepoLink}>
               (ENVIRONMENT:
-              <Link target="_blank" href={SparkRoutes.getEnvironmentPathOnSPA(environmentWithOrigin!.name())}>
+              <Link href={SparkRoutes.getEnvironmentPathOnSPA(environmentWithOrigin!.name())}>
                 {environmentWithOrigin!.name()}
               </Link>
               )

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/environments_widget.tsx
@@ -109,7 +109,7 @@ export class EnvironmentsWidget extends MithrilViewComponent<Attrs> {
       <li>An Environment is a grouping of pipelines and agents.</li>
       <li>By assigning an agent to an environment, it will be used to run only those jobs that belong to the pipelines of that environment.</li>
       <li>An agent can belong to more than one environment. A pipeline can, however, only be assigned to a single environment.
-        <Link href={docsUrl('configuration/managing_environments.html')} externalLinkIcon={true}> Learn More</Link>
+        <Link href={docsUrl('configuration/managing_environments.html')} target="_blank" externalLinkIcon={true}> Learn More</Link>
       </li>
     </ul> ;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_preferences.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_preferences.tsx
@@ -152,7 +152,7 @@ export class NewPreferencesPage extends Page<null, PreferencesState> {
     let smtpErrorMessage;
     if (!vnode.state.isSMTPConfigured) {
       const message    = <span>SMTP settings are currently not configured. If you are the administrator, you can configure email support at <Link
-        href={"/go/admin/config/server#!email-server"} externalLinkIcon={true}>Mail Server Configuration</Link>.</span>;
+        href={"/go/admin/config/server#!email-server"}>Mail Server Configuration</Link>.</span>;
       smtpErrorMessage = <FlashMessage type={MessageType.info} message={message}/>;
     }
     return [

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repositories_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/package_repositories_widget.tsx
@@ -46,7 +46,7 @@ export class PackageRepositoriesWidget extends MithrilViewComponent<Attrs> {
     return <ul>
       <li>Click on "Create Package Repository" to add new package repository.</li>
       <li>A package repository can be set up to use packages as a material in the pipelines. You can read more
-        from <Link target="_blank" href={docsUrl("extension_points/package_repository_extension.html")}>here</Link>.
+        from <Link href={docsUrl("extension_points/package_repository_extension.html")} target="_blank" externalLinkIcon={true}>here</Link>.
       </li>
     </ul>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.tsx
@@ -74,7 +74,7 @@ export class SiteFooter extends MithrilViewComponent<Attrs> {
       return (<div data-test-id="maintenance-mode-banner" class={styles.footerWarningBanner}>
         {updatedByMessage}
         &nbsp;
-        <Link target="_blank" href={docsUrl("/advanced_usage/maintenance_mode.html")}>Learn more..</Link>
+        <Link href={docsUrl("/advanced_usage/maintenance_mode.html")} target="_blank" externalLinkIcon={true}>Learn More</Link>
       </div>);
     }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity.tsx
@@ -176,7 +176,7 @@ export class PipelineActivityPage extends Page<null, State> implements ResultAwa
     return <div>
       The pipeline activity helps GoCD users to see the status of historical runs of a pipeline. The current page makes it easier to browse
       through the pipeline runs by filtering pipeline runs using label, user or material revision (e.g. git commit sha).
-      <Link href={docsUrl('advanced_usage/pipeline_activity.html')} externalLinkIcon={true}> Learn More</Link>
+      <Link href={docsUrl('advanced_usage/pipeline_activity.html')} target="_blank" externalLinkIcon={true}> Learn More</Link>
     </div>;
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines.tsx
@@ -164,7 +164,7 @@ export class PipelineCreatePage extends Page<{}, State> {
   helpText(): m.Children {
     return <div>
       To read about the basic pipeline setup, follow
-      <Link href={docsUrl('configuration/quick_pipeline_setup.html')} externalLinkIcon={true}> this.</Link>
+      <Link href={docsUrl('configuration/quick_pipeline_setup.html')} target="_blank" externalLinkIcon={true}>this.</Link>
     </div>;
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scms_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scms_widget.tsx
@@ -48,7 +48,7 @@ export class PluggableScmsWidget extends MithrilViewComponent<Attrs> {
     return <ul>
       <li>Click on "Create Pluggable Scm" to add new SCM.</li>
       <li>An SCM can be set up and used as a material in the pipelines. You can read more
-        from <Link target="_blank" href={docsUrl("extension_points/scm_extension.html")}>here</Link>.
+        from <Link href={docsUrl("extension_points/scm_extension.html")} target="_blank" externalLinkIcon={true}>here</Link>.
       </li>
     </ul>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/plugins.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/plugins.tsx
@@ -44,7 +44,7 @@ export class PluginsPage extends Page {
   helpText(): m.Children {
     return <div>
       Plugins allow users to extend the functionality of GoCD. You can read more about them from
-      <Link href={docsUrl("extension_points/plugin_user_guide.html")} externalLinkIcon={true}> here.</Link>
+      <Link href={docsUrl("extension_points/plugin_user_guide.html")} target="_blank" externalLinkIcon={true}>here.</Link>
     </div>;
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/preferences/notifications_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/preferences/notifications_widget.tsx
@@ -36,7 +36,7 @@ export class NotificationsWidget extends MithrilViewComponent<Attrs> {
         <ul>
           <li>Click on "Add Notification Filter" to add a new email notification filter.</li>
           <li>Notifications will only work if security is enabled and mailhost information is correct. You can read more
-            from <Link target="_blank" href={docsUrl("configuration/dev_notifications.html")}>here</Link>.
+            from <Link href={docsUrl("configuration/dev_notifications.html")} target="_blank" externalLinkIcon={true}>here</Link>.
           </li>
         </ul>
       </div>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/policy_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/policy_widget.tsx
@@ -206,7 +206,7 @@ export class CreatePolicyWidget extends MithrilViewComponent<AutoCompleteAttrs> 
       }
     };
     const message                  = <span>Configure the policy below to manage access to GoCD entities for users in this role. <Link
-      externalLinkIcon={true} target="_blank"
+      target="_blank" externalLinkIcon={true}
       href={docsUrl("configuration/dev_authorization.html#role-based-access-control")}>Learn More</Link></span>;
     const policyBody               = vnode.attrs.policy && _.isEmpty(vnode.attrs.policy())
                                      ? <FlashMessage type={MessageType.info}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/roles_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/roles_widget.tsx
@@ -55,7 +55,7 @@ export class RolesWidget extends MithrilViewComponent<Attrs> {
       <li>Click on "Add" to add new role configuration.</li>
       <li>A role configuration is used to define a group of users, along with the access permissions, who perform
         similar tasks. You can read more about roles based access control in GoCD
-        from <Link target="_blank"
+        from <Link target="_blank" externalLinkIcon={true}
                    href={docsUrl("configuration/dev_authorization.html#role-based-security")}>here</Link>.
       </li>
     </ul>;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/secret_configs_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/secret_configs_widget.tsx
@@ -42,7 +42,7 @@ export class SecretConfigsWidget extends MithrilViewComponent<Attrs> {
       <li>Click on "Add" to add new secret configuration.</li>
       <li>A secret configuration can be used to access secrets from an external secret management store.</li>
       <li>You can read more about secret configurations from
-        <Link target="_blank" href={docsUrl('configuration/secrets_management.html')}> here</Link>.
+        <Link href={docsUrl('configuration/secrets_management.html')} target="_blank" externalLinkIcon={true}> here</Link>.
       </li>
     </ul>;
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/shared/environment_variables_with_origin_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/shared/environment_variables_with_origin_widget.tsx
@@ -37,7 +37,7 @@ class EnvironmentVariableWithOriginWidget extends EnvironmentVariableWidget {
     const environmentVariable = vnode.attrs.environmentVariable as EnvironmentVariableWithOrigin;
     return <div>
       Cannot edit this environment variable as it is defined in config repository:&nbsp;
-      <Link target="_blank" href={SparkRoutes.ConfigRepoViewPath(environmentVariable.origin().id())}>{environmentVariable.origin().id()}</Link>
+      <Link href={SparkRoutes.ConfigRepoViewPath(environmentVariable.origin().id())}>{environmentVariable.origin().id()}</Link>
     </div>;
   }
 }


### PR DESCRIPTION
Fixes #9526, related to #9613

Internal links will open by default in the same window/tab, returning control to the user to be able to middle-click (CMD + click) for new tab/window, and shift/middle-click for new background tabs, reducing a relatively age-old user complaint about excessive tabs being opened, and getting lost in tabs.

External and docs links continue to generally open in new tabs for now, but link display has been made more consistent to generally give a good indicaation with the icon if something is about to force-open in a new tab, e.g 
![image](https://github.com/gocd/gocd/assets/29788154/926bc2f1-3ae2-480f-8e0f-72561e8eb228)
