### PR TITLE
Update sass-embedded to Java-based extensions installer

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ntkme/sass-embedded-host-ruby.git
-  revision: 4724a844b7cd29ffde084e9c94d93f60f6badc89
+  revision: 0d103fd1936aedc405d963da078ec7f2b313a1ac
   ref: main
   specs:
     sass-embedded (1.54.9)


### PR DESCRIPTION
Replaces use of unzip/powershell with Java-based installer on JRuby/Windows. See https://github.com/ntkme/sass-embedded-host-ruby/issues/62#issuecomment-1242712012