### PR TITLE
Fix rendering of elasticAgent job detail headers

### DIFF
--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_build_detail_summary_jstemplate.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_build_detail_summary_jstemplate.ftl
@@ -28,13 +28,8 @@
     <span>Not yet assigned</span>
   {/if}
   <#if doesUserHaveViewAccessToStatusReportPage?? && doesUserHaveViewAccessToStatusReportPage>
-    {if build.build_assigned_date != -1}
-    <a href="${req.getContextPath()}/admin/status_reports/${r'${% elasticAgentPluginId %}'}/agent/${r'${% elasticAgentId %}'}?job_id=${r'${% build.id %}'}"
+    <a href="${req.getContextPath()}/admin/status_reports/${elasticAgentPluginId}/agent/${elasticAgentId!'unassigned'}?job_id=${r'${% build.id %}'}"
        class="btn-primary btn-small status-report-btn-small">Check Agent Status</a>
-    {else}
-    <a href="${req.getContextPath()}/admin/status_reports/${r'${% elasticAgentPluginId %}'}/agent/unassigned?job_id=${r'${% build.id %}'}"
-       class="btn-primary btn-small status-report-btn-small">Check Agent Status</a>
-    {/if}
   </#if>
 </li>
   <li><span class="header">Completed on: </span><span id="build_completed_date">${r'${% build.build_completed_date %}'}</span></li>


### PR DESCRIPTION
Previous code assumed these were client-side vars, which was wrong. They are server side rendered. This fixes that issue from introducing FreeMarker rendering.

However even after this fix, this code is a bit buggy, but this restores it to previous Velocity-based state.

The bug is that at time of server-side rendering the `elasticAgentId` may not be known even though it *is* known that the build will run on an elastic agent. The logical error is that the `{if}` clause is client side JS template, and changes over time, but the client side is never informed of the `elasticAgentId` when it is allocated, and so it is unable to change the status report link to the specific elastic agent once it is "known". This change doesn't fix the race condition to avoid the need to refresh the entire page, but does fix the WTF in the code so it'll be easier to address in future.