### PR TITLE
Version lock angus-activation independently of angusMail/angusCore

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -128,7 +128,7 @@ task verifyJar(type: VerifyJarTask) {
     "lib": [
       "agent-${project.version}-classes.jar",
       "agent-common-${project.version}.jar",
-      "angus-activation-${project.versions.angusMailSmtp}.jar",
+      "angus-activation-${project.versions.angusActivation}.jar",
       "animal-sniffer-annotations-1.9.jar",
       "ant-${project.versions.apacheAnt}.jar",
       "base-${project.version}.jar",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -27,6 +27,7 @@ final Map<String, String> libraries = [
   // DO NOT interpolate version variables here because Dependabot is not smart enough to understand those. Dependabot's
   // version parsing is simply regex matching and never actually evaluates a gradle script.
   activeMQ            : 'org.apache.activemq:activemq-broker:5.17.3',
+  angusActivation     : 'org.eclipse.angus:activation:2.0.0', // Compatibility with JAXB and Angus Mail required
   angusMailSmtp       : 'org.eclipse.angus:smtp:2.0.1',
   apacheAnt           : 'org.apache.ant:ant:1.10.13',
   apacheHttpComponents: 'org.apache.httpcomponents:httpclient:4.5.14',
@@ -108,6 +109,7 @@ final Map<String, String> libraries = [
 // Export versions that are needed outside of this file (and elsewhere within)
 final Map<String, String> v = [
   activeMQ            : versionOf(libraries.activeMQ),
+  angusActivation     : versionOf(libraries.angusActivation),
   angusMailSmtp       : versionOf(libraries.angusMailSmtp),
   apacheAnt           : versionOf(libraries.apacheAnt),
   apacheHttpComponents: versionOf(libraries.apacheHttpComponents),
@@ -182,7 +184,6 @@ final Map<String, String> v = [
 // with dependencies declared above that are parseable by Dependabot, or are managed by platforms.
 // This is just a workaround to be DRY while still benefiting from Dependabot's automatic PR upgrades.
 final Map<String, String> related = [
-  angusActivation         : "org.eclipse.angus:angus-activation:${v.angusMailSmtp}",
   apacheHttpMime          : "org.apache.httpcomponents:httpmime:${v.apacheHttpComponents}",
   bouncyCastlePkix        : "org.bouncycastle:bcpkix-jdk18on:${v.bouncyCastle}",
   jacksonCore             : "com.fasterxml.jackson.core:jackson-core",

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -783,7 +783,7 @@ task verifyWar(type: VerifyJarTask) {
         "activemq-broker-${project.versions.activeMQ}.jar",
         "activemq-client-${project.versions.activeMQ}.jar",
         "activemq-openwire-legacy-${project.versions.activeMQ}.jar",
-        "angus-activation-${project.versions.angusMailSmtp}.jar",
+        "angus-activation-${project.versions.angusActivation}.jar",
         "angus-core-${project.versions.angusMailSmtp}.jar",
         "animal-sniffer-annotations-1.9.jar",
         "ant-${project.versions.apacheAnt}.jar",


### PR DESCRIPTION
Follow-up to #11246 - need to version lock angusActivation independently of angusMail