### PR TITLE
Fix deprecation warnings for rendering with `.` in template name

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/stage.json.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/stage.json.erb
@@ -1,20 +1,20 @@
 {
     <%case params[:action]
         when 'overview' %>
-            "jobs_failed": {"html": <%== render_json :partial => "jobs_breakdown.html.erb" , :locals=> {:scope => {:message => "Failed: #{@stage.nonPassedJobs().size()}", :jobs => @stage.nonPassedJobs(),:parent_id=>"jobs_failed"}} %>},
-            "jobs_passed": {"html": <%== render_json :partial => "jobs_breakdown.html.erb" , :locals=> {:scope => {:message => "Passed: #{@stage.passedJobs().size()}", :jobs => @stage.passedJobs(),:parent_id=>"jobs_passed"}} %>},
-            "jobs_in_progress": {"html": <%== render_json :partial => "jobs_breakdown.html.erb" , :locals=> {:scope => {:message => "In Progress: #{@stage.inProgressJobs().size()}", :jobs => @stage.inProgressJobs(),:parent_id=>"jobs_in_progress"}} %>},
+            "jobs_failed": {"html": <%== render_json :partial => "jobs_breakdown", :formats => [:html], :locals=> {:scope => {:message => "Failed: #{@stage.nonPassedJobs().size()}", :jobs => @stage.nonPassedJobs(),:parent_id=>"jobs_failed"}} %>},
+            "jobs_passed": {"html": <%== render_json :partial => "jobs_breakdown", :formats => [:html], :locals=> {:scope => {:message => "Passed: #{@stage.passedJobs().size()}", :jobs => @stage.passedJobs(),:parent_id=>"jobs_passed"}} %>},
+            "jobs_in_progress": {"html": <%== render_json :partial => "jobs_breakdown", :formats => [:html], :locals=> {:scope => {:message => "In Progress: #{@stage.inProgressJobs().size()}", :jobs => @stage.inProgressJobs(),:parent_id=>"jobs_in_progress"}} %>},
 
         <%when 'jobs'%>
-            "jobs_grid": {"html": <%== render_json :partial=> 'jobs', :locals => {:scope => {:jobs => @jobs, :stage => @stage, :has_operate_permissions => @has_operate_permissions }}  %>},
+            "jobs_grid": {"html": <%== render_json :partial => 'jobs', :formats => [:html], :locals => {:scope => {:jobs => @jobs, :stage => @stage, :has_operate_permissions => @has_operate_permissions }}  %>},
     <%end%>
-    "pipeline_status_bar": {"html": <%== render_json :partial => "pipelines/status_bar.html.erb", :locals => {:scope => {:pipeline => @pipeline, :current_config_version => @current_config_version, :stage_config_version => @stage.getStage().getConfigVersion()}} %>},
-    "stage_result": {"html": <%== render_json :partial => "stage_result", :locals => {:scope => {:state => @stage.getState(), :cancelledBy => @stage.getCancelledBy()}} %>},
-    "stage_run_details": {"html": <%== render_json :partial => "run_details", :locals => {:scope => {}} %>},
-    "other_stage_runs": {"html": <%== render_json :partial => "other_stage_runs", :locals => {:scope => {}}  %>},
-    "current_stage_run": {"html": <%== render_json :partial => "current_stage_run", :locals => {:scope => {}}  %>},
+    "pipeline_status_bar": {"html": <%== render_json :partial => "pipelines/status_bar", :formats => [:html], :locals => {:scope => {:pipeline => @pipeline, :current_config_version => @current_config_version, :stage_config_version => @stage.getStage().getConfigVersion()}} %>},
+    "stage_result": {"html": <%== render_json :partial => "stage_result", :formats => [:html], :locals => {:scope => {:state => @stage.getState(), :cancelledBy => @stage.getCancelledBy()}} %>},
+    "stage_run_details": {"html": <%== render_json :partial => "run_details", :formats => [:html], :locals => {:scope => {}} %>},
+    "other_stage_runs": {"html": <%== render_json :partial => "other_stage_runs", :formats => [:html], :locals => {:scope => {}}  %>},
+    "current_stage_run": {"html": <%== render_json :partial => "current_stage_run", :formats => [:html], :locals => {:scope => {}}  %>},
     <% unless ['pipeline','stats'].include?(params[:action]) -%>
-    "stage_history": {"html": <%== render_json :partial => "stage_history", :locals=> {:scope => {:stage_history_page => @stage_history_page, :tab => params[:action], :current_stage_pipeline => @pipeline, :current_config_version => @current_config_version}} %>},
+    "stage_history": {"html": <%== render_json :partial => "stage_history", :formats => [:html], :locals=> {:scope => {:stage_history_page => @stage_history_page, :tab => params[:action], :current_stage_pipeline => @pipeline, :current_config_version => @current_config_version}} %>},
     <% end %>
-    "pipeline_header": {"html": <%== render_json :partial => "pipelines/pipeline_header", :locals => {:scope => {}}  %>}
+    "pipeline_header": {"html": <%== render_json :partial => "pipelines/pipeline_header", :formats => [:html], :locals => {:scope => {}}  %>}
 }

--- a/server/src/main/webapp/WEB-INF/rails/spec/views/shared/_flash_message_html_spec.rb
+++ b/server/src/main/webapp/WEB-INF/rails/spec/views/shared/_flash_message_html_spec.rb
@@ -21,19 +21,19 @@ describe "shared/_flash_message.html.erb" do
 
     it "should read flash message from the session" do
       session[:notice] = FlashMessageModel.new("foo", "success")
-      render :partial => "shared/flash_message.html.erb"
+      render :partial => "shared/flash_message"
       expect(response.body).to have_selector("div#message_pane p.success", :text => "foo")
       expect(session[:notice]).to be(nil)
     end
 
    it "should not show flash message when its not defined in session" do
-      render :partial => "shared/flash_message.html.erb"
+      render :partial => "shared/flash_message"
       expect(response.body).to_not have_selector("div#message_pane p", :text => "foo")
     end
 
     it "should escape flash message" do
       session[:notice] = FlashMessageModel.new("<h2>", "success")
-      render :partial => "shared/flash_message.html.erb"
+      render :partial => "shared/flash_message"
       expect(response.body).to have_selector("div#message_pane p", :text => "<h2>")
     end
 
@@ -45,7 +45,7 @@ describe "shared/_flash_message.html.erb" do
       allow(view).to receive(:load_flash_message).with('flash_key').and_return(flash)
       assign(:flash_help_link, "<a href='foo'>Foo</a>")
 
-      render :partial => "shared/flash_message.html.erb"
+      render :partial => "shared/flash_message"
 
       Capybara.string(response.body).find("p.error").tap do |error|
         expect(error).to have_selector("a[href='foo']", :text => "Foo")
@@ -60,7 +60,7 @@ describe "shared/_flash_message.html.erb" do
       allow(view).to receive(:load_flash_message).with('flash_key').and_return(flash)
       assign(:flash_help_link, nil)
 
-      render :partial => "shared/flash_message.html.erb"
+      render :partial => "shared/flash_message"
 
       Capybara.string(response.body).find("p.error").tap do |error|
         expect(error).not_to have_selector("a[href='foo']", :text => "Foo")


### PR DESCRIPTION
Missing a rebase in #10703.