### PR TITLE
Exclude unnecessary Liquibase transitive dependencies

### DIFF
--- a/db-support/db-migration/build.gradle
+++ b/db-support/db-migration/build.gradle
@@ -28,6 +28,11 @@ dependencies {
     implementation(project.deps.liquibase) {
         // Not needed, according to https://github.com/liquibase/liquibase/issues/1866
         exclude group: 'javax.xml.bind', module: 'jaxb-api'
+
+        // These dependencies used to be shaded, but are now directly added. However they seem only related to use of
+        // CSV or YAML snapshots/changelogs and/or offline storage which does not seem relevant to GoCD.
+        exclude group: 'org.yaml', module: 'snakeyaml'
+        exclude group: 'com.opencsv', module: 'opencsv'
     }
 
     testImplementation project.deps.testcontainersJdbc


### PR DESCRIPTION
Liquibase 4.12 stopped shading some dependencies, so we can now exclude them properly. It seems our usage does not require these at this stage.

https://github.com/liquibase/liquibase/blob/master/changelog.txt and https://github.com/liquibase/liquibase/pull/2903 are relevant here, and this fixes validation issues with builds after #10535 

