### PR TITLE
Bump Centos7 git version from 2.18 to 2.27

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -122,7 +122,7 @@ enum Distro implements DistroBehavior {
     }
 
     String gitPackageFor(DistroVersion v) {
-      return v.lessThan(8) ? "rh-git218" : "git"
+      return v.lessThan(8) ? "rh-git227" : "git"
     }
 
     @Override


### PR DESCRIPTION
Appears to be the latest version available for older CentOS.