### PR TITLE
Include identifiers for licenses with bad URLs

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
@@ -151,14 +151,19 @@ class LicenseReport {
             }
           }
 
-          if (moduleLicenseData.moduleLicenses != null && !moduleLicenseData.moduleLicenses.moduleLicenses.isEmpty()) {
+          if (moduleLicenseData.moduleLicenses != null && !moduleLicenseData.moduleLicenses.isEmpty()) {
 
             checkIfLicensesAreAllowed(moduleLicenseData.moduleLicenses, moduleName, moduleLicenseData.moduleVersion)
 
             p {
-              strong("Manifest license URL(s):")
-              moduleLicenseData.moduleLicenses.findAll { it.moduleLicenseUrl && !it.moduleLicenseUrl.isEmpty() }.each { license ->
-                a(href: license.moduleLicenseUrl, normalizeLicense(license.moduleLicense as String))
+              strong("Manifest license(s):")
+              moduleLicenseData.moduleLicenses.each { license ->
+                def licenseIdentifier = normalizeLicense(license.moduleLicense as String)
+                if (license.moduleLicenseUrl != null && !license.moduleLicenseUrl.isBlank()) {
+                  a(href: license.moduleLicenseUrl, licenseIdentifier)
+                } else {
+                  span(licenseIdentifier)
+                }
               }
             }
           } else {

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/NonSpdxLicense.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/NonSpdxLicense.groovy
@@ -17,7 +17,7 @@
 package com.thoughtworks.go.build
 
 enum NonSpdxLicense {
-  EDL_1_0("EDL-1.0", "Eclipse Distribution License - v1.0", "Eclipse Distribution License v1.0", "Eclipse Distribution License (New BSD License)"),
+  EDL_1_0("EDL-1.0", "Eclipse Distribution License - v1.0", "Eclipse Distribution License - v 1.0", "Eclipse Distribution License v1.0", "Eclipse Distribution License (New BSD License)"),
   GPL_2_0_CLASSPATH_EXCEPTION('GPL-2.0+Classpath-exception-2.0', 'GPLv2 with the Classpath Exception', 'GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception'),
   GPL_2_0_UNIVERSAL_FOSS_EXCEPTION('GPL-2.0+Universal-FOSS-exception-1.0', 'GPLv2 with Oracle Universal FOSS exception', 'The GNU General Public License, v2 with FOSS exception', 'The GNU General Public License, v2 with Universal FOSS Exception, v1.0', 'https://oss.oracle.com/licenses/universal-foss-exception/'),
   MPL_2_0_EPL_1_0('MPL-2.0+EPL-1.0', 'MPL 2.0 or EPL 1.0', 'Dual license consisting of the MPL 2.0 or EPL 1.0', 'Mozilla Public License 2.0 or Eclipse Public License 1.0'),

--- a/buildSrc/src/main/resources/license-for-javascript-not-in-yarn.json
+++ b/buildSrc/src/main/resources/license-for-javascript-not-in-yarn.json
@@ -155,7 +155,8 @@
     ],
     "moduleLicenses": [
       {
-        "moduleLicense": "MIT"
+        "moduleLicense": "MIT",
+        "moduleLicenseUrl": "https://spdx.org/licenses/MIT.html"
       }
     ]
   },

--- a/buildSrc/src/main/resources/license-report.css
+++ b/buildSrc/src/main/resources/license-report.css
@@ -56,7 +56,7 @@ body {
   padding-left: 10px;
 }
 
-.module-info span {
+.module-header span {
   color:       #333;
   font-family: monospace;
 }


### PR DESCRIPTION
Ensure the license ID is included even if there is no URL to the license from the upstream project's POM.