### PR TITLE
Don't crop pipeline instance labels on pipeline activity page

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.tsx
@@ -94,30 +94,16 @@ export class StageOverview extends MithrilComponent<Attrs, State> {
     classNames.split(" ").filter(c => !!c).forEach(c => {vnode.dom.classList.add(c);});
 
     if (vnode.attrs.isDisplayedOnPipelineActivityPage) {
-      let top = 36;
-      let left = -6;
-
-      // for a user with no operate permission, the add comment feature is not available, making the stage overview mis-positioned,
-      // hence, position stage overview a little above for read only users.
-      if (!vnode.attrs.stageInstanceFromDashboard.canOperate) {
-        top = 27;
-      }
-
-      if (shouldAlignLeft) {
-        left = -655;
-      }
-
       // @ts-ignore
-      vnode.dom.style.top = `${top}px`;
+      vnode.dom.style.top = `-3px`;
       // @ts-ignore
-      vnode.dom.style.left = `${left}px`;
+      vnode.dom.style.left = `${shouldAlignLeft ? -655 : -6}px`;
       return;
     } else if (vnode.attrs.isDisplayedOnVSMPage) {
-      const left = vnode.attrs.leftPositionForVSMStageOverview!;
       // @ts-ignore
       vnode.dom.style.marginTop = `22px`;
       // @ts-ignore
-      vnode.dom.style.left = `${left}px`;
+      vnode.dom.style.left = `${vnode.attrs.leftPositionForVSMStageOverview!}px`;
       return;
     }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/index.scss
@@ -54,8 +54,8 @@ $stage-action-icon-z-index: 1;
     flex-direction: column;
     justify-content: center;
     width: 20%;
-    max-width: 200px;
-    min-width: 200px;
+    max-width: 325px;
+    min-width: 325px;
     margin-right: 16px;
     padding-bottom: 5px;
   }
@@ -96,6 +96,11 @@ $stage-action-icon-z-index: 1;
   justify-content: space-between;
   font-size: 16px;
 
+  .label {
+    word-break: break-all;
+    word-wrap: break-word;
+  }
+
   a {
     font-size: 14px;
     text-decoration: none;
@@ -122,10 +127,11 @@ $stage-action-icon-z-index: 1;
 
 .stage-box-pipeline-activity {
   max-width: $stage-width + 50px;
-  height: 100%;
   display: flex;
-  align-items: center;
+  align-items: start;
   justify-content: center;
+  padding-top: 36px;
+  padding-bottom: 36px;
 }
 
 .stage-status {
@@ -138,10 +144,10 @@ $stage-action-icon-z-index: 1;
 
 .stage-status-wrapper {
   display: flex;
-  height: 100%;
   position: relative;
   flex-direction: column;
-  justify-content: center;
+  justify-content: start;
+  padding-top: 5px;
 }
 
 .disabled-icon {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/pipeline_run_info_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/pipeline_run_info_widget.tsx
@@ -79,8 +79,8 @@ export class PipelineRunWidget extends MithrilViewComponent<PipelineRunAttrs> {
                data-test-id={this.dataTestId("pipeline-instance", pipelineRunInfo.label())}>
       <td class={styles.left} data-test-id={"meta"}>
         <div class={classnames(styles.run, styles.header)}>
-          <span data-test-id={"counter"}>
-            {pipelineRunInfo.label().substr(0, 17)}
+          <span class={styles.label} data-test-id={"counter"}>
+            {pipelineRunInfo.label()}
           </span>
           <span data-test-id={"vsm"}>
             {PipelineRunWidget.getVSMLink(vnode, pipelineRunInfo)}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/show_force_build_action_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/show_force_build_action_widget.tsx
@@ -46,7 +46,9 @@ export class ShowForceBuildActionWidget extends MithrilViewComponent<ShowForceBu
         {vnode.attrs.group.config().stages().map((stage, index) => {
           return <div class={classnames(styles.stageBoxPipelineActivity, styles.disabledIcon)}>
             {ShowForceBuildActionWidget.getStageApprovalIcon(index, stage)}
-            <span class={classnames(styles.stageStatus, styles.unknown)}/>
+            <div className={styles.stageStatusWrapper}>
+              <span class={classnames(styles.stageStatus, styles.unknown)}/>
+            </div>
           </div>;
         })}
       </td>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/spec/pipeline_run_info_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/spec/pipeline_run_info_widget_spec.tsx
@@ -163,16 +163,6 @@ describe("PipelineRunInfoWidget", () => {
     expect(helper.byTestId("stage-status-integration", pipelineRunContainer)).toHaveClass(styles.building);
   });
 
-  it("should truncate stage counter when it has more than 17 chars", () => {
-    const pipelineRunInfo = PipelineRunInfo.fromJSON(PipelineActivityData.pipelineRunInfo(passed("unit")));
-    pipelineRunInfo.label("This is more then 17 letters as pipeline label");
-    mount(pipelineRunInfo);
-
-    const pipelineRunContainer = helper.byTestId(`pipeline-instance-${pipelineRunInfo.label()}`);
-    expect(helper.byTestId("counter", pipelineRunContainer)).toBeInDOM();
-    expect(helper.byTestId("counter", pipelineRunContainer)).toHaveText("This is more then");
-  });
-
   describe("Stage gate icons", () => {
 
     describe("Gate title", () => {


### PR DESCRIPTION
- fixes #10891

Not sure why this was being done earlier at all, but let's try without it. Should only have an effect when people are using custom labels for pipeline instances rather than normal counters.
