### PR TITLE
Move SnakeYAML suppression to more appropriate group

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -55,6 +55,9 @@
 
     <cve>CVE-2022-38750</cve>
     <vulnerabilityName>CVE-2022-38750</vulnerabilityName>
+
+    <cve>CVE-2022-38751</cve>
+    <vulnerabilityName>CVE-2022-38751</vulnerabilityName>
   </suppress>
   <suppress until="2022-11-01Z">
     <notes><![CDATA[
@@ -66,9 +69,6 @@
     <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
     <cve>CVE-2022-38749</cve>
     <vulnerabilityName>CVE-2022-38749</vulnerabilityName>
-
-    <cve>CVE-2022-38751</cve>
-    <vulnerabilityName>CVE-2022-38751</vulnerabilityName>
 
     <cve>CVE-2022-38752</cve>
     <vulnerabilityName>CVE-2022-38752</vulnerabilityName>


### PR DESCRIPTION
The first group have fixes in SnakeYAML 1.31 but the second group are disputed/false positives :-) See https://nvd.nist.gov/vuln/detail/CVE-2022-38751

```
Up to (excluding)
1.31
```