### PR TITLE
Remove cruft left over from addons

### DIFF
--- a/server/src/test-fast/java/com/thoughtworks/go/server/AppServerStub.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/AppServerStub.java
@@ -30,11 +30,6 @@ public class AppServerStub extends AppServer {
     }
 
     @Override
-    void addExtraJarsToClasspath(String extraClasspath) {
-        calls.put("addExtraJarsToClasspath", extraClasspath);
-    }
-
-    @Override
     void setSessionConfig() {
         calls.put("setSessionCookieConfig", "something");
     }


### PR DESCRIPTION
Add-ons were removed in GoCD 20.6.0 so this is unnecessary now (missed a file in #10751)