### PR TITLE
Fix issues with wrapper stalling or crashing on container starts

### DIFF
--- a/installers/generic.gradle
+++ b/installers/generic.gradle
@@ -145,7 +145,8 @@ def configureGenericZip(Zip zipTask, InstallerType installerType) {
         if (eachLine == '#encoding=UTF-8') {
           def newLines = [
             '#encoding=UTF-8',
-            'wrapper.working.dir=..'
+            'wrapper.working.dir=..',
+            'wrapper.disable_console_input=TRUE'
           ]
 
           installerType.additionalEnvVars.forEach { k, v ->

--- a/installers/generic.gradle
+++ b/installers/generic.gradle
@@ -165,10 +165,6 @@ def configureGenericZip(Zip zipTask, InstallerType installerType) {
           eachLine = newLines.join('\n')
         }
 
-        if (eachLine == 'wrapper.java.additional.auto_bits=TRUE') {
-          eachLine = 'wrapper.java.additional.auto_bits=FALSE'
-        }
-
         if (eachLine == 'wrapper.java.classpath.1=../lib/wrapper.jar') {
           eachLine = [
             'wrapper.java.classpath.1=wrapper/wrapper.jar',

--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -227,10 +227,6 @@ def configureLinuxPackage(DefaultTask packageTask, InstallerType installerType, 
               eachLine = newLines.join('\n')
             }
 
-            if (eachLine == 'wrapper.java.additional.auto_bits=TRUE') {
-              eachLine = 'wrapper.java.additional.auto_bits=FALSE'
-            }
-
             if (eachLine == 'wrapper.java.command=java') {
               eachLine = "wrapper.java.command=/usr/share/${installerType.baseName}/jre/bin/java"
             }

--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -204,7 +204,8 @@ def configureLinuxPackage(DefaultTask packageTask, InstallerType installerType, 
             if (eachLine == '#encoding=UTF-8') {
               def newLines = [
                 '#encoding=UTF-8',
-                "wrapper.working.dir=/var/lib/${installerType.baseName}"
+                "wrapper.working.dir=/var/lib/${installerType.baseName}",
+                'wrapper.disable_console_input=TRUE'
               ]
 
               (installerType.additionalEnvVars + installerType.additionalLinuxEnvVars).forEach { k, v ->


### PR DESCRIPTION
Often (especially when testing the built docker images) we get errors when running within
containers (via `wrapper console`) such as:

```
  wrapper  | Failed to set JVM input handle to non blocking mode: Bad file descriptor (9)
  wrapper  | Failed to set JVM input handle to close on JVM exit: Bad file descriptor (9)
  wrapper  | Unable to set JVM's stdin: Bad file descriptor
  wrapper  | JVM exited while loading the application.
```

There are also sometimes weird delays starting the wrapper, which I think is due to this.

When running in regular mode on a direct Linux install via `wrapper start` the stdin isn't
attached to the wrapper anyway, so this should not be required at all. On advice from Tanuki
we can workaround this issue by disabling console input entirely. See
https://wrapper.tanukisoftware.com/doc/english/prop-disable-console-input.html