### PR TITLE
Migrate from sass-rails to sassc-rails native implementation

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile
@@ -7,7 +7,7 @@ gem 'rails'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 group :assets do
-  gem 'sass-rails'
+  gem 'sassc-rails'
   gem 'js-routes'
   gem 'ts_routes'
 end

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -180,12 +180,14 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     scss_lint (0.59.0)
       sass (~> 3.5, >= 3.5.5)
     spoon (0.0.6)
@@ -228,7 +230,7 @@ DEPENDENCIES
   rspec-instafail
   rspec-rails
   rspec_junit_formatter
-  sass-rails
+  sassc-rails
   scss_lint
   ts_routes
   tzinfo-data

--- a/server/src/main/webapp/WEB-INF/rails/config/environments/development.rb
+++ b/server/src/main/webapp/WEB-INF/rails/config/environments/development.rb
@@ -52,4 +52,7 @@ Rails.application.configure do
 
   # Headers are far too large in development environment, possibly see https://github.com/rails/rails/pull/39939
   config.action_view.preload_links_header = false
+
+  config.sass.line_comments = false
+  config.sass.inline_source_maps = true
 end


### PR DESCRIPTION
Recreating #10734 to ensure it can be run on Windows.

sass-rails is only a wrapper around sassc-rails now - see https://github.com/sass/sassc-rails
