### PR TITLE
Minor clean ups to Ruby/Rails asset packaging

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -709,17 +709,19 @@ task configureWar {
       into '/'
       exclude('WEB-INF/web.xml')
       exclude("**/rails/*.log")
-      exclude("**/rails/log/*")
+      exclude("**/rails/log*")
       exclude("**/rails/node_modules/")
       exclude("**/rails/spec/")
       exclude("**/rails/tmp/")
-      exclude("**/rails/**/jruby/*/cache/*.gem")
       exclude("**/rails/app/assets/")
       exclude("**/rails/webpack/")
-    new JsonSlurper().parse(findGemsToNotPack.outputFile).each { gem ->
+
+      exclude("**/rails/gems/jruby/${project.bundledGemRubyVersion}/bin")
+      exclude("**/rails/gems/jruby/${project.bundledGemRubyVersion}/cache")
+      new JsonSlurper().parse(findGemsToNotPack.outputFile).each { gem ->
         theSpec.exclude("**/rails/gems/jruby/${project.bundledGemRubyVersion}/gems/${gem}")
         theSpec.exclude("**/rails/gems/jruby/${project.bundledGemRubyVersion}/specifications/${gem}.gemspec")
-        theSpec.exclude("**/rails/gems/jruby/${project.bundledGemRubyVersion}/build_info/${gem}.info")
+        theSpec.exclude("**/rails/gems/jruby/${project.bundledGemRubyVersion}/extensions/**/${gem}")
       }
     }
   }

--- a/server/rails.gradle
+++ b/server/rails.gradle
@@ -211,7 +211,7 @@ task compileAssetsRailsTest(type: ExecuteUnderRailsTask) {
     'RAILS_ENV' : 'test',
   ]
 
-  args = ['-S', 'rake', '--trace', 'assets:clobber', "assets:precompile"]
+  args = ['-S', 'rake', '--trace', 'assets:clobber', 'assets:precompile']
 
   doFirst {
     delete "${project.railsRoot}/tmp"

--- a/server/src/main/webapp/WEB-INF/init.rb
+++ b/server/src/main/webapp/WEB-INF/init.rb
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-gem_home = nil
 gem_ruby_version = "#{RUBY_VERSION}".gsub(/\.[0-9]+$/, '.0')
 gemfile_location = nil
 
@@ -30,7 +29,3 @@ Gem.paths = {'GEM_HOME' => gem_home, 'GEM_PATH' => gem_home, 'GEM_SPEC_CACHE' =>
 ENV['BUNDLE_GEMFILE'] = gemfile_location
 ENV['RAILS_ENV'] ||= (ENV['RACK_ENV'] || 'production')
 
-if ENV['RAILS_ENV'] == 'production'
-  ENV['EXECJS_RUNTIME'] = 'Disabled'
-  ENV['BUNDLE_WITHOUT'] = 'development:test:assets'
-end

--- a/server/src/main/webapp/WEB-INF/rails/.bundle/config
+++ b/server/src/main/webapp/WEB-INF/rails/.bundle/config
@@ -2,3 +2,4 @@
 BUNDLE_PATH: "gems"
 BUNDLE_JOBS: "4"
 BUNDLE_CLEAN: "true"
+BUNDLE_DEPLOYMENT: "true"

--- a/server/src/main/webapp/WEB-INF/rails/config.ru
+++ b/server/src/main/webapp/WEB-INF/rails/config.ru
@@ -1,5 +1,0 @@
-# This file is used by Rack-based servers to start the application.
-
-require_relative 'config/environment'
-
-run Rails.application

--- a/server/src/main/webapp/WEB-INF/web.xml
+++ b/server/src/main/webapp/WEB-INF/web.xml
@@ -90,16 +90,6 @@
   </context-param>
 
   <context-param>
-    <param-name>gem.home</param-name>
-    <param-value>/WEB-INF/rails/gems/jruby/2.5.0</param-value>
-  </context-param>
-
-  <context-param>
-    <param-name>gem.path</param-name>
-    <param-value>/WEB-INF/rails/gems/jruby/2.5.0</param-value>
-  </context-param>
-
-  <context-param>
     <param-name>jruby.min.runtimes</param-name>
     <param-value>1</param-value>
   </context-param>


### PR DESCRIPTION
Cleans up some cruft during Rails/Ruby asset packaging

- removes unnecessary config files/logic no longer required
- ensures Gemfile.lock cannot be altered during builds
- tidies up exclusions from `cruise.war` to remove unnecesary cruft that is confusing during diffs 