### PR TITLE
Fix Alpine 3.16.2-based docker image builds

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -70,7 +70,7 @@ enum Distro implements DistroBehavior {
         '  SGERRAND_RSA_SHA256="823b54589c93b02497f1ba4dc622eaef9c813e6b0f0ebbb2f771e32adf9f4ef2"',
         '  echo "${SGERRAND_RSA_SHA256} */etc/apk/keys/sgerrand.rsa.pub" | sha256sum -c -',
         '  curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk > /tmp/glibc-${GLIBC_VER}.apk',
-        '  apk add /tmp/glibc-${GLIBC_VER}.apk',
+        '  apk add --force-overwrite /tmp/glibc-${GLIBC_VER}.apk',
         '  curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk > /tmp/glibc-bin-${GLIBC_VER}.apk',
         '  apk add /tmp/glibc-bin-${GLIBC_VER}.apk',
         '  curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk > /tmp/glibc-i18n-${GLIBC_VER}.apk',


### PR DESCRIPTION
Alpine 3.16.2 builds are currently failing due to
```
(1/1) Installing glibc (2.29-r0)
ERROR: glibc-2.29-r0: trying to overwrite etc/nsswitch.conf owned by alpine-baselayout-data-3.2.0-r23.
```

This change allows the install-glibc-on-alpine hack to overwrite `/etc/nssswitch.conf`

Since Alpine 3.6.2, /etc/nsswitch.conf is being managed by `alpine-baselayout`/`alpine-baselayout-data` due to the change in https://git.alpinelinux.org/aports/commit/main/alpine-baselayout/APKBUILD?id=9b1f229b2ee09165e4d4080075b117d4ce5bfced but is also contained within our dodgy glibc package (which is wildly out-of date, but can be seen at https://github.com/sgerrand/alpine-pkg-glibc/blob/82dd46a2293b3b177ec5d4ecf99d8ab697391fe0/APKBUILD#L21 )