### PR TITLE
Cleanup some old duplicated license headers

### DIFF
--- a/api/api-config-repos-v4/src/main/java/com/thoughtworks/go/apiv4/configrepos/representers/SvnMaterialRepresenter.java
+++ b/api/api-config-repos-v4/src/main/java/com/thoughtworks/go/apiv4/configrepos/representers/SvnMaterialRepresenter.java
@@ -13,23 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * Copyright 2022 Thoughtworks, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.thoughtworks.go.apiv4.configrepos.representers;
 
 import com.thoughtworks.go.api.base.OutputWriter;

--- a/plugin-infra/go-plugin-api/src/main/resources/gocd-bundle-descriptor.xsd
+++ b/plugin-infra/go-plugin-api/src/main/resources/gocd-bundle-descriptor.xsd
@@ -17,7 +17,7 @@
 <xsd:schema elementFormDefault="qualified" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <xsd:annotation>
     <xsd:documentation xml:lang="en">
-      Bundle Descriptor schema for GoCD. Copyright (c) 2019 Thoughtworks, Inc.
+      Bundle Descriptor schema for GoCD. Copyright (c) 2022 Thoughtworks, Inc.
       www.thoughtworks.com. All rights reserved.
     </xsd:documentation>
   </xsd:annotation>

--- a/plugin-infra/go-plugin-api/src/main/resources/plugin-descriptor.xsd
+++ b/plugin-infra/go-plugin-api/src/main/resources/plugin-descriptor.xsd
@@ -17,7 +17,7 @@
 <xsd:schema elementFormDefault="qualified" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <xsd:annotation>
     <xsd:documentation xml:lang="en">
-      Plugin Descriptor schema for GoCD. Copyright (c) 2016 Thoughtworks, Inc.
+      Plugin Descriptor schema for GoCD. Copyright (c) 2022 Thoughtworks, Inc.
       www.thoughtworks.com. All rights reserved.
     </xsd:documentation>
   </xsd:annotation>

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_font-awesome-sprockets.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_font-awesome-sprockets.scss
@@ -1,18 +1,3 @@
-/*
- * Copyright 2022 Thoughtworks, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 @charset "UTF-8";
 /*
  * Copyright 2022 Thoughtworks, Inc.


### PR DESCRIPTION
Follow-up to #10640 to fix some duplicate headers/outdated copyrights from around the place noted during review of diff.

