### PR TITLE
Minor improvements to agent startup and logging

### DIFF
--- a/agent-bootstrapper/src/main/java/com/thoughtworks/go/agent/bootstrapper/AgentBootstrapper.java
+++ b/agent-bootstrapper/src/main/java/com/thoughtworks/go/agent/bootstrapper/AgentBootstrapper.java
@@ -85,7 +85,11 @@ public class AgentBootstrapper {
                 resetContextClassLoader(tccl);
                 forceGCToPreventOOM();
             }
-            waitForRelaunchTime();
+
+            // Immediately restart if launcher isn't up to date.
+            if (returnValue != AgentLauncher.NOT_UP_TO_DATE) {
+                waitForRelaunchTime();
+            }
         } while (loop);
 
         LOG.info("Agent Bootstrapper stopped");
@@ -105,7 +109,7 @@ public class AgentBootstrapper {
         try {
             Thread.sleep(waitTimeBeforeRelaunch);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/agent-bootstrapper/src/main/java/com/thoughtworks/go/agent/bootstrapper/DefaultAgentLaunchDescriptorImpl.java
+++ b/agent-bootstrapper/src/main/java/com/thoughtworks/go/agent/bootstrapper/DefaultAgentLaunchDescriptorImpl.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 class DefaultAgentLaunchDescriptorImpl implements AgentLaunchDescriptor {
 
     private final AgentBootstrapper bootstrapper;
-    private final Map context = new ConcurrentHashMap();
+    private final Map<String, String> context = new ConcurrentHashMap<>();
 
     public DefaultAgentLaunchDescriptorImpl(AgentBootstrapperArgs bootstrapperArgs, AgentBootstrapper agentBootstrapper) {
         this.bootstrapper = agentBootstrapper;
@@ -38,7 +38,7 @@ class DefaultAgentLaunchDescriptorImpl implements AgentLaunchDescriptor {
     }
 
     @Override
-    public Map context() {
+    public Map<String, String> context() {
         return context;
     }
 

--- a/agent-common/src/main/java/com/thoughtworks/cruise/agent/common/launcher/AgentLaunchDescriptor.java
+++ b/agent-common/src/main/java/com/thoughtworks/cruise/agent/common/launcher/AgentLaunchDescriptor.java
@@ -22,7 +22,7 @@ import java.util.Map;
  */
 public interface AgentLaunchDescriptor {
 
-    Map context();
+    Map<String, String> context();
 
     /**
      * future proofing - in case we need the bootstrapper (reflection only)

--- a/agent-common/src/main/java/com/thoughtworks/cruise/agent/common/launcher/AgentLauncher.java
+++ b/agent-common/src/main/java/com/thoughtworks/cruise/agent/common/launcher/AgentLauncher.java
@@ -21,6 +21,7 @@ package com.thoughtworks.cruise.agent.common.launcher;
 public interface AgentLauncher {
 
     int IRRECOVERABLE_ERROR = 0xBADBAD;
+    int NOT_UP_TO_DATE = 60;
 
     int launch(AgentLaunchDescriptor descriptor);
 }

--- a/agent-common/src/main/java/com/thoughtworks/go/agent/common/util/JarUtil.java
+++ b/agent-common/src/main/java/com/thoughtworks/go/agent/common/util/JarUtil.java
@@ -100,7 +100,7 @@ public class JarUtil {
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }
-        }).collect(Collectors.toList()).toArray(new URL[0]);
+        }).toArray(URL[]::new);
     }
 
     public static URLClassLoader getClassLoaderFromJar(File aJarFile, Predicate<JarEntry> extractFilter, File outputTmpDir, ClassLoader parentClassLoader, Class... allowedClasses) {

--- a/agent-launcher/src/main/java/com/thoughtworks/go/agent/launcher/AgentLauncherImpl.java
+++ b/agent-launcher/src/main/java/com/thoughtworks/go/agent/launcher/AgentLauncherImpl.java
@@ -79,7 +79,7 @@ public class AgentLauncherImpl implements AgentLauncher {
 
             shutdownHook = registerShutdownHook();
 
-            Map context = descriptor.context();
+            Map<String, String> context = descriptor.context();
 
             AgentBootstrapperArgs bootstrapperArgs = AgentBootstrapperArgs.fromProperties(context);
             ServerUrlGenerator urlGenerator = new UrlConstructor(bootstrapperArgs.getServerUrl().toExternalForm());
@@ -115,13 +115,13 @@ public class AgentLauncherImpl implements AgentLauncher {
         if (shutdownHook != null) {
             try {
                 Runtime.getRuntime().removeShutdownHook(shutdownHook);
-            } catch (Exception e) {
+            } catch (Exception ignore) {
             }
         }
     }
 
     private Thread registerShutdownHook() {
-        Thread shutdownHook = new Thread(() -> lockFile.delete());
+        Thread shutdownHook = new Thread(lockFile::delete);
         Runtime.getRuntime().addShutdownHook(shutdownHook);
         return shutdownHook;
     }
@@ -131,12 +131,12 @@ public class AgentLauncherImpl implements AgentLauncher {
     }
 
     public interface AgentProcessParentRunner {
-        int run(String launcherVersion, String launcherMd5, ServerUrlGenerator urlGenerator, Map<String, String> environmentVariables, Map context);
+        int run(String launcherVersion, String launcherMd5, ServerUrlGenerator urlGenerator, Map<String, String> environmentVariables, Map<String, String> context);
     }
 
     private static class AgentJarBasedAgentParentRunner implements AgentProcessParentRunner {
         @Override
-        public int run(String launcherVersion, String launcherMd5, ServerUrlGenerator urlGenerator, Map<String, String> environmentVariables, Map context) {
+        public int run(String launcherVersion, String launcherMd5, ServerUrlGenerator urlGenerator, Map<String, String> environmentVariables, Map<String, String> context) {
             String agentProcessParentClassName = JarUtil.getManifestKey(Downloader.AGENT_BINARY_JAR, GO_AGENT_BOOTSTRAP_CLASS);
             String tempDirSuffix = new BigInteger(64, new SecureRandom()).toString(16) + "-" + Downloader.AGENT_BINARY_JAR;
             File tempDir = new File(FileUtil.TMP_PARENT_DIR, "deps-" + tempDirSuffix);

--- a/agent-launcher/src/main/java/com/thoughtworks/go/agent/launcher/AgentLauncherImpl.java
+++ b/agent-launcher/src/main/java/com/thoughtworks/go/agent/launcher/AgentLauncherImpl.java
@@ -71,8 +71,6 @@ public class AgentLauncherImpl implements AgentLauncher {
     private Integer doLaunch(AgentLaunchDescriptor descriptor) {
         Thread shutdownHook = null;
         try {
-            int returnValue;
-
             if (!lockFile.tryLock()) {
                 return IRRECOVERABLE_ERROR;
             }
@@ -92,16 +90,7 @@ public class AgentLauncherImpl implements AgentLauncher {
             ServerBinaryDownloader agentDownloader = new ServerBinaryDownloader(urlGenerator, bootstrapperArgs);
             agentDownloader.downloadIfNecessary(DownloadableFile.AGENT);
 
-            returnValue = agentProcessParentRunner.run(getLauncherVersion(), launcherDownloader.getMd5(), urlGenerator, System.getenv(), context);
-
-            try {
-                // Sleep a bit so that if there are problems we don't spin
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                return returnValue;
-            }
-            return returnValue;
-
+            return agentProcessParentRunner.run(getLauncherVersion(), launcherDownloader.getMd5(), urlGenerator, System.getenv(), context);
         } catch (Exception e) {
             LOG.error("Launch encountered an unknown exception", e);
             return UNKNOWN_EXCEPTION_OCCURRED;

--- a/build-platform/build.gradle
+++ b/build-platform/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     api project.deps.commonsCollections
     api project.deps.commonsBeanUtils
     api project.deps.objenesis
+    api project.deps.slf4j
   }
 
   api enforcedPlatform(project.deps.junit5Bom)

--- a/docker/gocd-agent/build.gradle
+++ b/docker/gocd-agent/build.gradle
@@ -112,15 +112,6 @@ subprojects {
 
       Thread.sleep(5000)
 
-      ByteArrayOutputStream containerOutput = new ByteArrayOutputStream()
-      project.exec {
-        workingDir = project.rootProject.projectDir
-        commandLine = ["docker", "logs", docker.dockerImageName]
-        standardOutput = containerOutput
-        errorOutput = containerOutput
-        ignoreExitValue = true
-      }
-
       // run a `ps aux`
       ByteArrayOutputStream psOutput = new ByteArrayOutputStream()
       project.exec {
@@ -128,6 +119,15 @@ subprojects {
         commandLine = ["docker", "exec", docker.dockerImageName, "ps", "aux"]
         standardOutput = new TeeOutputStream(psOutput, System.out)
         errorOutput = new TeeOutputStream(psOutput, System.err)
+        ignoreExitValue = true
+      }
+
+      ByteArrayOutputStream containerOutput = new ByteArrayOutputStream()
+      project.exec {
+        workingDir = project.rootProject.projectDir
+        commandLine = ["docker", "logs", docker.dockerImageName]
+        standardOutput = containerOutput
+        errorOutput = containerOutput
         ignoreExitValue = true
       }
 
@@ -140,10 +140,16 @@ subprojects {
       }
 
       // assert if process was running
-      def expectedString = "lib/agent-bootstrapper.jar -serverUrl http://localhost:8153/go"
+      def expectedProcess = "lib/agent-bootstrapper.jar -serverUrl http://localhost:8153/go"
+      def expectedOutput = /Connect to localhost:8153.*Connection refused/
       def processList = psOutput.toString()
-      if (!processList.contains(expectedString)) {
-        throw new GradleException("Expected process output to contain [${expectedString}], but was: [${processList}]\n\nContainer output:\n${containerOutput.toString()}")
+      def containerLog = containerOutput.toString()
+
+      if (!processList.contains(expectedProcess)) {
+        throw new GradleException("Expected process output to contain [${expectedProcess}], but was: [${processList}]\n\nContainer output:\n${containerOutput.toString()}")
+      }
+      if (!(containerLog =~ expectedOutput)) {
+        throw new GradleException("Agent process was up, but expected container output to match /${expectedOutput}/. Was: \n${containerOutput.toString()}")
       }
     }
   }

--- a/jetty9/src/main/java/com/thoughtworks/go/server/Jetty9Server.java
+++ b/jetty9/src/main/java/com/thoughtworks/go/server/Jetty9Server.java
@@ -51,7 +51,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class Jetty9Server extends AppServer {
     protected static String JETTY_XML_LOCATION_IN_JAR = "/defaultFiles/config";
     private static final String JETTY_XML = "jetty.xml";
-    private static final String JETTY_VERSION = "jetty-v9.4.8.v20171121";
+    private static final String JETTY_CONFIG_VERSION = "jetty-v9.4.48.v20220622";
     private Server server;
     private WebAppContext webAppContext;
     private static final Logger LOG = LoggerFactory.getLogger(Jetty9Server.class);
@@ -202,7 +202,7 @@ public class Jetty9Server extends AppServer {
     }
 
     protected void replaceJettyXmlIfItBelongsToADifferentVersion(File jettyConfig) throws IOException {
-        if (FileUtils.readFileToString(jettyConfig, UTF_8).contains(JETTY_VERSION)) return;
+        if (FileUtils.readFileToString(jettyConfig, UTF_8).contains(JETTY_CONFIG_VERSION)) return;
         replaceFileWithPackagedOne(jettyConfig);
     }
 

--- a/jetty9/src/main/java/com/thoughtworks/go/server/logging/Slf4jRequestLogger.java
+++ b/jetty9/src/main/java/com/thoughtworks/go/server/logging/Slf4jRequestLogger.java
@@ -15,22 +15,26 @@
  */
 package com.thoughtworks.go.server.logging;
 
-import org.eclipse.jetty.server.AbstractNCSARequestLog;
+import org.eclipse.jetty.server.CustomRequestLog;
+import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.RequestLog;
+import org.eclipse.jetty.server.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Slf4jRequestLogger extends AbstractNCSARequestLog implements RequestLog {
+public class Slf4jRequestLogger extends CustomRequestLog implements RequestLog {
 
-    private static Logger LOG = LoggerFactory.getLogger("org.eclipse.jetty.server.RequestLog");
+    private static final Logger LOG = LoggerFactory.getLogger("org.eclipse.jetty.server.RequestLog");
+    private static final String NCSA_FORMAT_WITH_LATENCY_MS = NCSA_FORMAT + " %{ms}T";
 
     public Slf4jRequestLogger() {
-        super(requestEntry -> LOG.info(requestEntry));
+        super(LOG::info, NCSA_FORMAT_WITH_LATENCY_MS);
     }
 
     @Override
-    protected boolean isEnabled() {
-        return LOG.isInfoEnabled();
+    public void log(Request request, Response response) {
+        if (LOG.isInfoEnabled()) {
+            super.log(request, response);
+        }
     }
-
 }

--- a/jetty9/src/test/java/com/thoughtworks/go/server/Jetty9ServerTest.java
+++ b/jetty9/src/test/java/com/thoughtworks/go/server/Jetty9ServerTest.java
@@ -15,7 +15,6 @@
  */
 package com.thoughtworks.go.server;
 
-import com.thoughtworks.go.util.ReflectionUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jetty.deploy.App;
@@ -112,7 +111,7 @@ public class Jetty9ServerTest {
 
         when(sslSocketFactory.getSupportedCipherSuites()).thenReturn(new String[]{});
         jetty9Server = new Jetty9Server(systemEnvironment, server, deploymentManager);
-        ReflectionUtil.setStaticField(Jetty9Server.class, "JETTY_XML_LOCATION_IN_JAR", "config");
+        Jetty9Server.JETTY_XML_LOCATION_IN_JAR = "config";
     }
 
     @Test
@@ -264,7 +263,7 @@ public class Jetty9ServerTest {
         File jettyXml = Files.createFile(temporaryFolder.resolve("jetty.xml")).toFile();
         when(systemEnvironment.getJettyConfigFile()).thenReturn(jettyXml);
 
-        String originalContent = "jetty-v9.4.8.v20171121\nsome other local changes";
+        String originalContent = "jetty-v9.4.48.v20220622\nsome other local changes";
         FileUtils.writeStringToFile(jettyXml, originalContent, UTF_8);
         jetty9Server.replaceJettyXmlIfItBelongsToADifferentVersion(systemEnvironment.getJettyConfigFile());
         assertThat(FileUtils.readFileToString(systemEnvironment.getJettyConfigFile(), UTF_8), is(originalContent));

--- a/server/config/jetty.xml
+++ b/server/config/jetty.xml
@@ -19,7 +19,7 @@
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
     <!--Do not remove/modify the below line containing jetty version, else all your changes to this file will be reverted.-->
-    <!--jetty-v9.4.8.v20171121-->
+    <!--jetty-v9.4.48.v20220622-->
     <!-- =========================================================== -->
     <!-- Server Thread Pool                                          -->
     <!-- =========================================================== -->
@@ -68,9 +68,6 @@
                 <New class="org.eclipse.jetty.server.handler.RequestLogHandler">
                     <Set name="requestLog">
                         <New class="com.thoughtworks.go.server.logging.Slf4jRequestLogger">
-                            <Set name="extended">false</Set>
-                            <Set name="logCookies">false</Set>
-                            <Set name="logLatency">true</Set>
                             <Set name="ignorePaths">
                               <Array type="java.lang.String">
                                 <Item>/go/assets/*</Item>

--- a/server/src/main/resources/config/logback.xml
+++ b/server/src/main/resources/config/logback.xml
@@ -79,6 +79,9 @@
   <logger name="com.thoughtworks.go.server.Rails" level="WARN"/>
   <logger name="com.thoughtworks.go.domain.AccessToken" level="DEBUG"/>
 
+  <!-- Change to INFO to enable request logging -->
+  <logger name="org.eclipse.jetty.server.RequestLog" level="WARN"/>
+
   <!-- make sure this is the last line in the config -->
   <include optional="true" file="${cruise.config.dir:-config}/logback-include.xml"/>
 </configuration>

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_pipeline-tab.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_pipeline-tab.scss
@@ -704,7 +704,6 @@ h1 .divider,
 
 .build-cause-summary-container table {
     width: 100%;
-* width : 96%;
     margin-top: 0;
     border-collapse: collapse;
     color: #FFF;


### PR DESCRIPTION
Makes some minor clean-ups/improvements discovered during addressing other issues

- removes an IE CSS hack which breaks on later sass versions
- fixes some warning nitpicks among agent bootstrapper code
- make more robust tests on Docker agent images to make sure they are in the "check for server connectivity" loop after start-up, rather than some other kind of boot loop.
- ensures SLF4j versions are consistent across the board using the `build-platform`
- fixes a deprecated Jetty logger usage.
  - this change will cause people's jetty.xml to be overridden with the packaged version and default settings.
- speeds up agent bootstrapping by backing off for 10s when there is an agent upgrade underway.
  - the intent here was to avoid spinning on temporary errors such as server connectivity issues; not when there is a need to upgrade. This will improve agent start time in the "normal" case that on first start an agent needs to upgrade, extremely common when using elastic agents.
- remove unnecessary 1 second "fudge factor" sleep within the launcher itself.
   - the bootstrapper already manages delays, no need to do it again here