### PR TITLE
Remove CVE suppression now fixed in NVD data

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -245,15 +245,6 @@
 
   <suppress>
     <notes><![CDATA[
-   Suppressing false positive on https://nvd.nist.gov/vuln/detail/CVE-2022-42003 as it is fixed in 2.13.4.1 but NIST NVD
-    has not yet been updated to reflect the patch releases.
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-    <cve>CVE-2022-42003</cve>
-  </suppress>
-
-  <suppress>
-    <notes><![CDATA[
     The Eclipse Angus Mail SMTP component is not the Eclipse IDE :-)
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.angus/smtp@.*$</packageUrl>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-42003 now reflects patched versions correctly.