### PR TITLE
Reduce the vertical size of the GoCD logo

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/login_page/gocd_logo.svg
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/login_page/gocd_logo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 786.0967 559.7343" style="enable-background:new 0 0 786.0967 559.7343;" xml:space="preserve">
+	 viewBox="0 0 786.0967 459.7343" style="enable-background:new 0 0 786.0967 459.7343;" xml:space="preserve">
 <style type="text/css">
 	.st0{enable-background:new    ;}
 </style>


### PR DESCRIPTION
After removal of the Thoughtworks part in #10640 , the dimensions are no longer appropriate, so fudging it down to something that looks appropriate (roughly 1.7:1 instead of 1.4:1)
