### PR TITLE
More conservatively avoid localization of values in FreeMarker templates

### DIFF
--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_build_detail_summary_jstemplate.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_build_detail_summary_jstemplate.ftl
@@ -29,10 +29,10 @@
   {/if}
   <#if doesUserHaveViewAccessToStatusReportPage?? && doesUserHaveViewAccessToStatusReportPage>
     {if build.build_assigned_date != -1}
-    <a href="${req.getContextPath()}/admin/status_reports/${elasticAgentPluginId}/agent/${elasticAgentId}?job_id=${build.id}"
+    <a href="${req.getContextPath()}/admin/status_reports/${elasticAgentPluginId?c}/agent/${elasticAgentId?c}?job_id=${build.id?c}"
        class="btn-primary btn-small status-report-btn-small">Check Agent Status</a>
     {else}
-    <a href="${req.getContextPath()}/admin/status_reports/${elasticAgentPluginId}/agent/unassigned?job_id=${build.id}"
+    <a href="${req.getContextPath()}/admin/status_reports/${elasticAgentPluginId?c}/agent/unassigned?job_id=${build.id?c}"
        class="btn-primary btn-small status-report-btn-small">Check Agent Status</a>
     {/if}
   </#if>

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_build_output_raw.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_build_output_raw.ftl
@@ -13,11 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 -->
-<div class="console-area" data-console-url="${presenter.consoleoutLocator}" >
+<div class="console-area" data-console-url="${presenter.consoleoutLocator?c}" >
 <div class="console-action-bar">
     <div>
         <a class="auto-scroll" title="Scroll to bottom">Scroll to end of logs</a>
-        <a href="${req.getContextPath()}/files/${presenter.consoleoutLocator}">Raw output</a>
+        <a href="${req.getContextPath()}/files/${presenter.consoleoutLocator?c}">Raw output</a>
         <a class='toggle-timestamps' href="#"><i class="fa fa-clock-o"></i> Timestamps</a>
         <a class='toggle-folding' href="#" data-collapsed="true"></a>
         <a id="full-screen">

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_materials.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_materials.ftl
@@ -15,7 +15,7 @@
  -->
 <div id="tab-content-of-materials" class="widget" ${modification_extra_attrs}>
     <script type="text/javascript">
-        var json = ${presenter.getMaterialRevisionsJson()};
+        var json = ${presenter.getMaterialRevisionsJson()?c};
     </script>
     <script type="text/javascript">
         Event.observe(window, 'load', function(){

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_tests.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_tests.ftl
@@ -16,7 +16,7 @@
 <div id="tab-content-of-tests" class="widget" ${tests_extra_attrs}>
     <div class="files">
         <#if presenter.hasTests()>
-            <iframe sandbox="allow-scripts" src="${req.getContextPath()}/${presenter.indexPageURL}" width="95%" height="500" frameborder="0"></iframe>
+            <iframe sandbox="allow-scripts" src="${req.getContextPath()}/${presenter.indexPageURL?c}" width="95%" height="500" frameborder="0"></iframe>
         <#else>
             <#include "_test_output_config.ftl">
         </#if>

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/build_detail_page.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/build_detail_page.ftl
@@ -35,14 +35,14 @@
           <div id="build-status-panel" class="bd-container rounded-corner-for-pipeline">
             <div class="maincol build_detail">
                 <#include "../shared/_flash_message.ftl">
-                <#assign jobConfigName = "${presenter.buildName}">
+                <#assign jobConfigName = "${presenter.buildName?c}">
               <div id="build_detail_summary_container" class="build_detail_summary">
                 <ul id="build-detail-summary" class="summary">
                   <li><span class="header">Scheduled on: </span><span id="build_scheduled_date">Loading...</span></li>
                   <li><span class="header">Agent: </span><span id="agent_name">Loading...</span></li>
                   <li><span class="header">Completed on: </span><span id="build_completed_date">Loading...</span></li>
                   <li><span class="header">Build cause: </span><span
-                    id="stage-${presenter.id}-buildCause">${presenter.buildCauseMessage?html}</span></li>
+                    id="stage-${presenter.id?c}-buildCause">${presenter.buildCauseMessage?html}</span></li>
                   <li class="timer_area">
                     <div class="progress-info">
                       <div id="${presenter.buildName}_progress_bar" class="progress-bar" style="display: none;">
@@ -58,7 +58,7 @@
                 <div class="clear"></div>
               </div>
 
-              <div class="job_details_content" data-pipeline="${presenter.pipelineName}" data-pipeline-counter="${presenter.pipelineCounter}" data-pipeline-label="${presenter.pipelineLabel}" data-stage="${presenter.stageName}" data-stage-counter="${presenter.stageCounter}" data-job="${presenter.id}" data-build="${presenter.buildName}" data-result="$presenter.result" data-websocket="${websocketEnabled?string("enabled", "disabled")}">
+              <div class="job_details_content" data-pipeline="${presenter.pipelineName?c}" data-pipeline-counter="${presenter.pipelineCounter?c}" data-pipeline-label="${presenter.pipelineLabel?c}" data-stage="${presenter.stageName}" data-stage-counter="${presenter.stageCounter?c}" data-job="${presenter.id?c}" data-build="${presenter.buildName}" data-result="${presenter.result?c}" data-websocket="${websocketEnabled?string("enabled", "disabled")}">
                 <div class="sub_tabs_container">
                   <ul>
                     <li class="current_tab" id="build_console">

--- a/server/src/main/webapp/WEB-INF/vm/shared/_job_details_breadcrumbs.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/shared/_job_details_breadcrumbs.ftl
@@ -20,18 +20,18 @@
     <ul class="entity_title">
       <li class="name">
         <span class="label">Pipeline</span>
-        <a href="${req.getContextPath()}/pipeline/activity/${presenter.pipelineName}"
+        <a href="${req.getContextPath()}/pipeline/activity/${presenter.pipelineName?c}"
            title="View this pipeline's activity">${presenter.pipelineName}</a>
       </li>
       <li class="pipeline_label">
         <span class="label">Instance</span>
         <span class="run_no">${presenter.pipelineLabel}</span>
-        <a href="${req.getContextPath()}/pipelines/value_stream_map/${presenter.pipelineName}/${presenter.pipelineCounter}"
+        <a href="${req.getContextPath()}/pipelines/value_stream_map/${presenter.pipelineName?c}/${presenter.pipelineCounter?c}"
            title="View this stage's jobs summary">VSM</a>
       </li>
       <li class="stage_name">
         <span class="label">Stage</span>
-        <a href="${req.getContextPath()}/pipelines/${presenter.stageLocator}"
+        <a href="${req.getContextPath()}/pipelines/${presenter.stageLocator?c}"
            title="View this stage's details">${presenter.stageName} / ${presenter.stageCounter}</a>
       </li>
       <li class='last'>
@@ -40,7 +40,7 @@
     </ul>
       <#if userHasAdministratorRights || userHasGroupAdministratorRights >
         <div class="job_detail_setting">
-            <a href="${req.getContextPath()}/admin/pipelines/${presenter.pipelineName}/general"
+            <a href="${req.getContextPath()}/admin/pipelines/${presenter.pipelineName?c}/general"
                class="icon16 setting"></a>
         </div>
       </#if>

--- a/server/src/main/webapp/WEB-INF/vm/sidebar/_sidebar_build_list.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/sidebar/_sidebar_build_list.ftl
@@ -22,7 +22,7 @@
         <ul class="buildlist dropdown-menu">
             <#list presenter.recent25 as listPresenter>
             <li id="build_list_${listPresenter?counter}" <#if listPresenter.isSame(presenter.id)> class="current" </#if> >
-                <a href="${req.getContextPath()}/tab/build/detail/${listPresenter.buildLocator}">
+                <a href="${req.getContextPath()}/tab/build/detail/${listPresenter.buildLocator?c}">
                     <#if listPresenter.copy>
                     <div class="color_code_small copied_job"></div>
                     <#else>
@@ -37,7 +37,7 @@
     </div>
     <script type="text/javascript">
         <#list presenter.recent25 as listPresenter>
-        json_to_css.update_build_list(eval(${listPresenter.toJsonString()}), ${listPresenter?counter}, "${req.getContextPath()}/${concatenatedStageBarCancelledIconFilePath}");
+        json_to_css.update_build_list(eval(${listPresenter.toJsonString()}), ${listPresenter?counter}, "${req.getContextPath()}/${concatenatedStageBarCancelledIconFilePath?c}");
         </#list>
 
       jQuery(function() {


### PR DESCRIPTION
Fixes issue in #10577 when rendering jobs, stages etc with IDs/counters > 999.

Freemarker applies locales to number/booleans etc when converting to strings which adds commas etc. Conservatively disable this when constructing URLs and `data-` elements.