### PR TITLE
Fix MySQL license error

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
@@ -29,15 +29,9 @@ import static com.thoughtworks.go.build.SpdxLicense.*
 class LicenseReport {
 
   private static Set<String> LICENSE_EXCEPTIONS = [
-    'Apple License',
     'Bouncy Castle Licence',
-    'BSD',
-    'Custom: https://raw.github.com/bjoerge/deferred.js/master/dist/dfrrd.js',
-    'dom4j BSD license',
-    'Similar to Apache License but with the acknowledgment clause removed',
+    'Similar to Apache License but with the acknowledgment clause removed', // JDOM2
     'The OpenSymphony Software License 1.1',
-    '(OFL-1.1 AND MIT)',
-    'MPL 2.0 or EPL 1.0',
   ]
 
   private static Set<String> ALLOWED_LICENSES = (LICENSE_EXCEPTIONS + [
@@ -49,16 +43,17 @@ class LicenseReport {
     BSD_3_CLAUSE,
     CDDL_1_0,
     CDDL_1_1,
-    CDDL_1_1_GPL_2_0,
     EDL_1_0,
     EPL_1_0,
     EPL_2_0,
     GPL_2_0_CLASSPATH_EXCEPTION,
+    GPL_2_0_UNIVERSAL_FOSS_EXCEPTION,
     LGPL_2_1,
     LGPL_3_0,
     LGPL_3_0_ONLY,
     MIT,
     MPL_1_1,
+    MPL_2_0_EPL_1_0,
     UNLICENSE,
     PUBLIC_DOMAIN,
     ISC

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/NonSpdxLicense.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/NonSpdxLicense.groovy
@@ -18,8 +18,9 @@ package com.thoughtworks.go.build
 
 enum NonSpdxLicense {
   EDL_1_0("EDL-1.0", "Eclipse Distribution License - v1.0", "Eclipse Distribution License v1.0", "Eclipse Distribution License (New BSD License)"),
-  CDDL_1_1_GPL_2_0('CDDL-1.1+GPL-2.0',    'CDDL+GPL License', 'Dual license consisting of the CDDL v1.1 and GPL v2', 'https://glassfish.java.net/public/CDDL+GPL_1_1.html'),
-  GPL_2_0_CLASSPATH_EXCEPTION('GPL-2.0+CE', 'GPLv2 with the Classpath Exception', 'GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception'),
+  GPL_2_0_CLASSPATH_EXCEPTION('GPL-2.0+Classpath-exception-2.0', 'GPLv2 with the Classpath Exception', 'GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception'),
+  GPL_2_0_UNIVERSAL_FOSS_EXCEPTION('GPL-2.0+Universal-FOSS-exception-1.0', 'GPLv2 with Oracle Universal FOSS exception', 'The GNU General Public License, v2 with FOSS exception', 'https://oss.oracle.com/licenses/universal-foss-exception/'),
+  MPL_2_0_EPL_1_0('MPL-2.0+EPL-1.0', 'MPL 2.0 or EPL 1.0', 'Dual license consisting of the MPL 2.0 or EPL 1.0', 'Mozilla Public License 2.0 or Eclipse Public License 1.0'),
   PUBLIC_DOMAIN("Public Domain"),
 
   public final Set<String> names

--- a/tfs-impl/tfs-impl-14/build.gradle
+++ b/tfs-impl/tfs-impl-14/build.gradle
@@ -62,6 +62,7 @@ task extractTfsSdk(type: Copy) {
 }
 
 compileJava.dependsOn extractTfsSdk
+generateLicenseReport.dependsOn extractTfsSdk
 
 task fatJar(type: Jar) {
   finalizedBy 'verifyJar'


### PR DESCRIPTION
#10627 introduced a new MySQL Connector version where the license is expressed slightly differently. This adds the GPL v2 with (Oracle) Universal FOSS Exception (see [Oracle](https://oss.oracle.com/licenses/universal-foss-exception/) and [SPDX](https://spdx.org/licenses/Universal-FOSS-exception-1.0.html)).

Additionally this removes some old license exceptions and tidies the allowlist slightly, while also fixing a Gradle dependency issue on the TFS SDK when generating licenses.