### PR TITLE
Make preparatory forward-compatible changes for Rails 6

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/configuration/edit.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/configuration/edit.html.erb
@@ -1,9 +1,9 @@
 <div class="sub_tab_container_content">
     <div id="tab-content-of-source-xml">
-        <%= render :partial => 'admin/configuration/heading.html', :locals => {:scope => {:go_config => @go_config}} -%>
-        <%= render :partial => "admin/shared/global_errors.html" -%>
+        <%= render :partial => 'admin/configuration/heading', :locals => {:scope => {:go_config => @go_config}} -%>
+        <%= render :partial => "admin/shared/global_errors" -%>
         <div class="admin_holder" id="admin-holder-for-admin-config-source-xml">
-            <%= render :partial => 'admin/configuration/form.html', :locals => {:scope => {:go_config => @go_config, :go_config_revision => @go_config_revision}} -%>
+            <%= render :partial => 'admin/configuration/form', :locals => {:scope => {:go_config => @go_config, :go_config_revision => @go_config_revision}} -%>
         </div>
     </div>
 </div>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/configuration/show.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/configuration/show.html.erb
@@ -9,7 +9,7 @@
 -%>
 <div class="sub_tab_container_content">
     <div id="tab-content-of-source-xml">
-        <%= render :partial => 'admin/configuration/heading.html', :locals => {:scope => {:go_config => @go_config}} -%>
+        <%= render :partial => 'admin/configuration/heading', :locals => {:scope => {:go_config => @go_config}} -%>
         <div class="admin_holder" id="admin-holder-for-admin-config-source-xml">
             <div class='form_heading'>
                 <div class="buttons-group">

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/configuration/split_pane.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/configuration/split_pane.html.erb
@@ -1,14 +1,14 @@
 <div class="sub_tab_container_content">
     <div id="tab-content-of-source-xml">
-                <%= render :partial => 'admin/configuration/heading.html', :locals => {:scope => {:go_config => @go_config}} -%>
-                <%= render :partial => "admin/shared/global_errors.html" -%>
+                <%= render :partial => 'admin/configuration/heading', :locals => {:scope => {:go_config => @go_config}} -%>
+                <%= render :partial => "admin/shared/global_errors" -%>
                 <div id="admin-holder-for-admin-config-source-xml">
                     <div class='conflicted_content'>
                         <h3>Your Changes</h3>
                         <pre class="wrap_pre"><%= html_escape @conflicted_config.content -%></pre>
                     </div>
                     <div class='current_content'>
-                        <%= render :partial => 'admin/configuration/form.html', :locals => {:scope => {:go_config => @go_config, :go_config_revision => @go_config_revision}} -%>
+                        <%= render :partial => 'admin/configuration/form', :locals => {:scope => {:go_config => @go_config, :go_config_revision => @go_config_revision}} -%>
                     </div>
                 </div>
 

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines_snippet/edit.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/pipelines_snippet/edit.html.erb
@@ -1,5 +1,5 @@
 <%- @view_title = "Administration" -%>
-<%= render :partial => "admin/shared/global_errors.html" -%>
+<%= render :partial => "admin/shared/global_errors" -%>
 <div id = "pipeline_snippet_edit">
     <%= render :partial => "pipeline_group_list", :locals => {:scope => {:modifiable_groups => @modifiable_groups, :group_name => @group_name}} %>
 

--- a/server/src/main/webapp/WEB-INF/rails/app/views/layouts/pipelines.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/layouts/pipelines.html.erb
@@ -38,7 +38,7 @@
               %>
               <div id="page_status_bar" class="page_status_bar <%= page_status_bar_class %>">
                 <% if @show_stage_status_bar %>
-                    <%= render :partial => "stages/status_bar.html" %>
+                    <%= render :partial => "stages/status_bar" %>
                 <% end %>
               </div>
             </div>
@@ -47,7 +47,7 @@
             <div class="rail">
               <% if show_stage_history_widget %>
                   <div id="stage_history" class="stage_history overview_widget">
-                    <%= render :partial => "stages/stage_history.html", :locals => {:scope => {:stage_history_page => @stage_history_page, :tab => params[:action], :current_stage_pipeline => @pipeline, :current_config_version => @current_config_version}} %>
+                    <%= render :partial => "stages/stage_history", :locals => {:scope => {:stage_history_page => @stage_history_page, :tab => params[:action], :current_stage_pipeline => @pipeline, :current_config_version => @current_config_version}} %>
                   </div>
                   <input type="hidden" id="stage-history-page" value="<%= @stage_history_page.currentPage() %>"/>
               <% end %>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/pipelines/_pipeline_header.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/pipelines/_pipeline_header.html.erb
@@ -5,7 +5,7 @@
 <div class="entity_status_wrapper page_header <%= scope[:entity_wrapper_class] %>">
   <div class="row">
     <span class="page_name">Stage Details</span>
-    <%= render :partial => "shared/pipeline_breadcrumb.html", :locals => {:scope => {:pipeline => @pipeline, :third => {:link => url_for_pipeline_value_stream_map(@pipeline), :text => @pipeline.getLabel()}, :fourth => @stage.getName()}} %>
+    <%= render :partial => "shared/pipeline_breadcrumb", :locals => {:scope => {:pipeline => @pipeline, :third => {:link => url_for_pipeline_value_stream_map(@pipeline), :text => @pipeline.getLabel()}, :fourth => @stage.getName()}} %>
 
     <% if @can_user_view_settings %>
         <div class="stage_detail_setting">

--- a/server/src/main/webapp/WEB-INF/rails/app/views/pipelines/_pipeline_stage_bar.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/pipelines/_pipeline_stage_bar.html.erb
@@ -43,6 +43,6 @@
 </div>
 <% if scope[:idx_in_status_bar] > 0 %>
     <div class="trigger_gate">
-        <%= render :partial => "pipelines/stage_trigger_gate.html", :locals => {:scope => {:stage_in_status_bar => scope[:stage_in_status_bar]}} %>
+        <%= render :partial => "pipelines/stage_trigger_gate", :locals => {:scope => {:stage_in_status_bar => scope[:stage_in_status_bar]}} %>
     </div>
 <% end %>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/pipelines/_status_bar.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/pipelines/_status_bar.html.erb
@@ -25,7 +25,7 @@
             %>
                     <li style='<%= scope[:pipeline].numberOfStages() < 9 ? "width: " + stage_width_percent(scope[:pipeline].numberOfStages(), scope[:selected], 100) : "max-width: 300px" %>' class="<%= scope[:stage_class] %>">
                         <div class="wrapper">
-                            <%= render :partial => "pipelines/pipeline_stage_bar.html", :locals => {:scope => {:idx_in_status_bar => idx_in_status_bar, :stage_in_status_bar => stage_in_status_bar, :pipeline_name => scope[:pipeline_name], :pipeline_counter => scope[:pipeline_counter], :stage_name => scope[:stage_name], :stage_counter => scope[:stage_counter], :stage_details_action => scope[:stage_details_action]}} -%>
+                            <%= render :partial => "pipelines/pipeline_stage_bar", :locals => {:scope => {:idx_in_status_bar => idx_in_status_bar, :stage_in_status_bar => stage_in_status_bar, :pipeline_name => scope[:pipeline_name], :pipeline_counter => scope[:pipeline_counter], :stage_name => scope[:stage_name], :stage_counter => scope[:stage_counter], :stage_details_action => scope[:stage_details_action]}} -%>
                         </div>
                     </li>
             <% end %>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/shared/_build_cause.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/shared/_build_cause.html.erb
@@ -7,10 +7,10 @@
             <div class="material_name"><%= "#{scope[:material].getTypeForDisplay()}" %> - <%= "#{scope[:material].getDisplayName()}" -%></div>
             <% if !dependency_material?(scope[:material]) %>
                 <%if scope[:show_latest_only]%>
-                    <%= render :partial => "shared/modification.html", :locals => {:scope => {:modification => material_revision_in_build_cause.getLatestModification(), :pipeline_name => scope[:pipeline_name], :show_files => scope[:show_files]}}-%>
+                    <%= render :partial => "shared/modification", :locals => {:scope => {:modification => material_revision_in_build_cause.getLatestModification(), :pipeline_name => scope[:pipeline_name], :show_files => scope[:show_files]}}-%>
                 <%else%>
                     <% material_revision_in_build_cause.getModifications().each do |mod_in_build_cause| %>
-                        <%= render :partial => "shared/modification.html", :locals => {:scope => {:modification => mod_in_build_cause, :pipeline_name => scope[:pipeline_name], :show_files => scope[:show_files]}}-%>
+                        <%= render :partial => "shared/modification", :locals => {:scope => {:modification => mod_in_build_cause, :pipeline_name => scope[:pipeline_name], :show_files => scope[:show_files]}}-%>
                     <% end %>
                 <%end%>
 

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/_config.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/_config.html.erb
@@ -2,12 +2,12 @@
     <% if is_user_an_admin? %>
         <% if scope[:config_revision] %>
             <% scope[:info_message] = "This version of config was edited by #{scope[:config_revision].getUsername()} on #{scope[:config_revision].getTime()}" -%>
-            <%= render :partial => "admin/shared/notification_information.html", :locals => {:scope => {:notification_message => scope[:info_message]}} -%>
+            <%= render :partial => "admin/shared/notification_information", :locals => {:scope => {:notification_message => scope[:info_message]}} -%>
             <pre id="content_container" class="wrap_pre code"><%= h(scope[:config_revision].getContent()) -%></pre>
         <% else %>
-            <%= render :partial => "admin/shared/notification_information.html", :locals => {:scope => {:notification_message => 'Historical configuration is not available for this stage run.'}} -%>
+            <%= render :partial => "admin/shared/notification_information", :locals => {:scope => {:notification_message => 'Historical configuration is not available for this stage run.'}} -%>
         <% end %>
     <% else %>
-        <%= render :partial => "admin/shared/notification_information.html", :locals => {:scope => {:notification_message => 'Historical configuration is available only for Go Administrators.'}} -%>
+        <%= render :partial => "admin/shared/notification_information", :locals => {:scope => {:notification_message => 'Historical configuration is available only for Go Administrators.'}} -%>
     <% end %>
 </div>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/_job_listing.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/_job_listing.html.erb
@@ -22,7 +22,7 @@
         </td>
         <td class="job_state"><%= job.getState() -%></td>
         <td class="duration">
-            <%= render :partial => "elapsed_time.html", :locals=> {:scope => {:job => job , :show_elapsed => false}} %>
+            <%= render :partial => "elapsed_time", :locals=> {:scope => {:job => job , :show_elapsed => false}} %>
         </td>
         <td class="agent">
             <%- if job.hasAgentInfo() -%>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/_jobs.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/_jobs.html.erb
@@ -20,7 +20,7 @@
         <th class="jobs_summary_header_agent">Agent</th>
     </tr>
 
-    <%= render :partial => "job_listing.html", :locals => {:scope => {:jobs => scope[:jobs], :stage_state => stage_state, :has_operate_permissions => scope[:has_operate_permissions]}} %>
+    <%= render :partial => "job_listing", :locals => {:scope => {:jobs => scope[:jobs], :stage_state => stage_state, :has_operate_permissions => scope[:has_operate_permissions]}} %>
 </table>
 <%- if scope[:stage].getState().completed() -%>
     </form>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/_jobs_breakdown.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/_jobs_breakdown.html.erb
@@ -9,7 +9,7 @@
                     <span class="wrapped_word"> <%= job_in_job_breakdown.getName() %> </span>
                 </a>
                 <% unless job_in_job_breakdown.isCompleted() %>
-                    <%= render :partial => "elapsed_time.html", :locals=> {:scope => {:job => job_in_job_breakdown }} %>
+                    <%= render :partial => "elapsed_time", :locals=> {:scope => {:job => job_in_job_breakdown }} %>
                 <% end %>
             </li>
         <% end %>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/_other_stage_runs.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/_other_stage_runs.html.erb
@@ -5,7 +5,7 @@
             <li>
                 <a href="<%= stage_detail_tab_path_for(:stage_counter => n_in_other_stage_runs, :action => params[:action]) %>">
                     <span style="float:left; margin-right: 10px;">Run: <%= n_in_other_stage_runs %> of <%= @stage.getTotalRuns() %></span>
-                    <%= render :partial=> "stages/stage_result.html", :locals=>{:scope => {:state=>@stage.getStateForRun(n_in_other_stage_runs)}} %>
+                    <%= render :partial=> "stages/stage_result", :locals=>{:scope => {:state=>@stage.getStateForRun(n_in_other_stage_runs)}} %>
                 </a>
             </li>
         <% end %>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/_overview.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/_overview.html.erb
@@ -13,5 +13,5 @@
 </div>
 
 <div class="materials_overview_wrapper">
-    <%= render :partial => 'shared/build_cause.html', :locals => { :scope => {:overview => true, :material_revisions => @pipeline.getCurrentRevisions(), :show_files => false, :pipeline_name => @pipeline.getName(), :show_latest_only => true}} -%>
+    <%= render :partial => 'shared/build_cause', :locals => { :scope => {:overview => true, :material_revisions => @pipeline.getCurrentRevisions(), :show_files => false, :pipeline_name => @pipeline.getName(), :show_latest_only => true}} -%>
 </div>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/_run_details.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/_run_details.html.erb
@@ -1,4 +1,4 @@
-<%=render :partial => "stages/schedule_info.html", :locals => {:scope => {:stage => @stage}} %>
+<%=render :partial => "stages/schedule_info", :locals => {:scope => {:stage => @stage}} %>
 
 <div class="duration">
     <span class="label">Duration:</span>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/_stage_history.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/_stage_history.html.erb
@@ -39,7 +39,7 @@
             </span>
         </div>
     <% end %>
-    <%= render :partial => "shared/pagination_bar.html", :locals => {:scope => {:page_handler => :stage_history_pagination_handler, :pagination => scope[:stage_history_page].getPagination(), :handler_args => [scope[:tab]]}} -%>
+    <%= render :partial => "shared/pagination_bar", :locals => {:scope => {:page_handler => :stage_history_pagination_handler, :pagination => scope[:stage_history_page].getPagination(), :handler_args => [scope[:tab]]}} -%>
 </div>
 <script type="text/javascript">
     Util.on_load(function() {

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/_status_bar.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/_status_bar.html.erb
@@ -2,21 +2,21 @@
     <div class="run">
         <span class="label">Run:</span>
         <span id="current_stage_run">
-            <%= render :partial => "stages/current_stage_run.html", :locals => {:scope => {}} %>
+            <%= render :partial => "stages/current_stage_run", :locals => {:scope => {}} %>
         </span>
 
         <div class="hidden enhanced_dropdown" id="other_stage_runs">
-            <%= render :partial => "stages/other_stage_runs.html", :locals => {:scope => {}} %>
+            <%= render :partial => "stages/other_stage_runs", :locals => {:scope => {}} %>
         </div>
     </div>
 
     <div class="result" id="stage_result">
-        <%= render :partial=> "stages/stage_result.html", :locals=>{:scope => {:state => @stage.getState(), :cancelledBy => @stage.getCancelledBy()}}%>
+        <%= render :partial=> "stages/stage_result", :locals=>{:scope => {:state => @stage.getState(), :cancelledBy => @stage.getCancelledBy()}}%>
     </div>
 </div>
 
 <div class="run_details section" id="stage_run_details">
-    <%= render :partial => "stages/run_details.html", :locals => {:scope => {} } %>
+    <%= render :partial => "stages/run_details", :locals => {:scope => {} } %>
 </div>
 
 <script type="text/javascript">

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/history.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/history.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => "stage_history.html", :locals => {:scope => {:stage_history_page => @stage_history_page, :tab => params[:tab], :current_stage_pipeline => @pipeline, :current_config_version => @current_config_version}} %>
+<%= render :partial => "stage_history", :locals => {:scope => {:stage_history_page => @stage_history_page, :tab => params[:tab], :current_stage_pipeline => @pipeline, :current_config_version => @current_config_version}} %>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/stage.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/stage.html.erb
@@ -21,7 +21,7 @@
         </div>
     <% when 'materials' %>
         <div class="material_tab">
-            <%= render :partial => 'shared/build_cause.html', :locals => {:scope => {:overview => false, :material_revisions => @pipeline.getCurrentRevisions(), :show_files => true, :pipeline_name => @pipeline.getName()}} -%>
+            <%= render :partial => 'shared/build_cause', :locals => {:scope => {:overview => false, :material_revisions => @pipeline.getCurrentRevisions(), :show_files => true, :pipeline_name => @pipeline.getName()}} -%>
         </div>
     <% when 'stats' %>
         <div id="stage_stats">
@@ -46,7 +46,7 @@
         </script>
     <% when 'stage_config' %>
         <div id="ran_with_config">
-            <%= render :partial => "config.html", :locals => {:scope => {:config_revision => @ran_with_config_revision}} -%>
+            <%= render :partial => "config", :locals => {:scope => {:config_revision => @ran_with_config_revision}} -%>
         </div>
     <% end %>
 </div>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/stage.json.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/stage.json.erb
@@ -6,15 +6,15 @@
             "jobs_in_progress": {"html": <%== render_json :partial => "jobs_breakdown.html.erb" , :locals=> {:scope => {:message => "In Progress: #{@stage.inProgressJobs().size()}", :jobs => @stage.inProgressJobs(),:parent_id=>"jobs_in_progress"}} %>},
 
         <%when 'jobs'%>
-            "jobs_grid": {"html": <%== render_json :partial=> 'jobs.html', :locals => {:scope => {:jobs => @jobs, :stage => @stage, :has_operate_permissions => @has_operate_permissions }}  %>},
+            "jobs_grid": {"html": <%== render_json :partial=> 'jobs', :locals => {:scope => {:jobs => @jobs, :stage => @stage, :has_operate_permissions => @has_operate_permissions }}  %>},
     <%end%>
     "pipeline_status_bar": {"html": <%== render_json :partial => "pipelines/status_bar.html.erb", :locals => {:scope => {:pipeline => @pipeline, :current_config_version => @current_config_version, :stage_config_version => @stage.getStage().getConfigVersion()}} %>},
-    "stage_result": {"html": <%== render_json :partial => "stage_result.html", :locals => {:scope => {:state => @stage.getState(), :cancelledBy => @stage.getCancelledBy()}} %>},
-    "stage_run_details": {"html": <%== render_json :partial => "run_details.html", :locals => {:scope => {}} %>},
-    "other_stage_runs": {"html": <%== render_json :partial => "other_stage_runs.html", :locals => {:scope => {}}  %>},
-    "current_stage_run": {"html": <%== render_json :partial => "current_stage_run.html", :locals => {:scope => {}}  %>},
+    "stage_result": {"html": <%== render_json :partial => "stage_result", :locals => {:scope => {:state => @stage.getState(), :cancelledBy => @stage.getCancelledBy()}} %>},
+    "stage_run_details": {"html": <%== render_json :partial => "run_details", :locals => {:scope => {}} %>},
+    "other_stage_runs": {"html": <%== render_json :partial => "other_stage_runs", :locals => {:scope => {}}  %>},
+    "current_stage_run": {"html": <%== render_json :partial => "current_stage_run", :locals => {:scope => {}}  %>},
     <% unless ['pipeline','stats'].include?(params[:action]) -%>
-    "stage_history": {"html": <%== render_json :partial => "stage_history.html", :locals=> {:scope => {:stage_history_page => @stage_history_page, :tab => params[:action], :current_stage_pipeline => @pipeline, :current_config_version => @current_config_version}} %>},
+    "stage_history": {"html": <%== render_json :partial => "stage_history", :locals=> {:scope => {:stage_history_page => @stage_history_page, :tab => params[:action], :current_stage_pipeline => @pipeline, :current_config_version => @current_config_version}} %>},
     <% end %>
-    "pipeline_header": {"html": <%== render_json :partial => "pipelines/pipeline_header.html", :locals => {:scope => {}}  %>}
+    "pipeline_header": {"html": <%== render_json :partial => "pipelines/pipeline_header", :locals => {:scope => {}}  %>}
 }

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/stats_iframe.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/stats_iframe.html.erb
@@ -11,7 +11,7 @@
 <body>
 
 <% if @no_chart_to_render %>
-  <%= render :partial => "admin/shared/notification_information.html", :locals => {:scope => {:notification_message => 'The graph will be available once there is at least one passed or failed stage.'}} -%>
+  <%= render :partial => "admin/shared/notification_information", :locals => {:scope => {:notification_message => 'The graph will be available once there is at least one passed or failed stage.'}} -%>
 <% else %>
   <script type="text/javascript">
       document.addEventListener('DOMContentLoaded', function () {

--- a/server/src/main/webapp/WEB-INF/rails/app/views/value_stream_map/show.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/value_stream_map/show.html.erb
@@ -18,7 +18,7 @@
 
 <div class="content">
   <% if supports_vsm_analytics? %>
-    <%= render :partial => "analytics_panel.html", :locals => {:scope =>
+    <%= render :partial => "analytics_panel", :locals => {:scope =>
                                                                  {:current => params[:pipeline_name],
                                                                   :title => vsm_analytics_chart_info["title"],
                                                                   :message => "Select a pipeline or material"}} -%>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/value_stream_map/show_material.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/value_stream_map/show_material.html.erb
@@ -17,7 +17,7 @@
 
 <div class="content">
   <% if supports_vsm_analytics? %>
-    <%= render :partial => "analytics_panel.html", :locals => {:scope =>
+    <%= render :partial => "analytics_panel", :locals => {:scope =>
                                                                  {:current => @material_display_name,
                                                                   :title => vsm_analytics_chart_info["title"],
                                                                   :message => "Select a downstream pipeline"}} -%>

--- a/server/src/main/webapp/WEB-INF/rails/config/application.rb
+++ b/server/src/main/webapp/WEB-INF/rails/config/application.rb
@@ -54,8 +54,8 @@ module Go
       end
     end
 
-    require Rails.root.join("lib", "log4j_logger.rb")
-    config.logger = Log4jLogger::Logger.new('com.thoughtworks.go.server.Rails')
+    require Rails.root.join("lib", "slf4j_logger.rb")
+    config.logger = Slf4jLogger::Logger.new('com.thoughtworks.go.server.Rails')
 
     config.generators do |g|
       g.test_framework        :rspec, :fixture_replacement => nil

--- a/server/src/main/webapp/WEB-INF/rails/lib/action_rescue.rb
+++ b/server/src/main/webapp/WEB-INF/rails/lib/action_rescue.rb
@@ -42,8 +42,8 @@ module ActionRescue
   end
 
   def collect_stacktrace
-    java.io.StringWriter writer = java.io.StringWriter.new();
+    java.io.StringWriter writer = java.io.StringWriter.new()
     yield print_writer
-    return writer.getBuffer().toString();
+    return writer.getBuffer().toString()
   end
 end

--- a/server/src/main/webapp/WEB-INF/rails/lib/all_libs.rb
+++ b/server/src/main/webapp/WEB-INF/rails/lib/all_libs.rb
@@ -24,6 +24,6 @@ require_relative 'spring'
 
 require_relative 'action_rescue'
 require_relative 'go_cache_store'
-require_relative 'log4j_logger'
+require_relative 'slf4j_logger'
 require_relative 'prototype_helper'
 require_relative 'current_gocd_version'

--- a/server/src/main/webapp/WEB-INF/rails/lib/slf4j_logger.rb
+++ b/server/src/main/webapp/WEB-INF/rails/lib/slf4j_logger.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-class Log4jLogger
+class Slf4jLogger
 
   module LoggerCompatibility # we don't use it, but it's needed as part of the API contract
     attr_accessor :formatter

--- a/server/src/main/webapp/WEB-INF/rails/spec/controllers/value_stream_map_controller_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/controllers/value_stream_map_controller_spec.rb
@@ -68,7 +68,7 @@ describe ValueStreamMapController do
 
     it "should show Error message when pipeline name and counter cannot be resolved to a unique instance" do
       pipeline = "foo"
-      allow(@pipeline_service).to receive(:findPipelineByNameAndCounter).with("foo", 1).and_throw(Exception.new());
+      allow(@pipeline_service).to receive(:findPipelineByNameAndCounter).with("foo", 1).and_throw(Exception.new())
       get :show, params:{pipeline_name: pipeline, pipeline_counter: 1}
 
       expect(assigns(:pipeline)).to eq(nil)

--- a/server/src/main/webapp/WEB-INF/rails/spec/lib/slf4j_logger_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/lib/slf4j_logger_spec.rb
@@ -16,13 +16,13 @@
 
 require 'rails_helper'
 
-describe "Log4jLogger" do
+describe "Slf4jLogger" do
   before(:each) do
     @message = SecureRandom.hex
     @integer_message = SecureRandom.random_number(100000000)
     logger_name = SecureRandom.hex
     @test_appender = LogFixture.logFixtureForLogger(logger_name)
-    @logger = Log4jLogger::Logger.new(logger_name)
+    @logger = Slf4jLogger::Logger.new(logger_name)
   end
 
   after(:each) do

--- a/server/src/main/webapp/WEB-INF/rails/spec/models/value_stream_map_model_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/models/value_stream_map_model_spec.rb
@@ -117,8 +117,8 @@ describe ValueStreamMapModel do
     vsm.addUpstreamNode(PipelineDependencyNode.new(CaseInsensitiveString.new("p1"), "p1"), revision_p1_2, CaseInsensitiveString.new("p2"))
     modifications = modifications()
     vsm.addUpstreamMaterialNode(SCMDependencyNode.new("git", "git", "Git"), com.thoughtworks.go.config.CaseInsensitiveString.new("git-trunk"), CaseInsensitiveString.new("p1"), material_revision)
-    p3_node = vsm.addDownstreamNode(PipelineDependencyNode.new(CaseInsensitiveString.new("p3"), "p3"), CaseInsensitiveString.new("current"));
-    p3_node.addRevision(revision_p3_1);
+    p3_node = vsm.addDownstreamNode(PipelineDependencyNode.new(CaseInsensitiveString.new("p3"), "p3"), CaseInsensitiveString.new("current"))
+    p3_node.addRevision(revision_p3_1)
 
     vsm_path_partial = proc do |pipeline_name, counter|
       "some/path/to/#{pipeline_name}/#{counter}"
@@ -219,7 +219,7 @@ describe ValueStreamMapModel do
     vsm.addUpstreamNode(PipelineDependencyNode.new(CaseInsensitiveString.new("p1"), "p1"), revision_p1_1, CaseInsensitiveString.new("p2"))
     vsm.addUpstreamMaterialNode(SCMDependencyNode.new("git", "git", "Git"), com.thoughtworks.go.config.CaseInsensitiveString.new("git-trunk"), CaseInsensitiveString.new("p1"), material_revision)
 
-    p3_node = vsm.addDownstreamNode(PipelineDependencyNode.new(CaseInsensitiveString.new("p3"), "p3"), CaseInsensitiveString.new("current"));
+    p3_node = vsm.addDownstreamNode(PipelineDependencyNode.new(CaseInsensitiveString.new("p3"), "p3"), CaseInsensitiveString.new("current"))
     p3_node.setViewType(com.thoughtworks.go.domain.valuestreammap.VSMViewType::NO_PERMISSION)
     p3_node.setMessage("You are not authorized to view this pipeline")
 

--- a/server/src/main/webapp/WEB-INF/rails/spec/support/util/test_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/support/util/test_controller.rb
@@ -106,7 +106,7 @@ module Api
       render_localized_operation_result(hor)
     end
 
-    def test_action;
+    def test_action
     end
   end
 end

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/admin/shared/_global_errors_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/admin/shared/_global_errors_html_spec.rb
@@ -22,7 +22,7 @@ describe "global errors on popups" do
       configErrors.add("some field", "<h2>")
       assign(:errors, configErrors.getAll())
 
-      render :partial => "admin/shared/global_errors.html.erb"
+      render :partial => "admin/shared/global_errors"
 
       expect(response.body).to have_selector("li.error", :text => "<h2>") #<h2> is visible to user.
   end

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/layouts/admin_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/layouts/admin_html_spec.rb
@@ -17,7 +17,7 @@
 require 'rails_helper'
 require_relative 'layout_html_examples'
 
-describe "/layouts/admin" do
+describe "layouts/admin" do
   it_should_behave_like :layout
 
   before do

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/layouts/application_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/layouts/application_html_spec.rb
@@ -17,7 +17,7 @@
 require 'rails_helper'
 require_relative 'layout_html_examples'
 
-describe "/layouts/application" do
+describe "layouts/application" do
   it_should_behave_like :layout
 
   before do

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/layouts/pipelines_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/layouts/pipelines_html_spec.rb
@@ -105,7 +105,7 @@ describe "layouts/pipelines.html.eb" do
         assign(:show_stage_status_bar,true)
         assign(:stage_history_page,last_stage_history_page(1))
         assign(:stage,stage_with_three_runs)
-        allow(view).to receive(:stage_detail_tab_path_for).and_return("some_tab_path");
+        allow(view).to receive(:stage_detail_tab_path_for).and_return("some_tab_path")
         render :inline => '<div>content</div>', :layout=>@layout_name
         expect(response.body).to have_selector("script[type='text/javascript']", :text=>/new\sMicroContentPopup\(\$\('other_stage_runs'\),\snew\sMicroContentPopup\.NoOpHandler\(\)\)/, :visible=>false)
       end
@@ -252,7 +252,7 @@ describe "layouts/pipelines.html.eb" do
 
     describe "graphs tab" do
       it "should not render stage history widget pane" do
-        allow(view).to receive(:stage_detail_tab_path_for).and_return("some_tab_path");
+        allow(view).to receive(:stage_detail_tab_path_for).and_return("some_tab_path")
         in_params(:action => "stats")
 
         render :inline => '<div>content</div>', :layout=>@layout_name

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/pipelines/_stage_trigger_gate_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/pipelines/_stage_trigger_gate_html_spec.rb
@@ -28,7 +28,7 @@ describe "stage_trigger_gate.html" do
   it "should show approver when a stage is not automatically approved" do
     @stage.setCanRun(false)
     @stage.setApprovedBy("admin")
-    render :partial => "pipelines/stage_trigger_gate.html", :locals => {:scope => {:stage_in_status_bar => @stage}}
+    render :partial => "pipelines/stage_trigger_gate", :locals => {:scope => {:stage_in_status_bar => @stage}}
     expect(response).to have_selector("span[title='Approved by admin']")
   end
 
@@ -40,7 +40,7 @@ describe "stage_trigger_gate.html" do
     @stage.setScheduled(false)
     @stage.setApprovedBy(nil)
     @stage.setApprovalType("manual")
-    render :partial => "pipelines/stage_trigger_gate.html",
+    render :partial => "pipelines/stage_trigger_gate",
            :locals => {:scope => {:stage_in_status_bar => @stage, :update_opts => {}}}
     expect(response).to have_selector("a[title='Awaiting approval'][class='manual']")
   end
@@ -54,7 +54,7 @@ describe "stage_trigger_gate.html" do
     @stage.setApprovedBy(nil)
     @stage.setApprovalType("success")
 
-    render :partial => "pipelines/stage_trigger_gate.html",
+    render :partial => "pipelines/stage_trigger_gate",
            :locals => {:scope => {:stage_in_status_bar => @stage, :update_opts => {}}}
     expect(response).to have_selector("a[title='Awaiting approval'][class='auto']")
   end

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/pipelines/_stage_trigger_gate_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/pipelines/_stage_trigger_gate_html_spec.rb
@@ -21,8 +21,8 @@ describe "stage_trigger_gate.html" do
   before do
     now = org.joda.time.DateTime.new
     @stage = PipelineHistoryMother.stagePerJob("stage", [PipelineHistoryMother.job(JobState::Completed, JobResult::Cancelled, now.toDate())]).first()
-    @stage.setId(12);
-    @stage.setOperatePermission(true);
+    @stage.setId(12)
+    @stage.setOperatePermission(true)
   end
 
   it "should show approver when a stage is not automatically approved" do

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/shared/_build_cause_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/shared/_build_cause_html_spec.rb
@@ -16,7 +16,7 @@
 
 require 'rails_helper'
 
-describe "/shared/_build_cause.html.erb" do
+describe "shared/_build_cause.html.erb" do
   include StageModelMother
 
   before do

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/shared/_build_cause_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/shared/_build_cause_html_spec.rb
@@ -41,7 +41,7 @@ describe "shared/_build_cause.html.erb" do
   end
 
   it "should not display modified files if the flag is not set" do
-    allow(view).to receive(:go_config_service).and_return(config_service = double('go_config_service'));
+    allow(view).to receive(:go_config_service).and_return(config_service = double('go_config_service'))
     allow(config_service).to receive(:getCommentRendererFor).with("foo").and_return(TrackingTool.new("http://pavan/${ID}", "#(\\d+)"))
 
     render :partial => "shared/build_cause", :locals => {:scope => {:material_revisions => @revisions, :show_files => false, :pipeline_name => "foo"}}
@@ -127,7 +127,7 @@ describe "shared/_build_cause.html.erb" do
   end
 
   it "should html espace all the user entered fields" do
-    allow(view).to receive(:go_config_service).and_return(config_service = double('go_config_service'));
+    allow(view).to receive(:go_config_service).and_return(config_service = double('go_config_service'))
     allow(config_service).to receive(:getCommentRendererFor).with("foo").and_return(TrackingTool.new("http://pavan/${ID}", "#(\\d+)"))
 
     @modification.setComment("<script>alert('Check-in comment')</script>")
@@ -151,7 +151,7 @@ describe "shared/_build_cause.html.erb" do
   end
 
   it "should html espace all the user entered fields" do
-    allow(view).to receive(:go_config_service).and_return(config_service = double('go_config_service'));
+    allow(view).to receive(:go_config_service).and_return(config_service = double('go_config_service'))
     allow(config_service).to receive(:getCommentRendererFor).with("foo").and_return(TrackingTool.new("http://pavan/${ID}", "#(\\d+)"))
 
     @modification.setComment("<script>alert('Check-in comment')</script>")

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/shared/_flash_message_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/shared/_flash_message_html_spec.rb
@@ -16,7 +16,7 @@
 
 require 'rails_helper'
 
-describe "/shared/_flash_message.html.erb" do
+describe "shared/_flash_message.html.erb" do
   describe "flash message obtained from session" do
 
     it "should read flash message from the session" do

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/shared/_subheader_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/shared/_subheader_html_spec.rb
@@ -16,7 +16,7 @@
 
 require 'rails_helper'
 
-describe "/shared/_subheader.html.erb" do
+describe "shared/_subheader.html.erb" do
 
   it 'should display title' do
     assign(:page_header, '<h1 class="entity_title">My Title</h1>')


### PR DESCRIPTION
- Resolves behaviour deprecated in Rails 6.1 regarding template names with `.` in them (makes things consistent across the codebase)
- Avoid naming specs starting with `/` which seems to confuse rspec-rails 6 (or rails itself)
- Fix some minor technical debt