### PR TITLE
Bump bundled Java version from 17.0.4 to 17.0.4.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 # Configuration for https://github.com/asdf-vm/asdf as an alternative to jabba, rvm, nvm etc
-java temurin-17.0.4+8
+java temurin-17.0.4+101
 ruby jruby-9.3.7.0
 nodejs 16.17.0

--- a/build.gradle
+++ b/build.gradle
@@ -170,9 +170,10 @@ project.ext.toolchains = [
 project.ext.packaging = [
   adoptOpenjdk: [
     featureVersion: 17,
-    interimVersion: 0, // set to `null` for the first release
-    updateVersion : 4, // set to `null` for the first release
-    buildVersion  : 8
+    interimVersion: 0, // set to `null` for the first release of a new featureVersion
+    updateVersion : 4, // set to `null` for the first release of a new featureVersion
+    patchVersion  : 1, // set to `null` for most releases. Patch releases are "exceptional".
+    buildVersion  : 1
   ]
 ]
 

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/AdoptiumUrlHelper.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/AdoptiumUrlHelper.groovy
@@ -18,14 +18,14 @@ package com.thoughtworks.go.build
 
 
 class AdoptiumUrlHelper {
-  static String downloadURL(OperatingSystem operatingSystem, Integer featureVersion, Integer interimVersion, Integer updateVersion, Integer buildVersion) {
-    String versionComponent = [featureVersion, interimVersion, updateVersion].findAll({ it != null }).join('.')
+  static String downloadURL(OperatingSystem operatingSystem, Integer featureVersion, Integer interimVersion, Integer updateVersion, Integer patchVersion, Integer buildVersion) {
+    String versionComponent = [featureVersion, interimVersion, updateVersion, patchVersion].findAll({ it != null }).join('.')
     String featureSuffix = updateVersion == null ? '' : 'U'
 
     "https://github.com/adoptium/temurin${featureVersion}-binaries/releases/download/jdk-${versionComponent}%2B${buildVersion}/OpenJDK${featureVersion}${featureSuffix}-jre_x64_${operatingSystem.adoptiumAlias()}_hotspot_${versionComponent}_${buildVersion}.${operatingSystem.extension}"
   }
 
-  static String sha256sumURL(OperatingSystem operatingSystem, Integer featureVersion, Integer interimVersion, Integer updateVersion, Integer buildVersion) {
-    "${downloadURL(operatingSystem, featureVersion, interimVersion, updateVersion, buildVersion)}.sha256.txt"
+  static String sha256sumURL(OperatingSystem operatingSystem, Integer featureVersion, Integer interimVersion, Integer updateVersion, Integer patchVersion, Integer buildVersion) {
+    "${downloadURL(operatingSystem, featureVersion, interimVersion, updateVersion, patchVersion, buildVersion)}.sha256.txt"
   }
 }

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
@@ -128,7 +128,7 @@ class LicenseReport {
             renderModuleData(markup, counter.incrementAndGet(), moduleName, moduleLicenseData)
           }
 
-          renderModuleData(markup, counter.incrementAndGet(), "openjdk", openJdkLicense())
+          renderModuleData(markup, counter.incrementAndGet(), openJdkLicense().moduleName, openJdkLicense())
 
           div(class: "footer") {
             span("This report was generated at ")

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
@@ -59,6 +59,7 @@ trait DistroBehavior {
       project.packaging.adoptOpenjdk.featureVersion,
       project.packaging.adoptOpenjdk.interimVersion,
       project.packaging.adoptOpenjdk.updateVersion,
+      project.packaging.adoptOpenjdk.patchVersion,
       project.packaging.adoptOpenjdk.buildVersion)
 
     return [

--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -110,6 +110,7 @@ task downloadLinuxJreChecksum(type: DownloadFile) {
     project.packaging.adoptOpenjdk.featureVersion,
     project.packaging.adoptOpenjdk.interimVersion,
     project.packaging.adoptOpenjdk.updateVersion,
+    project.packaging.adoptOpenjdk.patchVersion,
     project.packaging.adoptOpenjdk.buildVersion
   )
   src srcUrl
@@ -124,6 +125,7 @@ task downloadLinuxJre(type: DownloadFile) {
     project.packaging.adoptOpenjdk.featureVersion,
     project.packaging.adoptOpenjdk.interimVersion,
     project.packaging.adoptOpenjdk.updateVersion,
+    project.packaging.adoptOpenjdk.patchVersion,
     project.packaging.adoptOpenjdk.buildVersion
   )
   src srcUrl

--- a/installers/osx.gradle
+++ b/installers/osx.gradle
@@ -29,6 +29,7 @@ task downloadOsxJreChecksum(type: DownloadFile) {
     project.packaging.adoptOpenjdk.featureVersion,
     project.packaging.adoptOpenjdk.interimVersion,
     project.packaging.adoptOpenjdk.updateVersion,
+    project.packaging.adoptOpenjdk.patchVersion,
     project.packaging.adoptOpenjdk.buildVersion
   )
   src srcUrl
@@ -42,6 +43,7 @@ task downloadOsxJre(type: DownloadFile) {
     project.packaging.adoptOpenjdk.featureVersion,
     project.packaging.adoptOpenjdk.interimVersion,
     project.packaging.adoptOpenjdk.updateVersion,
+    project.packaging.adoptOpenjdk.patchVersion,
     project.packaging.adoptOpenjdk.buildVersion
   )
   src srcUrl

--- a/installers/windows.gradle
+++ b/installers/windows.gradle
@@ -31,6 +31,7 @@ task downloadWindowsJreChecksum(type: DownloadFile) {
     project.packaging.adoptOpenjdk.featureVersion,
     project.packaging.adoptOpenjdk.interimVersion,
     project.packaging.adoptOpenjdk.updateVersion,
+    project.packaging.adoptOpenjdk.patchVersion,
     project.packaging.adoptOpenjdk.buildVersion
   )
   src srcUrl
@@ -44,6 +45,7 @@ task downloadWindowsJre(type: DownloadFile) {
     project.packaging.adoptOpenjdk.featureVersion,
     project.packaging.adoptOpenjdk.interimVersion,
     project.packaging.adoptOpenjdk.updateVersion,
+    project.packaging.adoptOpenjdk.patchVersion,
     project.packaging.adoptOpenjdk.buildVersion
   )
   src srcUrl


### PR DESCRIPTION
See https://www.oracle.com/java/technologies/javase/17-0-4-relnotes.html - there's a C2 JIT compiler crash in some circumstances, so an urgent patch release was done.