### PR TITLE
Revert some vendor prefix changes made during stylelint autofixes

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/agents.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/agents.scss
@@ -279,7 +279,7 @@ $icon-color: #647984;
     padding: 0 10px 0 40px;
     margin: 0;
     border: 1px solid #d6e0e2;
-    appearance: none;
+    -webkit-appearance: none;
     box-shadow: none;
     border-radius: 3px;
     background: #fff;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_build_detail.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_build_detail.scss
@@ -345,7 +345,7 @@ div.build_detail_container_content {
   @include console-action;
 }
 
-@keyframes pulsate {
+@-moz-keyframes pulsate {
   0% {
     @include -go-opacity(100);
   }
@@ -363,7 +363,7 @@ div.build_detail_container_content {
   }
 }
 
-@keyframes pulsate {
+@-webkit-keyframes pulsate {
   0% {
     @include -go-opacity(100);
   }
@@ -381,7 +381,7 @@ div.build_detail_container_content {
   }
 }
 
-@keyframes pulsate {
+@-o-keyframes pulsate {
   0% {
     @include -go-opacity(100);
   }
@@ -399,7 +399,7 @@ div.build_detail_container_content {
   }
 }
 
-@keyframes pulsate {
+@-ms-keyframes pulsate {
   0% {
     @include -go-opacity(100);
   }

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_console-log.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_console-log.scss
@@ -40,7 +40,7 @@ $PROGRESS_BAR_BG_SIZE: 70px;
   }
 }
 
-@keyframes progress-bar-stripes {
+@-webkit-keyframes progress-bar-stripes {
   from {
     background-position: 0 0;
   }

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/patterns/_buttons.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/patterns/_buttons.scss
@@ -80,7 +80,7 @@ a.link_as_button span {
   white-space: nowrap;
 }
 
-@media screen and (min-device-pixel-ratio: 0) {
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
   /* Safari and Google Chrome only - fix margins */
   button span,
   a.link_as_button span {

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/vm/_structure_for_old_ui.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/vm/_structure_for_old_ui.scss
@@ -162,7 +162,7 @@ a.link_as_button span {
   white-space: nowrap;
 }
 
-@media screen and (min-device-pixel-ratio: 0) {
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
   /* Safari and Google Chrome only - fix margins */
   button span,
   a.link_as_button span {


### PR DESCRIPTION
Not sure if these are still required or not, but were made during #10790 as part of stylelint autofixes. Being conservative by leaving them for now.