### PR TITLE
Fix SASS 2 deprecation warnings

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_settings.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_settings.scss
@@ -517,7 +517,7 @@ $table-row-hover: darken($table-background, $table-hover-scale);
 $table-row-stripe-hover: darken($table-background, $table-color-scale + $table-hover-scale);
 $table-striped-background: smart-scale($table-background, $table-color-scale);
 $table-stripe: even;
-$table-head-background: smart-scale($table-background, $table-color-scale / 2);
+$table-head-background: smart-scale($table-background, calc($table-color-scale / 2));
 $table-foot-background: smart-scale($table-background, $table-color-scale);
 $table-head-font-color: $body-font-color;
 $show-header-for-stacked: false;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/hierarchy/tree.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/hierarchy/tree.scss
@@ -16,7 +16,7 @@
 @import "../../global/common";
 
 $indent-width: 15px;
-$under-label-indent-width: (2 * $indent-width) / 3;
+$under-label-indent-width: calc((2 * $indent-width) / 3);
 $tree-connector-color: #ddd;
 $tick-width: $under-label-indent-width;
 $selected-color: #d2ebf0;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/defined_structs.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/defined_structs.scss
@@ -20,7 +20,7 @@
 $inline-radius: 4px;
 $inline-spacing: 20px;
 $arrow-size: 6px;
-$arrow-horiz: ($arrow-size + $inline-spacing) / 2;
+$arrow-horiz: calc(($arrow-size + $inline-spacing) / 2);
 $stage-color: #4ad9d9;
 $fg-color: #023550;
 $label-color-group: #dee;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/foundation_hax.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/foundation_hax.scss
@@ -521,7 +521,7 @@ $table-row-hover: darken($table-background, $table-hover-scale);
 $table-row-stripe-hover: darken($table-background, $table-color-scale + $table-hover-scale);
 $table-striped-background: smart-scale($table-background, $table-color-scale);
 $table-stripe: even;
-$table-head-background: smart-scale($table-background, $table-color-scale / 2);
+$table-head-background: smart-scale($table-background, calc($table-color-scale / 2));
 $table-foot-background: smart-scale($table-background, $table-color-scale);
 $table-head-font-color: $body-font-color;
 $show-header-for-stacked: false;


### PR DESCRIPTION
Remaining deprecation warnings appear to be in FontAwesome, Foundation Sites, Bourbon or Normalize SCSS libraries which will need separate upgrades and/or post-processing.

`DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.`
