### PR TITLE
Supported building aarch64 images locally

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/AdoptiumVersion.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/AdoptiumVersion.groovy
@@ -53,13 +53,13 @@ class AdoptiumVersion implements Serializable {
     update == null ? '' : 'U'
   }
 
-  def toDownloadURLFor(OperatingSystem os, Architecture arch = Architecture.x64) {
+  def toDownloadURLFor(OperatingSystem os, Architecture arch) {
     "https://github.com/adoptium/temurin${feature}-binaries/releases/download/" +
       "jdk-${urlSafeDisplayVersion()}/" +
       "OpenJDK${feature}${featureSuffix()}-jre_${arch.canonicalName}_${os.adoptiumAlias}_hotspot_${fileSafeDisplayVersion()}.${os.extension}"
   }
 
-  def toSha256SumURLFor(OperatingSystem os, Architecture arch = Architecture.x64) {
+  def toSha256SumURLFor(OperatingSystem os, Architecture arch) {
     "${toDownloadURLFor(os, arch)}.sha256.txt"
   }
 

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/BuildDockerImageTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/BuildDockerImageTask.groovy
@@ -85,7 +85,7 @@ class BuildDockerImageTask extends DefaultTask {
     if (!project.hasProperty('skipDockerBuild')) {
       def targetArch = distro.dockerTargetArchitecture(project.hasProperty('dockerBuildIgnoreLocalArch'))
 
-      logger.lifecycle("Building ${distro} image for ${targetArch}. (Current build architecture is ${Architecture.current()}).")
+      logger.lifecycle("Building ${distro} image for ${targetArch}. (Current build architecture is ${Architecture.current()}).\n")
 
       // build image
       executeInGitRepo("docker", "build",
@@ -96,13 +96,14 @@ class BuildDockerImageTask extends DefaultTask {
         "--tag", imageNameWithTag
       )
 
+      logger.lifecycle("\nVerifying ${imageNameWithTag} image for ${targetArch}. (Current build architecture is ${Architecture.current()}).\n")
+
       // verify image
       if (verifyHelper != null) {
         verifyHelper.call()
       }
 
-      // give docker some some to stop the container (from the verify helper)
-      Thread.sleep(10000)
+      logger.lifecycle("\nVerification of ${imageNameWithTag} image on ${targetArch} successful. Exporting...\n")
 
       // export to tar
       project.mkdir(imageTarFile.parentFile)

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/BuildDockerImageTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/BuildDockerImageTask.groovy
@@ -100,7 +100,7 @@ class BuildDockerImageTask extends DefaultTask {
 
       // verify image
       if (verifyHelper != null) {
-        verifyHelper.call()
+        verifyHelper.call(targetArch == Architecture.current())
       }
 
       logger.lifecycle("\nVerification of ${imageNameWithTag} image on ${targetArch} successful. Exporting...\n")

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -16,17 +16,13 @@
 
 package com.thoughtworks.go.build.docker
 
+import com.thoughtworks.go.build.Architecture
 import com.thoughtworks.go.build.OperatingSystem
 import org.gradle.api.Project
 
 enum Distro implements DistroBehavior {
 
   alpine{
-    @Override
-    OperatingSystem getOperatingSystem() {
-      OperatingSystem.linux
-    }
-
     @Override
     List<DistroVersion> getSupportedVersions() {
       return [
@@ -95,6 +91,11 @@ enum Distro implements DistroBehavior {
 
   centos{
     @Override
+    Set<Architecture> getSupportedArchitectures() {
+      [Architecture.x64, Architecture.aarch64]
+    }
+
+    @Override
     String getBaseImageRegistry(DistroVersion v) {
       v.lessThan(8) ? super.baseImageRegistry : "quay.io/centos"
     }
@@ -109,8 +110,8 @@ enum Distro implements DistroBehavior {
 
       String git = gitPackageFor(v)
       commands += "${pkg} install -y ${git} mercurial subversion openssh-clients bash unzip procps" +
-          (v.lessThan(8) ? ' sysvinit-tools coreutils' : ' procps-ng coreutils-single') +
-          (v.lessThan(9) ? ' curl' : ' curl-minimal')
+        (v.lessThan(8) ? ' sysvinit-tools coreutils' : ' procps-ng coreutils-single') +
+        (v.lessThan(9) ? ' curl' : ' curl-minimal')
 
       if (v.lessThan(8)) {
         commands += "cp /opt/rh/${git}/enable /etc/profile.d/${git}.sh"
@@ -155,6 +156,11 @@ enum Distro implements DistroBehavior {
 
   debian{
     @Override
+    Set<Architecture> getSupportedArchitectures() {
+      [Architecture.x64, Architecture.aarch64]
+    }
+
+    @Override
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
       return [
         'apt-get update',
@@ -176,6 +182,11 @@ enum Distro implements DistroBehavior {
   },
 
   ubuntu{
+    @Override
+    Set<Architecture> getSupportedArchitectures() {
+      debian.supportedArchitectures
+    }
+
     @Override
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
       return debian.getInstallPrerequisitesCommands(v)

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -169,7 +169,7 @@ enum Distro implements DistroBehavior {
         'apt-get clean all',
         'rm -rf /var/lib/apt/lists/*',
         'echo \'en_US.UTF-8 UTF-8\' > /etc/locale.gen && /usr/sbin/locale-gen'
-      ]
+      ].collect {cmd -> cmd.startsWith('apt-get') ? "DEBIAN_FRONTEND=noninteractive $cmd" : cmd }
     }
 
     @Override

--- a/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
@@ -19,6 +19,7 @@
 
 FROM curlimages/curl:latest as gocd-server-unzip
 USER root
+ARG TARGETARCH
 ARG UID=1000
 <#if useFromArtifact >
 COPY go-server-${fullVersion}.zip /tmp/go-server-${fullVersion}.zip
@@ -26,20 +27,22 @@ RUN \
 <#else>
 RUN curl --fail --location --silent --show-error "https://download.gocd.org/binaries/${fullVersion}/generic/go-server-${fullVersion}.zip" > /tmp/go-server-${fullVersion}.zip && \
 </#if>
-    unzip /tmp/go-server-${fullVersion}.zip -d / && \
+    unzip -q /tmp/go-server-${fullVersion}.zip -d / && \
     mkdir -p /go-server/wrapper /go-server/bin && \
-    mv /go-server-${goVersion}/LICENSE /go-server/LICENSE && \
-    mv /go-server-${goVersion}/bin/go-server /go-server/bin/go-server && \
-    mv /go-server-${goVersion}/lib /go-server/lib && \
-    mv /go-server-${goVersion}/logs /go-server/logs && \
-    mv /go-server-${goVersion}/run /go-server/run && \
-    mv /go-server-${goVersion}/wrapper-config /go-server/wrapper-config && \
-    mv /go-server-${goVersion}/wrapper/wrapper-linux* /go-server/wrapper/ && \
-    mv /go-server-${goVersion}/wrapper/libwrapper-linux* /go-server/wrapper/ && \
-    mv /go-server-${goVersion}/wrapper/wrapper.jar /go-server/wrapper/ && \
+    mv -v /go-server-${goVersion}/LICENSE /go-server/LICENSE && \
+    mv -v /go-server-${goVersion}/bin/go-server /go-server/bin/go-server && \
+    mv -v /go-server-${goVersion}/lib /go-server/lib && \
+    mv -v /go-server-${goVersion}/logs /go-server/logs && \
+    mv -v /go-server-${goVersion}/run /go-server/run && \
+    mv -v /go-server-${goVersion}/wrapper-config /go-server/wrapper-config && \
+    WRAPPERARCH=${dockerAliasToWrapperArchAsShell} && \
+    mv -v /go-server-${goVersion}/wrapper/wrapper-linux-$WRAPPERARCH* /go-server/wrapper/ && \
+    mv -v /go-server-${goVersion}/wrapper/libwrapper-linux-$WRAPPERARCH* /go-server/wrapper/ && \
+    mv -v /go-server-${goVersion}/wrapper/wrapper.jar /go-server/wrapper/ && \
     chown -R ${r"${UID}"}:0 /go-server && chmod -R g=u /go-server
 
 FROM ${distro.getBaseImageLocation(distroVersion)}
+ARG TARGETARCH
 
 LABEL gocd.version="${goVersion}" \
   description="GoCD server based on ${distro.getBaseImageLocation(distroVersion)}" \

--- a/docker/gocd-agent/build.gradle
+++ b/docker/gocd-agent/build.gradle
@@ -101,10 +101,19 @@ subprojects {
       }
     }
 
-    task.verifyHelper = {
-      // test image
+    // test image
+    task.verifyHelper = { boolean isNative ->
+      def cleanContainer = {     // remove the container
+        project.exec {
+          workingDir = project.rootProject.projectDir
+          commandLine = ["docker", "rm", "--force", docker.dockerImageName]
+          standardOutput = System.out
+          errorOutput = System.err
+        }
+      }
 
       // daemonize the container
+      cleanContainer.call() // Clean-up after any previous aborted runs
       project.exec {
         workingDir = project.rootProject.projectDir
         commandLine = ["docker", "run", "-e", "GO_SERVER_URL=http://localhost:8153/go", "-d", "--name", docker.dockerImageName, docker.imageNameWithTag]
@@ -112,7 +121,11 @@ subprojects {
         errorOutput = System.err
       }
 
-      Thread.sleep(5000)
+      // Need to wait for start. Would be better to have some polling mechanism here with a timeout.
+      def sleep = isNative ? 5000 : 10000
+      logger.lifecycle("\nWaiting ${sleep}ms for ${isNative ? 'native' : 'emulated'} agent container to start...")
+      Thread.sleep(sleep)
+      logger.lifecycle("Should be started now...")
 
       // run a `ps aux`
       ByteArrayOutputStream psOutput = new ByteArrayOutputStream()
@@ -134,12 +147,7 @@ subprojects {
       }
 
       // remove the container
-      project.exec {
-        workingDir = project.rootProject.projectDir
-        commandLine = ["docker", "rm", "--force", docker.dockerImageName]
-        standardOutput = System.out
-        errorOutput = System.err
-      }
+      cleanContainer.call()
 
       // assert if process was running
       def expectedProcess = "lib/agent-bootstrapper.jar -serverUrl http://localhost:8153/go"

--- a/docker/gocd-server/build.gradle
+++ b/docker/gocd-server/build.gradle
@@ -92,10 +92,19 @@ subprojects {
       }
     }
 
-    task.verifyHelper = {
-      // test image
+    // test image
+    task.verifyHelper = { boolean isNative ->
+      def cleanContainer = {     // remove the container
+        project.exec {
+          workingDir = project.rootProject.projectDir
+          commandLine = ["docker", "rm", "--force", docker.dockerImageName]
+          standardOutput = System.out
+          errorOutput = System.err
+        }
+      }
 
       // daemonize the container
+      cleanContainer.call() // Clean-up after any previous aborted runs
       project.exec {
         workingDir = project.rootProject.projectDir
         commandLine = ["docker", "run", "-d", "--name", docker.dockerImageName, docker.imageNameWithTag]
@@ -103,16 +112,11 @@ subprojects {
         errorOutput = System.err
       }
 
-      Thread.sleep(10000)
-
-      ByteArrayOutputStream containerOutput = new ByteArrayOutputStream()
-      project.exec {
-        workingDir = project.rootProject.projectDir
-        commandLine = ["docker", "logs", docker.dockerImageName]
-        standardOutput = containerOutput
-        errorOutput = containerOutput
-        ignoreExitValue = true
-      }
+      // Need to wait for start. Would be better to have some polling mechanism here with a timeout.
+      def sleep = isNative ? 10000 : 15000
+      logger.lifecycle("\nWaiting ${sleep}ms for ${isNative ? 'native' : 'emulated'} agent container to start...")
+      Thread.sleep(sleep)
+      logger.lifecycle("Should be started now...")
 
       // run a `ps aux`
       ByteArrayOutputStream psOutput = new ByteArrayOutputStream()
@@ -124,19 +128,23 @@ subprojects {
         ignoreExitValue = true
       }
 
-      // remove the container
+      ByteArrayOutputStream containerOutput = new ByteArrayOutputStream()
       project.exec {
         workingDir = project.rootProject.projectDir
-        commandLine = ["docker", "rm", "--force", docker.dockerImageName]
-        standardOutput = System.out
-        errorOutput = System.err
+        commandLine = ["docker", "logs", docker.dockerImageName]
+        standardOutput = containerOutput
+        errorOutput = containerOutput
+        ignoreExitValue = true
       }
 
+      // remove the container
+      cleanContainer.call()
+
       // assert if process was running
-      def expectedString = "lib/go.jar"
+      def expectedProcess = "lib/go.jar"
       def processList = psOutput.toString()
-      if (!processList.contains(expectedString)) {
-        throw new GradleException("Expected process output to contain ${expectedString}, but was: [${processList}]\n\nContainer output:\n${containerOutput.toString()}")
+      if (!processList.contains(expectedProcess)) {
+        throw new GradleException("Expected process output to contain ${expectedProcessg}, but was: [${processList}]\n\nContainer output:\n${containerOutput.toString()}")
       }
     }
   }

--- a/installers/generic.gradle
+++ b/installers/generic.gradle
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import com.thoughtworks.go.build.Architecture
 import com.thoughtworks.go.build.InstallerMetadataTask
 import com.thoughtworks.go.build.InstallerType
 import org.apache.tools.ant.filters.ConcatFilter
@@ -242,7 +243,7 @@ def configureGenericZip(Zip zipTask, InstallerType installerType) {
   }
 
   zipTask.finalizedBy(project.tasks.create("${zipTask.name}Metadata", InstallerMetadataTask.class) {
-    architecture = com.thoughtworks.go.build.Architecture.all
+    architecture = Architecture.all
     packageTask = zipTask
     type = installerType
   })

--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import com.thoughtworks.go.build.Architecture
-import com.thoughtworks.go.build.DownloadFile
-import com.thoughtworks.go.build.InstallerMetadataTask
-import com.thoughtworks.go.build.InstallerType
+import com.thoughtworks.go.build.*
 import groovy.json.JsonOutput
 import org.apache.commons.codec.digest.DigestUtils
 import org.apache.tools.ant.filters.ConcatFilter
@@ -105,13 +102,13 @@ private File destFile(String url) {
 }
 
 task downloadLinuxJreChecksum(type: DownloadFile) {
-  src project.packaging.adoptiumJavaVersion.toSha256SumURLFor(com.thoughtworks.go.build.OperatingSystem.linux)
+  src project.packaging.adoptiumJavaVersion.toSha256SumURLFor(OperatingSystem.linux, Architecture.x64)
   dest destFile(src.toString())
 }
 
 task downloadLinuxJre(type: DownloadFile) {
   dependsOn downloadLinuxJreChecksum
-  src project.packaging.adoptiumJavaVersion.toDownloadURLFor(com.thoughtworks.go.build.OperatingSystem.linux)
+  src project.packaging.adoptiumJavaVersion.toDownloadURLFor(OperatingSystem.linux, Architecture.x64)
   dest destFile(src.toString())
   checksum = { downloadLinuxJreChecksum.outputs.files.singleFile.getText("utf-8").trim().split(" ").first() }
 }

--- a/installers/osx.gradle
+++ b/installers/osx.gradle
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-import com.thoughtworks.go.build.Architecture
-import com.thoughtworks.go.build.DownloadFile
-import com.thoughtworks.go.build.InstallerMetadataTask
-import com.thoughtworks.go.build.InstallerType
+
+import com.thoughtworks.go.build.*
 import org.apache.commons.codec.digest.DigestUtils
 
 private File destFile(String url) {
@@ -25,25 +23,25 @@ private File destFile(String url) {
 }
 
 task downloadMacJreX64Checksum(type: DownloadFile) {
-  src project.packaging.adoptiumJavaVersion.toSha256SumURLFor(com.thoughtworks.go.build.OperatingSystem.mac)
+  src project.packaging.adoptiumJavaVersion.toSha256SumURLFor(OperatingSystem.mac, Architecture.x64)
   dest destFile(src.toString())
 }
 
 task downloadMacJreX64(type: DownloadFile) {
   dependsOn downloadMacJreX64Checksum
-  src project.packaging.adoptiumJavaVersion.toDownloadURLFor(com.thoughtworks.go.build.OperatingSystem.mac)
+  src project.packaging.adoptiumJavaVersion.toDownloadURLFor(OperatingSystem.mac, Architecture.x64)
   dest destFile(src.toString())
   checksum = { downloadMacJreX64Checksum.outputs.files.singleFile.getText("utf-8").trim().split(" ").first() }
 }
 
 task downloadMacJreArm64Checksum(type: DownloadFile) {
-  src project.packaging.adoptiumJavaVersion.toSha256SumURLFor(com.thoughtworks.go.build.OperatingSystem.mac, Architecture.aarch64)
+  src project.packaging.adoptiumJavaVersion.toSha256SumURLFor(OperatingSystem.mac, Architecture.aarch64)
   dest destFile(src.toString())
 }
 
 task downloadMacJreArm64(type: DownloadFile) {
   dependsOn downloadMacJreArm64Checksum
-  src project.packaging.adoptiumJavaVersion.toDownloadURLFor(com.thoughtworks.go.build.OperatingSystem.mac, Architecture.aarch64)
+  src project.packaging.adoptiumJavaVersion.toDownloadURLFor(OperatingSystem.mac, Architecture.aarch64)
   dest destFile(src.toString())
   checksum = { downloadMacJreArm64Checksum.outputs.files.singleFile.getText("utf-8").trim().split(" ").first() }
 }

--- a/installers/windows.gradle
+++ b/installers/windows.gradle
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-import com.thoughtworks.go.build.Architecture
-import com.thoughtworks.go.build.DownloadFile
-import com.thoughtworks.go.build.InstallerMetadataTask
-import com.thoughtworks.go.build.InstallerType
+
+import com.thoughtworks.go.build.*
 import org.apache.commons.codec.digest.DigestUtils
 import org.apache.tools.ant.filters.FixCrLfFilter
 
@@ -26,13 +24,13 @@ private File destFile(String url) {
 }
 
 task downloadWindowsJreChecksum(type: DownloadFile) {
-  src project.packaging.adoptiumJavaVersion.toSha256SumURLFor(com.thoughtworks.go.build.OperatingSystem.windows)
+  src project.packaging.adoptiumJavaVersion.toSha256SumURLFor(OperatingSystem.windows, Architecture.x64)
   dest destFile(src.toString())
 }
 
 task downloadWindowsJre(type: DownloadFile) {
   dependsOn downloadWindowsJreChecksum
-  src project.packaging.adoptiumJavaVersion.toDownloadURLFor(com.thoughtworks.go.build.OperatingSystem.windows)
+  src project.packaging.adoptiumJavaVersion.toDownloadURLFor(OperatingSystem.windows, Architecture.x64)
   dest destFile(src.toString())
   checksum = { downloadWindowsJreChecksum.outputs.files.singleFile.getText("utf-8").trim().split(" ").first() }
 }


### PR DESCRIPTION
In particular on Apple Silicom/arm64/aarch4 machines

1) Includes only necessary wrapper architectures required for agent images for clarity (matches current server semantics)
2) Adds support during docker build of images to use the correct architecture for tini & downloaded JRE
2) Defaults Gradle docker builds to the user/environment's local architecture.

This is backwards compatible with the current build process so does not change the released/built architectures of images.
- If you are running on Apple Silicon it will build native images by default which can be much more quickly tested and sanity checked locally
- For images which are not supported on your local arch, will fail fast (e.g Alpine images on arm64 don't work currently due to needing glibc compiled for aarch64)
- Can pass `-PdockerBuildIgnoreLocalArch` to build for GoCD's preferred/released arch (always x64 right now)

This is a stepping stone towards arm64/aarch64 support in #8544 and improves the local dev experience for folks running arm64/aarch64 hardware.