### PR TITLE
Improve handling when siteUrls are configured with whitespace only

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/ServerConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/ServerConfig.java
@@ -294,15 +294,12 @@ public class ServerConfig implements Validatable {
 
 
     public ServerSiteUrlConfig getSiteUrlPreferablySecured() {
-        SiteUrl siteUrl = getSiteUrl();
-        SecureSiteUrl secureSiteUrlConfig = getSecureSiteUrl();
-        if (secureSiteUrlConfig.hasNonNullUrl()) {
-            return secureSiteUrlConfig;
+        SecureSiteUrl secureSiteUrl = getSecureSiteUrl();
+        if (!secureSiteUrl.isBlank()) {
+            return secureSiteUrl;
+        } else {
+            return getSiteUrl();
         }
-        if (!secureSiteUrlConfig.hasNonNullUrl()) {
-            return siteUrl;
-        }
-        return new SiteUrl();
     }
 
     public ServerSiteUrlConfig getHttpsUrl() {
@@ -311,7 +308,7 @@ public class ServerConfig implements Validatable {
     }
 
     public boolean hasAnyUrlConfigured() {
-        return getSiteUrl().hasNonNullUrl() || getSecureSiteUrl().hasNonNullUrl();
+        return !getSiteUrl().isBlank() || !getSecureSiteUrl().isBlank();
     }
 
     public Double getPurgeStart() {

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/ServerSiteUrlConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/ServerSiteUrlConfig.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.domain;
 
 import com.thoughtworks.go.config.ConfigValue;
+import org.apache.commons.lang3.StringUtils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -32,8 +33,8 @@ public abstract class ServerSiteUrlConfig {
         this.url = url;
     }
 
-    public boolean hasNonNullUrl() {
-        return getUrl() != null;
+    public boolean isBlank() {
+        return StringUtils.isBlank(url);
     }
 
     public String getUrl() {
@@ -68,14 +69,22 @@ public abstract class ServerSiteUrlConfig {
     }
 
     public String siteUrlFor(String givenUrl, boolean honorGivenHostName) throws URISyntaxException {
-        if (url == null || isPath(givenUrl)) {
+        if (isBlank() || isPath(givenUrl)) {
             return givenUrl; //it is a path
         }
 
         URI baseUri = new URI(url);
         URI givenUri = new URI(givenUrl);
 
-        return new URI(baseUri.getScheme(), getOrDefault(givenUri, baseUri, URI::getUserInfo), honorGivenHostName ? givenUri.getHost() : baseUri.getHost(), baseUri.getPort(), getOrDefault(givenUri, baseUri, URI::getPath), getOrDefault(givenUri, baseUri, URI::getQuery), getOrDefault(givenUri, baseUri, URI::getFragment)).toString();
+        return new URI(
+            baseUri.getScheme(),
+            getOrDefault(givenUri, baseUri, URI::getUserInfo),
+            honorGivenHostName ? givenUri.getHost() : baseUri.getHost(),
+            baseUri.getPort(),
+            getOrDefault(givenUri, baseUri, URI::getPath),
+            getOrDefault(givenUri, baseUri, URI::getQuery),
+            getOrDefault(givenUri, baseUri, URI::getFragment)
+        ).toString();
     }
 
     private boolean isPath(String givenUrl) {
@@ -88,7 +97,7 @@ public abstract class ServerSiteUrlConfig {
     }
 
     public boolean isAHttpsUrl() {
-        return url != null && url.matches(HTTPS_URL_REGEX);
+        return !isBlank() && url.matches(HTTPS_URL_REGEX);
     }
 
     interface Getter {
@@ -97,7 +106,7 @@ public abstract class ServerSiteUrlConfig {
 
     @Override
     public String toString() {
-        return hasNonNullUrl() ? url : "";
+        return isBlank() ? "" : url;
     }
 }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/ServerConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/ServerConfigTest.java
@@ -61,11 +61,11 @@ public class ServerConfigTest {
     public void shouldReturnBlankUrlBothSiteUrlAndSecureSiteUrlIsNotDefined() {
         defaultServerConfig.setSiteUrl(null);
         defaultServerConfig.setSecureSiteUrl(null);
-        assertThat(defaultServerConfig.getSiteUrlPreferablySecured().hasNonNullUrl(), is(false));
+        assertThat(defaultServerConfig.getSiteUrlPreferablySecured().isBlank(), is(true));
     }
 
     @Test
-    public void shouldReturnAnEmptyForSecureSiteUrlIfOnlySiteUrlIsConfigured() throws Exception {
+    public void shouldReturnAnEmptyForSecureSiteUrlIfOnlySiteUrlIsConfigured() {
         ServerConfig serverConfig = new ServerConfig(null, null, new SiteUrl("http://foo.bar:813"), new SecureSiteUrl());
         assertThat(serverConfig.getHttpsUrl(), is(new SecureSiteUrl()));
     }

--- a/config/config-api/src/test/java/com/thoughtworks/go/domain/ServerSiteUrlConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/domain/ServerSiteUrlConfigTest.java
@@ -16,11 +16,14 @@
 package com.thoughtworks.go.domain;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.net.URISyntaxException;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class ServerSiteUrlConfigTest {
     @Test
@@ -77,9 +80,14 @@ public class ServerSiteUrlConfigTest {
         assertThat(url.toString(), is("http://someurl.com"));
     }
 
-    @Test
-    public void shouldReturnEmptyStringForToStringWhenTheUrlIsNotSet() throws Exception {
-        ServerSiteUrlConfig url = new SiteUrl();
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " "})
+    public void shouldHandleBlankUrlsConsistently(String input) throws Exception {
+        ServerSiteUrlConfig url = new SiteUrl(input);
         assertThat(url.toString(), is(""));
+        assertThat(url.isBlank(), is(true));
+        assertThat(url.isAHttpsUrl(), is(false));
+        assertThat(url.siteUrlFor("http://test.host/foo/bar?foo=bar#quux"), is("http://test.host/foo/bar?foo=bar#quux"));
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/providers/WebBasedPluginAuthenticationProvider.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/providers/WebBasedPluginAuthenticationProvider.java
@@ -88,12 +88,12 @@ public class WebBasedPluginAuthenticationProvider extends AbstractPluginAuthenti
         return new AuthenticationToken<>(userPrinciple, credentials, pluginId, clock.currentTimeMillis(), authConfigId);
     }
 
-    private String getRootUrl(String string) {
+    private String rootUrlFrom(String urlString) {
         try {
-            final URL url = new URL(string);
+            final URL url = new URL(urlString);
             return new URL(url.getProtocol(), url.getHost(), url.getPort(), "").toString();
         } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException(String.format("Configured siteUrl [%s] does not appear to be a valid URL", urlString), e);
         }
     }
 
@@ -107,11 +107,12 @@ public class WebBasedPluginAuthenticationProvider extends AbstractPluginAuthenti
         return goConfigService.security().securityAuthConfigs().findByPluginId(pluginId);
     }
 
-    public String getAuthorizationServerUrl(String pluginId, String rootURL) {
-        if (goConfigService.serverConfig().hasAnyUrlConfigured()) {
-            rootURL = getRootUrl(goConfigService.serverConfig().getSiteUrlPreferablySecured().getUrl());
-        }
-        return authorizationExtension.getAuthorizationServerUrl(pluginId, getAuthConfigs(pluginId), rootURL);
+    public String getAuthorizationServerUrl(String pluginId, String alternateRootUrl) {
+        String chosenRootUrl =
+            goConfigService.serverConfig().hasAnyUrlConfigured()
+                ? rootUrlFrom(goConfigService.serverConfig().getSiteUrlPreferablySecured().getUrl())
+                : alternateRootUrl;
+        return authorizationExtension.getAuthorizationServerUrl(pluginId, getAuthConfigs(pluginId), chosenRootUrl);
     }
 
 }


### PR DESCRIPTION
Currently this causes confusion because they are correctly validated by the UI, but then cause authorization plugins to 500 when determining the root URL to use. This is caused by different validation logic vs interpretation logic. This change aligns the logic used by plugins to be based on blank = "not set", consistent with the validation.

- fixes #10036