### PR TITLE
Ensure the PluginInfo entity hash changes when plugin is updated

### DIFF
--- a/api/api-plugin-infos-v7/src/main/java/com/thoughtworks/go/apiv7/plugininfos/PluginInfosControllerV7.java
+++ b/api/api-plugin-infos-v7/src/main/java/com/thoughtworks/go/apiv7/plugininfos/PluginInfosControllerV7.java
@@ -18,7 +18,6 @@ package com.thoughtworks.go.apiv7.plugininfos;
 import com.thoughtworks.go.api.ApiController;
 import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
-import com.thoughtworks.go.api.spring.ToggleRegisterLatest;
 import com.thoughtworks.go.apiv7.plugininfos.representers.PluginInfoRepresenter;
 import com.thoughtworks.go.apiv7.plugininfos.representers.PluginInfosRepresenter;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;

--- a/server/src/main/java/com/thoughtworks/go/server/service/EntityHashes.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EntityHashes.java
@@ -107,6 +107,7 @@ public class EntityHashes implements DigestMixin {
         JsonSerializer<PluginInfo> PLUGIN_INFO = (src, typeOfSrc, context) -> {
             final JsonObject result = new JsonObject();
             result.addProperty("id", src.getDescriptor().id());
+            result.addProperty("version", src.getDescriptor().version());
             result.addProperty("extension", src.getExtensionName());
             result.add("settings", context.serialize(src.getPluginSettings()));
             return result;


### PR DESCRIPTION
We can expect if other descriptor fields of a plugin change, its version should be updated, without specifically including the description, targetGoCdVersion etc in the hash. May still cause some staleness during local dev iterating on the same version, but that's not the primary concern here.

- fixes #10648 
