### PR TITLE
Allow Git submodule tests to pass after fix to CVE-2022-39253

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
@@ -835,7 +835,7 @@ public class GitCommandTest {
 
         @Test
         void shouldNotCleanIgnoredFilesIfToggleIsEnabled() throws IOException {
-            System.setProperty("toggle.agent.git.clean.keep.ignored.files", "Y");
+            systemProperties.set(GitCommand.GIT_CLEAN_KEEP_IGNORED_FILES_FLAG, "Y");
             InMemoryStreamConsumer output = inMemoryConsumer();
             File gitIgnoreFile = new File(repoLocation, ".gitignore");
             FileUtils.writeStringToFile(gitIgnoreFile, "*.foo", UTF_8);
@@ -850,7 +850,7 @@ public class GitCommandTest {
 
         @Test
         void shouldNotThrowExceptionWhenSubmoduleIsAddedWithACustomName() {
-            git_C(gitLocalRepoDir, "submodule", "add", "--name", "Custom", gitFooBranchBundle.projectRepositoryUrl());
+            git_C(gitLocalRepoDir, "-c", "protocol.file.allow=always", "submodule", "add", "--name", "Custom", gitFooBranchBundle.projectRepositoryUrl());
             git.fetchAndResetToHead(inMemoryConsumer(), false);
         }
 


### PR DESCRIPTION
Fix an additional test missed by #10959 which manually adds a named submodule.