### PR TITLE
Suppress reviewed jquery-ui vulnerability

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -331,12 +331,13 @@
   <suppress>
     <notes><![CDATA[
    GoCD is not vulnerable to these issues as it does not use the relevant widgets of jQuery UI in a vulnerable way.
-   (does not use `dialog.closeText`, `datepicker` or `element.position()` with `of` parameter.
+   (does not use `dialog.closeText`, `datepicker`, `element.position()` with `of` parameter or `checkboxradio`.
    ]]></notes>
     <packageUrl regex="true">^pkg:javascript/jquery\-ui\-dialog@.*$</packageUrl>
     <cve>CVE-2016-7103</cve>
     <cve>CVE-2021-41182</cve>
     <cve>CVE-2021-41183</cve>
     <cve>CVE-2021-41184</cve>
+    <cve>CVE-2022-31160</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
GoCD does not use this functionality of JQuery UI, and is thus not vulnerable to https://github.com/jquery/jquery-ui/security/advisories/GHSA-h6gj-6jjq-h8g9