### PR TITLE
Temporarily disable nant test as currently can't install nant on the Windows agent

### DIFF
--- a/server/src/test-fast/java/com/thoughtworks/go/remote/work/BuildWorkTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/remote/work/BuildWorkTest.java
@@ -39,6 +39,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -499,7 +500,7 @@ class BuildWorkTest {
     }
 
     @Test
-    @EnabledOnOs(OS.WINDOWS)
+    @Disabled(value = "As of Oct 2022 nant currently cant be downloaded for installation")
     void nantTest() throws Exception {
         buildWork = getWork(NANT, PIPELINE_NAME);
         buildWork.doWork(environmentVariableContext, new AgentWorkContext(agentIdentifier, buildRepository, artifactManipulator, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie"), packageRepositoryExtension, scmExtension, taskExtension, null, pluginRequestProcessorRegistry));


### PR DESCRIPTION
Currently install is failing on the Windows agent. Need to see if this is a temporary issue as it installs on my local VM, but want to move forward with other changes which need new build agents.

https://github.com/gocd-contrib/gocd-oss-cookbooks/actions/runs/3345083367/jobs/5543790944