### PR TITLE
Correct APT lists cleaning

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -157,7 +157,7 @@ enum Distro implements DistroBehavior {
         'apt-get update',
         'apt-get install -y git subversion mercurial openssh-client bash unzip curl ca-certificates locales procps sysvinit-utils coreutils',
         'apt-get clean all',
-        'rm -rf "/var/lib/apt/lists/*"',
+        'rm -rf /var/lib/apt/lists/*',
         'echo \'en_US.UTF-8 UTF-8\' > /etc/locale.gen && /usr/sbin/locale-gen'
       ]
     }


### PR DESCRIPTION
Seems the quoting here is causing it to not work as intended, probably because within Dockerfile it's not a real shell. Follow-up to #10723 