### PR TITLE
Fix display padding in agents tables on Chromium-based browsers

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/agents/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/agents/index.scss
@@ -87,16 +87,23 @@ $dropdown-button-content-z-index: 5;
     height: 100%;
   }
 
+  table tbody tr {
+    height: 30px;
+  }
+
   table tbody td {
     padding: 0;
     display: table-cell;
     vertical-align: middle;
-    height: 24px;
+    height: inherit;
   }
 
   table tbody .table-cell {
     padding: 10px;
-    height: 100%;
+    height: inherit;
+    line-height: 100%;
+    overflow: hidden;
+    word-break: break-word;
   }
 }
 


### PR DESCRIPTION
- fixes #8999


**Firefox**
![image](https://user-images.githubusercontent.com/29788154/198825508-c7e52754-928e-45ed-b648-2d37c502affd.png)

**Chrome**
![image](https://user-images.githubusercontent.com/29788154/198825523-398bae2c-73d0-47fd-a2c7-af7c5f0de72d.png)

**Safari**
![image](https://user-images.githubusercontent.com/29788154/198825538-5b4419ca-5bfe-49ef-ad2a-6e71263eb0e6.png)

