### PR TITLE
Improve logging of output to assist with backup debugging

### DIFF
--- a/db-support/db-support-mysql/src/main/java/com/thoughtworks/go/server/database/mysql/MySQLBackupProcessor.java
+++ b/db-support/db-support-mysql/src/main/java/com/thoughtworks/go/server/database/mysql/MySQLBackupProcessor.java
@@ -93,8 +93,8 @@ public class MySQLBackupProcessor implements BackupProcessor {
         argv.add(connectionUrlInstance.getDatabase());
 
         ProcessExecutor processExecutor = new ProcessExecutor();
-        processExecutor.redirectOutputAlsoTo(Slf4jStream.of(getClass()).asDebug());
-        processExecutor.redirectErrorAlsoTo(Slf4jStream.of(getClass()).asDebug());
+        processExecutor.redirectOutputAlsoTo(Slf4jStream.of(getClass()).asInfo());
+        processExecutor.redirectErrorAlsoTo(Slf4jStream.of(getClass()).asWarn());
         processExecutor.environment(env);
         processExecutor.command(argv);
         return processExecutor;

--- a/db-support/db-support-postgresql/src/main/java/com/thoughtworks/go/server/database/pg/PostgresqlBackupProcessor.java
+++ b/db-support/db-support-postgresql/src/main/java/com/thoughtworks/go/server/database/pg/PostgresqlBackupProcessor.java
@@ -86,8 +86,8 @@ public class PostgresqlBackupProcessor implements BackupProcessor {
         }
         argv.add("--file=" + new File(targetDir, "db." + dbName));
         ProcessExecutor processExecutor = new ProcessExecutor();
-        processExecutor.redirectOutputAlsoTo(Slf4jStream.of(getClass()).asDebug());
-        processExecutor.redirectErrorAlsoTo(Slf4jStream.of(getClass()).asDebug());
+        processExecutor.redirectOutputAlsoTo(Slf4jStream.of(getClass()).asInfo());
+        processExecutor.redirectErrorAlsoTo(Slf4jStream.of(getClass()).asWarn());
         processExecutor.environment(env);
         processExecutor.command(argv);
         return processExecutor;


### PR DESCRIPTION
Currently the output isnt actually logged at defaultish levels, even though the error tells you to look at the server logs. This fixes that so users have a chance of debugging an unexpected error.
