### PR TITLE
Clarify that we build Adoptium / Eclipse Temurin

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
@@ -142,15 +142,16 @@ class LicenseReport {
 
   private Map<String, Object> openJdkLicense() {
     [
-      "moduleName": "openjdk",
+      "moduleName": "net.adoptium:eclipse-temurin-jre",
       "moduleVersion": "${project.packaging.adoptOpenjdk.featureVersion}",
       "moduleUrls": [
-        "https://jdk.java.net/${project.packaging.adoptOpenjdk.featureVersion}/"
+        "https://adoptium.net/",
+        "https://adoptium.net/about/"
       ],
       "moduleLicenses": [
         [
           "moduleLicense": "GPLv2 with the Classpath Exception",
-          "moduleLicenseUrl": "https://openjdk.java.net/legal/gplv2+ce.html"
+          "moduleLicenseUrl": "https://openjdk.org/legal/gplv2+ce.html"
         ]
       ]
     ]


### PR DESCRIPTION
Previously GoCD bundled core OpenJDK builds but technically we now bundle binaries from Adoptium/Temurin which re-use the same license.
