### PR TITLE
Bump chromedriver to 106

### DIFF
--- a/server/jasmine.gradle
+++ b/server/jasmine.gradle
@@ -26,7 +26,7 @@ OperatingSystem currentOS = OperatingSystem.current()
 // Firefox/gecko: See https://github.com/mozilla/geckodriver/releases and review compatibility at
 //                https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html
 final Map<String, String> seleniumDrivers = [
-  chromedriver: '105.0.5195.52',
+  chromedriver: '106.0.5249.61',
   geckodriver: '0.31.0',
 ]
 


### PR DESCRIPTION
Matches/requires `v3.9.7` of Windows agent which bundles Chrome 106