### PR TITLE
Remove Centos 8 server builds

### DIFF
--- a/settings-docker.gradle
+++ b/settings-docker.gradle
@@ -29,6 +29,5 @@ Distro.values().each { distro ->
   }
 }
 
-include ":docker:gocd-server:${Distro.centos.projectName(Distro.centos.getVersion('8'))}"
 include ":docker:gocd-server:${Distro.centos.projectName(Distro.centos.getVersion('9'))}"
 include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.17'))}"


### PR DESCRIPTION
These have never been officially published on the website, so they are likely to have low usage, and there is no official support policy. Let's remove a headache for ourselves by removing Centos Stream 8 so we have focus on Centos Stream 9 which has been out over a year now.