### PR TITLE
Upgrade SLF4j to v2.0.x and logback to v1.4.x

### DIFF
--- a/agent-bootstrapper/src/main/resources/config/agent-bootstrapper-logback.xml
+++ b/agent-bootstrapper/src/main/resources/config/agent-bootstrapper-logback.xml
@@ -22,6 +22,7 @@
     scan="${gocd.agentBootstrapper.logback.scan:-true}"
     scanPeriod="${gocd.agentBootstrapper.logback.scanPeriod:-5 seconds}"
 >
+  <shutdownHook/>
 
   <appender name="FileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>${gocd.agent.log.dir:-logs}/go-agent-bootstrapper.log</file>

--- a/agent-launcher/src/main/resources/config/agent-launcher-logback.xml
+++ b/agent-launcher/src/main/resources/config/agent-launcher-logback.xml
@@ -22,6 +22,7 @@
     scan="${gocd.agentLauncher.logback.scan:-true}"
     scanPeriod="${gocd.agentLauncher.logback.scanPeriod:-5 seconds}"
 >
+  <shutdownHook/>
 
   <appender name="FileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>${gocd.agent.log.dir:-logs}/go-agent-launcher.log</file>

--- a/agent/src/main/resources/config/agent-logback.xml
+++ b/agent/src/main/resources/config/agent-logback.xml
@@ -22,6 +22,7 @@
     scan="${gocd.agent.logback.scan:-true}"
     scanPeriod="${gocd.agent.logback.scanPeriod:-5 seconds}"
 >
+  <shutdownHook/>
 
   <appender name="FileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>${gocd.agent.log.dir:-logs}/go-agent.log</file>

--- a/base/src/main/java/com/thoughtworks/go/logging/LogConfigurator.java
+++ b/base/src/main/java/com/thoughtworks/go/logging/LogConfigurator.java
@@ -20,7 +20,6 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.core.Context;
-import ch.qos.logback.core.hook.DelayingShutdownHook;
 import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.util.StatusPrinter;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -71,8 +70,6 @@ public class LogConfigurator {
             return;
         }
 
-        allowCleanShutdown();
-
         File logbackFile = new File(configDir, childLogbackConfigFile);
 
         if (logbackFile.exists()) {
@@ -91,17 +88,6 @@ public class LogConfigurator {
                 configureWith(resource);
             }
         }
-    }
-
-    // add a shutdown hook that explicitly calls `stop` on the logging context to give it time to shutdown
-    // can be removed if logback is >= 1.3
-    // see https://jira.qos.ch/browse/LOGBACK-1162
-    private void allowCleanShutdown() {
-        DelayingShutdownHook hook = new DelayingShutdownHook();
-        Context context = (Context) this.loggerFactory;
-        hook.setContext(context);
-        Thread hookThread = new Thread(hook, "Logback shutdown hook [" + context.getName() + "]");
-        Runtime.getRuntime().addShutdownHook(hookThread);
     }
 
     protected void configureDefaultLogging() {

--- a/base/src/main/java/com/thoughtworks/go/logging/LogConfigurator.java
+++ b/base/src/main/java/com/thoughtworks/go/logging/LogConfigurator.java
@@ -122,7 +122,7 @@ public class LogConfigurator {
             configurator.doConfigure(resource);
         } catch (JoranException ignore) {
         }
-        StatusPrinter.printInCaseOfErrorsOrWarnings((Context) loggerFactory);
+        StatusPrinter.printIfErrorsOccured((Context) loggerFactory);
     }
 
     private void configureWith(File logbackFile) {

--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -18,7 +18,6 @@ package com.thoughtworks.go.util;
 import ch.qos.logback.classic.Level;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.TestOnly;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
@@ -35,8 +34,6 @@ import static java.util.concurrent.TimeUnit.*;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class SystemEnvironment implements Serializable, ConfigDirProvider {
-
-    private static final Logger LOG = LoggerFactory.getLogger(SystemEnvironment.class);
 
     public static final String CRUISE_LISTEN_HOST = "cruise.listen.host";
     public static final String CRUISE_SERVER_PORT = "cruise.server.port";
@@ -406,7 +403,9 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
             try (InputStream is = getClass().getResourceAsStream(CRUISE_PROPERTIES)) {
                 properties.load(is);
             } catch (Exception e) {
-                LOG.error("Unable to load newProperties file {}", CRUISE_PROPERTIES);
+                // Deliberately avoiding initializing the logger during class load to allow for manual
+                // logger configuration during startup
+                LoggerFactory.getLogger(SystemEnvironment.class).error("Unable to load newProperties file {}", CRUISE_PROPERTIES);
             }
         }
         return properties;

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -78,7 +78,7 @@ final Map<String, String> libraries = [
   junit5Bom           : 'org.junit:junit-bom:5.10.0',
   liquibase           : 'org.liquibase:liquibase-core:4.20.0',
   liquibaseSlf4j      : 'com.mattbertolini:liquibase-slf4j:5.0.0',
-  logback             : 'ch.qos.logback:logback-classic:1.2.12',
+  logback             : 'ch.qos.logback:logback-classic:1.4.11',
   lombok              : 'org.projectlombok:lombok:1.18.30',
   mockitoBom          : 'org.mockito:mockito-bom:5.6.0',
   mybatis             : 'org.mybatis:mybatis:3.5.13',
@@ -93,7 +93,7 @@ final Map<String, String> libraries = [
   rack                : 'org.jruby.rack:jruby-rack:1.1.22',
   semanticVersion     : 'de.skuzzle:semantic-version:2.1.1',
   servletApi          : 'jakarta.servlet:jakarta.servlet-api:4.0.4', // Should be compatible with Jetty and Spring implementations
-  slf4j               : 'org.slf4j:slf4j-api:1.7.36',
+  slf4j               : 'org.slf4j:slf4j-api:2.0.9',
   spark               : 'com.sparkjava:spark-core:2.7.2',
   spring              : 'org.springframework:spring-core:4.3.30.RELEASE',
   springSecurity      : 'org.springframework.security:spring-security-config:4.2.20.RELEASE',

--- a/server/src/main/resources/config/logback.xml
+++ b/server/src/main/resources/config/logback.xml
@@ -22,6 +22,7 @@
     scan="${gocd.server.logback.scan:-true}"
     scanPeriod="${gocd.server.logback.scanPeriod:-5 seconds}"
 >
+  <shutdownHook/>
 
   <appender name="FileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>${gocd.server.log.dir:-logs}/go-server.log</file>

--- a/test/test-utils/resource-include-in-all-projects/logback-test.xml
+++ b/test/test-utils/resource-include-in-all-projects/logback-test.xml
@@ -23,6 +23,7 @@
     debug="false"
     scan="false"
 >
+  <shutdownHook/>
 
   <!-- since `base` module is on CP of all projects, this will be inherited by all projects -->
   <appender name="FileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">


### PR DESCRIPTION
* Upgrades Logback to 1.4.x
* Upgrades SLF4J API to 2.0.x
* Removes old shutdown hook workaround/hack no longer needed on 1.3+

See https://logback.qos.ch/news.html and https://www.slf4j.org/news.html

**Version Considerations**
Note that technically Logback 1.4.0 requires use of `jakarta.servlet` namespace, however that would require a Jetty 11 upgrade (and a whole lot of other dependency changes). However GoCD doesn't seem to be relying on magic from logback to attach itself to the servlet context right now, so this seems not important. Since 1.4.0 is compiled against Java 11 rather than Java 8 (for 1.3.0) it seems better to move to 1.4.0 if there are no other issues.

**Tested**

Combinations all tested for
 - server logging working OK
 - server plugin logs OK
 - agent bootstrapper OK
 - agent launcher OK
 - agent itself OK

Combinations:
- [x] New bootstrapper (SLF4J 2) bootstrapping new agent (SLF4j 2)
  - [x] fresh bootstrap
  - [x] upgrade/downgrade of agent  
- [x] New bootstrapper (SLF4J 2) bootstrapping old agent (SLF4j 1.7.x via `23.1.0`)
  - [x] fresh bootstrap
  - [x] upgrade/downgrade of agent  
- [x] Old bootstrapper (SLF4J 1.7.x  via `23.1.0`) bootstrapping new agent (SLF4J 2)
  - [x] fresh bootstrap
  - [x] upgrade/downgrade of agent  
- [x] OSGi and plugins that include SLF4J or a logger impl in them work as before (SLF4j 2.x server  2.x plugin)
- [x] OSGi and plugins that include SLF4J or a logger impl in them work as before (SLF4j 1.7.x server  2.x plugin)
- [x] OSGi and plugins that include SLF4J or a logger impl in them work as before (SLF4j 2.x server, 1.7.x plugin)
- [x] TFS usage and logging (since it has a weird special classloader setup)