### PR TITLE
Improve test teardown ordering

### DIFF
--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ChangeMaterialsTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ChangeMaterialsTest.java
@@ -53,6 +53,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 })
 public class ChangeMaterialsTest {
 
+    @TempDir
+    private static Path tempDir;
+
     @Autowired
     private ScheduleService scheduleService;
     @Autowired
@@ -81,7 +84,7 @@ public class ChangeMaterialsTest {
 
 
     @BeforeAll
-    public static void startP4Server(@TempDir Path tempDir) throws Exception {
+    public static void startP4Server() throws Exception {
         p4TestRepo = P4TestRepo.createP4TestRepo(tempDir, TempDirUtils.createRandomDirectoryIn(tempDir).toFile());
         p4TestRepo.onSetup();
     }


### PR DESCRIPTION
It seems that the ordering between the `@AfterAll` and the `@TempDir` cleanup might not be deterministic here, and sometimes causing attempts to remove the TempDir before the Perforce daemon stops, which causes a failure on Windows due to filelocks. This change tries using a static field rather than injecting to @BeforeAll to see whether that helps make the ordering more deterministic.