### PR TITLE
Fix automatic iframe height resizing on custom tabs

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/old_application.js
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/old_application.js
@@ -72,7 +72,7 @@ function iframeResizer(Iframe){
         Iframe.contents().find("body > pre").css({whiteSpace:'pre-wrap',margin : 0,fontSize : '12px',fontFamily: 'consolas, monaco, courier', wordWrap:'break-word', '-ms-word-wrap':'break-word', overflow:'hidden'});
         setTimeout(function(){
             jQuery('iframe').each(function(){
-                Iframe.height(Iframe.contents().find("body").contents().height());
+                Iframe.height(Iframe.contents().find("body").height());
             });
         }, 200);
     }


### PR DESCRIPTION
Fixes #10610

It's not clear why there was the extra `.contents()` call here, but this doesn't seem to work when the body has multiple elements in it. This seems to fix it. 

- [x] Validated with dependency check report (multiple divs in `<body>`)
- [x] Validate with single-element things
- [x] Double check other iframes are still OK
   - [x] Stage details graph seems OK
   - [x] Tests tab?
   - [x] Analytics?

