### PR TITLE
Make GoCD server build reproducible

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
@@ -129,12 +129,6 @@ class LicenseReport {
           }
 
           renderModuleData(markup, counter.incrementAndGet(), openJdkLicense().moduleName, openJdkLicense())
-
-          div(class: "footer") {
-            span("This report was generated at ")
-            span(class: "timestamp", new Date().format("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone("UTC")))
-            span(".")
-          }
         }
       }
     }


### PR DESCRIPTION
Removes footer from dependency license report which breaks build reproducibility.

The footer includes a timestamp which breaks reproducibility and appears to be one of very few reproducibility problems with GoCD. This adds no value currently, and see https://reproducible-builds.org/ for why determinism is useful and important.