### PR TITLE
Tweak installer builds for upcoming EOLs

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -205,7 +205,7 @@
     <vulnerabilityName>CWE-94: Improper Control of Generation of Code ('Code Injection')</vulnerabilityName>
   </suppress>
 
-  <suppress until="2022-11-01Z">
+  <suppress until="2023-01-01Z">
     <notes><![CDATA[
     Time-limited suppression for https://nvd.nist.gov/vuln/detail/CVE-2021-29425. GoCD is not vulnerable as the use of
     FilenameUtils.normalize does not "use the result to construct a path value" as required by the defect. Neither does

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/BuildDockerImageTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/BuildDockerImageTask.groovy
@@ -51,12 +51,16 @@ class BuildDockerImageTask extends DefaultTask {
 
   @TaskAction
   def perform() {
-    if (distroVersion.eolDate.before(new Date())) {
-      throw new RuntimeException("The image $distro:v$distroVersion.version is unsupported. EOL was ${distroVersion.eolDate}.")
+    if (distroVersion.pastEolGracePeriod) {
+      throw new RuntimeException("The image $distro:v$distroVersion.version is unsupported. EOL was ${distroVersion.eolDate}, and GoCD build grace period has passed.")
     }
 
-    if (distroVersion.aboutToEol && !distroVersion.continueToBuild) {
-      throw new RuntimeException("The image $distro:v$distroVersion.version is supposed to be EOL in ${(distroVersion.eolDate - new Date())} day(s), on ${distroVersion.eolDate}. Set :continueToBuild option to continue building.")
+    if (distroVersion.eol && !distroVersion.continueToBuild) {
+      throw new RuntimeException("The image $distro:v$distroVersion.version was EOL on ${distroVersion.eolDate}. Set :continueToBuild option to continue building through the grace period.")
+    }
+
+    if (distroVersion.aboutToEol) {
+      println("WARNING: The image $distro:v$distroVersion.version is supposed to be EOL on ${distroVersion.eolDate}. Derived GoCD image will be marked as deprecated.")
     }
 
     project.delete(gitRepoDirectory)

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroVersion.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroVersion.groovy
@@ -24,7 +24,7 @@ class DistroVersion implements Serializable {
   List<String> installPrerequisitesCommands = []
 
   boolean isAboutToEol() {
-    return eolDate.before(new Date() + 95)
+    return eolDate.before(new Date() + 180)
   }
 
   boolean lessThan(int target) {

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroVersion.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroVersion.groovy
@@ -27,6 +27,15 @@ class DistroVersion implements Serializable {
     return eolDate.before(new Date() + 180)
   }
 
+  boolean isEol() {
+    return eolDate.before(new Date())
+  }
+
+  boolean isPastEolGracePeriod() {
+    // Allow a 30 day grace period after EOL where we can keep building
+    return eolDate.before(new Date() - 30)
+  }
+
   boolean lessThan(int target) {
     return Integer.parseInt(version) < target
   }


### PR DESCRIPTION
- Extends a suppression for commons-io that has no fixed version we can use
- Tweaks container image builds to keep building until EOL by default, and allow extension of 30 days on opt-in, if necessary
- Changes deprecation warnings on Docker images to ~6 months (previously ~3 months)
