### PR TITLE
Remove bundling of the yum-repo-poller plugin

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1013,7 +1013,6 @@ task licenseReportAggregate {
                                  'gocd-yaml-config-plugin.jar',
                                  'gocd-filebased-authentication-plugin.jar',
                                  'gocd-ldap-authentication-plugin.jar',
-                                 'gocd-yum-repository-poller-plugin.jar',
                                  'gocd-file-based-secrets-plugin.jar']
 
   def getAllJarDependencies = {

--- a/tw-go-plugins/build.gradle
+++ b/tw-go-plugins/build.gradle
@@ -39,13 +39,6 @@ def dependencies = [
     checksum: 'f8603c66007feb5bccda62a7a9169a7d1c6dabad2775277fcd9b8641f4687065'
   ),
   new GithubArtifact(
-    user: 'gocd',
-    repo: 'gocd-yum-repository-poller-plugin',
-    tagName: 'v2.0.6-135',
-    asset: 'gocd-yum-repo-plugin-2.0.6-135.jar',
-    checksum: '5988384979750c4f450896ab52af8729f4a8602ec2c37ed45da5482a13539654'
-  ),
-  new GithubArtifact(
     user: 'tomzo',
     repo: 'gocd-yaml-config-plugin',
     tagName: '0.14.1',


### PR DESCRIPTION
Having [this plugin](https://github.com/gocd/gocd-yum-repository-poller-plugin) bundled imposes a cost on all agent initialisations since it is a package repo plugin and a relatively uncommon use case in the current setup. Better to allow people to add this if they need it IMHO.

It also has some challenges due to compatibility with various RHEL/CentOS versions over time and the transition from yum to dnf (and aliasing of dnf back to `yum`) as per #3974 and https://github.com/gocd/gocd/issues/3974#issuecomment-1003149583

This is a **breaking change** and will need to be communicated in the release notes with indication of how to add it back.

Other things to do
- [x] Validate that config is not lost if server started without the plugin, and then functionality restored when plugin added
- [ ] Add it back to build.gocd.org plugin install automation (not used, but can be useful)
- [x] Ensure it is available for ruby-functional-test regression suite if used there
- [ ] Change the ruby-functional-test expectations to expect to be bundled
- [x] Update the README for the plugin itself
  - Done [here](https://github.com/gocd/gocd-yum-repository-poller-plugin/commit/f6d705d9afbdcfce58890ab581b6dad91329cb6c)
- [x] Prepare instructions for upgrade in release notes and update plugins page
  - Done [here](https://github.com/gocd/www.go.cd/pull/1436)
- [x] Update docs on docs.gocd.org  
  - Done [here](https://github.com/gocd/docs.go.cd/commit/8ee877bdfaba073aa9b1eb25e7ad8a9a9707904c)