### PR TITLE
Include the aboutVersion of the plugin

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/EntityHashes.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EntityHashes.java
@@ -26,12 +26,14 @@ import com.thoughtworks.go.config.MagicalGoConfigXmlWriter;
 import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
 import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.plugin.api.info.PluginDescriptor;
 import com.thoughtworks.go.plugin.domain.common.PluginInfo;
 import com.thoughtworks.go.server.util.DigestMixin;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -108,6 +110,7 @@ public class EntityHashes implements DigestMixin {
             final JsonObject result = new JsonObject();
             result.addProperty("id", src.getDescriptor().id());
             result.addProperty("version", src.getDescriptor().version());
+            result.addProperty("aboutVersion", Optional.ofNullable(src.getDescriptor().about()).map(PluginDescriptor.About::version).orElse(null));
             result.addProperty("extension", src.getExtensionName());
             result.add("settings", context.serialize(src.getPluginSettings()));
             return result;

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/EntityHashingServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/EntityHashingServiceTest.java
@@ -91,7 +91,7 @@ public class EntityHashingServiceTest {
         ), actual);
 
         final CombinedPluginInfo info2v2 = new CombinedPluginInfo(
-            new NotificationPluginInfo(GoPluginDescriptor.builder().id("bar").version("2").build(), testSettings)
+            new NotificationPluginInfo(GoPluginDescriptor.builder().id("bar").about(GoPluginDescriptor.About.builder().version("2").build()).build(), testSettings)
         );
 
         assertThat(service.hashForEntity(info2v2)).isNotEqualTo(service.hashForEntity(info2));


### PR DESCRIPTION
Follows up on #10649 to include `about.version()` as well, which is likely needed as the plugin descriptor version seems to largely be unused.