### PR TITLE
Workaround OpenJDK 17.0.3 issue breaking parts of Rails/Rack on Windows

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeServer.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeServer.groovy
@@ -62,7 +62,10 @@ class InstallerTypeServer implements InstallerType {
       // This writing to disk and then sending the contents over an http socket can cause significant performance overhead
       // so we increase the buffer limit to 30mb.
       // See org.jruby.rack.servlet.RewindableInputStream
-      '-Djruby.rack.request.size.threshold.bytes=30000000'
+      '-Djruby.rack.request.size.threshold.bytes=30000000',
+      // Workaround JDK 17.0.3 issue https://bugs.openjdk.java.net/browse/JDK-8285445 on Windows. See https://github.com/jruby/jruby/issues/7182
+      // Should be able to be removed after OpenJDK 17.0.4 (July 2022)
+      '-Djdk.io.File.enableADS=true',
     ]
   }
 


### PR DESCRIPTION
Apply same workaround as commit 98e395ab2cdbcd109d17a76b97fc23d7675edde5 to the server.

On Windows Rails/Rack seems to fail to initialize due to a bundler problem (?) due to use of the NUL device without this. We should remove these workarounds once we upgrade to JDK 17.0.4+. Note that Oracle JDK released a patch in 17.0.3.1 for which Adoptium/Eclipse Temurin did not release a similar patch release.

See https://bugs.openjdk.java.net/browse/JDK-8285445 and https://github.com/jruby/jruby/issues/7182