### PR TITLE
Fix Postgres backups via pg_dump on Windows

### DIFF
--- a/db-support/db-support-postgresql/src/main/java/com/thoughtworks/go/server/database/pg/PostgresqlBackupProcessor.java
+++ b/db-support/db-support-postgresql/src/main/java/com/thoughtworks/go/server/database/pg/PostgresqlBackupProcessor.java
@@ -71,18 +71,18 @@ public class PostgresqlBackupProcessor implements BackupProcessor {
 
         String dbName = pgProperties.getProperty("PGDBNAME");
         argv.add("pg_dump");
-        argv.add("--no-password");
         argv.add("--host=" + pgProperties.getProperty("PGHOST"));
         argv.add("--port=" + pgProperties.getProperty("PGPORT"));
+        argv.add("--dbname=" + dbName);
         if (isNotBlank(dbProperties.user())) {
             argv.add("--username=" + dbProperties.user());
         }
-        argv.add(pgProperties.getProperty("PGDBNAME"));
+        argv.add("--no-password");
         // append any user specified args for pg_dump
         if (isNotBlank(dbProperties.extraBackupCommandArgs())) {
             Collections.addAll(argv, Commandline.translateCommandline(dbProperties.extraBackupCommandArgs()));
         }
-        argv.add("--file=" + new File(targetDir, "db." + dbName).toString());
+        argv.add("--file=" + new File(targetDir, "db." + dbName));
         ProcessExecutor processExecutor = new ProcessExecutor();
         processExecutor.redirectOutputAlsoTo(Slf4jStream.of(getClass()).asDebug());
         processExecutor.redirectErrorAlsoTo(Slf4jStream.of(getClass()).asDebug());


### PR DESCRIPTION
It seems the order of arguments can be important on some versions of PostgreSQL / `pg_dump`. Avoid this by using the `--dbname` option to specify the database name.

Technically non-options should be the last arg of the dump as documented for all versions (`9.6` -> `15`): https://www.postgresql.org/docs/15/app-pgdump.html

See https://groups.google.com/g/go-cd/c/AMtgQQS3Gck