### PR TITLE
Change next version to 23.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ List<String> partitionFiles(Collection originalFiles) {
 
 def GO_VERSION_PREVIOUS = '22.2.0'
 def GO_VERSION_SEGMENTS = [year: 22, releaseInYear: 3, patch: 0]
-def GO_VERSION_NEXT = '22.4.0'
+def GO_VERSION_NEXT = '23.1.0'
 
 def GO_VERSION = [GO_VERSION_SEGMENTS.year, GO_VERSION_SEGMENTS.releaseInYear, GO_VERSION_SEGMENTS.patch].join('.')
 def DIST_VERSION = releaseRevision()

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "scripts",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
Seems unlikely that we will get to a 22.4.0 this year, but easier to assume not and then introduce it later without having to go through and clean up all the branches in docs repos :-)