### PR TITLE
Bump packaged JRE from 17.0.5 to 17.0.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,9 +160,9 @@ project.ext.packaging = [
   adoptiumJavaVersion: new AdoptiumVersion(
     feature: 17,
     interim: 0,    // set to `null` for the first release of a new featureVersion
-    update : 5,    // set to `null` for the first release of a new featureVersion
+    update : 6,    // set to `null` for the first release of a new featureVersion
     patch  : null, // set to `null` for most releases. Patch releases are "exceptional".
-    build  : 8
+    build  : 10
   )
 ]
 


### PR DESCRIPTION
See https://www.oracle.com/java/technologies/javase/17-0-6-relnotes.html

https://github.com/adoptium/adoptium/issues/202
- [ ] Pending only aarch64 Mac