### PR TITLE
Remove a dead docs link from dashboard personalization page

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/personalization_modal_widget.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/personalization_modal_widget.js.msx
@@ -15,7 +15,6 @@
  */
 import m from "mithril";
 import {SearchBox} from "views/components/search_box";
-import {docsUrl} from "gen/gocd_version";
 
 import _ from "lodash";
 import {f} from "helpers/form_helper";
@@ -174,11 +173,6 @@ export const PersonalizationModalWidget = {
             <f.checkbox name="include-new-pipelines" model={vm} attrName="includeNewPipelines" label="New" labelClass="checkbox-help_label"/>
             <Tooltip vm={vm} name="include-new-pipelines">
               {"Include pipelines created since this view was last updated "}
-              <f.link
-                href={docsUrl("/navigation/pipelines_dashboard_page.html#personalize-pipelines-view")}
-                target="_blank">
-                More&hellip;
-              </f.link>
             </Tooltip>
           </div>
           <StageStateCriteria vm={vm}/>


### PR DESCRIPTION
The target page here was removed in https://github.com/gocd/docs.go.cd/commit/68a5b973ad7e5215857020f30c21fd302d6ab663