### PR TITLE
Fix sidebar display of how long ago each job was

### DIFF
--- a/server/src/main/webapp/WEB-INF/vm/sidebar/_sidebar_build_list.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/sidebar/_sidebar_build_list.ftl
@@ -29,7 +29,7 @@
                     <div class="color_code_small"></div>
                     </#if>
                     <strong>${listPresenter.buildLocatorForDisplay}</strong>
-                    <div class="time_ago" data="${r'${listPresenter.scheduledTime}'}"></div>
+                    <div class="time_ago" data="${listPresenter.scheduledTime}"></div>
                 </a>
             </li>
             </#list>


### PR DESCRIPTION
Another follow-up from #10577. One element here was incorrectly escaped.
