### PR TITLE
Suppress temporarily additional reported SnakeYaml vulnerability

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -49,6 +49,16 @@
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
     <cve>CVE-2022-25857</cve>
+    <vulnerabilityName>CVE-2022-25857</vulnerabilityName>
+  </suppress>
+  <suppress until="2022-11-01Z">
+    <notes><![CDATA[
+   Temporary suppression as there is no fix, and the developers do not agree that it is a vulnerability. See
+   https://bitbucket.org/snakeyaml/snakeyaml/issues/531/stackoverflow-oss-fuzz-47081 and https://nvd.nist.gov/vuln/detail/CVE-2022-38752
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+    <cve>CVE-2022-38752</cve>
+    <vulnerabilityName>CVE-2022-38752</vulnerabilityName>
   </suppress>
   <suppress>
     <notes><![CDATA[


### PR DESCRIPTION
Extends #10767 to also include the OSSINDEX version of the vuln in the temporary suppressions, and temporarily suppress an additional disputed vulnerability.