### PR TITLE
Revert "ui: bump net-imap from 0.3.1 to 0.3.2 in /server/src/main/webapp/WEB-INF/rails"

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -82,7 +82,6 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
-    date (3.3.0)
     diff-lcs (1.5.0)
     erubi (1.11.0)
     ffi (1.15.5-java)
@@ -107,8 +106,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.16.3)
-    net-imap (0.3.2)
-      date
+    net-imap (0.3.1)
       net-protocol
     net-pop (0.1.2)
       net-protocol


### PR DESCRIPTION
Reverts gocd/gocd#11091

`date` `3.3.0` doesn't seem to install on JRuby:

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/go/pipelines/build-linux/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/gems/date-3.3.0/ext/date
/go/pipelines/build-linux/server/scripts/jruby -I
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib extconf.rb
checking for rb_category_warn()... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=uri:classloader:/META-INF/jruby.home/bin/jruby
RuntimeError: The compiler failed to generate an executable file.
You have to install development tools first.

try_do at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/mkmf.rb:456
try_link0 at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/mkmf.rb:541
try_link at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/mkmf.rb:556
try_func at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/mkmf.rb:765
have_func at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/mkmf.rb:1051
checking_for at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/mkmf.rb:942
postpone at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/mkmf.rb:350
open at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/mkmf.rb:320
postpone at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/mkmf.rb:350
open at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/mkmf.rb:320
postpone at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/mkmf.rb:346
checking_for at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/mkmf.rb:941
have_func at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/mkmf.rb:1050
        <main> at extconf.rb:6
... 15 levels...

To see why this extension failed to compile, please check the mkmf.log which can
be found here:

/go/pipelines/build-linux/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/extensions/universal-java-17/3.1.0/date-3.3.0/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in
/go/pipelines/build-linux/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/gems/date-3.3.0
for inspection.
Results logged to
/go/pipelines/build-linux/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/extensions/universal-java-17/3.1.0/date-3.3.0/gem_make.out

uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:102:in
`run'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/ext_conf_builder.rb:28:in
`build'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:171:in
`build_extension'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:205:in
`block in build_extensions'
  org/jruby/RubyArray.java:1988:in `each'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:202:in
`build_extensions'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/installer.rb:843:in
`build_extensions'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/rubygems_gem_installer.rb:72:in
`build_extensions'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/rubygems_gem_installer.rb:28:in
`install'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/source/rubygems.rb:207:in
`install'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/installer/gem_installer.rb:54:in
`install'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/installer/gem_installer.rb:16:in
`install_from_spec'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/installer/parallel_installer.rb:186:in
`do_install'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/installer/parallel_installer.rb:177:in
`block in worker_pool'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/worker.rb:62:in
`apply_func'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/worker.rb:57:in
`block in process_queue'
  org/jruby/RubyKernel.java:1586:in `loop'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/worker.rb:54:in
`process_queue'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/worker.rb:91:in
`block in create_threads'

An error occurred while installing date (3.3.0), and Bundler cannot continue.

In Gemfile:
  rails was resolved to 6.1.7, which depends on
    actionmailbox was resolved to 6.1.7, which depends on
      mail was resolved to 2.8.0, which depends on
        net-imap was resolved to 0.3.2, which depends on
          date
```