### PR TITLE
Workaround Sprockets issue with unicode chars inside SCSS and config.assets.debug=true

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/new-theme.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/new-theme.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /*
  * Copyright 2022 Thoughtworks, Inc.
  *

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/admin_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/admin_controller.rb
@@ -36,7 +36,7 @@ class AdminController < ApplicationController
     args.inject(@asserted_variables ||= {}) do |map, name|
       unless (var = instance_variable_get("@#{name}"))
         Rails.logger.warn("Could not load '#{name}', rendering failure #{caller[0..10].join("\n")}")
-        if(@should_not_render_layout)
+        if @should_not_render_layout
           options = options.merge(:layout => nil)
         end
         render_assertion_failure(options)

--- a/server/src/main/webapp/WEB-INF/rails/app/controllers/stages_controller.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/controllers/stages_controller.rb
@@ -55,7 +55,7 @@ class StagesController < ApplicationController
     page_number = params[:page_number].nil? ? 1 : params[:page_number].to_i
     stage_summary_models = stage_service.findStageHistoryForChart(@stage.getPipelineName(), @stage.getName(), page_number, STAGE_DURATION_RANGE, current_user)
     @no_chart_to_render = false
-    if (stage_summary_models.size() > 0)
+    if stage_summary_models.size() > 0
       @pagination = stage_summary_models.getPagination()
 
       # sort/filter/unique until we get the "latest" passed and "latest" failed stage for each pipeline counter.
@@ -147,7 +147,7 @@ class StagesController < ApplicationController
 
   def load_stage_history
     pageNum = params["stage-history-page"]
-    if (pageNum)
+    if pageNum
       load_stage_history_for_page pageNum
     else
       @stage_history_page = stage_service.findStageHistoryPage(@stage.getStage(), STAGE_HISTORY_PAGE_SIZE)

--- a/server/src/main/webapp/WEB-INF/rails/app/helpers/application_helper.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/helpers/application_helper.rb
@@ -104,7 +104,7 @@ module ApplicationHelper
     options.merge!(disabled: 'disabled') unless system_environment.isServerActive()
     options[:value] ||= name
     lambda_text, options_without_onclick = onclick_lambda(options)
-    if (options[:type] == "image")
+    if options[:type] == "image"
       button_body = image_button(name, options_without_onclick)
     else
       button_body = options[:type] == "select" ?
@@ -312,7 +312,7 @@ module ApplicationHelper
 
   def vsm_analytics_chart_info
     plugin_info = first_plugin_which_supports_vsm_analytics
-    if (plugin_info)
+    if plugin_info
       supported_analytics = plugin_info.getCapabilities().supportedVSMAnalytics().get(0)
       {
         "type" => 'vsm',

--- a/server/src/main/webapp/WEB-INF/rails/app/models/value_stream_map_model.rb
+++ b/server/src/main/webapp/WEB-INF/rails/app/models/value_stream_map_model.rb
@@ -39,11 +39,11 @@ class ValueStreamMapModel
         level.nodes = Array.new
         nodes.each do |node|
           node_type = node.getType().to_s
-          if (node_type == NODE_TYPE_FOR_MATERIAL)
+          if node_type == NODE_TYPE_FOR_MATERIAL
             level.nodes << VSMSCMDependencyNodeModel.new(node.getId().toString(), node.getName(), node.getChildren().map { |child| child.getId().toString() },
                                                          node.getParents().map { |parent| parent.getId().toString() }, node.getMaterialType().upcase,
                                                          node.getDepth(), node.getMaterialNames(), vsm_material_path_partial, node.getMaterialRevisions(), node.getViewType(), node.getMessageString())
-          elsif (node_type == NODE_TYPE_FOR_PIPELINE)
+          elsif node_type == NODE_TYPE_FOR_PIPELINE
             level.nodes << VSMPipelineDependencyNodeModel.new(node.getId().toString(), node.getName(), node.getChildren().map { |child| child.getId().toString() },
                                                               node.getParents().map { |parent| parent.getId().toString() }, node_type,
                                                               node.getDepth(), node.revisions(), node.getMessageString(), node.getViewType(),

--- a/server/src/main/webapp/WEB-INF/rails/app/views/shared/_head.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/shared/_head.html.erb
@@ -8,7 +8,7 @@
 
 <%= javascript_include_tag "application", debug: Rails.env.development? && params[:debug_assets] %>
 
-<%- unless(Rails.env.test?) %>
+<%- unless Rails.env.test? %>
   <%= javascript_include_tag *webpack_assets_service.getJSAssetPathsFor("single_page_apps/polyfill", "single_page_apps/header_footer_shim") %>
   <%= stylesheet_link_tag *webpack_assets_service.getCSSAssetPathsFor("single_page_apps/header_footer_shim") %>
 <%- end %>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/stats_iframe.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/stats_iframe.html.erb
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <%- unless (Rails.env.test?) %>
+  <%- unless Rails.env.test? %>
     <%= javascript_include_tag *webpack_assets_service.getJSAssetPathsFor("single_page_apps/global", "single_page_apps/polyfill", "single_page_apps/show_stage_duration_graph_shim") %>
   <%- end %>
 </head>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/value_stream_map/show.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/value_stream_map/show.html.erb
@@ -11,7 +11,7 @@
           <h1><%= @pipeline!=nil ? @pipeline.getLabel() : params[:pipeline_counter] %> </h1>
         </li>
     </ul>
-    <% if (supports_vsm_analytics?) %>
+    <% if supports_vsm_analytics? %>
     <button class="btn-primary enable-analytics"><i class="icon_vsm_analytics"></i>Analytics</button>
     <% end %>
 </div>

--- a/server/src/main/webapp/WEB-INF/rails/app/views/value_stream_map/show_material.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/value_stream_map/show_material.html.erb
@@ -10,7 +10,7 @@
       <span class="label">Revision</span>
       <h1><%= params[:revision] %> </h1></li>
   </ul>
-  <% if (supports_vsm_analytics?) %>
+  <% if supports_vsm_analytics? %>
     <button class="btn-primary enable-analytics"><i class="icon_vsm_analytics"></i>Analytics</button>
   <% end %>
 </div>

--- a/server/src/main/webapp/WEB-INF/rails/config/environments/development.rb
+++ b/server/src/main/webapp/WEB-INF/rails/config/environments/development.rb
@@ -55,4 +55,7 @@ Rails.application.configure do
 
   config.sass.line_comments = false
   config.sass.inline_source_maps = true
+  # Workaround Sprockets encoding issue with config.assets.debug = true, either inline or non-inline sourcemaps
+  # and SCSS assets with Unicode chars in them.
+  Sprockets.register_mime_type 'application/css-sourcemap+json', extensions: ['.css.map'], charset: :unicode
 end


### PR DESCRIPTION
There seems to be some kind of encodings issue with Sprockets 4.x when
* `config.assets.debug = true` and/or `debug: true` for a given SCSS asset
* that asset contains a Unicode char and is encoded as UTF-8

Seems to relate somehow to sourcemaps, which are not able to be fully disabled on Sprockets 4.x without disabling debug entirely according to https://github.com/rails/sprockets/issues/656#issuecomment-784526502 Appears to be no issue with production asset compilation (debug=off), but repeatable during development by loading Stages view, due to `new-theme.scss` and the `×` for close icon in the Modalbox `MB_Close`.

More detail at https://github.com/ntkme/sass-embedded-host-ruby/issues/71#issuecomment-1284173330 - will look to fix the underlying issue a bit later, although looks like a similar fix is needed to https://github.com/rails/sprockets/pull/669

Also include some minor Ruby style nitpicks while I'm here.