### PR TITLE
Minor display tweaks to plugin representation

### DIFF
--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/plugininfo/TrimStringAdapter.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/plugininfo/TrimStringAdapter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.infra.plugininfo;
+
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+import org.apache.commons.lang3.StringUtils;
+
+public class TrimStringAdapter extends XmlAdapter<String, String> {
+    @Override
+    public String unmarshal(String v) {
+        return StringUtils.trim(v);
+    }
+
+    /**
+     * Not used, but included for completeness
+     */
+    @Override
+    public String marshal(String v) {
+        return StringUtils.trim(v);
+    }
+}

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/plugininfo/package-info.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/plugininfo/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@XmlJavaTypeAdapter(value = TrimStringAdapter.class, type = String.class)
+package com.thoughtworks.go.plugin.infra.plugininfo;
+
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;

--- a/plugin-infra/go-plugin-infra/src/test/resources/defaultFiles/gocd-bundle.xml
+++ b/plugin-infra/go-plugin-infra/src/test/resources/defaultFiles/gocd-bundle.xml
@@ -22,10 +22,10 @@
         <name>Plugin 1</name>
         <version>1.0.0</version>
         <target-go-version>19.5</target-go-version>
-        <description>Example plugin 1</description>
+        <description> Example plugin 1 </description>
         <vendor>
           <name>GoCD Team</name>
-          <url>https://gocd.org</url>
+          <url> https://gocd.org </url>
         </vendor>
         <target-os>
           <value>Linux</value>

--- a/plugin-infra/go-plugin-infra/src/test/resources/defaultFiles/valid-plugin.xml
+++ b/plugin-infra/go-plugin-infra/src/test/resources/defaultFiles/valid-plugin.xml
@@ -19,8 +19,10 @@
   <about>
     <name>Plugin Descriptor Validator</name>
     <version>1.0.1</version>
-    <target-go-version>17.12</target-go-version>
-    <description>Validates its own plugin descriptor</description>
+    <target-go-version> 17.12 </target-go-version>
+    <description>
+      Validates its own plugin descriptor
+    </description>
     <vendor>
       <name>GoCD Team</name>
       <url>https://gocd.org</url>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/about.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/about.ts
@@ -52,7 +52,7 @@ export class About {
     if (_.isEmpty(this.targetOperatingSystems)) {
       return "No restrictions";
     }
-    return _.join(this.targetOperatingSystems, ",");
+    return _.join(this.targetOperatingSystems, ", ");
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
@@ -20,6 +20,7 @@ import m from "mithril";
 import {ElasticAgentExtension} from "models/shared/plugin_infos_new/extensions";
 import {ExtensionTypeString} from "models/shared/plugin_infos_new/extension_type";
 import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
+import s from "underscore.string";
 import * as Buttons from "views/components/buttons";
 import {ButtonIcon} from "views/components/buttons";
 import {CollapsiblePanel} from "views/components/collapsible_panel";
@@ -123,7 +124,7 @@ export class PluginWidget extends MithrilViewComponent<Attrs> {
   }
 
   private getAuthorInfo(pluginInfo: PluginInfo): m.Children {
-    return (
+    return s.isBlank(pluginInfo.about.vendor.name) ? "" : (
       <a target="_blank" href={pluginInfo.about.vendor.url}>
         {pluginInfo.about.vendor.name}
       </a>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
@@ -43,7 +43,7 @@ class PluginHeaderWidget extends MithrilViewComponent<PluginHeaderAttrs> {
                          ]);
     return [
       (
-        <KeyValueTitle image={vnode.attrs.image} titleTestId="plugin-name" title={vnode.attrs.pluginName}/>
+        <KeyValueTitle image={vnode.attrs.image} titleTestId="plugin-name" title={s.isBlank(vnode.attrs.pluginName) ? <em>(Not specified)</em> : vnode.attrs.pluginName}/>
       ),
       (
         <KeyValuePair inline={true} data={data}/>


### PR DESCRIPTION
- Trim strings from plugin manifests on parsing
- Include spacing when concatenating operating systems
- Avoid showing a blank author when it is not set or able to be parsed
- Ensure `(Not specified)` is displayed for plugin names where the manifest is invalid (for consistency)

(Curl task plugin has leading and trailing whitespace in the description)

![image](https://user-images.githubusercontent.com/29788154/182183276-5360034f-c3a2-4db6-9a82-31d40d879176.png)
