### PR TITLE
Remove cruft from legacy rails page footer

### DIFF
--- a/server/src/main/webapp/WEB-INF/vm/shared/_footer.vm
+++ b/server/src/main/webapp/WEB-INF/vm/shared/_footer.vm
@@ -23,10 +23,4 @@
 <div id="app-footer"></div>
            <div id="back_to_top" class='back_to_top' title="Scroll to Top">Top</div>
     </body>
-
-    <script type="text/javascript">
-        #if($global_error_message && $global_error_message != "")
-            FlashMessageLauncher.warn("$esc.javascript("$global_error_message")", null, true);
-        #end
-    </script>
 </html>


### PR DESCRIPTION
`global_error_message` seemed to related to licensing and was removed during 39987f486ffad7a8b1bb0b5b6d98f78b9613e00e