### PR TITLE
Ensure errors for FetchPluggableArtifactTasks are available after validation

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/update/PipelineConfigErrorCopier.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/PipelineConfigErrorCopier.java
@@ -69,6 +69,9 @@ public class PipelineConfigErrorCopier {
                     if (toTask instanceof ExecTask) {
                         copyCollectionErrors(((ExecTask) fromTask).getArgList(), ((ExecTask) toTask).getArgList());
                     }
+                    if (toTask instanceof FetchPluggableArtifactTask) {
+                        copyCollectionErrors(((FetchPluggableArtifactTask) fromTask).getConfiguration(), ((FetchPluggableArtifactTask) toTask).getConfiguration());
+                    }
                 }
                 List<PluggableArtifactConfig> toPluggableArtifactConfigs = toJob.artifactTypeConfigs().getPluggableArtifactConfigs();
                 List<PluggableArtifactConfig> fromPluggableArtifactConfigs = fromJob.artifactTypeConfigs().getPluggableArtifactConfigs();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/mixins/errors.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/mixins/errors.ts
@@ -72,11 +72,11 @@ export class Errors {
   }
 
   errorsForDisplay(attrName: string) {
-    return _.map(this._errors[attrName] || [], s.terminateWithPeriod).join(" ");
+    return _.uniq(_.map(this._errors[attrName] || [], s.terminateWithPeriod)).join(" ");
   }
 
   allErrorsForDisplay(): string[] {
-    return _.map(this.keys(), (key) => this.errorsForDisplay(key));
+    return _.uniq(_.map(this.keys(), (key) => this.errorsForDisplay(key)));
   }
 
   count() {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/mixins/spec/errors_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/mixins/spec/errors_spec.ts
@@ -78,4 +78,22 @@ describe("Errors", () => {
 
     expect(errors.errorsForDisplay("name")).toEqual("should not be blank. bar.");
   });
+
+  it("should de-duplicate `errorsForDisplay` while retaining order", () => {
+    const errors = new Errors({name: ["should not be blank", "bar", "should not be blank"]});
+
+    expect(errors.errorsForDisplay("name")).toEqual("should not be blank. bar.");
+  });
+
+  it("should respond to `allErrorsForDisplay`", () => {
+    const errors = new Errors({name: ["should not be blank", "bar"], something: ["something else"]});
+
+    expect(errors.allErrorsForDisplay()).toEqual(["should not be blank. bar.", "something else."]);
+  });
+
+  it("should de-duplicate `allErrorsForDisplay` while retaining order", () => {
+    const errors = new Errors({name: ["should not be blank"], something: ["else"], else: ["should not be blank"]});
+
+    expect(errors.allErrorsForDisplay()).toEqual(["should not be blank.", "else."]);
+  });
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/modal/material_modal.tsx
@@ -122,7 +122,7 @@ export class MaterialModal extends Modal {
             if (errorResponse) {
               const parse            = JSON.parse(JSON.parse(errorResponse).body);
               const unconsumedErrors = this.entity().consumeErrorsResponse(parse.data);
-              this.errorMessage(<span>{parse.message}<br/> {unconsumedErrors.allErrorsForDisplay()}</span>);
+              this.errorMessage(<span>{parse.message}<br/> {unconsumedErrors.allErrorsForDisplay().join(" ")}</span>);
               this.parentFlashMessage.clear();
             }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/job/tasks/fetch/external_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/job/tasks/fetch/external_spec.tsx
@@ -170,6 +170,17 @@ describe("External Fetch Artifact Task", () => {
     expect(pluginIdDropdown).toBeDisabled();
   });
 
+  it("should auto select plugin id based on selected artifact id with optional pipeline", () => {
+    attributes.pipeline(undefined);
+    mount();
+
+    expect(attributes.pipeline()).toBeUndefined();
+
+    const pluginIdDropdown = (helper.byTestId("form-field-input-plugin-id") as HTMLInputElement);
+    expect(pluginIdDropdown.value).toEqual("cd.go.artifact.docker.registry");
+    expect(pluginIdDropdown).toBeDisabled();
+  });
+
   it("should show plugin select error when can not auto detect plugin", () => {
     mount();
 
@@ -217,7 +228,14 @@ describe("External Fetch Artifact Task", () => {
     }
 
     const autoSuggestions = {
-      pipeline: {
+      "pipeline": {
+        stage: {
+          job: {
+            id1: "cd.go.artifact.docker.registry"
+          }
+        }
+      },
+      "": {
         stage: {
           job: {
             id1: "cd.go.artifact.docker.registry"

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks/fetch.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks/fetch.tsx
@@ -31,7 +31,7 @@ export class FetchArtifactTaskModal extends AbstractTaskModal {
   private readonly task: FetchArtifactTask;
   private readonly showOnCancel: boolean;
   private readonly pluginInfos: PluginInfos;
-  private autoSuggestions: Stream<any>;
+  private readonly autoSuggestions: Stream<any>;
   private readonly readonly: boolean;
 
   constructor(task: Task | undefined,

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks/fetch/external.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks/fetch/external.tsx
@@ -26,8 +26,12 @@ import {PluginInfos} from "models/shared/plugin_infos_new/plugin_info";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {AutocompleteField} from "views/components/forms/autocomplete";
 import {SelectField, SelectFieldOptions} from "views/components/forms/input_fields";
-import {ArtifactIdAutocompletionProvider} from "views/pages/clicky_pipeline_config/tabs/job/tasks/fetch/artifact_id_autocompletion_provider";
-import {UpstreamJobToFetchArtifactFromWidget} from "views/pages/clicky_pipeline_config/tabs/job/tasks/fetch/upstream_job_info_to_fetch_artifact_from_widget";
+import {
+  ArtifactIdAutocompletionProvider
+} from "views/pages/clicky_pipeline_config/tabs/job/tasks/fetch/artifact_id_autocompletion_provider";
+import {
+  UpstreamJobToFetchArtifactFromWidget
+} from "views/pages/clicky_pipeline_config/tabs/job/tasks/fetch/upstream_job_info_to_fetch_artifact_from_widget";
 
 import * as foundationStyles from "views/pages/new_plugins/foundation_hax.scss";
 import styles from "../fetch.scss";
@@ -135,6 +139,6 @@ export class ExternalFetchArtifactView extends MithrilComponent<Attrs, State> {
     const job        = attrs.job();
     const artifactId = attrs.artifactId();
 
-    return _.get(vnode.attrs.autoSuggestions(), `${pipeline}.${stage}.${job}.${artifactId}`);
+    return _.get(vnode.attrs.autoSuggestions(), `${pipeline || ""}.${stage}.${job}.${artifactId}`);
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
@@ -207,7 +207,7 @@ export class TasksWidget extends MithrilComponent<Attrs, State> {
       if (parsed.body) {
         const errorData        = JSON.parse(parsed.body);
         const unconsumedErrors = vnode.state.modal.getTask()!.consumeErrorsResponse(errorData.data);
-        vnode.state.modal.flashMessage.setMessage(MessageType.alert, <span>{parsed.message}<br/> {unconsumedErrors.allErrorsForDisplay().join(" ")}</span>);
+        vnode.state.modal.flashMessage.setMessage(MessageType.alert, <span>{errorData.message}<br/> {unconsumedErrors.allErrorsForDisplay().join(" ")}</span>);
       } else {
         vnode.state.modal.flashMessage.setMessage(MessageType.alert, parsed.message);
       }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
@@ -207,7 +207,7 @@ export class TasksWidget extends MithrilComponent<Attrs, State> {
       if (parsed.body) {
         const errorData        = JSON.parse(parsed.body);
         const unconsumedErrors = vnode.state.modal.getTask()!.consumeErrorsResponse(errorData.data);
-        vnode.state.modal.flashMessage.setMessage(MessageType.alert, <span>{parsed.message}<br/> {unconsumedErrors.allErrorsForDisplay()}</span>);
+        vnode.state.modal.flashMessage.setMessage(MessageType.alert, <span>{parsed.message}<br/> {unconsumedErrors.allErrorsForDisplay().join(" ")}</span>);
       } else {
         vnode.state.modal.flashMessage.setMessage(MessageType.alert, parsed.message);
       }


### PR DESCRIPTION
Fixes #10668 

Currently the errors are not returned in the response via the API, nor displayed against the relevant fields on the UI. This addresses that. I don't really understand why, but for everything except the `PluggableTask`s it seems necessary to copy over errors from `preProcessedConfig` to the actual config being updated in:

https://github.com/gocd/gocd/blob/5c7c6c226dc2caa1fe729f5142536634912e795a/server/src/main/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommand.java#L67-L78

Seems this requires some dodgy `instanceof` stuff, already done for `ExecTask`, otherwise the errors disappear into the ether.

A response on fetch task edit via `PUT http://localhost:8153/go/api/admin/pipelines/up42` with the **Docker Registry Artifact Plugin**.


```json
{
  "message" : "Validations failed for pipeline 'up42'. Error(s): [Validation failed.]. Please correct and resubmit.",
  "data" : {
// ... stuff
       {
          "type" : "fetch",
          "attributes" : {
            "artifact_origin" : "external",
            "pipeline" : "up42",
            "stage" : "up42_stage",
            "job" : "up42_job",
            "run_if" : [ "passed" ],
            "artifact_id" : "test-thingy",
            "configuration" : [ {
              "key" : "EnvironmentVariablePrefix",
              "value" : "1",
              "errors" : {
                "EnvironmentVariablePrefix" : [ "Invalid environment name prefix. Valid prefixes contain characters, numbers, and underscore; and can't start with a number." ]
              }
            }, {
              "key" : "SkipImagePulling"
            } ]
          }
        } 
// ... stuff
```

Afterwards:
![image](https://user-images.githubusercontent.com/29788154/183462540-91eb97bb-7eec-49cc-8c3f-3e39c92100e3.png)

![image](https://user-images.githubusercontent.com/29788154/183462508-39e8846f-fd65-416b-bd01-7cb3c0a7769a.png)
