### PR TITLE
Fix expected version of httpcore jar after httpclient upgrade

### DIFF
--- a/agent-bootstrapper/build.gradle
+++ b/agent-bootstrapper/build.gradle
@@ -71,7 +71,7 @@ task verifyJar(type: VerifyJarTask) {
       "commons-io-${project.versions.commonsIO}.jar",
       "commons-lang3-${project.versions.commonsLang3}.jar",
       "httpclient-${project.versions.apacheHttpComponents}.jar",
-      "httpcore-4.4.13.jar",
+      "httpcore-4.4.16.jar",
       "jcl-over-slf4j-${project.versions.slf4j}.jar",
       "jcommander-${project.versions.jcommander}.jar",
       "joda-time-${project.versions.jodaTime}.jar",

--- a/agent-launcher/build.gradle
+++ b/agent-launcher/build.gradle
@@ -64,7 +64,7 @@ task verifyJar(type: VerifyJarTask) {
           "commons-io-${project.versions.commonsIO}.jar",
           "commons-lang3-${project.versions.commonsLang3}.jar",
           "httpclient-${project.versions.apacheHttpComponents}.jar",
-          "httpcore-4.4.13.jar",
+          "httpcore-4.4.16.jar",
           "jcl-over-slf4j-${project.versions.slf4j}.jar",
           "jcommander-${project.versions.jcommander}.jar",
           "joda-time-${project.versions.jodaTime}.jar",

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -158,7 +158,7 @@ task verifyJar(type: VerifyJarTask) {
       "gson-${project.versions.gson}.jar",
       "guava-${project.versions.guava}.jar",
       "httpclient-${project.versions.apacheHttpComponents}.jar",
-      "httpcore-4.4.13.jar",
+      "httpcore-4.4.16.jar",
       "httpmime-${project.versions.apacheHttpComponents}.jar",
       "istack-commons-runtime-4.1.1.jar",
       "j2objc-annotations-1.3.jar",

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -856,7 +856,7 @@ task verifyWar(type: VerifyJarTask) {
         "hibernate-ehcache-${project.versions.hibernate}.jar",
         "hibernate-jpa-2.0-api-1.0.1.Final.jar",
         "httpclient-${project.versions.apacheHttpComponents}.jar",
-        "httpcore-4.4.13.jar",
+        "httpcore-4.4.16.jar",
         "httpmime-${project.versions.apacheHttpComponents}.jar",
         "istack-commons-runtime-4.1.1.jar",
         "j2objc-annotations-1.3.jar",


### PR DESCRIPTION
Follow-up to #11076 to fix expectations on transient dependency jars.