### PR TITLE
Bump default build JDK to 17.0.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 # Configuration for https://github.com/asdf-vm/asdf as an alternative to jabba, rvm, nvm etc
-java temurin-17.0.4+101
+java temurin-17.0.5+8
 ruby 3.1.2
 nodejs 18.12.0


### PR DESCRIPTION
Bumps the default JDK used for build via ASDF.