### PR TITLE
Bump chromedriver from 103 to 104

### DIFF
--- a/server/jasmine.gradle
+++ b/server/jasmine.gradle
@@ -26,7 +26,7 @@ OperatingSystem currentOS = OperatingSystem.current()
 // Firefox/gecko: See https://github.com/mozilla/geckodriver/releases and review compatibility at
 //                https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html
 final Map<String, String> seleniumDrivers = [
-  chromedriver: '103.0.5060.53',
+  chromedriver: '104.0.5112.79',
   geckodriver: '0.31.0',
 ]
 


### PR DESCRIPTION
Required for build agent versions [v3.6.1](https://github.com/gocd-contrib/gocd-oss-cookbooks/releases/tag/v3.6.1) and above.