### PR TITLE
Add direct sprockets dependency for forward compat with Rails 7

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile
@@ -3,6 +3,7 @@ ruby '3.1.0'
 
 platforms :jruby do
   gem 'rails'
+  gem 'sprockets-rails'
 
   # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
   gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -250,6 +250,7 @@ DEPENDENCIES
   sassc!
   sassc-embedded
   sassc-rails
+  sprockets-rails
   ts_routes
   tzinfo-data
 


### PR DESCRIPTION
See https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#sprockets-is-now-an-optional-dependency