### PR TITLE
Correct aggregation of  test results with minified XML

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/domain/UnitTestReportGeneratorTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/UnitTestReportGeneratorTest.java
@@ -182,6 +182,32 @@ public class UnitTestReportGeneratorTest {
         }
 
         @Test
+        public void shouldGenerateReportForMinifiedJunit() throws Exception {
+            copyAndClose(source("junit-minified-from-pytest.xml"), target("junit-minified-from-pytest.xml"));
+
+            generator.generate(testFolder.listFiles(), "testoutput");
+
+            verify(publisher).upload(uploadedFile.capture(), any(String.class));
+            assertTestReportCssFor(CSS_TOTAL_TEST_COUNT).isEqualTo("1");
+            assertTestReportCssFor(CSS_FAILED_TEST_COUNT).isEqualTo("0");
+            assertTestReportCssFor(CSS_IGNORED_TEST_COUNT).isEqualTo("0");
+            assertTestReportCssFor(CSS_TEST_TIME).isEqualTo("15.839");
+        }
+
+        @Test
+        public void shouldGenerateReportForMinifiedJunitWithoutDeclaration() throws Exception {
+            copyAndClose(source("junit-minified-from-pytest-no-decl.xml"), target("junit-minified-from-pytest.xml"));
+
+            generator.generate(testFolder.listFiles(), "testoutput");
+
+            verify(publisher).upload(uploadedFile.capture(), any(String.class));
+            assertTestReportCssFor(CSS_TOTAL_TEST_COUNT).isEqualTo("1");
+            assertTestReportCssFor(CSS_FAILED_TEST_COUNT).isEqualTo("0");
+            assertTestReportCssFor(CSS_IGNORED_TEST_COUNT).isEqualTo("0");
+            assertTestReportCssFor(CSS_TEST_TIME).isEqualTo("15.839");
+        }
+
+        @Test
         public void shouldGenerateReportForJUnitWithMultipleFiles() throws Exception {
             copyAndClose(source("junit-result-four-tests.xml"), target("junit-result-four-tests.xml"));
             copyAndClose(source("junit-result-single-test.xml"), target("junit-result-single-test.xml"));
@@ -193,6 +219,20 @@ public class UnitTestReportGeneratorTest {
             assertTestReportCssFor(CSS_FAILED_TEST_COUNT).isEqualTo("3");
             assertTestReportCssFor(CSS_IGNORED_TEST_COUNT).isEqualTo("0");
             assertTestReportCssFor(CSS_TEST_TIME).isEqualTo("1.286");
+        }
+
+        @Test
+        public void shouldGenerateReportForMinifiedMixedWithOthersJunit() throws Exception {
+            copyAndClose(source("junit-minified-from-pytest.xml"), target("junit-minified-from-pytest.xml"));
+            copyAndClose(source("junit-result-four-tests.xml"), target("junit-result-single-test.xml"));
+
+            generator.generate(testFolder.listFiles(), "testoutput");
+
+            verify(publisher).upload(uploadedFile.capture(), any(String.class));
+            assertTestReportCssFor(CSS_TOTAL_TEST_COUNT).isEqualTo("5");
+            assertTestReportCssFor(CSS_FAILED_TEST_COUNT).isEqualTo("3");
+            assertTestReportCssFor(CSS_IGNORED_TEST_COUNT).isEqualTo("0");
+            assertTestReportCssFor(CSS_TEST_TIME).isEqualTo("16.669");
         }
     }
 

--- a/common/src/test/resources/data/test-results/junit-minified-from-pytest-no-decl.xml
+++ b/common/src/test/resources/data/test-results/junit-minified-from-pytest-no-decl.xml
@@ -1,0 +1,1 @@
+<testsuites><testsuite errors="0" failures="0" hostname="57ceaf161752" name="pytest" skipped="0" tests="1" time="17.323" timestamp="2023-01-04T17:55:43.134227"><testcase classname="tests.auth_test.SimpleAuthTest" file="tests/auth_test.py" line="24" name="test_backup_via_unprivileged_user" time="15.839"></testcase></testsuite></testsuites>

--- a/common/src/test/resources/data/test-results/junit-minified-from-pytest.xml
+++ b/common/src/test/resources/data/test-results/junit-minified-from-pytest.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite errors="0" failures="0" hostname="57ceaf161752" name="pytest" skipped="0" tests="1" time="17.323" timestamp="2023-01-04T17:55:43.134227"><testcase classname="tests.auth_test.SimpleAuthTest" file="tests/auth_test.py" line="24" name="test_backup_via_unprivileged_user" time="15.839"></testcase></testsuite></testsuites>

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/UnitTestReportGenerator.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/UnitTestReportGenerator.java
@@ -19,6 +19,7 @@ import com.thoughtworks.go.util.TestFileUtil;
 import com.thoughtworks.go.util.XpathUtils;
 import com.thoughtworks.go.work.GoPublisher;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RegExUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,12 +31,14 @@ import javax.xml.transform.stream.StreamSource;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
+import java.util.regex.Pattern;
 
 public class UnitTestReportGenerator {
     private static final String TEST_RESULTS_FILE = "index.html";
+    private static final Pattern LINE_STARTING_WITH_XML_DECLARATION = Pattern.compile("^\\s*<\\?xml.*?\\?>");
 
     private final File folderToUpload;
-    private GoPublisher publisher;
+    private final GoPublisher publisher;
     private static Templates templates;
 
     private static final Logger LOG = LoggerFactory.getLogger(UnitTestReportGenerator.class);
@@ -113,9 +116,7 @@ public class UnitTestReportGenerator {
     private void pumpFileContent(File file, PrintStream out) throws IOException {
         try (BufferedReader bufferedReader = new BufferedReader(new FileReader(file))) {
             String line = bufferedReader.readLine();
-            if (!line.contains("<?xml")) { // skip prolog
-                out.println(line);
-            }
+            out.println(RegExUtils.removeFirst(line, LINE_STARTING_WITH_XML_DECLARATION));
             while ((line = bufferedReader.readLine()) != null) {
                 out.println(line);
             }


### PR DESCRIPTION
- fixes #11159 
- fixes #266 
(there's also #983, #1132, #4732, #5319 and probably others)

This PR
- Uses a simple/dumb regex checked against only the first line to remove the XML declaration
- Avoids the mistakes of #1685 (revert in #1747) by still not attempting to parse the XML, and using a regex which should be able to abort scanning very quickly in most cases

In addition to the tests here, validated with the below (`-Xmx256m`)
- a 15MB test results file, with XML declaration on separate line
- a 15MB test results file, with XML declaration on same line (minified)