### PR TITLE
Revert Gradle to 7.5.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=312eb12875e1747e05c2f81a4789902d7e4ec5defbd1eefeaccc08acf096505d
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
-networkTimeout=10000
+distributionSha256Sum=db9c8211ed63f61f60292c69e80d89196f9eb36665e369e7f00ac4cc841c2219
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
There seem to be memory issues with 7.6 that need to be addressed.

Builds such as https://build.gocd.org/go/tab/build/detail/build-linux/6481/build-non-server/1/FastTests-runInstance-3 failing due to `java.lang.OutOfMemoryError: Java heap space` within the compiler when using daemons.

There are some related issues at https://github.com/gradle/gradle/issues/23215 so will see where it goes in `7.6.1`.