### PR TITLE
Correct misleading error message when webpack assets have been cleaned

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/WebpackAssetsService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/WebpackAssetsService.java
@@ -100,7 +100,7 @@ public class WebpackAssetsService implements ServletContextAware {
         File manifestFile = new File(servletContext.getRealPath(servletContext.getInitParameter("rails.root") + "/public/assets/webpack/manifest.json"));
 
         if (!manifestFile.exists()) {
-            throw new RuntimeException("Could not load compiled manifest from 'webpack/manifest.json' - have you run `rake webpack:compile`?");
+            throw new RuntimeException("Could not load compiled manifest from 'webpack/manifest.json' - have you run `./gradlew prepare` OR `./gradlew compileAssetsWebpackDev` since last clean?");
         }
 
         Gson gson = new Gson();

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/WebpackAssetsServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/WebpackAssetsServiceTest.java
@@ -144,10 +144,10 @@ public class WebpackAssetsServiceTest {
     }
 
     @Test
-    public void shouldBlowUpIfManifestIsNotFound() throws IOException {
+    public void shouldBlowUpIfManifestIsNotFound() {
         assertThatThrownBy(() -> webpackAssetsService.getAssetPaths("junk"))
                 .isExactlyInstanceOf(RuntimeException.class)
-                .hasMessage("Could not load compiled manifest from 'webpack/manifest.json' - have you run `rake webpack:compile`?");
+                .hasMessageContaining("Could not load compiled manifest from 'webpack/manifest.json' - have you run");
     }
 
     @Test


### PR DESCRIPTION
I think `rake webpack:compile` disappeared a long time ago. Entrypoint is now gradle or yarn. This confuses newcomers to the codebase - me at one point in time, someone else more recently. 😅