### PR TITLE
Correct ruby-date java dependency variant

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -82,14 +82,13 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
-    date (3.3.3)
+    date (3.3.3-java)
     diff-lcs (1.5.0)
     erubi (1.11.0)
     ffi (1.15.5-java)
     globalid (1.0.0)
       activesupport (>= 5.0)
     google-protobuf (3.21.12-java)
-    google-protobuf (3.21.12-x86_64-linux)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     js-routes (1.4.14)
@@ -116,11 +115,8 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    nio4r (2.5.8)
     nio4r (2.5.8-java)
     nokogiri (1.13.10-java)
-      racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     pry (0.14.1-java)
       coderay (~> 1.1)
@@ -130,7 +126,6 @@ GEM
       pry (>= 0.13, < 0.15)
       ruby-debug-base (>= 0.10.4, < 0.12)
     public_suffix (5.0.1)
-    racc (1.6.1)
     racc (1.6.1-java)
     rack (2.2.4)
     rack-test (2.0.2)
@@ -223,8 +218,6 @@ GEM
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2022.7)
       tzinfo (>= 1.0.0)
-    websocket-driver (0.7.5)
-      websocket-extensions (>= 0.1.0)
     websocket-driver (0.7.5-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -235,7 +228,6 @@ GEM
 PLATFORMS
   java
   universal-java-17
-  x86_64-linux
 
 DEPENDENCIES
   capybara


### PR DESCRIPTION
Follow-up to #11115 to correct the Java variant of ruby-date