### PR TITLE
Fix display of timestamps in job history sidebar

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/presentation/models/JobStatusJsonPresentationModel.java
+++ b/server/src/main/java/com/thoughtworks/go/server/presentation/models/JobStatusJsonPresentationModel.java
@@ -141,7 +141,7 @@ public class JobStatusJsonPresentationModel {
     }
 
 
-    private long getScheduledTime() {
+    public long getScheduledTime() {
         Date date = instance.getScheduledDate();
         if (date != null) {
             return date.getTime();

--- a/server/src/main/java/freemarker_implicit.ftl
+++ b/server/src/main/java/freemarker_implicit.ftl
@@ -1,0 +1,38 @@
+[#ftl]
+[#-- @implicitly included --]
+[#-- @ftlvariable name="req" type="javax.servlet.http.HttpServletRequest" --]
+
+[#-- @ftlvariable name="presenter" type="com.thoughtworks.go.server.presentation.models.JobDetailPresentationModel" --]
+[#-- @ftlvariable name="isAgentAlive" type="boolean" --]
+[#-- @ftlvariable name="websocketEnabled" type="boolean" --]
+[#-- @ftlvariable name="isEditableViaUI" type="boolean" --]
+
+[#-- @ftlvariable name="doesUserHaveViewAccessToStatusReportPage" type="boolean" --]
+[#-- @ftlvariable name="clusterProfileId" type="java.lang.String" --]
+[#-- @ftlvariable name="elasticAgentProfileId" type="java.lang.String" --]
+[#-- @ftlvariable name="elasticAgentPluginId" type="java.lang.String" --]
+[#-- @ftlvariable name="elasticAgentId" type="java.lang.String" --]
+
+[#-- @ftlvariable name="userHasAdministratorRights" type="boolean" --]
+[#-- @ftlvariable name="userHasTemplateAdministratorRights" type="boolean" --]
+[#-- @ftlvariable name="userHasTemplateAdministratorRights" type="boolean" --]
+[#-- @ftlvariable name="userHasViewAdministratorRights" type="boolean" --]
+[#-- @ftlvariable name="userHasTemplateViewUserRights" type="boolean" --]
+[#-- @ftlvariable name="userHasGroupAdministratorRights" type="boolean" --]
+[#-- @ftlvariable name="useCompressJS" type="boolean" --]
+
+[#-- @ftlvariable name="currentGoCDVersion" type="com.thoughtworks.go.CurrentGoCDVersion" --]
+[#-- @ftlvariable name="concatenatedStageBarCancelledIconFilePath" type="java.lang.String" --]
+[#-- @ftlvariable name="concatenatedSpinnerIconFilePath" type="java.lang.String" --]
+[#-- @ftlvariable name="concatenatedCruiseIconFilePath" type="java.lang.String" --]
+
+[#-- @ftlvariable name="pathResolver" type="com.thoughtworks.go.server.service.RailsAssetsService" --]
+[#-- @ftlvariable name="goUpdate" type="java.lang.String" --]
+[#-- @ftlvariable name="goUpdateCheckEnabled" type="boolean" --]
+
+[#-- @ftlvariable name="showAnalyticsDashboard" type="boolean" --]
+[#-- @ftlvariable name="webpackAssetsService" type="com.thoughtworks.go.server.service.WebpackAssetsService" --]
+[#-- @ftlvariable name="maintenanceModeService" type="com.thoughtworks.go.server.service.MaintenanceModeService" --]
+
+[#-- @ftlvariable name="principal" type="java.lang.String" --]
+[#-- @ftlvariable name="isAnonymousUser" type="boolean" --]

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_artifacts.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_artifacts.ftl
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  -->
+<#-- @ftlvariable name="artifacts_extra_attrs" type="java.lang.String" -->
 <div class="widget container-in-body" id="tab-content-of-artifacts" ${artifacts_extra_attrs}>
     <#if presenter.artifactFiles??>
         <#if presenter.artifactFiles?size > 0>

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_buildoutput.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_buildoutput.ftl
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  -->
+<#-- @ftlvariable name="buildoutput_extra_attrs" type="java.lang.String" -->
 <div id="tab-content-of-console" class="ansi-color-toggle" ${buildoutput_extra_attrs}>
     <#include "_build_output_raw.ftl">
 </div>

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_customized.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_customized.ftl
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  -->
+<#-- @ftlvariable name="customized_name" type="java.lang.String" -->
+<#-- @ftlvariable name="customized_path" type="java.lang.String" -->
 <div id="tab-content-of-${customized_name?lower_case}" style='display:none'>
 </div>
 <script>

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_materials.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_materials.ftl
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  -->
+<#-- @ftlvariable name="modification_extra_attrs" type="java.lang.String" -->
 <div id="tab-content-of-materials" class="widget" ${modification_extra_attrs}>
     <script type="text/javascript">
         var json = ${presenter.getMaterialRevisionsJson()};

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_tests.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_tests.ftl
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  -->
+<#-- @ftlvariable name="tests_extra_attrs" type="java.lang.String" -->
 <div id="tab-content-of-tests" class="widget" ${tests_extra_attrs}>
     <div class="files">
         <#if presenter.hasTests()>

--- a/server/src/main/webapp/WEB-INF/vm/exceptions_page.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/exceptions_page.ftl
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  -->
+<#-- @ftlvariable name="errorMessage" type="java.lang.String" -->
 <#assign title = 'Exception Detail - GoCD'>
 <#include "shared/_header.ftl">
 <#include "shared/_flash_message.ftl">

--- a/server/src/main/webapp/WEB-INF/vm/rest/html.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/rest/html.ftl
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  -->
+<#-- @ftlvariable name="jobIdentifier" type="com.thoughtworks.go.domain.JobIdentifier" -->
 <#assign title = "Artifacts for ${jobIdentifier.pipelineName} > ${jobIdentifier.pipelineLabel} > ${jobIdentifier.stageName} > ${jobIdentifier.stageCounter} > ${jobIdentifier.buildName}">
 <#include "../shared/_header.ftl">
 

--- a/server/src/main/webapp/WEB-INF/vm/sidebar/_sidebar_build_list.ftl
+++ b/server/src/main/webapp/WEB-INF/vm/sidebar/_sidebar_build_list.ftl
@@ -29,7 +29,7 @@
                     <div class="color_code_small"></div>
                     </#if>
                     <strong>${listPresenter.buildLocatorForDisplay}</strong>
-                    <div class="time_ago" data="${listPresenter.scheduledTime}"></div>
+                    <div class="time_ago" data="${listPresenter.scheduledTime?c}"></div>
                 </a>
             </li>
             </#list>


### PR DESCRIPTION
Another follow-up from #10577, fixes display of the timestamps in the Job History sidebar

![image](https://user-images.githubusercontent.com/29788154/190913597-276a2a7d-c9ea-4efe-9b15-88309ad29de5.png)

Also adds implicit variable definitions for FreeMarker to make it easier to debug these things upfront, since there are weak tests in this area.