### PR TITLE
Correct loading of materials page under MySQL

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/persistence/MaterialRepository.java
+++ b/server/src/main/java/com/thoughtworks/go/server/persistence/MaterialRepository.java
@@ -1031,7 +1031,7 @@ public class MaterialRepository extends HibernateDaoSupport {
     public List<Modification> getLatestModificationForEachMaterial() {
         String queryString = "SELECT mods.* " +
                 "FROM (" +
-                "   SELECT MAX(id) OVER (PARTITION BY materialid) as max_id, * " +
+                "   SELECT MAX(id) OVER (PARTITION BY materialid) as max_id, modifications.* " +
                 "   FROM modifications " +
                 ") mods " +
                 "JOIN materials m ON mods.materialid=m.id " +


### PR DESCRIPTION
Fixes #11260

Query used to bulk load latest modifications for materials to display on Materials page currently doesn't work on MySQL due to use of an unqualified wildcard.

Verified locally with MySQL `8.0.31`.