### PR TITLE
Correct minor typo and doclink on personal email preferences

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/preferences/email_settings_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/preferences/email_settings_widget.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {docsUrl} from "gen/gocd_version";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import m from "mithril";
 import Stream from "mithril/stream";
@@ -44,8 +43,8 @@ export class EmailSettingsWidget extends MithrilViewComponent<Attrs> {
           <Form compactForm={true}>
             <TextField label="Email" type={"email"}
                        property={currentUser.email}
-                       helpText={"The email to which the notification is send."}
-                       docLink={docsUrl("configuration/dev_notifications.html")}
+                       helpText={"The email to which the notification is sent."}
+                       docLink={"configuration/dev_notifications.html"}
                        placeholder={"Email not set"}/>
             <CheckboxField dataTestId="enable-email-notification"
                            property={currentUser.emailMe}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/preferences/spec/email_settings_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/preferences/spec/email_settings_widget_spec.tsx
@@ -45,7 +45,7 @@ describe('EmailSettingsWidgetSpec', () => {
     expect(helper.byTestId('save-email-settings')).toBeInDOM();
     expect(helper.byTestId('save-email-settings')).toBeDisabled();
 
-    expect(helpText('form-field-input-email')).toContainText('The email to which the notification is send.');
+    expect(helpText('form-field-input-email')).toContainText('The email to which the notification is sent.');
     expect(helpText('form-field-input-my-check-in-aliases')).toContainText("Usually the commits will be either in 'user' or 'username'. Specify both the values here.");
   });
 


### PR DESCRIPTION
* Correct typo in grammar
* Fix the doclink when clicking "learn more"