### PR TITLE
Remove legacy Windows quoting strategy deprecated in 22.2.0

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/domain/builder/BaseCommandBuilder.java
+++ b/common/src/main/java/com/thoughtworks/go/domain/builder/BaseCommandBuilder.java
@@ -28,11 +28,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.nio.charset.Charset;
-import java.util.Collections;
-import java.util.List;
 
 public abstract class BaseCommandBuilder extends Builder {
-    static final String QUOTE_ALL_WINDOWS_ARGS = "toggle.agent.windows.command.quote.all.args";
     private static final Logger LOG = LoggerFactory.getLogger(BaseCommandBuilder.class);
 
     protected String command;
@@ -92,10 +89,10 @@ public abstract class BaseCommandBuilder extends Builder {
         if (SystemUtils.IS_OS_WINDOWS) {
             return CommandLine.createCommandLine("cmd")
                     .withWorkingDir(workingDir)
-                    .withArgs(windowsCmdArgsStart())
+                    .withArgs("/s", "/c", "\"")
                     .withArg(translateToWindowsPath(this.command))
                     .withArgs(argList())
-                    .withArgs(windowsCmdArgsEnd());
+                    .withArg("\"");
         } else {
             return CommandLine.createCommandLine(this.command)
                     .withWorkingDir(workingDir)
@@ -120,22 +117,6 @@ public abstract class BaseCommandBuilder extends Builder {
                 ", workingDir=" + workingDir +
                 ", errorString='" + errorString + '\'' +
                 "} " + super.toString();
-    }
-
-    private List<String> windowsCmdArgsStart() {
-        return shouldQuoteAllWindowsArgs()
-                ? List.of("/s", "/c", "\"")
-                : List.of("/c");
-    }
-
-    private List<String> windowsCmdArgsEnd() {
-        return shouldQuoteAllWindowsArgs()
-                ? List.of("\"")
-                : Collections.emptyList();
-    }
-
-    private boolean shouldQuoteAllWindowsArgs() {
-        return "Y".equalsIgnoreCase(System.getProperty(QUOTE_ALL_WINDOWS_ARGS, "Y"));
     }
 
     private String translateToWindowsPath(String command) {

--- a/common/src/test/java/com/thoughtworks/go/domain/builder/AbstractCommandBuilderScriptRunnerTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/builder/AbstractCommandBuilderScriptRunnerTest.java
@@ -32,8 +32,8 @@ import java.util.stream.Collectors;
 
 public abstract class AbstractCommandBuilderScriptRunnerTest {
 
-    static final Path ATTRIB = Path.of("C:\\Windows\\system32\\attrib.exe");
-    static final Path TAR = Path.of("C:\\Windows\\system32\\tar.exe");
+    static final Path ATTRIB_WINDOWS = Path.of("C:\\Windows\\system32\\attrib.exe");
+    static final Path TAR_WINDOWS = Path.of("C:\\Windows\\system32\\tar.exe");
 
 
     static final String DIR_WINDOWS = "C:\\Windows";
@@ -56,11 +56,19 @@ public abstract class AbstractCommandBuilderScriptRunnerTest {
         return paths;
     }
 
-    protected void doPossiblyQuotedArgsTest(String executableLocation, String... executableArgs) throws CheckedCommandLineException {
-        doPossiblyQuotedArgsTest(executableLocation, new String[0], executableArgs);
+    protected void assertThatExecutableOutputIncludesArgs(String executableLocation, String... executableArgs) throws CheckedCommandLineException {
+        assertThatExecutableOutputIncludesArgs(executableLocation, new String[0], executableArgs);
     }
 
-    protected void doPossiblyQuotedArgsTest(String executableLocation, String[] executableFlags, String... executableArgs) throws CheckedCommandLineException {
+    /**
+     * Executes the passed executable with the passed args, validating that the executable can be found invoked on the
+     * filesystem, and that the args were interpreted correctly, by assuming the executable will print the raw args
+     * somewhere in its output.
+     * <p/>
+     * Will likely only work correctly with certain executables or shell built-ins, such as `attrib`, `ls`, `dir`, `tar`
+     * etc that print their args in the output and can validate that the args were interpreted successfully.
+     */
+    protected void assertThatExecutableOutputIncludesArgs(String executableLocation, String[] executableFlags, String... executableArgs) throws CheckedCommandLineException {
         ExecScript script = new ExecScript("");
         InMemoryConsumer output = new InMemoryConsumer();
         commandFor(executableLocation, ArrayUtils.addAll(executableFlags, executableArgs))

--- a/common/src/test/java/com/thoughtworks/go/domain/builder/CommandBuilderScriptRunnerTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/builder/CommandBuilderScriptRunnerTest.java
@@ -17,17 +17,12 @@ package com.thoughtworks.go.domain.builder;
 
 import com.thoughtworks.go.domain.RunIfConfigs;
 import com.thoughtworks.go.util.command.CommandLine;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import uk.org.webcompere.systemstubs.jupiter.SystemStub;
-import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
-import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -36,66 +31,33 @@ public class CommandBuilderScriptRunnerTest extends AbstractCommandBuilderScript
 
     @Nested
     @EnabledOnOs(OS.WINDOWS)
-    class WindowsCorrectedQuotingStrategy {
+    class Windows {
         @ParameterizedTest
         @ValueSource(strings = {DIR_WINDOWS, DIR_WINDOWS_QUOTED, DIR_PROGRAM_FILES_QUOTED})
         void commandInSpacePathCanRunArgsWithSpacesAndQuotes(String attribArg) throws Exception {
-            doPossiblyQuotedArgsTest(executableWithPathSpaces(ATTRIB).toString(), attribArg);
+            assertThatExecutableOutputIncludesArgs(executableWithPathSpaces(ATTRIB_WINDOWS).toString(), attribArg);
         }
 
         @Test
         void commandInSpacePathCanRunMultipleArgsInclSpaces() throws Exception {
             List<String> paths = createTestFoldersIn();
             String[] pathsAsStrings = paths.stream().map(s -> '"' + s + '"').toArray(String[]::new);
-            doPossiblyQuotedArgsTest(executableWithPathSpaces(TAR).toString(), new String[] { "-cvf", "test.tar"}, pathsAsStrings);
+            assertThatExecutableOutputIncludesArgs(executableWithPathSpaces(TAR_WINDOWS).toString(), new String[] { "-cvf", "test.tar"}, pathsAsStrings);
         }
 
         @ParameterizedTest
         @ValueSource(strings = {DIR_WINDOWS, DIR_WINDOWS_QUOTED, DIR_PROGRAM_FILES_QUOTED})
         void commandInNormalPathCanRunArgsWithSpacesAndQuotes(String attribArg) throws Exception {
-            doPossiblyQuotedArgsTest(ATTRIB.toString(), attribArg);
+            assertThatExecutableOutputIncludesArgs(ATTRIB_WINDOWS.toString(), attribArg);
         }
 
         @Test
         void commandInNormalPathCanRunMultipleArgsInclSpaces() throws Exception {
             List<String> paths = createTestFoldersIn();
             String[] pathsAsStrings = paths.stream().map(s -> '"' + s + '"').toArray(String[]::new);
-            doPossiblyQuotedArgsTest(TAR.toString(), new String[] { "-cvf", "test.tar"}, pathsAsStrings);
+            assertThatExecutableOutputIncludesArgs(TAR_WINDOWS.toString(), new String[] { "-cvf", "test.tar"}, pathsAsStrings);
         }
     }
-
-    @Nested
-    @EnabledOnOs(OS.WINDOWS)
-    @ExtendWith(SystemStubsExtension.class)
-    class WindowsLegacyQuotingStrategy {
-        @SystemStub
-        SystemProperties props;
-
-        @BeforeEach
-        void enableLegacyWindowsProps() {
-            props.set(BaseCommandBuilder.QUOTE_ALL_WINDOWS_ARGS, "N");
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {DIR_WINDOWS})
-        void commandInSpacePathCanRunArgsWithoutSpacesOrQuotes(String attribArg) throws Exception {
-            doPossiblyQuotedArgsTest(executableWithPathSpaces(ATTRIB).toString(), attribArg);
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {DIR_WINDOWS, DIR_WINDOWS_QUOTED, DIR_PROGRAM_FILES_QUOTED})
-        void commandInNormalPathCanRunArgsWithSpacesAndQuotes(String attribArg) throws Exception {
-            doPossiblyQuotedArgsTest(ATTRIB.toString(), attribArg);
-        }
-
-        @Test
-        void commandInNormalPathCanRunMultipleArgsInclSpaces() throws Exception {
-            List<String> paths = createTestFoldersIn();
-            String[] pathsAsStrings = paths.stream().map(s -> '"' + s + '"').toArray(String[]::new);
-            doPossiblyQuotedArgsTest(TAR.toString(), new String[] { "-cvf", "test.tar"}, pathsAsStrings);
-        }
-    }
-
 
     @Override
     CommandLine commandFor(String executableLocation, String... executableArgs) {

--- a/common/src/test/java/com/thoughtworks/go/domain/builder/CommandBuilderWithArgsListScriptRunnerTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/builder/CommandBuilderWithArgsListScriptRunnerTest.java
@@ -17,17 +17,12 @@ package com.thoughtworks.go.domain.builder;
 
 import com.thoughtworks.go.domain.RunIfConfigs;
 import com.thoughtworks.go.util.command.CommandLine;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import uk.org.webcompere.systemstubs.jupiter.SystemStub;
-import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
-import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -36,69 +31,31 @@ public class CommandBuilderWithArgsListScriptRunnerTest extends AbstractCommandB
 
     @Nested
     @EnabledOnOs(OS.WINDOWS)
-    class WindowsCorrectedQuotingStrategy {
+    class Windows {
         @ParameterizedTest
         @ValueSource(strings = {DIR_WINDOWS, DIR_WINDOWS_QUOTED, DIR_PROGRAM_FILES, DIR_PROGRAM_FILES_QUOTED, "", " "})
         void commandInSpacePathCanRunArgsWithSpacesAndQuotes(String attribArg) throws Exception {
-            doPossiblyQuotedArgsTest(executableWithPathSpaces(ATTRIB).toString(), attribArg);
+            assertThatExecutableOutputIncludesArgs(executableWithPathSpaces(ATTRIB_WINDOWS).toString(), attribArg);
         }
 
         @Test
         void commandInSpacePathCanRunMultipleArgsInclSpaces() throws Exception {
             List<String> paths = createTestFoldersIn();
-            doPossiblyQuotedArgsTest(executableWithPathSpaces(TAR).toString(), new String[]{"-cvf", "test.tar"}, paths.toArray(String[]::new));
+            assertThatExecutableOutputIncludesArgs(executableWithPathSpaces(TAR_WINDOWS).toString(), new String[]{"-cvf", "test.tar"}, paths.toArray(String[]::new));
         }
 
         @ParameterizedTest
         @ValueSource(strings = {DIR_WINDOWS, DIR_WINDOWS_QUOTED, DIR_PROGRAM_FILES, DIR_PROGRAM_FILES_QUOTED})
         void commandInNormalPathCanRunArgsWithSpacesAndQuotes(String attribArg) throws Exception {
-            doPossiblyQuotedArgsTest(ATTRIB.toString(), attribArg);
+            assertThatExecutableOutputIncludesArgs(ATTRIB_WINDOWS.toString(), attribArg);
         }
 
         @Test
         void commandInNormalPathCanRunMultipleArgsInclSpaces() throws Exception {
             List<String> paths = createTestFoldersIn();
-            doPossiblyQuotedArgsTest(TAR.toString(), new String[]{"-cvf", "test.tar"}, paths.toArray(String[]::new));
+            assertThatExecutableOutputIncludesArgs(TAR_WINDOWS.toString(), new String[]{"-cvf", "test.tar"}, paths.toArray(String[]::new));
         }
     }
-
-    @Nested
-    @EnabledOnOs(OS.WINDOWS)
-    @ExtendWith(SystemStubsExtension.class)
-    class WindowsLegacyQuotingStrategy {
-        @SystemStub
-        SystemProperties props;
-
-        @BeforeEach
-        void enableLegacyWindowsProps() {
-            props.set(BaseCommandBuilder.QUOTE_ALL_WINDOWS_ARGS, "N");
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {DIR_WINDOWS})
-        void commandInSpacePathCanRunArgsWithoutSpacesOrQuotes(String attribArg) throws Exception {
-            doPossiblyQuotedArgsTest(executableWithPathSpaces(ATTRIB).toString(), attribArg);
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {DIR_WINDOWS, DIR_WINDOWS_QUOTED, DIR_PROGRAM_FILES, DIR_PROGRAM_FILES_QUOTED})
-        void commandInSpacePathCanRunArgsWithSpacesWithWorkaround(String attribArg) throws Exception {
-            doPossiblyQuotedArgsTest('"' + executableWithPathSpaces(ATTRIB).toString(), attribArg + '"');
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {DIR_WINDOWS, DIR_WINDOWS_QUOTED, DIR_PROGRAM_FILES, DIR_PROGRAM_FILES_QUOTED})
-        void commandInNormalPathCanRunArgsWithSpacesAndQuotes(String attribArg) throws Exception {
-            doPossiblyQuotedArgsTest(ATTRIB.toString(), attribArg);
-        }
-
-        @Test
-        void commandInNormalPathCanRunMultipleArgsInclSpaces() throws Exception {
-            List<String> paths = createTestFoldersIn();
-            doPossiblyQuotedArgsTest(TAR.toString(), new String[]{"-cvf", "test.tar"}, paths.toArray(String[]::new));
-        }
-    }
-
 
     @Override
     CommandLine commandFor(String executableLocation, String... executableArgs) {


### PR DESCRIPTION
Since August 2022 release there have been no issues reported with the change in quoting approach, so removing this old feature flag which is likely no longer required. Feature flag wasn't published and only kept as a backup in case of unintended regressions, so unlikely folks are using it, and have interacted with some folks using Windows more extensively recently so have a reasonable degree of confidence we have this correct.

Will keep the nested tests here in case we want to go back and add proper coverage for POSIX/non-Windows setups.
