### PR TITLE
Correct upstream pipeline autosuggestions when switching stages changes

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks_tab_content.tsx
@@ -290,8 +290,10 @@ export class TasksWidget extends MithrilComponent<Attrs, State> {
 
 export class TasksTabContent extends TabContent<Job> {
   private readonly pluginInfos: Stream<PluginInfos> = Stream(new PluginInfos());
+  private readonly autoSuggestions: Stream<any>     = Stream();
+
+  private entityPath: PipelineConfigRouteParams | undefined;
   private originalTasks: string[] | undefined;
-  private autoSuggestions: Stream<any>              = Stream();
   private entityReOrderHandler: EntityReOrderHandler | undefined;
 
   constructor() {
@@ -312,6 +314,8 @@ export class TasksTabContent extends TabContent<Job> {
           reset: () => any): m.Children {
 
     const selectedJob = this.selectedEntity(pipelineConfig, routeParams);
+    const entityChanged = !_.isEqual(routeParams, this.entityPath);
+    this.entityPath = routeParams;
 
     const onReset = () => {
       this.entityReOrderHandler = undefined;
@@ -326,7 +330,7 @@ export class TasksTabContent extends TabContent<Job> {
       this.originalTasks = selectedJob.tasks().map(t => t.toJSON());
     }
 
-    if (!this.autoSuggestions()) {
+    if (!this.autoSuggestions() || entityChanged) {
       this.fetchUpstreamPipelines(pipelineConfig.name(), routeParams.stage_name!, !this.isPipelineConfigView());
     }
 


### PR DESCRIPTION
- fixes #10943

Auto-suggestions are based on upstream stages and pipelines from the current pipeline, so in a multi-stage pipeline, the list of upstreams change when you switch to configure jobs in different stages.

The current code appears to just load them once for a given pipeline config editing session, based on whichever stage's job you happen to open/view first.

This means even resetting (and reloading autosuggestions) on **save** isn't sufficient (or always necessary) - you really need to reload suggestions every time the context for the tab changes. Since the content object is re-used within a single pipeline's config, we need to detect this and reload when the content is changed in an "important" way, to avoid giving the user "stale" auto-suggestions that don't reflect a new stage/job added/deleted/re-ordered - or upstreams intended for a different stage.

