### PR TITLE
Fix ASDF tool versions to avoid confusing GoCD tests

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 # Configuration for https://github.com/asdf-vm/asdf as an alternative to jabba, rvm, nvm etc
 java temurin-17.0.4+101
-ruby jruby-9.3.7.0
+ruby 3.1.2
 nodejs 16.17.0

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -708,6 +708,7 @@ task configureWar {
     war.from(project.webAppDir) { theSpec ->
       into '/'
       exclude('WEB-INF/web.xml')
+      exclude("**/rails/.tool-versions")
       exclude("**/rails/*.log")
       exclude("**/rails/log/")
       exclude("**/rails/logs/")

--- a/server/src/main/webapp/WEB-INF/rails/.tool-versions
+++ b/server/src/main/webapp/WEB-INF/rails/.tool-versions
@@ -1,2 +1,2 @@
 # Configuration for https://github.com/asdf-vm/asdf as an alternative to jabba, rvm, nvm etc
-ruby 3.1.2
+ruby jruby-9.3.7.0


### PR DESCRIPTION
Current the `.tool-versions` can confuse GoCD tests since they are running in a login shell.

This should improve things.