### PR TITLE
Bump sass-embedded from using a main/github revision to RubyGems 1.55.0

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile
@@ -9,9 +9,11 @@ platforms :jruby do
 
   group :assets do
     gem 'sassc-rails'
+    # Switch sassc to be able to use sass-embedded (and dart-sass) rather than libsass.
+    # See https://github.com/sass/sassc-ruby/pull/233
     gem 'sassc', github: 'sass/sassc-ruby', ref: 'refs/pull/233/head'
     gem 'sassc-embedded'
-    gem 'sass-embedded', github: 'ntkme/sass-embedded-host-ruby', ref: 'main'
+
     gem 'js-routes'
     gem 'ts_routes'
   end

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/ntkme/sass-embedded-host-ruby.git
-  revision: 6d0e9b8bab662e8258addcac475f379cf43ba881
-  ref: main
-  specs:
-    sass-embedded (1.54.9)
-      google-protobuf (~> 3.19)
-      rake (>= 10.0.0)
-
-GIT
   remote: https://github.com/sass/sassc-ruby.git
   revision: 244d3dcc8b985e25bab066b296f0f202e43e41ad
   ref: refs/pull/233/head
@@ -184,6 +175,9 @@ GEM
     rspec_junit_formatter (0.5.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     ruby-debug-base (0.11.0-java)
+    sass-embedded (1.55.0)
+      google-protobuf (~> 3.19)
+      rake (>= 10.0.0)
     sassc-embedded (1.54.0)
       sass-embedded (~> 1.54)
       sassc (~> 2.0)
@@ -231,7 +225,6 @@ DEPENDENCIES
   rspec-instafail
   rspec-rails
   rspec_junit_formatter
-  sass-embedded!
   sassc!
   sassc-embedded
   sassc-rails


### PR DESCRIPTION
Removes dependency on a main revision temporarily introduced in order to fix Windows installs of dart-sass on Windows 2019 Server Core. (follow-up from #10796)