### PR TITLE
Fix issues running Windows commands that have spaces in paths

### DIFF
--- a/commandline/src/test/java/com/thoughtworks/go/util/command/CommandLineScriptRunnerTest.java
+++ b/commandline/src/test/java/com/thoughtworks/go/util/command/CommandLineScriptRunnerTest.java
@@ -24,7 +24,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-class ScriptRunnerTest {
+class CommandLineScriptRunnerTest {
     @Test
     @EnabledOnOs(OS.LINUX)
     void shouldReplaceSecretsOnTheOutputUnderLinux() throws CheckedCommandLineException {
@@ -79,7 +79,7 @@ class ScriptRunnerTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS)
-    void shouldMaskOutOccuranceOfSecureEnvironmentVariablesValuesInTheScriptOutputOnLinux() throws CheckedCommandLineException {
+    void shouldMaskOutOccurrenceOfSecureEnvironmentVariablesValuesInTheScriptOutputOnLinux() throws CheckedCommandLineException {
         EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
         environmentVariableContext.setProperty("secret", "the_secret_password", true);
         CommandLine command = CommandLine.createCommandLine("echo").withArg("the_secret_password").withEncoding(UTF_8);
@@ -93,7 +93,7 @@ class ScriptRunnerTest {
 
     @Test
     @EnabledOnOs(OS.WINDOWS)
-    void shouldMaskOutOccuranceOfSecureEnvironmentVariablesValuesInTheScriptOutput() throws CheckedCommandLineException {
+    void shouldMaskOutOccurrenceOfSecureEnvironmentVariablesValuesInTheScriptOutput() throws CheckedCommandLineException {
         EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
         environmentVariableContext.setProperty("secret", "the_secret_password", true);
         CommandLine command = CommandLine.createCommandLine("cmd")

--- a/common/src/main/java/com/thoughtworks/go/domain/builder/CommandBuilder.java
+++ b/common/src/main/java/com/thoughtworks/go/domain/builder/CommandBuilder.java
@@ -15,12 +15,10 @@
  */
 package com.thoughtworks.go.domain.builder;
 
-import java.io.File;
-
 import com.thoughtworks.go.domain.RunIfConfigs;
 import com.thoughtworks.go.util.command.CommandLine;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.SystemUtils;
+
+import java.io.File;
 
 public class CommandBuilder extends BaseCommandBuilder {
     protected String args;
@@ -39,26 +37,8 @@ public class CommandBuilder extends BaseCommandBuilder {
     }
 
     @Override
-    protected CommandLine buildCommandLine() {
-        CommandLine command = null;
-        if (SystemUtils.IS_OS_WINDOWS) {
-            command = CommandLine.createCommandLine("cmd").withWorkingDir(workingDir);
-            command.withArg("/c");
-            command.withArg(translateToWindowsPath(this.command));
-        }
-        else {
-            command = CommandLine.createCommandLine(this.command).withWorkingDir(workingDir);
-        }
-        String[] argsArray = CommandLine.translateCommandLine(args);
-        for (int i = 0; i < argsArray.length; i++) {
-            String arg = argsArray[i];
-            command.withArg(arg);
-        }
-        return command;
-    }
-
-    private String translateToWindowsPath(String command) {
-        return StringUtils.replace(command, "/", "\\");
+    protected String[] argList() {
+        return CommandLine.translateCommandLine(args);
     }
 
     public File getWorkingDir() {

--- a/common/src/main/java/com/thoughtworks/go/domain/builder/CommandBuilderWithArgList.java
+++ b/common/src/main/java/com/thoughtworks/go/domain/builder/CommandBuilderWithArgList.java
@@ -15,14 +15,12 @@
  */
 package com.thoughtworks.go.domain.builder;
 
+import com.thoughtworks.go.domain.RunIfConfigs;
+
 import java.io.File;
 
-import com.thoughtworks.go.domain.RunIfConfigs;
-import com.thoughtworks.go.util.command.CommandLine;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.SystemUtils;
-
 public class CommandBuilderWithArgList extends BaseCommandBuilder {
+
     private String[] args;
 
     public CommandBuilderWithArgList(String command, String[] args, File workingDir, RunIfConfigs conditions,
@@ -32,24 +30,8 @@ public class CommandBuilderWithArgList extends BaseCommandBuilder {
     }
 
     @Override
-    protected CommandLine buildCommandLine() {
-        CommandLine command = null;
-        if (SystemUtils.IS_OS_WINDOWS) {
-            command = CommandLine.createCommandLine("cmd").withWorkingDir(workingDir);
-            command.withArg("/c");
-            command.withArg(translateToWindowsPath(this.command));
-        }
-        else {
-            command = CommandLine.createCommandLine(this.command).withWorkingDir(workingDir);
-        }
-        for (String arg : args) {
-            command.withArg(arg);
-        }
-        return command;
-    }
-
-    private String translateToWindowsPath(String command) {
-        return StringUtils.replace(command, "/", "\\");
+    protected String[] argList() {
+        return args;
     }
 
 }

--- a/common/src/test/java/com/thoughtworks/go/domain/builder/AbstractCommandBuilderScriptRunnerTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/builder/AbstractCommandBuilderScriptRunnerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.builder;
+
+import com.thoughtworks.go.util.StringUtil;
+import com.thoughtworks.go.util.command.*;
+import org.apache.commons.lang3.ArrayUtils;
+import org.assertj.core.api.SoftAssertions;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class AbstractCommandBuilderScriptRunnerTest {
+
+    static final Path ATTRIB = Path.of("C:\\Windows\\system32\\attrib.exe");
+    static final Path TAR = Path.of("C:\\Windows\\system32\\tar.exe");
+
+
+    static final String DIR_WINDOWS = "C:\\Windows";
+    static final String DIR_WINDOWS_QUOTED = "\"C:\\Windows\"";
+    static final String DIR_PROGRAM_FILES = "C:\\Program Files (x86)";
+    static final String DIR_PROGRAM_FILES_QUOTED = "\"C:\\Program Files (x86)\"";
+
+
+    @TempDir
+    Path tempWorkDir;
+
+    public List<String> createTestFoldersIn() throws IOException  {
+        List<String> paths = List.of(
+            "dir1", // Regular dir without spaces
+            "dir 2", // Regular dir with space
+            "\"dir3\""); // Regular dir without spaces pre-quoted
+        for (Path dir : paths.stream().map(p -> tempWorkDir.resolve(StringUtil.unQuote(p))).collect(Collectors.toList())) {
+            Files.createDirectory(dir);
+        }
+        return paths;
+    }
+
+    protected void doPossiblyQuotedArgsTest(String executableLocation, String... executableArgs) throws CheckedCommandLineException {
+        doPossiblyQuotedArgsTest(executableLocation, new String[0], executableArgs);
+    }
+
+    protected void doPossiblyQuotedArgsTest(String executableLocation, String[] executableFlags, String... executableArgs) throws CheckedCommandLineException {
+        ExecScript script = new ExecScript("");
+        InMemoryConsumer output = new InMemoryConsumer();
+        commandFor(executableLocation, ArrayUtils.addAll(executableFlags, executableArgs))
+            .runScript(script, output, new EnvironmentVariableContext(), null);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(output.toString())
+                .contains(Arrays.stream(executableArgs)
+                    .map(CommandBuilderWithArgsListScriptRunnerTest::trimWrappingQuotesAndWhiteSpace)
+                    .collect(Collectors.toList()))
+                .doesNotContainIgnoringCase("not found")
+                .doesNotContainIgnoringCase("no such file");
+            softly.assertThat(script.foundError()).isFalse();
+            softly.assertThat(script.getExitCode()).withFailMessage(() -> "Non-zero exit code indicates failure: " + output).isZero();
+        });
+    }
+
+    abstract CommandLine commandFor(String executableLocation, String... executableArgs);
+
+
+    @NotNull
+    Path executableWithPathSpaces(Path sourceExecutablePath) throws IOException {
+        Path executable = Files.createDirectory(tempWorkDir.resolve("Directory With Spaces")).resolve(sourceExecutablePath.getFileName());
+        Files.copy(sourceExecutablePath, executable);
+        return executable;
+    }
+
+    static String trimWrappingQuotesAndWhiteSpace(String arg) {
+        return arg.trim().replaceAll("(^\"*)|(\"*$)", "");
+    }
+}

--- a/common/src/test/java/com/thoughtworks/go/domain/builder/CommandBuilderScriptRunnerTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/builder/CommandBuilderScriptRunnerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2022 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.domain.builder;
+
+import com.thoughtworks.go.domain.RunIfConfigs;
+import com.thoughtworks.go.util.command.CommandLine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class CommandBuilderScriptRunnerTest extends AbstractCommandBuilderScriptRunnerTest {
+
+    @Nested
+    @EnabledOnOs(OS.WINDOWS)
+    class WindowsCorrectedQuotingStrategy {
+        @ParameterizedTest
+        @ValueSource(strings = {DIR_WINDOWS, DIR_WINDOWS_QUOTED, DIR_PROGRAM_FILES_QUOTED})
+        void commandInSpacePathCanRunArgsWithSpacesAndQuotes(String attribArg) throws Exception {
+            doPossiblyQuotedArgsTest(executableWithPathSpaces(ATTRIB).toString(), attribArg);
+        }
+
+        @Test
+        void commandInSpacePathCanRunMultipleArgsInclSpaces() throws Exception {
+            List<String> paths = createTestFoldersIn();
+            String[] pathsAsStrings = paths.stream().map(s -> '"' + s + '"').toArray(String[]::new);
+            doPossiblyQuotedArgsTest(executableWithPathSpaces(TAR).toString(), new String[] { "-cvf", "test.tar"}, pathsAsStrings);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {DIR_WINDOWS, DIR_WINDOWS_QUOTED, DIR_PROGRAM_FILES_QUOTED})
+        void commandInNormalPathCanRunArgsWithSpacesAndQuotes(String attribArg) throws Exception {
+            doPossiblyQuotedArgsTest(ATTRIB.toString(), attribArg);
+        }
+
+        @Test
+        void commandInNormalPathCanRunMultipleArgsInclSpaces() throws Exception {
+            List<String> paths = createTestFoldersIn();
+            String[] pathsAsStrings = paths.stream().map(s -> '"' + s + '"').toArray(String[]::new);
+            doPossiblyQuotedArgsTest(TAR.toString(), new String[] { "-cvf", "test.tar"}, pathsAsStrings);
+        }
+    }
+
+    @Nested
+    @EnabledOnOs(OS.WINDOWS)
+    @ExtendWith(SystemStubsExtension.class)
+    class WindowsLegacyQuotingStrategy {
+        @SystemStub
+        SystemProperties props;
+
+        @BeforeEach
+        void enableLegacyWindowsProps() {
+            props.set(BaseCommandBuilder.QUOTE_ALL_WINDOWS_ARGS, "N");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {DIR_WINDOWS})
+        void commandInSpacePathCanRunArgsWithoutSpacesOrQuotes(String attribArg) throws Exception {
+            doPossiblyQuotedArgsTest(executableWithPathSpaces(ATTRIB).toString(), attribArg);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {DIR_WINDOWS, DIR_WINDOWS_QUOTED, DIR_PROGRAM_FILES_QUOTED})
+        void commandInNormalPathCanRunArgsWithSpacesAndQuotes(String attribArg) throws Exception {
+            doPossiblyQuotedArgsTest(ATTRIB.toString(), attribArg);
+        }
+
+        @Test
+        void commandInNormalPathCanRunMultipleArgsInclSpaces() throws Exception {
+            List<String> paths = createTestFoldersIn();
+            String[] pathsAsStrings = paths.stream().map(s -> '"' + s + '"').toArray(String[]::new);
+            doPossiblyQuotedArgsTest(TAR.toString(), new String[] { "-cvf", "test.tar"}, pathsAsStrings);
+        }
+    }
+
+
+    @Override
+    CommandLine commandFor(String executableLocation, String... executableArgs) {
+        return new CommandBuilder(executableLocation, String.join(" ", executableArgs), tempWorkDir.toFile(), RunIfConfigs.CONFIGS, null, "go")
+            .buildCommandLine()
+            .withEncoding(StandardCharsets.UTF_8);
+    }
+
+}

--- a/common/src/test/java/com/thoughtworks/go/domain/builder/CommandBuilderTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/builder/CommandBuilderTest.java
@@ -21,29 +21,29 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CommandBuilderTest {
 
     @TempDir
-    File tempWorkDir;
+    Path tempWorkDir;
 
     @Test
     @EnabledOnOs(OS.WINDOWS)
     void commandWithArgsList_shouldAddCmdBeforeAWindowsCommand() {
         String[] args = {"some thing"};
-        CommandBuilderWithArgList commandBuilderWithArgList = new CommandBuilderWithArgList("echo", args, tempWorkDir, null, null, "some desc");
+        CommandBuilderWithArgList commandBuilderWithArgList = new CommandBuilderWithArgList("echo", args, tempWorkDir.toFile(), null, null, "some desc");
         CommandLine commandLine = commandBuilderWithArgList.buildCommandLine();
-        assertThat(commandLine.toStringForDisplay()).isEqualTo("cmd /c echo some thing");
+        assertThat(commandLine.toStringForDisplay()).isEqualTo("cmd /s /c \" echo some thing \"");
     }
 
     @Test
     @EnabledOnOs(OS.WINDOWS)
     void commandWithArgs_shouldAddCmdBeforeAWindowsCommand() {
-        CommandBuilder commandBuilder = new CommandBuilder("echo", "some thing", tempWorkDir, null, null, "some desc");
+        CommandBuilder commandBuilder = new CommandBuilder("echo", "some thing", tempWorkDir.toFile(), null, null, "some desc");
         CommandLine commandLine = commandBuilder.buildCommandLine();
-        assertThat(commandLine.toStringForDisplay()).isEqualTo("cmd /c echo some thing");
+        assertThat(commandLine.toStringForDisplay()).isEqualTo("cmd /s /c \" echo some thing \"");
     }
 }

--- a/common/src/test/java/com/thoughtworks/go/domain/builder/CommandBuilderWithArgsListScriptRunnerTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/builder/CommandBuilderWithArgsListScriptRunnerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.domain.builder;
+
+import com.thoughtworks.go.domain.RunIfConfigs;
+import com.thoughtworks.go.util.command.CommandLine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class CommandBuilderWithArgsListScriptRunnerTest extends AbstractCommandBuilderScriptRunnerTest {
+
+    @Nested
+    @EnabledOnOs(OS.WINDOWS)
+    class WindowsCorrectedQuotingStrategy {
+        @ParameterizedTest
+        @ValueSource(strings = {DIR_WINDOWS, DIR_WINDOWS_QUOTED, DIR_PROGRAM_FILES, DIR_PROGRAM_FILES_QUOTED, "", " "})
+        void commandInSpacePathCanRunArgsWithSpacesAndQuotes(String attribArg) throws Exception {
+            doPossiblyQuotedArgsTest(executableWithPathSpaces(ATTRIB).toString(), attribArg);
+        }
+
+        @Test
+        void commandInSpacePathCanRunMultipleArgsInclSpaces() throws Exception {
+            List<String> paths = createTestFoldersIn();
+            doPossiblyQuotedArgsTest(executableWithPathSpaces(TAR).toString(), new String[]{"-cvf", "test.tar"}, paths.toArray(String[]::new));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {DIR_WINDOWS, DIR_WINDOWS_QUOTED, DIR_PROGRAM_FILES, DIR_PROGRAM_FILES_QUOTED})
+        void commandInNormalPathCanRunArgsWithSpacesAndQuotes(String attribArg) throws Exception {
+            doPossiblyQuotedArgsTest(ATTRIB.toString(), attribArg);
+        }
+
+        @Test
+        void commandInNormalPathCanRunMultipleArgsInclSpaces() throws Exception {
+            List<String> paths = createTestFoldersIn();
+            doPossiblyQuotedArgsTest(TAR.toString(), new String[]{"-cvf", "test.tar"}, paths.toArray(String[]::new));
+        }
+    }
+
+    @Nested
+    @EnabledOnOs(OS.WINDOWS)
+    @ExtendWith(SystemStubsExtension.class)
+    class WindowsLegacyQuotingStrategy {
+        @SystemStub
+        SystemProperties props;
+
+        @BeforeEach
+        void enableLegacyWindowsProps() {
+            props.set(BaseCommandBuilder.QUOTE_ALL_WINDOWS_ARGS, "N");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {DIR_WINDOWS})
+        void commandInSpacePathCanRunArgsWithoutSpacesOrQuotes(String attribArg) throws Exception {
+            doPossiblyQuotedArgsTest(executableWithPathSpaces(ATTRIB).toString(), attribArg);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {DIR_WINDOWS, DIR_WINDOWS_QUOTED, DIR_PROGRAM_FILES, DIR_PROGRAM_FILES_QUOTED})
+        void commandInSpacePathCanRunArgsWithSpacesWithWorkaround(String attribArg) throws Exception {
+            doPossiblyQuotedArgsTest('"' + executableWithPathSpaces(ATTRIB).toString(), attribArg + '"');
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {DIR_WINDOWS, DIR_WINDOWS_QUOTED, DIR_PROGRAM_FILES, DIR_PROGRAM_FILES_QUOTED})
+        void commandInNormalPathCanRunArgsWithSpacesAndQuotes(String attribArg) throws Exception {
+            doPossiblyQuotedArgsTest(ATTRIB.toString(), attribArg);
+        }
+
+        @Test
+        void commandInNormalPathCanRunMultipleArgsInclSpaces() throws Exception {
+            List<String> paths = createTestFoldersIn();
+            doPossiblyQuotedArgsTest(TAR.toString(), new String[]{"-cvf", "test.tar"}, paths.toArray(String[]::new));
+        }
+    }
+
+
+    @Override
+    CommandLine commandFor(String executableLocation, String... executableArgs) {
+        return new CommandBuilderWithArgList(executableLocation, executableArgs, tempWorkDir.toFile(), RunIfConfigs.CONFIGS, null, "go")
+            .buildCommandLine()
+            .withEncoding(StandardCharsets.UTF_8);
+    }
+
+}


### PR DESCRIPTION
- fixes #4173, #2153
- fixes #10521 

This change resolves issues repeatedly reported over the years on Windows, especially _when running executables that have spaces in the path_.

It does this by correcting the way things are quoted for use of `cmd`. GoCD runs everything via `cmd /c`, presumably to allow "shell" built-ins such as `dir` to be run.

Unfortunately the current strategy doesn't quote things correctly, so if the executable path has a space in it things will not work correctly. This change corrects the quoting by adding an extra pair of quotes around the args per https://superuser.com/questions/238810/problem-with-quotes-around-file-names-in-windows-command-shell which should allow things to run as expected.

_Relevant section from cmd /?_:
```
If /C or /K is specified, then the remainder of the command line after
the switch is processed as a command line, where the following logic is
used to process quote (") characters:

    1.  If all of the following conditions are met, then quote characters
        on the command line are preserved:

        - no /S switch
        - exactly two quote characters
        - no special characters between the two quote characters,
          where special is one of: &<>()@^|
        - there are one or more whitespace characters between the
          two quote characters
        - the string between the two quote characters is the name
          of an executable file.

    2.  Otherwise, old behavior is to see if the first character is
        a quote character and if so, strip the leading character and
        remove the last quote character on the command line, preserving
        any text after the last quote character.
```

This change does two things
- Adds the `/S` switch to ensure that the logic in the second clause is applied, regardless of the number of quotes or special chars.
- Surrounds the args with `" {argsList} "` to allow first and last quote characters to be stripped. Other quotes within will be retained as-is.

New behaviour is enabled by default but allows fallback to the old behaviour by defining the system property on server of `-Dgocd.agent.extra.properties=toggle.agent.windows.command.quote.all.args=N`. The intent is to remove this toggle if no issues are reported.

**Example commands**

1. Executable with spaces in it (previously ❌)
2. Arg non-quoted with spaces (previously ✅)
3. Arg _pre_-quoted with spaces (previously ✅)
4. cmd in-built multiple args with spaces in them (previously ✅)

![image](https://user-images.githubusercontent.com/29788154/180652297-baad06bb-3eaf-4aa9-803d-1555d5c7635d.png)

**BEFORE**:
![image](https://user-images.githubusercontent.com/29788154/180652827-d9cd5f6b-b7f9-4fcc-94b8-bf1d8000a67a.png)


**AFTER**:
_Note_: quotes in below are inserted by the "display" logic for commands.
![image](https://user-images.githubusercontent.com/29788154/180652472-71b13a9b-868d-451f-bc5e-ee9a24f97ffb.png)
