### PR TITLE
Remove unnecesary OWASP dependency check suppression

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -216,15 +216,6 @@
 
   <suppress>
     <notes><![CDATA[
-    This is a false positive and not a vulnerability according to https://github.com/h2database/h2database/issues/3175#issuecomment-1142186324
-    - it's being reported against the wrong version from OSSINDEX.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.h2database/h2@.*$</packageUrl>
-    <vulnerabilityName>CVE-2018-14335</vulnerabilityName>
-  </suppress>
-
-  <suppress>
-    <notes><![CDATA[
     From review of https://nvd.nist.gov/vuln/detail/CVE-2021-23463 GoCD is not subject to this XXE vulnerability, because
     neither GoCD, Hibernate or MyBatis use JdbcResultSet.getSQLXML(). It seems this is unlikely to get a backport to
     H2 1.4.x which is a breaking change. See https://github.com/h2database/h2database/issues/3195 and

--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -39,8 +39,7 @@
     as JRuby independently. These are not the same things.
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jruby\.rack/jruby\-rack@.*$</packageUrl>
-    <vulnerabilityName>CVE-2010-1330</vulnerabilityName>
-    <vulnerabilityName>CVE-2011-4838</vulnerabilityName>
+    <cpe>cpe:/a:jruby:jruby</cpe>
   </suppress>
   <suppress>
     <notes><![CDATA[


### PR DESCRIPTION
Minor cleanup of suppressions no longer needed, or better conveyed.