### PR TITLE
Clean up Docker images

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -155,7 +155,7 @@ enum Distro implements DistroBehavior {
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
       return [
         'apt-get update',
-        'apt-get install -y git subversion mercurial openssh-client bash unzip curl locales procps sysvinit-utils coreutils',
+        'apt-get install -y git subversion mercurial openssh-client bash unzip curl ca-certificates locales procps sysvinit-utils coreutils',
         'apt-get clean all',
         'rm -rf "/var/lib/apt/lists/*"',
         'echo \'en_US.UTF-8 UTF-8\' > /etc/locale.gen && /usr/sbin/locale-gen'

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -156,7 +156,8 @@ enum Distro implements DistroBehavior {
       return [
         'apt-get update',
         'apt-get install -y git subversion mercurial openssh-client bash unzip curl locales procps sysvinit-utils coreutils',
-        'apt-get autoclean',
+        'apt-get clean all',
+        'rm -rf "/var/lib/apt/lists/*"',
         'echo \'en_US.UTF-8 UTF-8\' > /etc/locale.gen && /usr/sbin/locale-gen'
       ]
     }

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
@@ -45,7 +45,7 @@ trait DistroBehavior {
 
   List<String> getCreateUserAndGroupCommands() {
     return [
-      'useradd -u ${UID} -g root -d /home/go -m go'
+      'useradd -l -u ${UID} -g root -d /home/go -m go'
     ]
   }
 

--- a/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
@@ -22,11 +22,14 @@ USER root
 ARG UID=1000
 <#if useFromArtifact >
 COPY go-agent-${fullVersion}.zip /tmp/go-agent-${fullVersion}.zip
+RUN \
 <#else>
-RUN curl --fail --location --silent --show-error "https://download.gocd.org/binaries/${fullVersion}/generic/go-agent-${fullVersion}.zip" > /tmp/go-agent-${fullVersion}.zip
+RUN curl --fail --location --silent --show-error "https://download.gocd.org/binaries/${fullVersion}/generic/go-agent-${fullVersion}.zip" > /tmp/go-agent-${fullVersion}.zip && \
 </#if>
-RUN unzip /tmp/go-agent-${fullVersion}.zip -d /
-RUN mv /go-agent-${goVersion} /go-agent && chown -R ${r"${UID}"}:0 /go-agent && chmod -R g=u /go-agent
+    unzip /tmp/go-agent-${fullVersion}.zip -d / && \
+    mv /go-agent-${goVersion} /go-agent && \
+    chown -R ${r"${UID}"}:0 /go-agent && \
+    chmod -R g=u /go-agent
 
 FROM ${distro.getBaseImageLocation(distroVersion)}
 
@@ -85,8 +88,8 @@ COPY --chown=go:root agent-bootstrapper-logback-include.xml agent-launcher-logba
 COPY --chown=root:root dockerd-sudo /etc/sudoers.d/dockerd-sudo
 </#if>
 
-RUN chown -R go:root /docker-entrypoint.d /go /godata /docker-entrypoint.sh \
-    && chmod -R g=u /docker-entrypoint.d /go /godata /docker-entrypoint.sh
+RUN chown -R go:root /docker-entrypoint.d /go /godata /docker-entrypoint.sh && \
+    chmod -R g=u /docker-entrypoint.d /go /godata /docker-entrypoint.sh
 
 <#if distro.name() == "docker">
   COPY --chown=root:root run-docker-daemon.sh /

--- a/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
@@ -22,11 +22,12 @@ USER root
 ARG UID=1000
 <#if useFromArtifact >
 COPY go-server-${fullVersion}.zip /tmp/go-server-${fullVersion}.zip
+RUN \
 <#else>
-RUN curl --fail --location --silent --show-error "https://download.gocd.org/binaries/${fullVersion}/generic/go-server-${fullVersion}.zip" > /tmp/go-server-${fullVersion}.zip
+RUN curl --fail --location --silent --show-error "https://download.gocd.org/binaries/${fullVersion}/generic/go-server-${fullVersion}.zip" > /tmp/go-server-${fullVersion}.zip && \
 </#if>
-RUN unzip /tmp/go-server-${fullVersion}.zip -d /
-RUN mkdir -p /go-server/wrapper /go-server/bin && \
+    unzip /tmp/go-server-${fullVersion}.zip -d / && \
+    mkdir -p /go-server/wrapper /go-server/bin && \
     mv /go-server-${goVersion}/LICENSE /go-server/LICENSE && \
     mv /go-server-${goVersion}/bin/go-server /go-server/bin/go-server && \
     mv /go-server-${goVersion}/lib /go-server/lib && \
@@ -94,8 +95,8 @@ COPY --from=gocd-server-unzip /go-server /go-server
 COPY --chown=go:root logback-include.xml /go-server/config/logback-include.xml
 COPY --chown=go:root install-gocd-plugins git-clone-config /usr/local/sbin/
 
-RUN chown -R go:root /docker-entrypoint.d /go-working-dir /godata /docker-entrypoint.sh \
-    && chmod -R g=u /docker-entrypoint.d /go-working-dir /godata /docker-entrypoint.sh
+RUN chown -R go:root /docker-entrypoint.d /go-working-dir /godata /docker-entrypoint.sh && \
+    chmod -R g=u /docker-entrypoint.d /go-working-dir /godata /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 


### PR DESCRIPTION
- Removes unnecessary apt cache data from debian and ubuntu agent images (fixes #10705)
- Consolidates some `RUN` instructions that hadolint complains about
- Avoids logging user initialization, following hadolint recommendation