### PR TITLE
Upgrade FontAwesome from v4 to v6

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/console_log_foldable_section.js
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/console_log_foldable_section.js
@@ -199,7 +199,7 @@
       if (!section.priv.multiline) {
         section.body = cursor.body = c("dd", {class: "fs-multiline"});
         cursor.appendChild(cursor.body);
-        section.insertBefore(c("a", {class: "fa toggle"}), section.childNodes[0]);
+        section.insertBefore(c("a", {class: "fas toggle"}), section.childNodes[0]);
         section.priv.multiline = true;
       }
     }

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_font-awesome-glyphs.scss.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_font-awesome-glyphs.scss.erb
@@ -15,23 +15,22 @@
  * limitations under the License.
  */
 @import "font-awesome-sprockets";
-@import "font-awesome/scss/variables";
 @import "bourbon/core/bourbon";
 
 <%
   variables = {}
-  variable_definitions = File.read(File.join(Rails.root, 'node_modules/font-awesome/scss/_variables.scss')).lines.grep(/\$fa-var-/).collect(&:strip)
+  variable_definitions = File.read(File.join(Rails.root, 'node_modules/@fortawesome/fontawesome-free/scss/_variables.scss')).lines.grep(/\$fa-var-/).collect(&:strip)
   variable_definitions.each do |definition|
-    definition =~ /\$fa-var-(.*): "\\(.*)";/
-    variables[$1] = $2;
+    definition =~ /\$fa-var-(.*): \\(.*);/
+    variables[$1] = $2
   end
 %>
 
 $fa-font-icons: (
-                <% variables.each do |name, unicode| %>
-                  fa-var-<%= name %>: '<%= unicode %>',
-                <% end %>
-                );
+<% variables.each do |name, unicode| %>
+  fa-var-<%= name %>: "<%= unicode %>",
+<% end %>
+);
 
 @function unicode($str) {
   @return unquote("\"")+unquote(str-insert($str, "\\", 1))+unquote("\"")
@@ -45,23 +44,29 @@ $fa-font-icons: (
   }
 }
 
-@mixin icon-only($type, $font: 'font-awesome') {
-  @if $font == 'font-awesome' {
-    font-family: 'FontAwesome';
-    @include icon-glyph("fa-var-#{$type}");
+$fa-style-family-brands: "#{str-slice($fa-style-family, 1, -5)} Brands";
+
+@mixin icon-only($type, $font: "font-awesome") {
+  @if $font == "font-awesome" {
+    font-family: $fa-style-family, sans-serif;
+    font-weight: 900;
+  } @else if $font == "font-awesome-brands" {
+    font-family: $fa-style-family-brands, sans-serif;
+    font-weight: 400;
   } @else {
     @error "Could not find font family #{$font}";
   }
+
+  @include icon-glyph("fa-var-#{$type}");
 }
 
-@mixin icon($type, $size: auto, $margin: auto, $line-height: 1em, $color: auto, $top: auto, $shadow: none, $font: 'font-awesome') {
+@mixin icon($type, $size: auto, $margin: auto, $line-height: 1em, $color: auto, $top: auto, $shadow: none, $font: "font-awesome") {
   @include icon-only($type: $type, $font: $font);
 
-  font-weight:            normal;
-  font-style:             normal;
-  display:                inline-block;
-  text-decoration:        inherit;
-  line-height:            $line-height;
+  font-style: normal;
+  display: inline-block;
+  text-decoration: inherit;
+  line-height: $line-height;
 
   @if $margin != auto {
     margin: $margin;
@@ -71,7 +76,7 @@ $fa-font-icons: (
   }
   @if $top != auto {
     position: relative;
-    top:      $top;
+    top: $top;
   }
   @if $color != auto {
     color: $color;
@@ -82,12 +87,12 @@ $fa-font-icons: (
   -webkit-font-smoothing: antialiased;
 }
 
-@mixin in-progress-spinner($type: spinner, $font: 'font-awesome') {
-  @include icon-only($type: $type, $font: $font);
+@mixin in-progress-spinner($type: spinner) {
+  @include icon-only($type: $type);
   @include animation(spin 1s linear infinite);
 }
 
-@mixin icon-before($type, $size: auto, $margin: 5px, $line-height: 1em, $color: auto, $top: auto, $shadow: none, $font: 'font-awesome', $progress-spinner: false) {
+@mixin icon-before($type, $size: auto, $margin: 5px, $line-height: 1em, $color: auto, $top: auto, $shadow: none, $font: "font-awesome", $progress-spinner: false) {
   &:before {
     @include icon($type, $size, $margin, $line-height, $color, $top, $shadow, $font: $font);
     @content;
@@ -100,7 +105,7 @@ $fa-font-icons: (
   }
 }
 
-@mixin icon-after($type, $size: auto, $margin: 5px, $line-height: 1em, $color: auto, $top: auto, $shadow: none, $font: 'font-awesome', $progress-spinner: false) {
+@mixin icon-after($type, $size: auto, $margin: 5px, $line-height: 1em, $color: auto, $top: auto, $shadow: none, $font: "font-awesome", $progress-spinner: false) {
   &:after {
     @include icon($type, $size, $margin, $line-height, $color, $top, $shadow, $font: $font);
     @content;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_font-awesome-sprockets.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_font-awesome-sprockets.scss
@@ -16,26 +16,28 @@
  * limitations under the License.
  */
 
-$fa-font-path: "font-awesome/fonts";
-
 @import "bourbon/core/bourbon";
+@import "@fortawesome/fontawesome-free/scss/fontawesome";
 
-// this file is a copy of font-awesome.scss, with changes to `path.scss` substituted in this file
-@import "font-awesome/scss/variables";
-@import "font-awesome/scss/mixins";
-@import "font-awesome/scss/core";
-@import "font-awesome/scss/larger";
-@import "font-awesome/scss/fixed-width";
-@import "font-awesome/scss/list";
-@import "font-awesome/scss/bordered-pulled";
-@import "font-awesome/scss/animated";
-@import "font-awesome/scss/rotated-flipped";
-@import "font-awesome/scss/stacked";
-@import "font-awesome/scss/icons";
-@import "font-awesome/scss/screen-reader";
+$fa-font-path: "@fortawesome/fontawesome-free/webfonts";
+$fa-style-family-brands: "#{str-slice($fa-style-family, 1, -5)} Brands";
+
 @include font-face(
-  $font-family: "FontAwesome",
-  $file-path: "#{$fa-font-path}/fontawesome-webfont",
-  $file-formats: ("woff2", "woff"),
+  $font-family: $fa-style-family,
+  $file-path: "#{$fa-font-path}/fa-solid-900",
+  $file-formats: ("woff2"),
   $asset-pipeline: true
-);
+) {
+  font-style: normal;
+  font-weight: 900;
+}
+
+@include font-face(
+  $font-family: $fa-style-family-brands,
+  $file-path: "#{$fa-font-path}/fa-brands-400",
+  $file-formats: ("woff2"),
+  $asset-pipeline: true
+) {
+  font-style: normal;
+  font-weight: 400;
+}

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_action_buttons.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_action_buttons.scss
@@ -58,7 +58,7 @@ $btn-border: $border-grey;
 }
 
 .edit-button {
-  @include icon-before($type: pencil-square-o, $color: $go-icon-color);
+  @include icon-before($type: pencil, $color: $go-icon-color);
 
   &:not(.disabled) {
     &:hover {
@@ -76,7 +76,7 @@ $btn-border: $border-grey;
 }
 
 .delete-button {
-  @include icon-before($type: trash, $color: $go-icon-color);
+  @include icon-before($type: trash-can, $color: $go-icon-color);
 
   &:not(.disabled) {
     &:hover {

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_common.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_common.scss
@@ -66,7 +66,7 @@ $auth-config-icon-text-padding: 20px;
 }
 
 .delete-button {
-  @include icon-before($type: trash, $color: $white, $margin: 0 5px 0 0, $progress-spinner: true);
+  @include icon-before($type: trash-can, $color: $white, $margin: 0 5px 0 0, $progress-spinner: true);
 }
 
 .app-footer {

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_notifications.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_notifications.scss
@@ -96,7 +96,7 @@
   }
 
   .bell {
-    @include icon-before(bell-o, $color: #fff);
+    @include icon-before(bell, $color: #fff);
 
     font-size: 18px;
   }

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_schmodal.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_schmodal.scss
@@ -132,7 +132,7 @@ $overlay-border-radius: 3px;
 }
 
 .close-icon {
-  @include icon-before($type: close);
+  @include icon-before($type: xmark);
 }
 
 .overlay-content {

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/agents.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/agents.scss
@@ -585,7 +585,7 @@ $arrow-color: #000;
 }
 
 .agent-analytics {
-  @include icon-before($type: bar-chart);
+  @include icon-before($type: chart-bar);
 
   padding: 0;
   font-size: 14px;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -33,6 +33,7 @@
 $dark-gray: #333;
 $pipeline-icons-size: 16px;
 $icon-color: #647984;
+$icon-size: 12px;
 $filter-width: 362px;
 $pipeline-list-height: 265px;
 $modal-header-height: 55px;
@@ -379,7 +380,7 @@ body {
 }
 
 .pipeline-analytics {
-  @include icon-before($type: bar-chart);
+  @include icon-before($type: chart-bar);
 
   padding: 0;
   font-size: $pipeline-icons-size;
@@ -584,14 +585,14 @@ body {
     text-align: center;
 
     &.passed {
-      @include icon-before($passed-icon, 12px, 0);
+      @include icon-before($passed-icon, $icon-size, 1.5px);
 
       background: $passed;
       color: #fff;
     }
 
     &.failed {
-      @include icon-before($failed-icon, 12px, 0);
+      @include icon-before($failed-icon, $icon-size, 1.5px);
 
       background: $failed;
       color: #fff;
@@ -619,7 +620,7 @@ body {
     }
 
     &.cancelled {
-      @include icon-before($cancelled-icon, 12px, 0);
+      @include icon-before($cancelled-icon, $icon-size, 1.5px);
 
       background: $building;
       color: $dark-gray;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_dashboard_view_tabs.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_dashboard_view_tabs.scss
@@ -429,7 +429,7 @@ button {
 }
 
 .revert {
-  @include icon-before($type: close);
+  @include icon-before($type: xmark);
 
   position: absolute;
   right: 5px;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_personalize_views_editor.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_personalize_views_editor.scss
@@ -85,7 +85,7 @@ $icon-color: #647984;
   z-index: 100;
 
   .close-button {
-    @include icon-before($type: close);
+    @include icon-before($type: xmark);
 
     position: absolute;
     right: 20px;
@@ -380,7 +380,7 @@ $icon-color: #647984;
 }
 
 .btn-delete {
-  @include icon-before($type: trash, $margin: 0 10px 0 0, $progress-spinner: true);
+  @include icon-before($type: trash-can, $margin: 0 10px 0 0, $progress-spinner: true);
 
   float: left;
   background: #fff;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/_vsm.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/_vsm.scss
@@ -332,7 +332,7 @@ $btn-default: #d6d5d5;
 }
 
 .analytics-close {
-  @include icon-before("close", $margin: 10, $size: 20px);
+  @include icon-before("times", $margin: 10, $size: 20px);
 
   width: 20px;
   background: transparent;
@@ -401,7 +401,7 @@ $btn-default: #d6d5d5;
 }
 
 .icon_vsm_analytics {
-  @include icon-before($type: bar-chart);
+  @include icon-before($type: chart-bar);
 
   padding: 0;
   font-size: 15px;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_build_detail.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_build_detail.scss
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "font-awesome/scss/variables";
+@import "@fortawesome/fontawesome-free/scss/functions";
+@import "@fortawesome/fontawesome-free/scss/variables";
 @import "../new_stylesheets/shared/go-variables";
 @import "css_sass/base/mixins";
 @import "_font-awesome-glyphs";

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_console-log.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_console-log.scss
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "font-awesome/scss/variables";
-@import "font-awesome/scss/mixins";
+@import "@fortawesome/fontawesome-free/scss/functions";
+@import "@fortawesome/fontawesome-free/scss/variables";
+@import "@fortawesome/fontawesome-free/scss/mixins";
 
 $CONSOLE_SECTION_HEADER: #383838;
 $CONSOLE_SECTION_HEADER_WHITE: #f5f5f5;
@@ -87,8 +88,9 @@ $PROGRESS_BAR_BG_SIZE: 70px;
   font-family: Monaco, Consolas, Inconsolata, "Liberation Mono", "Courier New", monospace;
   font-size: 13px;
 
-  .fa {
-    font-family: FontAwesome;
+  .fas {
+    font-family: $fa-style-family, sans-serif;
+    font-weight: 900;
   }
 
   .white-theme & {
@@ -122,7 +124,7 @@ $PROGRESS_BAR_BG_SIZE: 70px;
 
     &::before {
       font-size: 120%;
-      content: $fa-var-caret-right;
+      content: fa-content($fa-var-caret-right);
     }
 
     &:last-child {
@@ -136,7 +138,7 @@ $PROGRESS_BAR_BG_SIZE: 70px;
     }
 
     .toggle::before {
-      content: $fa-var-caret-down;
+      content: fa-content($fa-var-caret-down);
     }
   }
 }
@@ -197,6 +199,7 @@ code {
 .log-fs-status {
   &::before {
     @include fa-icon;
+    font-family: $fa-style-family, sans-serif;
 
     position: absolute;
     left: -30px;
@@ -211,7 +214,7 @@ code {
 .log-fs-task-status-passed,
 .log-fs-job-status-passed {
   &::before {
-    content: $fa-var-check;
+    content: fa-content($fa-var-check);
     color: $CONSOLE_PASS;
   }
 
@@ -224,7 +227,7 @@ code {
 .log-fs-job-status-failed,
 .log-fs-publish-failed {
   &::before {
-    content: $fa-var-exclamation-circle;
+    content: fa-content($fa-var-exclamation-circle);
     color: red;
   }
 
@@ -262,7 +265,7 @@ code {
 
 .log-fs-task-status-cancelled {
   &::before {
-    content: $fa-var-ban;
+    content: fa-content($fa-var-ban);
     color: $CONSOLE_CALLOUT;
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/new-theme.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/new-theme.scss
@@ -92,99 +92,6 @@ h4 {
   font-size: 18px;
 }
 
-.environment-listview {
-  border: 1px solid #ececec;
-  margin: 0 15px;
-  border-radius: 3px;
-  background: #fff;
-}
-
-.environment-listview .environment-header {
-  display: flex;
-  height: 30px;
-  cursor: pointer;
-  padding: 10px 50px 10px 20px;
-  overflow: hidden;
-
-  &::after {
-    content: "\f105";
-    font-family: FontAwesome;
-    position: absolute;
-    right: 35px;
-    font-size: 30px;
-    font-weight: 400;
-    color: #ccc;
-  }
-
-  h2.entity_title {
-    font-size: 14px;
-    font-weight: 600;
-    color: black;
-    line-height: 30px;
-    min-width: 325px;
-    max-width: 325px;
-    padding: 0;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-
-    &.disabled {
-      color: #999;
-      font-style: italic;
-    }
-  }
-
-  .key-value-pair {
-    padding-left: 15px;
-    line-height: 30px;
-    min-width: 250px;
-    max-width: 250px;
-
-    .key {
-      min-width: auto;
-    }
-  }
-}
-
-.environment-listview .environment-body {
-  border-top: 1px solid #ececec;
-  padding: 15px;
-  display: none;
-
-  h3 {
-    margin: 10px 0 20px;
-    border-bottom: 1px dotted #ccc;
-    padding-bottom: 10px;
-  }
-
-  .added_item ul {
-    margin-left: 23px;
-
-    li {
-      margin-top: 10px;
-      font-size: rem-calc(13px);
-    }
-  }
-}
-
-.environment-listview.expanded {
-  box-shadow: 0 3px 11px 0 rgba(0, 0, 0, 15%);
-
-  .environment-body {
-    display: block;
-  }
-
-  .environment-header::after {
-    content: "\f107";
-  }
-}
-
-.environment_show {
-  .row {
-    margin-top: 15px;
-  }
-}
-
 .yui-t7 #yui-main .yui-b {
   background: transparent;
 }
@@ -2088,12 +1995,6 @@ code,
 
 .content_wrapper_outer {
   clear: both;
-}
-
-.edit_icon_disabled,
-.lock_icon_disabled,
-.view_icon_disabled {
-  margin-top: 3px;
 }
 
 #links {

--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -21,6 +21,7 @@
     "postinstall": "patch-package --patch-dir spec/javascripts/support"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.4.0",
     "@shopify/draggable": "^1.0.0-beta.12",
     "angular": "file:node-vendor/angular",
     "awesomplete": "^1.1.5",
@@ -30,7 +31,6 @@
     "classnames": "^2.3.2",
     "core-js": "^3.30.2",
     "filesize": "^10.0.7",
-    "font-awesome": "^4.7.0",
     "foundation-sites": "=6.4.3",
     "hack-font": "^3.3.0",
     "jquery": "^3.7.0",

--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/global.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/global.scss
@@ -94,11 +94,25 @@ p {
   margin: 0 0 20px 0;
 }
 
-@include font-face($font-family: "FontAwesome",
-$file-path: "~font-awesome/fonts/fontawesome-webfont",
-$file-formats: ("woff2", "woff")) {
-  font-weight: normal;
+$fa-font-path: "@fortawesome/fontawesome-free/webfonts";
+$fa-style-family-brands: "#{str-slice($fa-style-family, 1, -5)} Brands";
+
+@include font-face(
+  $font-family: $fa-style-family,
+  $file-path: "#{$fa-font-path}/fa-solid-900",
+  $file-formats: ("woff2"),
+) {
   font-style: normal;
+  font-weight: 900;
+}
+
+@include font-face(
+  $font-family: $fa-style-family-brands,
+  $file-path: "#{$fa-font-path}/fa-brands-400",
+  $file-formats: ("woff2"),
+) {
+  font-style: normal;
+  font-weight: 400;
 }
 
 // stylelint-disable value-keyword-case

--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/global.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/global.scss
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "~normalize-scss/sass/normalize/import-now";
+@import "normalize-scss/sass/normalize/import-now";
 @import "../views/global/common";
 
 $headings-margin-bottom: $global-margin-bottom;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/buttons/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/buttons/index.scss
@@ -125,7 +125,7 @@
 }
 
 .icon-remove {
-  @include icon-before($type: $fa-var-trash, $color: $icon-color);
+  @include icon-before($type: $fa-var-trash-can, $color: $icon-color);
 
   &::before {
     margin: 5px 10px 5px -5px;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/click_2_copy/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/click_2_copy/index.scss
@@ -53,7 +53,7 @@ $overlay-index: 10;
   }
 
   &.icon-fail {
-    @include icon-before($fa-var-times, $color: $go-danger);
+    @include icon-before($fa-var-xmark, $color: $go-danger);
   }
 
   &.icon-ellipsis {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/forms/autocomplete.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/forms/autocomplete.scss
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 @import "../../global/common";
-@import "~awesomplete/awesomplete"; // don't add the `.css` extension!! See https://github.com/sass/node-sass/issues/2362#issuecomment-388634848
+@import "awesomplete/awesomplete";
 
 .awesomplete > ul > li {
   color: $black;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.scss
@@ -59,15 +59,15 @@ $console-icon-color: #fff;
 }
 
 .settings {
-  @include icon-before($type: $fa-var-cog);
+  @include icon-before($type: $fa-var-gear);
 }
 
 .analytics {
-  @include icon-before($type: $fa-var-bar-chart);
+  @include icon-before($type: $fa-var-chart-bar);
 }
 
 .edit {
-  @include icon-before($type: $fa-var-pencil-square-o);
+  @include icon-before($type: $fa-var-edit);
 }
 
 .view {
@@ -80,7 +80,7 @@ $console-icon-color: #fff;
 
 // delete is a keyword, a literal syntax; can't be accessed using styles.delete hence renaming it to remove
 .remove {
-  @include icon-before($type: $fa-var-trash);
+  @include icon-before($type: $fa-var-trash-can);
 }
 
 .lock {
@@ -88,7 +88,7 @@ $console-icon-color: #fff;
 }
 
 .close {
-  @include icon-before($type: $fa-var-times);
+  @include icon-before($type: $fa-var-xmark);
 }
 
 .question {
@@ -116,11 +116,11 @@ $console-icon-color: #fff;
 }
 
 .refresh {
-  @include icon-before($type: $fa-var-refresh);
+  @include icon-before($type: $fa-var-sync);
 }
 
 .usage {
-  @include icon-before($type: $fa-var-pie-chart);
+  @include icon-before($type: $fa-var-chart-pie);
 }
 
 .minus {
@@ -174,7 +174,7 @@ $console-icon-color: #fff;
 }
 
 .chevron-right-round {
-  @include icon-before($type: $fa-var-arrow-circle-o-right);
+  @include icon-before($type: $fa-var-arrow-alt-circle-right);
 }
 
 .trigger {
@@ -182,7 +182,7 @@ $console-icon-color: #fff;
 }
 
 .repeat {
-  @include icon-before($type: $fa-var-repeat);
+  @include icon-before($type: $fa-var-rotate-right);
 }
 
 .comment {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/link/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/link/index.scss
@@ -27,5 +27,5 @@
 }
 
 .external-icon {
-  @include icon-after($type: $fa-var-external-link);
+  @include icon-after($type: $fa-var-external-link-alt);
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss
@@ -99,7 +99,7 @@ $spinner-wrapper-height: 200px;
 }
 
 .close-icon {
-  @include icon-before($type: $fa-var-close);
+  @include icon-before($type: $fa-var-xmark);
 }
 
 .overlay-fixed-height {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/notification_center/system_notifications.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/notification_center/system_notifications.scss
@@ -39,7 +39,7 @@ $icon-background: #e0dede;
 }
 
 .bell {
-  @include icon-before($fa-var-bell-o, $color: $header-text-color);
+  @include icon-before($fa-var-bell, $color: $header-text-color);
 
   font-size: 18px;
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/rules/rules.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/rules/rules.scss
@@ -67,7 +67,7 @@
 }
 
 .icon-delete {
-  @include icon-before($type: $fa-var-times);
+  @include icon-before($type: $fa-var-xmark);
 
   border: none;
   display: inline;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/table/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/table/index.scss
@@ -76,7 +76,7 @@ $draggable-row-color: #e2f7fa;
 }
 
 .sort-button-asc {
-  @include icon-before($fa-var-sort-asc);
+  @include icon-before($fa-var-sort-up);
 
   margin-left: 2px;
   cursor: pointer;
@@ -84,7 +84,7 @@ $draggable-row-color: #e2f7fa;
 }
 
 .sort-button-desc {
-  @include icon-before($fa-var-sort-desc);
+  @include icon-before($fa-var-sort-down);
 
   margin-left: 2px;
   cursor: pointer;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
@@ -373,7 +373,7 @@ $dark-gray: #2f4f4f;
   &::before {
     position: relative;
     top: -4px;
-    left: -1.5px;
+    left: -0.7px;
   }
 }
 
@@ -385,7 +385,7 @@ $dark-gray: #2f4f4f;
   &::before {
     position: relative;
     top: -4px;
-    left: -0.7px;
+    left: -1.5px;
   }
 }
 
@@ -397,7 +397,7 @@ $dark-gray: #2f4f4f;
   &::before {
     position: relative;
     top: -4px;
-    left: -0.7px;
+    left: -1.5px;
   }
 }
 
@@ -409,10 +409,10 @@ $dark-gray: #2f4f4f;
 .rerun-wrapper {
   transform: rotate(150deg);
   font-weight: 900;
-  font-size: 14px;
+  font-size: 12px;
   position: relative;
-  left: 38px;
-  top: 29px;
+  left: 39px;
+  top: 30px;
   width: 0;
   height: 0;
   color: $dark-gray;
@@ -776,14 +776,14 @@ $dark-gray: #2f4f4f;
 }
 
 .asc {
-  @include icon-before($fa-var-sort-asc);
+  @include icon-before($fa-var-sort-up);
 
   color: $dark-gray;
   margin-left: 2px;
 }
 
 .desc {
-  @include icon-before($fa-var-sort-desc);
+  @include icon-before($fa-var-sort-down);
 
   color: $dark-gray;
   margin-left: 2px;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/global/_fontawesome.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/global/_fontawesome.scss
@@ -13,17 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "~font-awesome/scss/variables";
+@import "@fortawesome/fontawesome-free/scss/functions";
+@import "@fortawesome/fontawesome-free/scss/variables";
 
 @mixin icon-only($type, $font: "font-awesome") {
   @if $font == "font-awesome" {
-    // stylelint-disable font-family-no-missing-generic-family-keyword
-    font-family: FontAwesome;
-    // stylelint-enable font-family-no-missing-generic-family-keyword
-    content: $type;
+    font-family: $fa-style-family, sans-serif;
+    font-weight: 900;
+  } @else if $font == "font-awesome-brands" {
+    font-family: "#{str-slice($fa-style-family, 1, -5)} Brands", sans-serif;
+    font-weight: 400;
   } @else {
     @error "Could not find font family #{$font}";
   }
+
+  content: fa-content($type);
 }
 
 @mixin icon(
@@ -37,7 +41,6 @@
   $font: "font-awesome") {
   @include icon-only($type: $type, $font: $font);
 
-  font-weight: normal;
   font-style: normal;
   display: inline-block;
   text-decoration: inherit;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/global/_mixins.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/global/_mixins.scss
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "~bourbon/core/bourbon";
+@import "bourbon/core/bourbon";
 
 $spinner-wrapper-height: 175px;
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/edit_pipeline_group.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/edit_pipeline_group.scss
@@ -16,7 +16,7 @@
 @import "../../global/common";
 
 .icon-delete {
-  @include icon-before($type: $fa-var-times);
+  @include icon-before($type: $fa-var-xmark);
 
   border: none;
   display: inline;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_templates/modals.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_templates/modals.scss
@@ -85,7 +85,7 @@
 }
 
 .icon-delete {
-  @include icon-before($type: $fa-var-times);
+  @include icon-before($type: $fa-var-xmark);
 
   border: none;
   display: inline;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/agents/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/agents/index.scss
@@ -183,7 +183,7 @@ $dropdown-button-content-z-index: 5;
 }
 
 .agent-analytics a {
-  @include icon-before($type: $fa-var-bar-chart);
+  @include icon-before($type: $fa-var-chart-bar);
 
   padding: 0;
   font-size: 14px;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/stages/stages.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/stages/stages.scss
@@ -58,14 +58,14 @@ $icon-size: 10px;
 }
 
 .cancelled {
-  @include icon-before($fa-var-ban, $icon-size, 0);
+  @include icon-before($fa-var-ban, $icon-size, 1px);
 
   color: $black;
   background: transparent url("../../../../../app/assets/images/building.png");
 }
 
 .failed {
-  @include icon-before($fa-var-info-circle, $icon-size, 0);
+  @include icon-before($fa-var-exclamation-circle, $icon-size, 1px);
 
   background: $failed;
 }
@@ -75,7 +75,7 @@ $icon-size: 10px;
 }
 
 .passed {
-  @include icon-before($fa-var-check, $icon-size, 0);
+  @include icon-before($fa-var-check, $icon-size, 1px);
 
   background: $passed;
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/index.scss
@@ -40,7 +40,7 @@ $input-length-for-rules: 300px;
 }
 
 .error-last-modification-icon {
-  @include key-pair-icon($type: $fa-var-remove, $color: $failed);
+  @include key-pair-icon($type: $fa-var-xmark, $color: $failed);
 
   margin-right: 10px;
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new-environments/index.scss
@@ -88,7 +88,7 @@ $border-color: #ddd;
 }
 
 .warning-icon {
-  @include icon-before($type: $fa-var-info-circle, $color: darken($warning, 30%));
+  @include icon-before($type: $fa-var-exclamation-circle, $color: darken($warning, 30%));
 
   &::before {
     font-size: 20px;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/foundation_hax.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/foundation_hax.scss
@@ -891,7 +891,7 @@ $grid-container-padding: $grid-padding-gutters;
 $grid-container-max: $global-width;
 $xy-block-grid-max: 8;
 
-@import "~foundation-sites/scss/foundation";
+@import "foundation-sites/scss/foundation";
 
 // stylelint-enable
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/styles.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pac/styles.scss
@@ -16,7 +16,7 @@
 
 @import "../pipelines/vals";
 @import "../../components/buttons/index";
-@import "~prismjs/themes/prism"; // don't add the `.css` extension!! See https://github.com/sass/node-sass/issues/2362#issuecomment-388634848
+@import "prismjs/themes/prism";
 
 $syntax-bg: #282923;
 $error-container-width: 450px;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.scss
@@ -94,12 +94,12 @@ $maintenance-mode-banner-message-font-size: 17px;
   text-decoration: none;
   margin: 0 3px;
 
-  @mixin footer-icon($icon) {
-    @include icon-before($type: $icon, $color: $icon-color, $size: 16px, $line-height: 1.5rem);
+  @mixin footer-icon($icon, $font: "font-awesome") {
+    @include icon-before($type: $icon, $color: $icon-color, $size: 16px, $line-height: 1.5rem, $font: $font);
   }
 
   &.github {
-    @include footer-icon($icon: $fa-var-github);
+    @include footer-icon($icon: $fa-var-github, $font: "font-awesome-brands");
   }
 
   &.forums {
@@ -115,7 +115,7 @@ $maintenance-mode-banner-message-font-size: 17px;
   }
 
   &.cctray {
-    @include footer-icon($icon: $fa-var-feed);
+    @include footer-icon($icon: $fa-var-rss);
   }
 
   &.api {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/site_header.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/site_header.scss
@@ -231,7 +231,7 @@ $bar-spacing: 7px;
     padding: 0 10px;
   }
 
-  .fa {
+  .fas {
     margin: 0 3px;
     color: $icon-color;
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/site_header.scss.d.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/site_header.scss.d.ts
@@ -3,7 +3,7 @@ export const animate: string;
 export const bar: string;
 export const caretDownIcon: string;
 export const caret_down_icon: string;
-export const fa: string;
+export const fas: string;
 export const gocdLogo: string;
 export const gocd_logo: string;
 export const isDropDown: string;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/index.scss
@@ -24,6 +24,7 @@ $stage-status-unknown: #fafafa;
 $build-details-z-index: 5;
 $modification-text-color: #ff6;
 $dropdown-background-color: #333;
+$icon-size: 10px;
 $disabled-icon-color: #e0e0e0;
 $stage-status-bar-z-index: 2;
 $stage-action-icon-z-index: 1;
@@ -190,26 +191,26 @@ $stage-action-icon-z-index: 1;
 }
 
 .cancelled {
-  @include icon-before($fa-var-ban, 12px, 0);
+  @include icon-before($fa-var-ban, $icon-size, 1px);
 
   color: $black;
   background: transparent url("../../../../app/assets/images/building.png") repeat-x;
 }
 
 .failed {
-  @include icon-before($fa-var-info-circle, 12px, 0);
+  @include icon-before($fa-var-exclamation-circle, $icon-size, 1px);
 
   background: $failed;
 }
 
 .passed {
-  @include icon-before($fa-var-check, 12px, 0);
+  @include icon-before($fa-var-check, $icon-size, 1px);
 
   background: $passed;
 }
 
 .waiting {
-  @include icon-before($fa-var-spinner, 12px, 0);
+  @include icon-before($fa-var-spinner, $icon-size, 1px);
 
   color: $black;
   background: transparent url("../../../../app/assets/images/building.png") repeat-x;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/index.scss
@@ -146,7 +146,7 @@ input[type="radio"][disabled] + label[for] {
 }
 
 .icon-delete {
-  @include icon-before($type: $fa-var-times);
+  @include icon-before($type: $fa-var-xmark);
 
   border: none;
   display: inline;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/index.scss
@@ -99,7 +99,7 @@
 }
 
 .icon-delete {
-  @include icon-before($type: $fa-var-times);
+  @include icon-before($type: $fa-var-xmark);
 
   border: none;
   display: inline;

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -1120,6 +1120,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.41.0.tgz#080321c3b68253522f7646b55b577dd99d2950b3"
   integrity sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==
 
+"@fortawesome/fontawesome-free@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.0.tgz#1ee0c174e472c84b23cb46c995154dc383e3b4fe"
+  integrity sha512-0NyytTlPJwB/BF5LtRV8rrABDbe3TdTXqNB3PdZ+UUUZAEIrdOJdmABqKjt4AXwIoJNaRVVZEXxpNrqvE1GAYQ==
+
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
@@ -3979,11 +3984,6 @@ follow-redirects@^1.0.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
-
-font-awesome@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
-  integrity sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==
 
 for-each@^0.3.3:
   version "0.3.3"

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_build_output_raw.ftlh
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_build_output_raw.ftlh
@@ -18,7 +18,7 @@
     <div>
         <a class="auto-scroll" title="Scroll to bottom">Scroll to end of logs</a>
         <a href="${req.getContextPath()}/files/${presenter.consoleoutLocator}">Raw output</a>
-        <a class='toggle-timestamps' href="#"><i class="fa fa-clock-o"></i> Timestamps</a>
+        <a class='toggle-timestamps' href="#"><i class="fas fa-clock"></i> Timestamps</a>
         <a class='toggle-folding' href="#" data-collapsed="true"></a>
         <a id="full-screen">
           <span class="expand">Fullscreen</span>


### PR DESCRIPTION
FontAwesome 4 has a lot of SCSS deprecations that will break when Dart Sass gets to v2.

- GoCD is currently using what looks like "regular" versions of Font Awesome Icons, however these are not available with the "free" version from v5 onwards, requiring replacement with the "solid" variants. These look slightly different but very similar overall.
- A number of icons were split into a separate "brands" font making some of the existing automation not work so well. We only use the GitHub icon from this pack, it seems so seems limited impact.