### PR TITLE
Refactor PerforceFixture to supporter wider use across tests

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/config/materials/perforce/P4MaterialTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/perforce/P4MaterialTest.java
@@ -21,7 +21,6 @@ import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.perforce.P4Client;
 import com.thoughtworks.go.helper.MaterialsMother;
-import com.thoughtworks.go.helper.P4TestRepo;
 import com.thoughtworks.go.util.ReflectionUtil;
 import com.thoughtworks.go.util.TempDirUtils;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
@@ -38,13 +37,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class P4MaterialTest extends P4MaterialTestBase {
-
-    @Override
-    protected P4TestRepo createTestRepo() throws Exception {
-        P4TestRepo repo = P4TestRepo.createP4TestRepo(tempDir, clientFolder);
-        repo.onSetup();
-        return repo;
-    }
 
     @Test
     void shouldAddServerSideEnvironmentVariablesClientNameEnvironmentVariable() throws IOException {
@@ -76,6 +68,7 @@ public class P4MaterialTest extends P4MaterialTestBase {
 
     @Test
     void shouldGenerateTheSameP4ClientValueForCommandAndEnvironment() throws Exception {
+        File workingDir = TempDirUtils.createRandomDirectoryIn(tempDir).toFile();
 
         P4Material p4Material = new P4Material("server:10", "out-of-the-window");
         ReflectionUtil.setField(p4Material, "folder", "crapy_dir");

--- a/common/src/test/java/com/thoughtworks/go/config/materials/perforce/P4MaterialTestBase.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/perforce/P4MaterialTestBase.java
@@ -112,7 +112,7 @@ public abstract class P4MaterialTestBase extends PerforceFixture {
                     .hasSize(2);
             assertThat(outputconsumer.getStdOut()).contains("Working directory has changed. Deleting and re-creating it.");
         } finally {
-            secondTestRepo.stop();
+            secondTestRepo.stopP4d();
             secondTestRepo.tearDown();
         }
     }

--- a/common/src/test/java/com/thoughtworks/go/config/materials/perforce/P4MultipleMaterialsTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/perforce/P4MultipleMaterialsTest.java
@@ -19,63 +19,26 @@ import com.thoughtworks.go.config.materials.Materials;
 import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.MaterialRevisions;
 import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
-import com.thoughtworks.go.domain.materials.perforce.P4Client;
-import com.thoughtworks.go.domain.materials.perforce.P4Fixture;
+import com.thoughtworks.go.domain.materials.perforce.PerforceFixture;
 import com.thoughtworks.go.helper.P4TestRepo;
-import com.thoughtworks.go.util.TempDirUtils;
-import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
 
 import static com.thoughtworks.go.config.MaterialRevisionsMatchers.containsModifiedFile;
 import static com.thoughtworks.go.util.command.ProcessOutputStreamConsumer.inMemoryConsumer;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class P4MultipleMaterialsTest {
-    public static final String DEFAULT_CLIENT_NAME = "p4test_2";
-
-    protected P4Client p4;
-    protected File clientFolder;
-    protected P4Fixture p4Fixture;
-
+public class P4MultipleMaterialsTest extends PerforceFixture {
     private static final String VIEW_SRC = "//depot/src/... //something/...";
     private static final String VIEW_LIB = "//depot/lib/... //something/...";
+    private P4TestRepo testRepo;
 
-    P4TestRepo p4TestRepo;
-
-    @BeforeEach
-    public void setUp(@TempDir Path tempDir) throws Exception {
-        p4Fixture = new P4Fixture();
-        clientFolder = TempDirUtils.createRandomDirectoryIn(tempDir).toFile();
-        p4TestRepo = createTestRepo(tempDir);
-        p4Fixture.setRepo(p4TestRepo);
-        p4 = P4Client.fromServerAndPort(null, p4Fixture.port(), "cceuser", null, DEFAULT_CLIENT_NAME, false, clientFolder, "", inMemoryConsumer(), true);
-        p4TestRepo.onSetup();
-        p4Fixture.start();
-    }
-
-
-    @AfterEach
-    public void stopP4Server() {
-        try {
-            FileUtils.deleteDirectory(clientFolder);
-            p4Fixture.stop(p4);
-        } catch (IOException ignore) {
-
-        }
-    }
-
-    protected P4TestRepo createTestRepo(Path tempDir) throws Exception {
-        P4TestRepo repo = P4TestRepo.createP4TestRepo(tempDir, clientFolder);
-        repo.onSetup();
-        return repo;
+    @Override
+    protected P4TestRepo createTestRepo() throws Exception {
+        testRepo = super.createTestRepo();
+        return testRepo;
     }
 
     @Test
@@ -107,8 +70,8 @@ public class P4MultipleMaterialsTest {
         P4Material p4Material2 = p4Fixture.material(VIEW_LIB, "lib");
         Materials materials = new Materials(p4Material1, p4Material2);
 
-        p4TestRepo.checkInOneFile(p4Material1, "filename.txt");
-        p4TestRepo.checkInOneFile(p4Material2, "filename2.txt");
+        testRepo.checkInOneFile(p4Material1, "filename.txt");
+        testRepo.checkInOneFile(p4Material2, "filename2.txt");
 
         MaterialRevisions materialRevisions = materials.latestModification(clientFolder, new TestSubprocessExecutionContext());
 

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/perforce/P4ClientTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/perforce/P4ClientTest.java
@@ -15,21 +15,12 @@
  */
 package com.thoughtworks.go.domain.materials.perforce;
 
-import com.thoughtworks.go.helper.P4TestRepo;
 import org.junit.jupiter.api.Test;
 
 public class P4ClientTest extends P4CommandTestBase {
-
-    @Override
-    protected P4TestRepo createTestRepo() throws Exception {
-        P4TestRepo repo = P4TestRepo.createP4TestRepo(tempDir, clientFolder);
-        repo.onSetup();
-        return repo;
-    }
 
     @Test
     void dummyTestSoIntelliJNoticesMe() {
 
     }
-
 }

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/perforce/P4Fixture.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/perforce/P4Fixture.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.domain.materials.perforce;
 
 import com.thoughtworks.go.config.materials.perforce.P4Material;
+import com.thoughtworks.go.config.materials.perforce.P4MaterialConfig;
 import com.thoughtworks.go.helper.P4TestRepo;
 import com.thoughtworks.go.util.command.CommandLineException;
 import com.thoughtworks.go.util.command.ConsoleResult;
@@ -72,7 +73,10 @@ public class P4Fixture {
 
     public P4Material material(String view) {
         return repo.material(view);
+    }
 
+    public P4MaterialConfig materialConfig(String view) {
+        return repo.materialConfig(view);
     }
 
     public P4Material material(String view, String dest) {

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/perforce/P4MaterialTicketTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/perforce/P4MaterialTicketTest.java
@@ -23,9 +23,7 @@ public class P4MaterialTicketTest extends P4MaterialTestBase {
 
     @Override
     protected P4TestRepo createTestRepo() throws Exception {
-        P4TestRepo repo = P4TestRepo.createP4TestRepoWithTickets(tempDir, clientFolder);
-        repo.onSetup();
-        return repo;
+        return P4TestRepo.createP4TestRepoWithTickets(tempDir, clientFolder);
     }
 
     @Test

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/perforce/P4TicketCommandTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/perforce/P4TicketCommandTest.java
@@ -22,9 +22,7 @@ public class P4TicketCommandTest extends P4CommandTestBase {
 
     @Override
     protected P4TestRepo createTestRepo() throws Exception {
-        P4TestRepo repo = P4TestRepo.createP4TestRepoWithTickets(tempDir, clientFolder);
-        repo.onSetup();
-        return repo;
+        return P4TestRepo.createP4TestRepoWithTickets(tempDir, clientFolder);
     }
 
     @Test

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/perforce/PerforceFixture.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/perforce/PerforceFixture.java
@@ -27,28 +27,28 @@ import java.io.File;
 import java.nio.file.Path;
 
 public abstract class PerforceFixture {
+    public static final String DEFAULT_CLIENT_NAME = "p4test_1";
+
     protected P4Client p4;
     protected File clientFolder;
-    public static final String DEFAULT_CLIENT_NAME = "p4test_1";
     protected P4Fixture p4Fixture;
     protected InMemoryStreamConsumer outputconsumer;
 
     @TempDir
     protected Path tempDir;
 
-    protected File workingDir;
-
     @BeforeEach
     public void setUp() throws Exception {
         p4Fixture = new P4Fixture();
         clientFolder = TempDirUtils.createTempDirectoryIn(tempDir, "p4Client").toFile();
-        p4Fixture.setRepo(createTestRepo());
+        p4Fixture.setRepo(createTestRepo().onSetup());
         outputconsumer = ProcessOutputStreamConsumer.inMemoryConsumer();
         p4 = p4Fixture.createClient();
-        workingDir = TempDirUtils.createRandomDirectoryIn(tempDir).toFile();
     }
 
-    protected abstract P4TestRepo createTestRepo() throws Exception;
+    protected P4TestRepo createTestRepo() throws Exception {
+        return P4TestRepo.createP4TestRepo(tempDir, clientFolder);
+    }
 
     @AfterEach
     public void stopP4Server() {

--- a/domain/src/test/java/com/thoughtworks/go/helper/TestRepo.java
+++ b/domain/src/test/java/com/thoughtworks/go/helper/TestRepo.java
@@ -48,8 +48,8 @@ public abstract class TestRepo {
 
     public abstract List<Modification> latestModification() throws IOException;
 
-    public void onSetup() throws Exception {
-
+    public TestRepo onSetup() {
+        return null;
     }
 
     public abstract Material material();


### PR DESCRIPTION
Try to make ChangeMaterialsTest more reliable on Windows by using the PerforceFixture/P4Fixture style of daemon shut down, which properly waits for shutdown.
