### PR TITLE
Remove unused dynamic_form rails helper

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile
@@ -4,8 +4,6 @@ ruby '2.6.8'
 gem 'rails'
 gem 'sass-rails'
 
-gem 'dynamic_form'
-
 gem 'js-routes'
 gem 'ts_routes'
 

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -63,7 +63,6 @@ GEM
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     diff-lcs (1.5.0)
-    dynamic_form (1.1.4)
     erubi (1.10.0)
     ffi (1.15.5)
     ffi (1.15.5-java)
@@ -213,7 +212,6 @@ DEPENDENCIES
   brakeman
   bundler-audit
   capybara
-  dynamic_form
   js-routes
   pry-debugger-jruby
   rails


### PR DESCRIPTION
I believe this is now unused after the remaining last batch of Rails-based editing pieces were removed.