### PR TITLE
Bump dependency-check-gradle from 7.2.1 to 7.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:7.2.1'
+    classpath 'org.owasp:dependency-check-gradle:7.3.0'
     classpath 'gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1'
     classpath 'com.github.jk1:gradle-license-report:2.1'
   }

--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -26,15 +26,6 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
-    Suppressing false positive caused by OWASP Dependency Check thinking shaded RubyGems are the same thing as
-    as JRuby or their related libraries independently. These are not the same things.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/rubygems/jruby\-(openssl|readline)@.*$</packageUrl>
-    <cpe>cpe:/a:jruby:jruby</cpe>
-    <cpe>cpe:/a:openssl:openssl</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
     Suppressing false positive caused by OWASP Dependency Check thinking jruby-rack is the same thing as
     as JRuby independently. These are not the same things.
     ]]></notes>

--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -16,6 +16,7 @@
   -->
 
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+
   <suppress>
     <notes><![CDATA[
     Suppressing false positive caused by OWASP Dependency Check thinking the shaded/packaged dirgra library is the same
@@ -32,6 +33,7 @@
     <packageUrl regex="true">^pkg:maven/org\.jruby\.rack/jruby\-rack@.*$</packageUrl>
     <cpe>cpe:/a:jruby:jruby</cpe>
   </suppress>
+
   <suppress until="2022-11-01Z">
     <notes><![CDATA[
    This is a false positive from OSSIndex which is already fixed in SnakeYAML 1.31 according to devs and NIST NVD,
@@ -48,6 +50,7 @@
     <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
     <cve>CVE-2022-38752</cve>
   </suppress>
+
   <suppress>
     <notes><![CDATA[
     https://nvd.nist.gov/vuln/detail/CVE-2020-13697 as described only affects usage of "Nanolets" which is packaged
@@ -90,7 +93,6 @@
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-webmvc@4\.3.*$</packageUrl>
     <vulnerabilityName>CVE-2020-5397</vulnerabilityName>
   </suppress>
-
   <suppress>
     <notes><![CDATA[
     Spring WebMVC 4.3.x does not appear to be affected by https://tanzu.vmware.com/security/cve-2021-22060 based on review
@@ -112,7 +114,6 @@
     <cve>CVE-2022-22965</cve>
     <vulnerabilityName>CVE-2022-22965</vulnerabilityName>
   </suppress>
-
   <suppress>
     <notes><![CDATA[
     GoCD does not allow SpEL expressions to be supplied by users anywhere that can be found, so we do not seem to be
@@ -122,7 +123,6 @@
     <cve>CVE-2022-22950</cve>
     <vulnerabilityName>CVE-2022-22950</vulnerabilityName>
   </suppress>
-
   <suppress>
     <notes><![CDATA[
     GoCD is not affected by this as we do not use disallowedFieldPatterns on DataBinders as required to trigger the issue
@@ -132,7 +132,6 @@
     <cve>CVE-2022-22968</cve>
     <vulnerabilityName>CVE-2022-22968</vulnerabilityName>
   </suppress>
-
   <suppress>
     <notes><![CDATA[
     GoCD is not vulnerable to the default as described at https://nvd.nist.gov/vuln/detail/CVE-2022-22970 as we do not
@@ -153,7 +152,6 @@
     </packageUrl>
     <cve>CVE-2021-22112</cve>
   </suppress>
-
   <suppress>
     <notes><![CDATA[
     GoCD does not use bcrypt from Spring Security, so does not seem vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2022-22976
@@ -162,7 +160,6 @@
     </packageUrl>
     <cve>CVE-2022-22976</cve>
   </suppress>
-
   <suppress>
     <notes><![CDATA[
     GoCD does not use RegexRequestMatchers from Spring Security with a value of '.' as required by https://nvd.nist.gov/vuln/detail/CVE-2022-22978
@@ -183,7 +180,6 @@
     <packageUrl regex="true">^pkg:maven/org\.hibernate/hibernate\-(core|ehcache)@.*$</packageUrl>
     <cve>CVE-2019-14900</cve>
   </suppress>
-
   <suppress>
     <notes><![CDATA[
     From review of https://nvd.nist.gov/vuln/detail/CVE-2020-25638 and https://bugzilla.redhat.com/show_bug.cgi?id=1881353
@@ -203,7 +199,6 @@
     <packageUrl regex="true">^pkg:maven/com\.h2database/h2@.*$</packageUrl>
     <cve>CVE-2021-23463</cve>
   </suppress>
-
   <suppress>
     <notes><![CDATA[
     The CVEs as documented at https://github.com/h2database/h2database/security/advisories/GHSA-h376-j262-vhq6 and


### PR DESCRIPTION
Also removes an unnecessary false positive fixed in latest release