### PR TITLE
Correct wrapper log location for docker images

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-agent/docker-entrypoint.sh
+++ b/buildSrc/src/main/resources/gocd-docker-agent/docker-entrypoint.sh
@@ -124,7 +124,7 @@ if [ "$1" = "${AGENT_WORK_DIR}/bin/go-agent" ]; then
 
   # setup the java binary and wrapper log
   try sed -i \
-    -e "s@wrapper.logfile=.*@/wrapper.logfile=${AGENT_WORK_DIR}/logs/go-agent-bootstrapper-wrapper.log@g" \
+    -e "s@wrapper.logfile=.*@wrapper.logfile=${AGENT_WORK_DIR}/logs/go-agent-bootstrapper-wrapper.log@g" \
     -e "s@wrapper.java.command=.*@wrapper.java.command=${GO_JAVA_HOME}/bin/java@g" \
     -e "s@wrapper.working.dir=.*@wrapper.working.dir=${AGENT_WORK_DIR}@g" \
     /go-agent/wrapper-config/wrapper.conf

--- a/buildSrc/src/main/resources/gocd-docker-server/docker-entrypoint.sh
+++ b/buildSrc/src/main/resources/gocd-docker-server/docker-entrypoint.sh
@@ -80,7 +80,7 @@ if [ "$1" = "${SERVER_WORK_DIR}/bin/go-server" ]; then
 
   # setup the java binary and wrapper log
   try sed -i \
-    -e "s@wrapper.logfile=.*@/wrapper.logfile=${SERVER_WORK_DIR}/logs/go-server-wrapper.log@g" \
+    -e "s@wrapper.logfile=.*@wrapper.logfile=${SERVER_WORK_DIR}/logs/go-server-wrapper.log@g" \
     -e "s@wrapper.java.command=.*@wrapper.java.command=${GO_JAVA_HOME}/bin/java@g" \
     -e "s@wrapper.working.dir=.*@wrapper.working.dir=${SERVER_WORK_DIR}@g" \
     /go-server/wrapper-config/wrapper.conf


### PR DESCRIPTION
Seemed to be a typo in the sed command that updates the wrapper log location during startup. Intent is surely to store the logs in `/godata/logs` so they persist after restart, rather than using the root working dir. Currently it's not working correctly, thus storing the log at `/go-working-dir/wrapper.log` as default location.