### PR TITLE
Fix minor nitpicks during build and startup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -934,7 +934,7 @@ task removeApi {
     file('settings.gradle').withWriter { out ->
       def newContents = settingsFileContents
         .stream()
-        .filter({ eachLine -> !eachLine.contains("api:${newProjectName}") })
+        .filter({ eachLine -> !eachLine.contains("':api:${newProjectName}'") })
         .collect(Collectors.joining("\n"))
         .trim() + "\n"
       out.println(newContents)

--- a/docker/gocd-agent/build.gradle
+++ b/docker/gocd-agent/build.gradle
@@ -123,7 +123,7 @@ subprojects {
 
       // Need to wait for start. Would be better to have some polling mechanism here with a timeout.
       def sleep = isNative ? 5000 : 10000
-      logger.lifecycle("\nWaiting ${sleep}ms for ${isNative ? 'native' : 'emulated'} agent container to start...")
+      logger.lifecycle("\nWaiting ${sleep}ms for ${isNative ? 'native' : 'emulated'} container to start...")
       Thread.sleep(sleep)
       logger.lifecycle("Should be started now...")
 

--- a/docker/gocd-server/build.gradle
+++ b/docker/gocd-server/build.gradle
@@ -114,7 +114,7 @@ subprojects {
 
       // Need to wait for start. Would be better to have some polling mechanism here with a timeout.
       def sleep = isNative ? 10000 : 15000
-      logger.lifecycle("\nWaiting ${sleep}ms for ${isNative ? 'native' : 'emulated'} agent container to start...")
+      logger.lifecycle("\nWaiting ${sleep}ms for ${isNative ? 'native' : 'emulated'} container to start...")
       Thread.sleep(sleep)
       logger.lifecycle("Should be started now...")
 

--- a/server/src/main/resources/applicationContext-global.xml
+++ b/server/src/main/resources/applicationContext-global.xml
@@ -121,7 +121,6 @@
   <context:component-scan base-package="com.thoughtworks.go.serverhealth"/>
   <context:component-scan base-package="com.thoughtworks.go.domain"/>
   <context:component-scan base-package="com.thoughtworks.go.service"/>
-  <context:component-scan base-package="com.thoughtworks.go.server.sweepers"/>
   <context:component-scan base-package="com.thoughtworks.go.server.cache"/>
   <context:component-scan base-package="com.thoughtworks.go.server.service"/>
   <context:component-scan base-package="com.thoughtworks.go.server.perf"/>


### PR DESCRIPTION
- remove an unnecessary non-existent package from Spring scanning
- fix some logging during testing docker images
- fix the `removeApi` helper to not remove `v1x` APIs when you intend to remove `v1`