### PR TITLE
Temporarily lock RetireJS vulnerability repository version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,9 @@ dependencyCheck {
     assemblyEnabled = false
     retirejs {
       filterNonVulnerable = true
+
+      // Repository version locked due to https://github.com/jeremylong/DependencyCheck/issues/4695
+      retireJsUrl = 'https://raw.githubusercontent.com/RetireJS/retire.js/33b4076ce87f3898b81af4fc1770a7b65aa54bcb/repository/jsrepository.json'
     }
   }
   skipConfigurations = ['pmd']


### PR DESCRIPTION
Fixes OWASP Dependency Check scans temporarily.

Latest RetireJS repository version does not work with OWASP Dependency Check 7.1.1 due to issue with `com.h3xstream.retirejs:retirejs-core:3.0.3` triggered by https://github.com/RetireJS/retire.js/commit/60ffbeb1523c503da886b2a47b39551697ed06c8

See https://github.com/jeremylong/DependencyCheck/issues/4695