### PR TITLE
Crop overly long log lines

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -173,6 +173,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static final GoSystemProperty<Long> REAUTHENTICATION_TIME_INTERVAL = new GoLongSystemProperty("go.security.reauthentication.interval", 1800 * 1000L);
     public static final GoSystemProperty<Boolean> CONSOLE_OUT_TO_STDOUT = new GoBooleanSystemProperty("go.console.stdout", false);
     private static final GoSystemProperty<String> CONSOLE_LOG_CHARSET = new GoStringSystemProperty("go.console.log.charset", "utf-8");
+    public static final GoSystemProperty<Integer> CONSOLE_LOG_MAX_LINE_LENGTH = new GoIntSystemProperty("go.console.log.max.line.length", 1_000_000);
     private static final GoSystemProperty<Boolean> AGENT_STATUS_API_ENABLED = new GoBooleanSystemProperty("go.agent.status.api.enabled", true);
     private static final GoSystemProperty<String> AGENT_STATUS_API_BIND_HOST = new GoStringSystemProperty("go.agent.status.api.bind.host", "localhost");
     private static final GoSystemProperty<Integer> AGENT_STATUS_API_BIND_PORT = new GoIntSystemProperty("go.agent.status.api.bind.port", 8152);

--- a/commandline/src/main/java/com/thoughtworks/go/util/command/CommandLine.java
+++ b/commandline/src/main/java/com/thoughtworks/go/util/command/CommandLine.java
@@ -327,7 +327,13 @@ public class CommandLine {
         ProcessWrapper process;
         int exitCode;
 
-        SafeOutputStreamConsumer streamConsumer = new SafeOutputStreamConsumer(new ProcessOutputStreamConsumer(outputStreamConsumer, errorStreamConsumer));
+        SafeOutputStreamConsumer streamConsumer =
+            new SafeOutputStreamConsumer(
+                new BoundedOutputStreamConsumer(
+                    new ProcessOutputStreamConsumer(outputStreamConsumer, errorStreamConsumer),
+                    new SystemEnvironment().get(SystemEnvironment.CONSOLE_LOG_MAX_LINE_LENGTH)
+                )
+        );
         streamConsumer.addArguments(getArguments());
         streamConsumer.addSecrets(environmentVariableContext.secrets());
         try {

--- a/commandline/src/test/java/com/thoughtworks/go/util/command/CommandLineScriptRunnerTest.java
+++ b/commandline/src/test/java/com/thoughtworks/go/util/command/CommandLineScriptRunnerTest.java
@@ -15,16 +15,25 @@
  */
 package com.thoughtworks.go.util.command;
 
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import static com.thoughtworks.go.util.SystemEnvironment.CONSOLE_LOG_MAX_LINE_LENGTH;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 class CommandLineScriptRunnerTest {
+
+    @AfterEach
+    public void tearDown() {
+        System.clearProperty(CONSOLE_LOG_MAX_LINE_LENGTH.propertyName());
+    }
+
     @Test
     @EnabledOnOs(OS.LINUX)
     void shouldReplaceSecretsOnTheOutputUnderLinux() {
@@ -108,5 +117,72 @@ class CommandLineScriptRunnerTest {
         command.runScript(script, output, environmentVariableContext, null);
         assertThat(script.getExitCode()).isEqualTo(0);
         assertThat(output.contains("the_secret_password")).as(output.toString()).isFalse();
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void shouldCropLongLinesUnderLinux() throws CheckedCommandLineException {
+        System.setProperty(CONSOLE_LOG_MAX_LINE_LENGTH.propertyName(), "30");
+
+        CommandLine command = CommandLine.createCommandLine("echo")
+            .withArg("This is a fairly ridiculously long line.")
+            .withEncoding(UTF_8);
+        InMemoryConsumer output = new InMemoryConsumer();
+
+        command.runScript(new ExecScript("FOO"), output, new EnvironmentVariableContext(), null);
+
+        assertThat(output.toString()).isEqualTo("This is ...[ cropped by GoCD ]");
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void shouldCropLongLinesUnderWindows() throws CheckedCommandLineException {
+        System.setProperty(CONSOLE_LOG_MAX_LINE_LENGTH.propertyName(), "30");
+
+        CommandLine command = CommandLine.createCommandLine("cmd")
+            .withArg("/c")
+            .withArg("echo")
+            .withArg("This is a fairly ridiculously long line.")
+            .withEncoding(UTF_8);
+        InMemoryConsumer output = new InMemoryConsumer();
+
+        command.runScript(new ExecScript("FOO"), output, new EnvironmentVariableContext(), null);
+
+        assertThat(output.toString()).isEqualTo("\"This is...[ cropped by GoCD ]");
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void shouldReplaceSecretsInCroppedOutputUnderLinux() throws CheckedCommandLineException {
+        System.setProperty(CONSOLE_LOG_MAX_LINE_LENGTH.propertyName(), "40");
+
+        CommandLine command = CommandLine.createCommandLine("echo")
+            .withArg("My password is")
+            .withArg(new PasswordArgument("secret"))
+            .withArg("and I really like it")
+            .withEncoding(UTF_8);
+        InMemoryConsumer output = new InMemoryConsumer();
+
+        command.runScript(new ExecScript("FOO"), output, new EnvironmentVariableContext(), null);
+        System.out.println(output.toString());
+        assertThat(output.toString()).isEqualTo("My password is ***...[ cropped by GoCD ]");
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void shouldReplaceSecretsInCroppedOutputUnderWindows() throws CheckedCommandLineException {
+        System.setProperty(CONSOLE_LOG_MAX_LINE_LENGTH.propertyName(), "42");
+
+        CommandLine command = CommandLine.createCommandLine("cmd")
+            .withArg("/c")
+            .withArg("echo")
+            .withArg("My password is ")
+            .withArg(new PasswordArgument("secret"))
+            .withArg("and I really like it")
+            .withEncoding(UTF_8);
+        InMemoryConsumer output = new InMemoryConsumer();
+
+        command.runScript(new ExecScript("FOO"), output, new EnvironmentVariableContext(), null);
+        assertThat(output.toString()).isEqualTo("\"My password is \" **...[ cropped by GoCD ]");
     }
 }

--- a/commandline/src/test/java/com/thoughtworks/go/util/command/CommandLineScriptRunnerTest.java
+++ b/commandline/src/test/java/com/thoughtworks/go/util/command/CommandLineScriptRunnerTest.java
@@ -121,7 +121,7 @@ class CommandLineScriptRunnerTest {
 
     @Test
     @EnabledOnOs(OS.LINUX)
-    void shouldCropLongLinesUnderLinux() throws CheckedCommandLineException {
+    void shouldCropLongLinesUnderLinux() {
         System.setProperty(CONSOLE_LOG_MAX_LINE_LENGTH.propertyName(), "30");
 
         CommandLine command = CommandLine.createCommandLine("echo")
@@ -136,7 +136,7 @@ class CommandLineScriptRunnerTest {
 
     @Test
     @EnabledOnOs(OS.WINDOWS)
-    void shouldCropLongLinesUnderWindows() throws CheckedCommandLineException {
+    void shouldCropLongLinesUnderWindows() {
         System.setProperty(CONSOLE_LOG_MAX_LINE_LENGTH.propertyName(), "30");
 
         CommandLine command = CommandLine.createCommandLine("cmd")
@@ -153,7 +153,7 @@ class CommandLineScriptRunnerTest {
 
     @Test
     @EnabledOnOs(OS.LINUX)
-    void shouldReplaceSecretsInCroppedOutputUnderLinux() throws CheckedCommandLineException {
+    void shouldReplaceSecretsInCroppedOutputUnderLinux() {
         System.setProperty(CONSOLE_LOG_MAX_LINE_LENGTH.propertyName(), "40");
 
         CommandLine command = CommandLine.createCommandLine("echo")
@@ -170,7 +170,7 @@ class CommandLineScriptRunnerTest {
 
     @Test
     @EnabledOnOs(OS.WINDOWS)
-    void shouldReplaceSecretsInCroppedOutputUnderWindows() throws CheckedCommandLineException {
+    void shouldReplaceSecretsInCroppedOutputUnderWindows() {
         System.setProperty(CONSOLE_LOG_MAX_LINE_LENGTH.propertyName(), "42");
 
         CommandLine command = CommandLine.createCommandLine("cmd")

--- a/util/src/main/java/com/thoughtworks/go/util/command/BoundedOutputStreamConsumer.java
+++ b/util/src/main/java/com/thoughtworks/go/util/command/BoundedOutputStreamConsumer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.util.command;
+
+public class BoundedOutputStreamConsumer implements ConsoleOutputStreamConsumer {
+
+    private static final String CROP_NOTICE = "...[ cropped by GoCD ]";
+
+    private final ConsoleOutputStreamConsumer consumer;
+    private final int maxLineLength;
+
+    public BoundedOutputStreamConsumer(ConsoleOutputStreamConsumer consumer, int maxLineLength) {
+        this.consumer = consumer;
+        this.maxLineLength = maxLineLength;
+    }
+
+    @Override
+    public void taggedStdOutput(String tag, String line) {
+        consumer.taggedStdOutput(tag, cropLongLine(line));
+    }
+
+    @Override
+    public void taggedErrOutput(String tag, String line) {
+        consumer.taggedErrOutput(tag, cropLongLine(line));
+    }
+
+    @Override
+    public void stdOutput(String line) {
+        consumer.stdOutput(cropLongLine(line));
+    }
+
+    @Override
+    public void errOutput(String line) {
+        consumer.errOutput(cropLongLine(line));
+    }
+
+    private String cropLongLine(String line) {
+        if (maxLineLength > 0 && line.length() > maxLineLength) {
+            return line.substring(0, Math.max(0, maxLineLength - CROP_NOTICE.length())) + CROP_NOTICE;
+        }
+        return line;
+    }
+
+}

--- a/util/src/test/java/com/thoughtworks/go/util/command/BoundedOutputStreamConsumerTest.java
+++ b/util/src/test/java/com/thoughtworks/go/util/command/BoundedOutputStreamConsumerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.util.command;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class BoundedOutputStreamConsumerTest {
+
+    @Test
+    public void shouldCropLongLines() {
+        InMemoryStreamConsumer actualConsumer = ProcessOutputStreamConsumer.inMemoryConsumer();
+        BoundedOutputStreamConsumer streamConsumer = new BoundedOutputStreamConsumer(actualConsumer, 30);
+
+        streamConsumer.stdOutput("This is a fairly ridiculously long line.");
+
+        assertThat(actualConsumer.getAllOutput(), is("This is ...[ cropped by GoCD ]\n"));
+    }
+
+    @Test
+    public void shouldNotCropShortLines() {
+        InMemoryStreamConsumer actualConsumer = ProcessOutputStreamConsumer.inMemoryConsumer();
+        BoundedOutputStreamConsumer streamConsumer = new BoundedOutputStreamConsumer(actualConsumer, 30);
+
+        streamConsumer.stdOutput("A short line");
+
+        assertThat(actualConsumer.getAllOutput(), is("A short line\n"));
+    }
+
+    @Test
+    public void shouldNotCropLongLinesIfUnbounded() {
+        InMemoryStreamConsumer actualConsumer = ProcessOutputStreamConsumer.inMemoryConsumer();
+        BoundedOutputStreamConsumer streamConsumer = new BoundedOutputStreamConsumer(actualConsumer, 0);
+
+        streamConsumer.stdOutput("This is a fairly ridiculously long line.");
+
+        assertThat(actualConsumer.getAllOutput(), is("This is a fairly ridiculously long line.\n"));
+    }
+
+    @Test
+    public void shouldKeepNoticeForSmallMaxLength() {
+        InMemoryStreamConsumer actualConsumer = ProcessOutputStreamConsumer.inMemoryConsumer();
+        BoundedOutputStreamConsumer streamConsumer = new BoundedOutputStreamConsumer(actualConsumer, 10);
+
+        streamConsumer.stdOutput("This is a fairly ridiculously long line.");
+
+        assertThat(actualConsumer.getAllOutput(), is("...[ cropped by GoCD ]\n"));
+    }
+}


### PR DESCRIPTION
Issue: #11100

Description:

Log lines exceeding a configurable threshold are cropped on agent side and a "...[ cropped by GoCD ]" notice appended to the line. This prevents extremely long log output from crashing the server with an Out Of Memory error.

The threshold defaults to 1 million characters per line, and can be configured on the server side like so:

-Dgocd.agent.extra.properties="go.console.log.max.line.length=1000000"

Cropping can be disabled by setting the threshold to 0.

This solution may still crash an agent, since a line is first read fully into memory before cropping. Rationale:

1. Protecting the central server is more important than individual agents
2. Secret redaction requires that the full line is known, otherwise we risk leaking a partially cropped secret.
3. Reading output into memory in a bounded fashion requires a deep dive into Java standard library code (i.e. BufferedReader). This could cause additional effort to keep in sync with later improvements or fixes (though it probably changes rarely).

The last two points are not impossible to solve, but the cost/benefit is questionable.

The cropping is implemented as an additional OutputStreamConsumer decorator and applied only in CommandLine::runScript. This method is used for user-defined pipeline tasks, but not for other commands, such as SCM tasks, where cropping is undesirable.