### PR TITLE
Remove unnecessary dependency check suppressions

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -19,23 +19,6 @@
 
   <suppress>
     <notes><![CDATA[
-    Suppressing false positive caused by OWASP Dependency Check thinking the shaded/packaged dirgra library is the same
-    as the JRuby version. These are versioned independently and not the same thing.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.jruby/dirgra@.*$</packageUrl>
-    <cpe>cpe:/a:jruby:jruby</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-    Suppressing false positive caused by OWASP Dependency Check thinking jruby-rack is the same thing as
-    as JRuby independently. These are not the same things.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.jruby\.rack/jruby\-rack@.*$</packageUrl>
-    <cpe>cpe:/a:jruby:jruby</cpe>
-  </suppress>
-
-  <suppress>
-    <notes><![CDATA[
     https://nvd.nist.gov/vuln/detail/CVE-2020-13697 as described only affects usage of "Nanolets" which is packaged
     separately and which is not used within GoCD.
     ]]></notes>
@@ -55,6 +38,7 @@
     <notes><![CDATA[
     Hibernate Commons Annotations is a different project, versioned separately to the core "Hibernate ORM", so CVEs against this are misleading
     and false positives. We will still seem them reported against other Hibernate dependencies, however.
+    See https://github.com/jeremylong/DependencyCheck/issues/4651
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.hibernate/hibernate\-commons\-annotations@.*$</packageUrl>
     <cpe>cpe:/a:hibernate:hibernate_orm</cpe>
@@ -214,7 +198,8 @@
 
   <suppress>
     <notes><![CDATA[
-    The Eclipse Angus Mail SMTP component is not the Eclipse IDE :-)
+    False positive CPE match - the Eclipse Angus Mail SMTP component is not the Eclipse IDE :-)
+    See https://github.com/jeremylong/DependencyCheck/issues/4653
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.angus/smtp@.*$</packageUrl>
     <cpe>cpe:/a:eclipse:eclipse_ide</cpe>


### PR DESCRIPTION
These false positives have been fixed in the base library. Clarify links to the remaining CPE-based false positives.