### PR TITLE
Ensure container images are patched for openssl CVE-2022-3602

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -108,7 +108,10 @@ enum Distro implements DistroBehavior {
 
     @Override
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
-      def commands = ['yum update -y']
+      def commands = [
+        'yum update -y',
+        'yum upgrade -y',
+      ]
 
       String git = gitPackageFor(v)
       commands.add(
@@ -160,6 +163,7 @@ enum Distro implements DistroBehavior {
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
       return [
         'apt-get update',
+        'apt-get upgrade -y',
         'apt-get install -y git subversion mercurial openssh-client bash unzip curl ca-certificates locales procps sysvinit-utils coreutils',
         'apt-get clean all',
         'rm -rf /var/lib/apt/lists/*',


### PR DESCRIPTION
Currently we upgrade dependencies for Alpine/Dind images, but not debian/ubuntu/centos so are relying on the upstream docker image to regularly be updated.

This does tend to happen regular for most images as they are official Docker images (except CentOS), but doing so ourselves allows us to ensure we get patches faster and with confidence.

This makes the behaviour more consistent across images.

**Affected images (based on latest)**
https://github.com/NCSC-NL/OpenSSL-2022/tree/main/software implies patches are in

* **Ubuntu 22.04**: `libssl3 3.0.2-0ubuntu1.7`
* **CentOS Stream 9**: `openssl 3.0.1-43`

Current experimental images vulnerable:
```shell
$ docker run -it --entrypoint='' -u root gocdexperimental/gocd-server-centos-9:v22.3.0-15279 bash -c 'yum list --installed | grep ssl'
apr-util-openssl.x86_64                1.6.1-20.el9                   @appstream
openssl.x86_64                         1:3.0.1-41.el9                 @baseos
openssl-libs.x86_64                    1:3.0.1-41.el9                 @System

$ docker run -it --entrypoint='' -u root gocdexperimental/gocd-agent-centos-9:v22.3.0-15279 bash -c 'yum list --installed | grep ssl'
apr-util-openssl.x86_64                1.6.1-20.el9                   @appstream
openssl.x86_64                         1:3.0.1-41.el9                 @baseos
openssl-libs.x86_64                    1:3.0.1-41.el9                 @System

$ docker run -it --entrypoint='' -u root gocdexperimental/gocd-agent-ubuntu-22.04:v22.3.0-15279 bash -c 'apt list --installed | grep ssl'

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

libssl3/now 3.0.2-0ubuntu1.6 amd64 [installed,local]
openssl/now 3.0.2-0ubuntu1.7 amd64 [installed,local]
```

