### PR TITLE
RUBY env var needs to be forward-slashed even on Windows

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -154,10 +154,12 @@ project.ext.jrubyScriptsDir = project.file("scripts")
 
 project.ext.additionalJRubyPaths = [jrubyScriptsDir, project.file("${project.bundledGemDir}/bin")]
 
+def forwardSlashedString = { File file -> file.toString().replaceAll('\\\\', '/') }
+
 project.ext.defaultJRubyEnvironment = [
   GEM_HOME: project.bundledGemDir,
   GEM_PATH: project.bundledGemDir,
-  RUBY    : project.file("${project.ext.jrubyScriptsDir}/jruby${org.gradle.internal.os.OperatingSystem.current().isWindows() ? '.bat' : ''}")
+  RUBY    : forwardSlashedString(project.file("${project.ext.jrubyScriptsDir}/jruby${org.gradle.internal.os.OperatingSystem.current().isWindows() ? '.bat' : ''}"))
 ]
 
 project.ext.rails = [:]


### PR DESCRIPTION
Without it being forward slashed, native builds of extensions for platforms that aren't included with a Gem don't seem to be possible as the back-slashes get stripped within RubyGems. (`C:\gocd\whatever\jruby.bat` becomes `C:gocdwhateverjruby.bat`) Strange, but true.

We don't currently rely on this on Windows, it seems, but it took a while to fix in order to unblock an experimental native compile of libsass/SassC for Windows so seems sensible to integrate.