### PR TITLE
Revert "Temporarily lock RetireJS vulnerability repository version"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,9 +196,6 @@ dependencyCheck {
     assemblyEnabled = false
     retirejs {
       filterNonVulnerable = true
-
-      // Repository version locked due to https://github.com/jeremylong/DependencyCheck/issues/4695
-      retireJsUrl = 'https://raw.githubusercontent.com/RetireJS/retire.js/33b4076ce87f3898b81af4fc1770a7b65aa54bcb/repository/jsrepository.json'
     }
   }
   skipConfigurations = ['pmd']


### PR DESCRIPTION
Reverts gocd/gocd#10621 - this has been fixed upstream at RetireJS for now: https://github.com/RetireJS/retire.js/commit/7007575f637b840016edf8a9512d608f00795b1b