### PR TITLE
Return job state transitions from /api/jobs "Get Job Instance" API

### DIFF
--- a/api/api-job-instance-v1/src/main/java/com/thoughtworks/go/apiv1/jobinstance/JobInstanceControllerV1.java
+++ b/api/api-job-instance-v1/src/main/java/com/thoughtworks/go/apiv1/jobinstance/JobInstanceControllerV1.java
@@ -89,7 +89,7 @@ public class JobInstanceControllerV1 extends ApiController implements SparkSprin
         String jobName = request.params("job_name");
         Integer pipelineCounter = getValue(request, "pipeline_counter");
         Integer stageCounter = getValue(request, "stage_counter");
-        JobInstance jobInstance = jobInstanceService.findJobInstance(pipelineName, stageName, jobName, pipelineCounter, stageCounter, currentUsername());
+        JobInstance jobInstance = jobInstanceService.findJobInstanceWithTransitions(pipelineName, stageName, jobName, pipelineCounter, stageCounter, currentUsername());
         if (jobInstance.isNull()) {
             throw new RecordNotFoundException(format("No job instance was found for '%s/%s/%s/%s/%s'.", pipelineName, pipelineCounter, stageName, stageCounter, jobName));
         }

--- a/api/api-job-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/jobinstance/JobInstanceControllerV1Test.groovy
+++ b/api/api-job-instance-v1/src/test/groovy/com/thoughtworks/go/apiv1/jobinstance/JobInstanceControllerV1Test.groovy
@@ -257,7 +257,7 @@ class JobInstanceControllerV1Test implements SecurityServiceTrait, ControllerTra
       @Test
       void 'should return job instance for given counters'() {
         def jobInstance = getJobInstance()
-        when(jobInstanceService.findJobInstance(eq(pipelineName), eq(stageName), eq(jobName), eq(1), eq(1), eq(currentUsername()))).thenReturn(jobInstance)
+        when(jobInstanceService.findJobInstanceWithTransitions(eq(pipelineName), eq(stageName), eq(jobName), eq(1), eq(1), eq(currentUsername()))).thenReturn(jobInstance)
 
         getWithApiHeader(controller.controllerPath(pipelineName, 1, stageName, 1, jobName), [:])
 
@@ -273,7 +273,7 @@ class JobInstanceControllerV1Test implements SecurityServiceTrait, ControllerTra
       @Test
       void 'should return null job instance if the job has not been ran for the given counters'() {
         def nullJobInstance = new NullJobInstance(jobName)
-        when(jobInstanceService.findJobInstance(eq(pipelineName), eq(stageName), eq(jobName), eq(10), eq(10), eq(currentUsername()))).thenReturn(nullJobInstance)
+        when(jobInstanceService.findJobInstanceWithTransitions(eq(pipelineName), eq(stageName), eq(jobName), eq(10), eq(10), eq(currentUsername()))).thenReturn(nullJobInstance)
 
         getWithApiHeader(controller.controllerPath(pipelineName, 10, stageName, 10, jobName), [:])
 
@@ -321,7 +321,7 @@ class JobInstanceControllerV1Test implements SecurityServiceTrait, ControllerTra
       @Test
       void 'should render error if pipeline does not exist'() {
         doThrow(new RecordNotFoundException(EntityType.Pipeline, pipelineName))
-          .when(jobInstanceService).findJobInstance(eq(pipelineName), eq(stageName), eq(jobName), eq(10), eq(10), eq(currentUsername()))
+          .when(jobInstanceService).findJobInstanceWithTransitions(eq(pipelineName), eq(stageName), eq(jobName), eq(10), eq(10), eq(currentUsername()))
 
         getWithApiHeader(controller.controllerPath(pipelineName, 10, stageName, 10, jobName), [:])
 
@@ -333,7 +333,7 @@ class JobInstanceControllerV1Test implements SecurityServiceTrait, ControllerTra
       @Test
       void 'should render error if the user does not have permission to view the pipeline'() {
         doThrow(new NotAuthorizedException("some message"))
-          .when(jobInstanceService).findJobInstance(eq(pipelineName), eq(stageName), eq(jobName), eq(10), eq(10), eq(currentUsername()))
+          .when(jobInstanceService).findJobInstanceWithTransitions(eq(pipelineName), eq(stageName), eq(jobName), eq(10), eq(10), eq(currentUsername()))
 
         getWithApiHeader(controller.controllerPath(pipelineName, 10, stageName, 10, jobName), [:])
 

--- a/domain/src/test/java/com/thoughtworks/go/helper/JobInstanceMother.java
+++ b/domain/src/test/java/com/thoughtworks/go/helper/JobInstanceMother.java
@@ -16,7 +16,6 @@
 package com.thoughtworks.go.helper;
 
 import com.thoughtworks.go.config.JobConfig;
-import com.thoughtworks.go.config.ResourceConfigs;
 import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.domain.*;
@@ -40,19 +39,10 @@ public class JobInstanceMother {
     }
 
     public static JobInstance scheduled(String jobConfigName) {
-        return scheduled(jobConfigName, new ResourceConfigs());
-    }
-
-    public static JobInstance scheduled(String jobConfigName, ResourceConfigs resourceConfigs) {
         JobInstance instance = new JobInstance(jobConfigName);
         instance.setId(999);
         instance.setIdentifier(defaultJobIdentifier(jobConfigName));
         return instance;
-    }
-
-    public static JobInstance jobInstance(String jobConfigName, String resourceName) {
-        return new JobInstance(jobConfigName
-        );
     }
 
     public static JobInstance completed(String jobConfigName) {

--- a/server/src/main/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDao.java
@@ -49,10 +49,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.thoughtworks.go.util.IBatisUtil.arguments;
 
@@ -204,8 +201,10 @@ public class JobInstanceSqlMapDao extends SqlMapClientDaoSupport implements JobI
 
     @Override
     public JobInstance mostRecentJobWithTransitions(JobIdentifier job) {
-        Long buildId = findOriginalJobIdentifier(job.getStageIdentifier(), job.getBuildName()).getBuildId();
-        return buildByIdWithTransitions(buildId);
+        return Optional.ofNullable(findOriginalJobIdentifier(job.getStageIdentifier(), job.getBuildName()))
+            .map(JobIdentifier::getBuildId)
+            .map(this::buildByIdWithTransitions)
+            .orElse(JobInstance.NULL);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/service/FeedService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/FeedService.java
@@ -92,7 +92,7 @@ public class FeedService {
 
     public Document jobXml(Username username, String pipelineName, Integer pipelineCounter, String stageName,
                            Integer stageCounter, String jobName, String baseUrl) {
-        JobInstance jobInstance = jobInstanceService.findJobInstance(pipelineName, stageName, jobName, pipelineCounter, stageCounter, username);
+        JobInstance jobInstance = jobInstanceService.findJobInstanceWithTransitions(pipelineName, stageName, jobName, pipelineCounter, stageCounter, username);
         return xmlApiService.write(new JobXmlRepresenter(jobInstance), baseUrl);
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/JobInstanceService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/JobInstanceService.java
@@ -113,7 +113,7 @@ public class JobInstanceService implements JobPlanLoader, ConfigChangedListener 
         return jobInstanceDao.findJobHistoryPage(pipelineName, stageName, jobConfigName, pagination.getPageSize(), pagination.getOffset());
     }
 
-    public JobInstance findJobInstance(String pipelineName, String stageName, String jobName, Integer pipelineCounter, Integer stageCounter, Username username) {
+    public JobInstance findJobInstanceWithTransitions(String pipelineName, String stageName, String jobName, Integer pipelineCounter, Integer stageCounter, Username username) {
         if (!goConfigService.currentCruiseConfig().hasPipelineNamed(new CaseInsensitiveString(pipelineName))) {
             throw new RecordNotFoundException(EntityType.Pipeline, pipelineName);
         }
@@ -121,7 +121,8 @@ public class JobInstanceService implements JobPlanLoader, ConfigChangedListener 
             throw new NotAuthorizedException(NOT_AUTHORIZED_TO_VIEW_PIPELINE);
         }
 
-        return jobInstanceDao.findJobInstance(pipelineName, stageName, jobName, pipelineCounter, stageCounter);
+        StageIdentifier stageIdentifier = new StageIdentifier(pipelineName, pipelineCounter, null, stageName, stageCounter.toString());
+        return jobInstanceDao.mostRecentJobWithTransitions(new JobIdentifier(stageIdentifier, jobName));
     }
 
     public JobInstance buildByIdWithTransitions(long buildId) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/controller/JobControllerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/controller/JobControllerTest.java
@@ -125,7 +125,7 @@ public class JobControllerTest {
             Pipeline pipeline = PipelineMother.passedPipelineInstance("p1", "s1", "build");
             JobIdentifier jobIdentifier = JobIdentifierMother.jobIdentifier("p1");
             StageIdentifier stageIdentifier = new StageIdentifier("p1", 1, "s1", "1");
-            JobInstance jobInstance = JobInstanceMother.jobInstance("building", "one");
+            JobInstance jobInstance = new JobInstance("building");
             jobInstance.setIdentifier(jobIdentifier);
             jobInstance.setId(12);
             jobInstance.setState(JobState.Building);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/FeedServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/FeedServiceTest.java
@@ -195,7 +195,7 @@ public class FeedServiceTest {
 
             assertThat(document).isNotNull();
             verify(xmlApiService).write(any(JobXmlRepresenter.class), eq(BASE_URL));
-            verify(jobInstanceService).findJobInstance(pipelineName, stageName, jobName, 100, 1, username);
+            verify(jobInstanceService).findJobInstanceWithTransitions(pipelineName, stageName, jobName, 100, 1, username);
             verifyNoMoreInteractions(xmlApiService);
             verifyNoMoreInteractions(jobInstanceService);
             verifyNoInteractions(stageService);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDaoCachingTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDaoCachingTest.java
@@ -31,8 +31,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.util.*;
 
 import static com.thoughtworks.go.util.IBatisUtil.arguments;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
@@ -163,7 +163,7 @@ public class JobInstanceSqlMapDaoCachingTest {
     }
 
     private JobInstance instance(long id) {
-        JobInstance instance = JobInstanceMother.jobInstance("first", "resource");
+        JobInstance instance = new JobInstance("first");
         instance.setId(id);
         return instance;
     }


### PR DESCRIPTION
Fixes #10566

- [x] Unit test gaps to be reviewed
- [x] Regression on usages of `findJobInstance` to be verified (should be OK, it's just the feed XML?)
- [x] Regression on usages of DAO to be verified
- [x] To check whether history should also return (decided that no, want address this now, possible performance implication and not worth the effort)
- [x] To update docs
   - [x] Add example of transitions
   - [x] Remove misleading empty transitions array from history api return
- [x] Looking for feedback on whether there are API, narrow integration tests or functional/regression tests that would normally be