### PR TITLE
Fix stage stats graph older/newer navigation

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -182,7 +182,6 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     private static GoSystemProperty<Boolean> ENABLE_ANALYTICS_ONLY_FOR_ADMINS = new GoBooleanSystemProperty("go.enable.analytics.only.for.admins", false);
     public static final GoSystemProperty<Boolean> FAIL_STARTUP_ON_DATA_ERROR = new GoBooleanSystemProperty("gocd.fail.startup.on.data.error", false);
-    private static final GoSystemProperty<Boolean> JOB_DETAILS_USE_IFRAME_SANDBOX = new GoBooleanSystemProperty("gocd.job.details.sandbox", true);
     private static GoSystemProperty<Boolean> GO_PLUGIN_CLASSLOADER_OLD = new GoBooleanSystemProperty("gocd.plugins.classloader.old", false);
     public static final GoSystemProperty<String> LOADING_PAGE = new GoStringSystemProperty("loading.page.resource.path", "/loading_pages/new.loading.page.html");
     public static GoSystemProperty<Long> NOTIFICATION_PLUGIN_MESSAGES_TTL = new GoLongSystemProperty("plugins.notification.message.ttl.millis", 2 * 60 * 1000L);
@@ -747,10 +746,6 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public boolean shouldFailStartupOnDataError() {
         return get(FAIL_STARTUP_ON_DATA_ERROR);
-    }
-
-    public boolean useIframeSandbox() {
-        return JOB_DETAILS_USE_IFRAME_SANDBOX.getValue();
     }
 
     public boolean pluginClassLoaderHasOldBehaviour() {

--- a/common/src/test/java/com/thoughtworks/go/util/SystemEnvironmentTest.java
+++ b/common/src/test/java/com/thoughtworks/go/util/SystemEnvironmentTest.java
@@ -84,11 +84,6 @@ class SystemEnvironmentTest {
     }
 
     @Test
-    void shouldSetTrueAsDefaultForUseIframeSandbox() {
-        assertThat(systemEnvironment.useIframeSandbox()).isTrue();
-    }
-
-    @Test
     void shouldCacheAgentConnectionSystemPropertyOnFirstAccess() {
         System.setProperty(SystemEnvironment.AGENT_CONNECTION_TIMEOUT_IN_SECONDS, "1");
         assertThat(systemEnvironment.getAgentConnectionTimeout()).isEqualTo(1);

--- a/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
@@ -180,7 +180,6 @@ public class JobController {
         Map<String, Object> data = new HashMap<>();
         data.put("presenter", presenter);
         data.put("websocketEnabled", Toggles.isToggleOn(Toggles.BROWSER_CONSOLE_LOG_WS));
-        data.put("useIframeSandbox", systemEnvironment.useIframeSandbox());
         data.put("isEditableViaUI", goConfigService.isPipelineEditable(jobDetail.getPipelineName()));
         data.put("isAgentAlive", agentService.isRegistered(jobDetail.getAgentUuid()));
         addElasticAgentInfo(jobDetail, data);

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/build_detail.js
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/build_detail.js
@@ -52,34 +52,3 @@ var BuildDetail = {
         }
     }
 };
-
-var BuildOutputDetector = Class.create({
-    initialize: function(pipelineId, stageName, debugMode){
-        this.url = context_path('files/pipeline/' + pipelineId + '/stage/' + stageName + '/cruise-output/console.log');
-        if(debugMode != undefined){
-            this.checkIfOutputAvailable();
-        } else {
-            this.checkIfOutputAvailable.bind(this).delay(0.1);
-        }
-    },
-    checkIfOutputAvailable: function(){
-        new Ajax.Request(this.url, {
-            method: 'HEAD',
-            on404: this.showNoOutputWarnning,
-            onFailure: this.showNoOutputWarnning,
-            onExeption: this.showNoOutputWarnning,
-            onSuccess: this.updateIframeSrc.bind(this)
-        });
-    },
-    showNoOutputWarnning: function(){
-        try{
-            $('build-output-console-warnning').show();
-        }catch(e){}
-    },
-    updateIframeSrc: function(){
-        var iframe = $('build-output-console-iframe');
-        if(iframe){
-            iframe.src = this.url;
-        }
-    }
-});

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/old_application.js
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/old_application.js
@@ -66,13 +66,13 @@ Ajax.Responders.register({
 
 
 //iframe resizer + back to top
-function iframeResizer(Iframe){
-    if(Iframe.is(':visible')) {
-        Iframe.contents().find("body").css({margin:0});
-        Iframe.contents().find("body > pre").css({whiteSpace:'pre-wrap',margin : 0,fontSize : '12px',fontFamily: 'consolas, monaco, courier', wordWrap:'break-word', '-ms-word-wrap':'break-word', overflow:'hidden'});
+function iframeResizer(iframe){
+    if (iframe.is(':visible') && iframe.attr('sandbox') === undefined) {
+        iframe.contents().find("body").css({margin:0});
+        iframe.contents().find("body > pre").css({whiteSpace:'pre-wrap',margin : 0,fontSize : '12px',fontFamily: 'consolas, monaco, courier', wordWrap:'break-word', '-ms-word-wrap':'break-word', overflow:'hidden'});
         setTimeout(function(){
             jQuery('iframe').each(function(){
-                Iframe.height(Iframe.contents().find("body").height());
+                iframe.height(iframe.contents().find("body").height());
             });
         }, 200);
     }

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/stage.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/stage.html.erb
@@ -33,9 +33,14 @@
         </div>
         <script>
             window.addEventListener("message", function(event) {
-                if (event.source === document.getElementById("chart_details_iframe").contentWindow) {
+              var chartIframe = document.getElementById("chart_details_iframe");
+              if (event.source === chartIframe.contentWindow) {
                     var data = JSON.parse(event.data);
-                    window.location.href = data.openLink;
+                    if (data.inFrame) {
+                        chartIframe.src = data.openLink;
+                    } else {
+                        window.location.href = data.openLink;
+                    }
                 }
             }, false);
         </script>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/stats_iframe.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/stats_iframe.html.erb
@@ -23,6 +23,10 @@
               document.getElementById('reset_zoom')
           );
       });
+
+      function changeFrameTo(link) {
+          parent.postMessage(JSON.stringify({openLink: link, inFrame: true}), "*");
+      }
   </script>
   <div>
     <!-- position absolute, so it is rendered on top of the canvas -->
@@ -33,11 +37,15 @@
 
     <!-- position absolute, so they are rendered on top of the canvas -->
     <% if @pagination.hasNextPage() %>
-      <%= link_to '<< Older', stage_detail_tab_stats_iframe_path(:page_number => @pagination.getNextPage()), style: "padding-left: 10px; position: absolute; bottom: 5px" -%>
+      <a id="stats-older" href="#" onclick="changeFrameTo('<%= stage_detail_tab_stats_iframe_path(:page_number => @pagination.getNextPage()) %>')" style="padding-left: 10px; position: absolute; bottom: 5px">
+        << Older
+      </a>
     <% end %>
 
     <% if @pagination.hasPreviousPage() %>
-      <%= link_to 'Newer >>', stage_detail_tab_stats_iframe_path(:page_number => @pagination.getPreviousPage()), style: "padding-right: 10px; position: absolute; bottom: 5px; right: 12px;" -%>
+      <a id="stats-newer" href="#" onclick="changeFrameTo('<%= stage_detail_tab_stats_iframe_path(:page_number => @pagination.getPreviousPage()) %>')" style="padding-right: 10px; position: absolute; bottom: 5px; right: 12px;">
+        Newer >>
+      </a>
     <% end %>
   </div>
 <% end %>

--- a/server/src/main/webapp/WEB-INF/rails/spec/javascripts/build_detail_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/javascripts/build_detail_spec.js
@@ -88,22 +88,4 @@ describe("build_detail", function(){
         var theContainer = BuildDetail.getSubContainer($("link"));
         assertTrue("should return dashboard_download_project1_log123.xml_abc", theContainer.id == "dashboard_download_project1_log123.xml_abc");
     });
-
-    it("test_should_show_no_output_message_when_server_return_404", function(){
-        prepareMockRequest({status: 404}, '');
-        $('build-output-console-warnning').hide();
-        assertFalse($('build-output-console-warnning').visible());
-        var bd = new BuildOutputDetector('pipeline-2', 'stageName', true);
-        assertEquals('/go/files/pipeline/pipeline-2/stage/stageName/cruise-output/console.log', bd.url);
-        assertTrue($('build-output-console-warnning').visible());
-    });
-
-    it("test_should_show_iframe_content_when_server_return_200", function(){
-        prepareMockRequest({status: 200}, 'out put file body');
-        $('build-output-console-warnning').hide();
-        assertFalse($('build-output-console-warnning').visible());
-        var bd = new BuildOutputDetector('pipeline-2', 'stageName', true);
-        assertEquals('/go/files/pipeline/pipeline-2/stage/stageName/cruise-output/console.log', bd.url);
-        assertFalse($('build-output-console-warnning').visible());
-    });
 });

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_tests.vm
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_tests.vm
@@ -16,11 +16,7 @@
 <div id="tab-content-of-tests" class="widget" $tests_extra_attrs>
     <div class="files">
         #if( $presenter.hasTests())
-            #if ($useIframeSandbox)
-                <iframe sandbox="allow-scripts" src="$req.getContextPath()/${presenter.indexPageURL}" width="95%" height="500" frameborder="0"></iframe>
-            #else
-              <iframe src="$req.getContextPath()/${presenter.indexPageURL}" width="95%" height="500" frameborder="0"></iframe>
-            #end
+            <iframe sandbox="allow-scripts" src="$req.getContextPath()/${presenter.indexPageURL}" width="95%" height="500" frameborder="0"></iframe>
         #else
             #parse("build_detail/_test_output_config.vm")
         #end

--- a/server/src/test-fast/java/com/thoughtworks/go/server/controller/JobControllerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/controller/JobControllerTest.java
@@ -155,7 +155,6 @@ public class JobControllerTest {
             ModelAndView modelAndView = jobController.jobDetail("p1", "1", "s1", "2",
                     "job1");
             assertThat(modelAndView.getModel().isEmpty()).isFalse();
-            assertThat(modelAndView.getModel().get("useIframeSandbox")).isEqualTo(false);
             assertThat(modelAndView.getModel().get("websocketEnabled")).isEqualTo(true);
             assertThat(modelAndView.getModel().get("isEditableViaUI")).isEqualTo(false);
             assertThat(modelAndView.getModel().get("isAgentAlive")).isEqualTo(false);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/view/velocity/BuildDetailPageVelocityTemplateTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/view/velocity/BuildDetailPageVelocityTemplateTest.java
@@ -59,28 +59,16 @@ public class BuildDetailPageVelocityTemplateTest {
     }
 
     @Test
-    public void shouldRenderIframeSandboxByDefaultForTestsTab() throws IOException {
+    public void shouldRenderIframeSandboxForTestsTab() throws IOException {
         HashMap<String, Object> data = new HashMap<>();
         JobDetailPresentationModel jobDetailPresentationModel = mock(JobDetailPresentationModel.class);
         data.put("presenter", jobDetailPresentationModel);
-        data.put("useIframeSandbox", true);
         when(jobDetailPresentationModel.hasTests()).thenReturn(true);
         Document actualDoc = Jsoup.parse(getBuildDetailVelocityView(data).render());
 
         assertThat(actualDoc.select("#tab-content-of-tests").last().html(), containsString("<iframe sandbox=\"allow-scripts\""));
     }
 
-    @Test
-    public void shouldRenderANormalIframeForTestsTabIfUserHasDisabledSandbox() throws IOException {
-        HashMap<String, Object> data = new HashMap<>();
-        JobDetailPresentationModel jobDetailPresentationModel = mock(JobDetailPresentationModel.class);
-        data.put("presenter", jobDetailPresentationModel);
-        data.put("useIframeSandbox", false);
-        when(jobDetailPresentationModel.hasTests()).thenReturn(true);
-        Document actualDoc = Jsoup.parse(getBuildDetailVelocityView(data).render());
-
-        assertThat(actualDoc.select("#tab-content-of-tests").last().html(), containsString("<iframe src="));
-    }
 
     private HashMap<String, Object> createJobDetailModel() {
         GitMaterialConfig gitMaterialConfig = gitMaterialConfig();


### PR DESCRIPTION
The navigation currently seems to be broken. No-one complained, so I guess folks don't use this so often :-)

Anyway, with the current iframe sandbox, on Chrome the authentication cookie is not sent for clicks on the links "inside" the iframe. (it's OK when the iframe is loaded from the parent page) This causes the server to think you are logged out, so you see a blank iframe due to the `302` redirect to login. This is because Chrome treats Cookies without a SameSite attribute as `Lax`, and won't send them via the iframe which is currently considered "cross-origin" due to the way the sandbox is defined.

![image](https://user-images.githubusercontent.com/29788154/183283612-908917a1-9381-40f1-87cf-f905a9302922.png)

![image](https://user-images.githubusercontent.com/29788154/183283650-c6784611-5eab-4170-830d-0a315596cf7a.png)

Other browsers are fine, because they assume `SameSite=None` when it is not specified (albeit a less secure option than Chrome). https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#browser_compatibility

We could
* set `sandbox="allow-scripts allow-same-origin"` (which works) however this leads to warnings on same browsers, as the combination would technically allow the iframe to remove its own sandbox, so gives you a false sense of security. 
* remove the sandbox entirely. This would probably be fine, since we don't allow any user control of the graph anyway.

However an alternative is to use the same `postMessage` mechanism we are currently using to allow the iframe to change the parent window location. We can use this to also allow it to change its own frame location and send the cookie correctly, since the action is triggered from the parent context.

Note that similar issues have been experienced with sandboxed iframes before, e.g #4829 where sandboxing was removed to allow people's custom tabs to generally retrieve other resources via links, while also allowing scripts in them.

This change also cleans up
* some iframe related cruft discovered when reviewing this functionality
* unnecessary system property toggle for job details > tests
* Removes console noise warnings from the `iframeResizer` trying to resize sandboxed iframes (which it cannot do)