### PR TITLE
Bump erubi from 1.10.0 to 1.11.0

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -63,8 +63,7 @@ GEM
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     diff-lcs (1.5.0)
-    erubi (1.10.0)
-    ffi (1.15.5)
+    erubi (1.11.0)
     ffi (1.15.5-java)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -82,11 +81,8 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.16.2)
-    nio4r (2.5.8)
     nio4r (2.5.8-java)
     nokogiri (1.13.8-java)
-      racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     pry (0.14.1-java)
       coderay (~> 1.1)
@@ -96,7 +92,6 @@ GEM
       pry (>= 0.13, < 0.15)
       ruby-debug-base (>= 0.10.4, < 0.12)
     public_suffix (4.0.7)
-    racc (1.6.0)
     racc (1.6.0-java)
     rack (2.2.4)
     rack-test (2.0.2)
@@ -185,7 +180,6 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     thor (1.2.1)
-    thread_safe (0.3.6)
     thread_safe (0.3.6-java)
     tilt (2.0.11)
     ts_routes (1.0.3)
@@ -194,8 +188,6 @@ GEM
       thread_safe (~> 0.1)
     tzinfo-data (1.2022.1)
       tzinfo (>= 1.0.0)
-    websocket-driver (0.7.5)
-      websocket-extensions (>= 0.1.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -204,9 +196,7 @@ GEM
 
 PLATFORMS
   java
-  universal-java-15
   universal-java-17
-  x86_64-linux
 
 DEPENDENCIES
   brakeman
@@ -226,7 +216,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.6.8p0 (jruby 9.3.4.0)
+   ruby 2.6.8p0 (jruby 9.3.6.0)
 
 BUNDLED WITH
    2.2.29


### PR DESCRIPTION
https://github.com/jeremyevans/erubi/blob/master/CHANGELOG

- Also cleans up the Gemfile (linux platform may end up re-added by dependabot, let's see)
