### PR TITLE
Exclude assets pipeline gems from production installers

### DIFF
--- a/server/rails.gradle
+++ b/server/rails.gradle
@@ -44,6 +44,7 @@ task generateJSRoutes(type: ExecuteUnderRailsTask) {
 
   environment(
     'RAILS_ENV': 'production',
+    'RAILS_GROUPS': 'assets',
     'OUTPUT_DIR': outputDir,
   )
 
@@ -128,7 +129,6 @@ task initializeRailsGems {
   }
 }
 
-
 task yarnInstall(type: YarnInstallTask) {
   // delete this in the compile phase, because otherwise the yarnInstall detects a new folder and reinstalls.
   project.delete(project.file("${project.railsRoot}/node_modules/.cache"))
@@ -209,6 +209,7 @@ task compileAssetsRailsTest(type: ExecuteUnderRailsTask) {
 
   environment += [
     'RAILS_ENV' : 'test',
+    'RAILS_GROUPS': 'assets',
   ]
 
   args = ['-S', 'rake', '--trace', 'assets:clobber', 'assets:precompile']
@@ -237,7 +238,8 @@ task compileAssetsRailsProd(type: ExecuteUnderRailsTask) {
   disableJRubyOptimization = true
 
   environment(
-    'RAILS_ENV': 'production'
+    'RAILS_ENV': 'production',
+    'RAILS_GROUPS': 'assets',
   )
 
   args = ['-S', 'rake', '--trace', 'assets:clobber', 'assets:precompile']

--- a/server/src/main/webapp/WEB-INF/init.rb
+++ b/server/src/main/webapp/WEB-INF/init.rb
@@ -28,7 +28,3 @@ end
 Gem.paths = {'GEM_HOME' => gem_home, 'GEM_PATH' => gem_home, 'GEM_SPEC_CACHE' => File.join(gem_home, 'specifications')}
 ENV['BUNDLE_GEMFILE'] = gemfile_location
 ENV['RAILS_ENV'] ||= (ENV['RACK_ENV'] || 'production')
-
-if ENV['RAILS_ENV'] == 'production'
-  ENV['BUNDLE_WITHOUT'] = 'development:test:assets'
-end

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile
@@ -2,13 +2,15 @@ source 'https://rubygems.org'
 ruby '2.6.8'
 
 gem 'rails'
-gem 'sass-rails'
-
-gem 'js-routes'
-gem 'ts_routes'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+group :assets do
+  gem 'sass-rails'
+  gem 'js-routes'
+  gem 'ts_routes'
+end
 
 group :development, :test do
   # make sure to `System.setProperty("jruby.runtime.arguments", "--debug")` before opening up pry

--- a/server/src/main/webapp/WEB-INF/rails/config/application.rb
+++ b/server/src/main/webapp/WEB-INF/rails/config/application.rb
@@ -23,7 +23,7 @@ require "action_view/railtie"
 require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
-Bundler.require(*Rails.groups)
+Bundler.require(*Rails.groups(assets: %w[development test]))
 
 module Go
   class Application < Rails::Application

--- a/server/src/main/webapp/WEB-INF/rails/config/boot.rb
+++ b/server/src/main/webapp/WEB-INF/rails/config/boot.rb
@@ -16,4 +16,12 @@
 
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+# Set up gems listed in the Gemfile.
+#
+# When running in production (NOT just building FOR production), force bundler to ignore groups including the assets pipeline stuff
+if ENV['RAILS_ENV'] == 'production' and not ENV.has_key?('RAILS_GROUPS')
+  require 'bundler'
+  Bundler.setup(:default)
+else
+  require 'bundler/setup'
+end

--- a/server/src/main/webapp/WEB-INF/rails/config/initializers/jsroutes.rb
+++ b/server/src/main/webapp/WEB-INF/rails/config/initializers/jsroutes.rb
@@ -14,22 +14,24 @@
 # limitations under the License.
 #
 
-JsRoutes.setup do |config|
-  config.prefix = com.thoughtworks.go.util.SystemEnvironment.new.getWebappContextPath
-  config.camel_case = true
-  config.include = [
-    /analytics/,
-    /^api_internal/,
-    /^apiv\d/,
-    /^admin_elastic_profile/,
-    /^admin_status_report/,
-    /^admin_cluster_status_report/,
-    /^pipeline_groups/,
-    /^environments/,
-    /^environment/,
-    /^pipeline_group/,
-    /^pipeline_edit/,
-    /^edit_admin_pipeline_config/,
-    /stage_detail_tab/
-  ]
+if ENV['RAILS_GROUPS'] =~ /assets/
+  JsRoutes.setup do |config|
+    config.prefix = com.thoughtworks.go.util.SystemEnvironment.new.getWebappContextPath
+    config.camel_case = true
+    config.include = [
+      /analytics/,
+      /^api_internal/,
+      /^apiv\d/,
+      /^admin_elastic_profile/,
+      /^admin_status_report/,
+      /^admin_cluster_status_report/,
+      /^pipeline_groups/,
+      /^environments/,
+      /^environment/,
+      /^pipeline_group/,
+      /^pipeline_edit/,
+      /^edit_admin_pipeline_config/,
+      /stage_detail_tab/
+    ]
+  end
 end


### PR DESCRIPTION
**Motivation**
Currently the packaged zips and installers include Gems that are not needed in production. It would better to remove these for a few reasons
- security attack surface area. If you're able to break he first layer and run arbitrary stuff inside the container, the less code/libs available the better.
- reduce size of container images and installers
- we are currently reliant on the Rails asset pipeline to compile some SASS/SCSS. `sass-rails` is EOL, and we are supposed to move to `sassc-rails` based on a native impl in #10734. If we do nothing, including this native gem will include an extra 40MB of random binaries and such in production.

**Background**
I'm no Rails historian, but I infer that in earlier Rails world, it seems there was a dedicated `assets` group, but this was removed as it caused some problems. This re-introduces the concept here in order to be able to run without these Gems during production. Don't fully understand how this all works, and best practice but...

**Changes**
- GoCD doesn't do a secondary `bundle install` after compiling assets. It just uses some random code to exclude non-default group Gems from the production war file. So from bundler's perspective they are still there.
- Thus we need to override during `boot.rb` to tell it to only setup the `default` gems, not everything implied by the `Gemfile` and `.bundle/config`, which has no `BUNDLE_WITHOUT` set. I use `RAILS_ENV=production` and `!RAILS_GROUPS` to determine this
- During asset compilation, tests, local dev `RAILS_GROUPS` is set to tell Rails to "add in" the assets pipelines gems to be able to compile on the fly.
- During `init.rb` some extra magic is required to require the rails groups, that I dont fully understand.
- We need to disable the `jsroutes.rb` initializer when running in production. Not sure if this should be an initializer but this seems to work fine.

These ideas came from https://nts.strzibny.name/removing-nodejs-dependency-from-a-rails-application/ and https://stackoverflow.com/a/39758749 along with a lot of trial and error. Some of the complications come from the JRuby-Rack based bootstrapping process, which seemingly works differently to other regular Rails apps in terms of env var visibility as well as recognition/ordering of `boot.rb`, `init.rb`, `application.rb` etc.

**Testing**
- [x] All tests run, etc etc
- [x] Can still do local dev just fine after `./gradlew prepare` including dynamically compiling assets
- [x] Diffed the zips before and after to make sure only the expected differences are discovered 

**Differences**

![image](https://user-images.githubusercontent.com/29788154/188262892-5b3184d0-a87d-42fd-b74b-ffe15af5d87d.png)

![image](https://user-images.githubusercontent.com/29788154/188262861-3881e647-3aeb-4d89-b22d-7fc4bf580d81.png)
