### PR TITLE
Allow Git submodule tests to pass after fix to CVE-2022-39253

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
@@ -235,6 +235,7 @@ public class GitCommandTest {
                 fail(outputStreamConsumer.getAllOutput());
             }
             gitFooBranchBundle = GitTestRepo.testRepoAtBranch(GIT_FOO_BRANCH_BUNDLE, BRANCH, tempDir);
+            systemProperties.set(GitCommand.GIT_SUBMODULE_ALLOW_FILE_PROTOCOL, "Y");
         }
 
         @AfterEach

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
@@ -44,7 +44,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,9 +67,13 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(SystemStubsExtension.class)
 public class GitMaterialTest {
     public static final GitVersion GIT_VERSION_1_9 = GitVersion.parse("git version 1.9.0");
     public static final GitVersion GIT_VERSION_1_5 = GitVersion.parse("git version 1.5.4.3");
+
+    @SystemStub
+    SystemProperties systemProperties;
 
     @TempDir
     Path tempDir;
@@ -77,6 +85,7 @@ public class GitMaterialTest {
     @BeforeEach
     void setUp() {
         outputStreamConsumer = inMemoryConsumer();
+        systemProperties.set(GitCommand.GIT_SUBMODULE_ALLOW_FILE_PROTOCOL, "Y");
     }
 
     @Nested

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialExpansionServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialExpansionServiceTest.java
@@ -24,6 +24,7 @@ import com.thoughtworks.go.config.materials.git.GitMaterial;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig;
 import com.thoughtworks.go.config.materials.svn.SvnMaterial;
 import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
+import com.thoughtworks.go.domain.materials.git.GitCommand;
 import com.thoughtworks.go.helper.FilterMother;
 import com.thoughtworks.go.helper.GitRepoContainingSubmodule;
 import com.thoughtworks.go.helper.MaterialConfigsMother;
@@ -37,6 +38,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -50,10 +54,14 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
 public class MaterialExpansionServiceTest {
 
     private static SvnTestRepoWithExternal svnRepo;
     private MaterialExpansionService materialExpansionService;
+
+    @SystemStub
+    SystemProperties systemProperties;
     @Mock
     private GoCache goCache;
     @Mock
@@ -150,6 +158,7 @@ public class MaterialExpansionServiceTest {
 
     @Test
     public void shouldNotExpandGitSubmodulesIntoMultipleMaterialsWhenExpandingGitMaterialForScheduling(@TempDir Path tempDir) throws Exception {
+        systemProperties.set(GitCommand.GIT_SUBMODULE_ALLOW_FILE_PROTOCOL, "Y");
         GitRepoContainingSubmodule submoduleRepos = new GitRepoContainingSubmodule(tempDir);
         submoduleRepos.addSubmodule("submodule-1", "sub1");
         GitMaterial gitMaterial = new GitMaterial(submoduleRepos.mainRepo().getUrl());


### PR DESCRIPTION
By default git submodules cannot be references to local file repos after these fixes. This adds an opt-in to set the appropriate config option for each operation, used only by tests by default. Theoretically available for users to override if necessary, but I don't see why use of file reference submodules is a legitimate use case in a CI system anyway, so don't plan to publicise it for.

Currently the git commands fail with `fatal: transport 'file' not allowed` during `submodule add` (tests only) and `submodule update` (on agents when running builds).

See
- https://github.com/git/git/security/advisories/GHSA-3wp6-j8xr-qw85
- https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253
- https://git-scm.com/docs/git-config#Documentation/git-config.txt-protocolallow
- https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586
