### PR TITLE
Remove reverse proxy misconfiguration as logged cause of agent connectivity ClientProtocolException

### DIFF
--- a/agent/src/main/java/com/thoughtworks/go/agent/RemotingClient.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/RemotingClient.java
@@ -46,7 +46,6 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.util.List;
 
-import static com.thoughtworks.go.CurrentGoCDVersion.docsUrl;
 import static com.thoughtworks.go.agent.ResponseHelpers.readBodyAsString;
 import static com.thoughtworks.go.agent.ResponseHelpers.readBodyAsStringOrElse;
 import static java.lang.String.format;
@@ -141,10 +140,7 @@ public class RemotingClient implements BuildRepositoryRemote {
             throw new ClientProtocolException(String.join("\n   - ", List.of(
                     format("The server returned status code %d. Possible reasons include:", status.getStatusCode()),
                     "This agent has been deleted from the configuration",
-                    "This agent is pending approval",
-                    "There is possibly a reverse proxy (or load balancer) that has been misconfigured. See "
-                            + docsUrl("/installation/configure-reverse-proxy.html#agents-and-reverse-proxies") +
-                            " for details."
+                    "This agent is pending approval"
             )));
         }
 


### PR DESCRIPTION
This log warning was previously possible if a load balancer or reverse proxy was terminating TLS, interfering with direct TLS connectivity to the GoCD Server, however GoCD no longer supports TLS termination, so a reverse proxy is required, and it should not be possible to get this error anymore due to a TLS issue. The specific documentation it refers to no longer exists either.

See #7872 