### PR TITLE
Enable fastestmirror plugin for CentOS image builds

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -104,6 +104,7 @@ enum Distro implements DistroBehavior {
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
       def pkg = v.lessThan(8) ? 'yum' : 'dnf'
       def commands = [
+        "echo 'fastestmirror=1' >> /etc/${pkg == 'yum' ? 'yum' : 'dnf/dnf'}.conf",
         "${pkg} update -y",
         "${pkg} upgrade -y",
       ]
@@ -120,6 +121,7 @@ enum Distro implements DistroBehavior {
       commands += [
         "${pkg} clean all",
         "rm -rf /var/cache/${pkg}",
+        "sed -i -e s/fastestmirror=1//g /etc/${pkg == 'yum' ? 'yum' : 'dnf/dnf'}.conf",
       ]
 
       return commands


### PR DESCRIPTION
CentOS mirrors seem randomly slow in Asia a lot of the time, causing Docker builds to crawl to a halt. Seems better to use the capacity provided to use the fastest mirror during builds.