### PR TITLE
Add Alpine 3.17 agent docker images, changing server default to Alpine 3.17

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -33,6 +33,7 @@ enum Distro implements DistroBehavior {
         new DistroVersion(version: '3.14', releaseName: '3.14', eolDate: parseDate('2023-05-01')),
         new DistroVersion(version: '3.15', releaseName: '3.15', eolDate: parseDate('2023-11-01')),
         new DistroVersion(version: '3.16', releaseName: '3.16', eolDate: parseDate('2024-05-23')),
+        new DistroVersion(version: '3.17', releaseName: '3.17', eolDate: parseDate('2024-11-22')),
       ]
     }
 

--- a/settings-docker.gradle
+++ b/settings-docker.gradle
@@ -31,4 +31,4 @@ Distro.values().each { distro ->
 
 include ":docker:gocd-server:${Distro.centos.projectName(Distro.centos.getVersion('8'))}"
 include ":docker:gocd-server:${Distro.centos.projectName(Distro.centos.getVersion('9'))}"
-include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.16'))}"
+include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.17'))}"


### PR DESCRIPTION
See https://alpinelinux.org/posts/Alpine-3.17.0-released.html