### PR TITLE
Update default packaged config version

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -237,7 +237,7 @@
     <vulnerabilityName>CWE-94: Improper Control of Generation of Code ('Code Injection')</vulnerabilityName>
   </suppress>
 
-  <suppress until="2022-08-01Z">
+  <suppress until="2022-10-01Z">
     <notes><![CDATA[
     Time-limited suppression for https://nvd.nist.gov/vuln/detail/CVE-2021-29425. GoCD is not vulnerable as the use of
     FilenameUtils.normalize does not "use the result to construct a path value" as required by the defect. Neither does

--- a/installers/go-server/release/cruise-config.xml
+++ b/installers/go-server/release/cruise-config.xml
@@ -15,6 +15,10 @@
   ~ limitations under the License.
   -->
 
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="110">
-    <server artifactsdir="artifacts"/>
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="139">
+  <server>
+    <artifacts>
+      <artifactsDir>artifacts</artifactsDir>
+    </artifacts>
+  </server>
 </cruise>


### PR DESCRIPTION
Converts pre-packaged config so it's on the latest version and doesn't require migration. Methodology:
- Take original pre-packaged default config and start server on it
- Remove the generated IDs/keys
- Remove the default `<backup>` section the migration adds as this doesn't seem important since backups are not enabled by default, and neither are emails configured by default.
- Re-test startup

This avoids some noise that sometimes happen when plugin jar monitoring is enabled such as
```
2022-08-03 08:48:10,299 WARN  [Thread-79] CachedGoConfig:103 - Error loading cruise-config.xml from disk, keeping previous one
com.thoughtworks.go.util.XsdValidationException: Value '110' of attribute 'schemaVersion' of element 'cruise' is not valid with respect to the corresponding attribute use. Attribute 'schemaVersion' has a fixed value of '139'.
	at com.thoughtworks.go.util.XmlUtils.buildXmlDocument(XmlUtils.java:58)
	at com.thoughtworks.go.util.XmlUtils.buildXmlDocument(XmlUtils.java:45)
```

Additionally extends a suppression where there is no acceptable fixed version right now.