### PR TITLE
Increase the default artifact IO buffer size from 4kB to 8kB

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -125,7 +125,8 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
             new GoStringSystemProperty("default.plugins.zip.location", "/defaultFiles/plugins.zip"));
     public static final GoSystemProperty<String> AGENT_PLUGINS_PATH = new CachedProperty<>(new GoStringSystemProperty("agent.plugins.path", PLUGINS_PATH));
     public static final GoSystemProperty<Integer> IDLE_TIMEOUT = new GoIntSystemProperty("idle.timeout", 30000);
-    public static final GoSystemProperty<Integer> RESPONSE_BUFFER_SIZE = new GoIntSystemProperty("response.buffer.size", 32768);
+    public static final GoSystemProperty<Integer> RESPONSE_BUFFER_SIZE = new GoIntSystemProperty("response.buffer.size", 32 * 1024);
+    public static final GoSystemProperty<Integer> ARTIFACT_COPY_BUFFER_SIZE = new GoIntSystemProperty("artifact.copy.buffer.size", 8 * 1024);
     public static final GoSystemProperty<Integer> API_REQUEST_IDLE_TIMEOUT_IN_SECONDS = new GoIntSystemProperty("api.request.idle.timeout.seconds", 300);
     public static final GoSystemProperty<Integer> AGENT_REQUEST_IDLE_TIMEOUT_IN_SECONDS = new GoIntSystemProperty("agent.request.idle.timeout.seconds", 30);
     public static final GoSystemProperty<Integer> GO_SERVER_SESSION_TIMEOUT_IN_SECONDS = new GoIntSystemProperty("go.server.session.timeout.seconds", 60 * 60 * 24 * 14);

--- a/base/src/main/java/com/thoughtworks/go/util/ZipUtil.java
+++ b/base/src/main/java/com/thoughtworks/go/util/ZipUtil.java
@@ -25,10 +25,12 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
+import static com.thoughtworks.go.util.SystemEnvironment.ARTIFACT_COPY_BUFFER_SIZE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ZipUtil {
     private static final Logger LOGGER = LoggerFactory.getLogger(ZipUtil.class);
+    private static final int BUFFER_SIZE = new SystemEnvironment().get(ARTIFACT_COPY_BUFFER_SIZE);
     private ZipEntryHandler zipEntryHandler = null;
 
     public ZipUtil() {
@@ -139,7 +141,7 @@ public class ZipUtil {
         try {
             outputFile.getParentFile().mkdirs();
             try (FileOutputStream os = new FileOutputStream(outputFile)) {
-                IOUtils.copyLarge(entryInputStream, os);
+                IOUtils.copy(entryInputStream, os, BUFFER_SIZE);
                 if (zipEntryHandler != null) {
                     FileInputStream stream = null;
                     try {


### PR DESCRIPTION
This aligns with the JDK and commons-io 2.7+ default (unable to upgrade right now due to regressions), but also makes it configurable for users to experiment with. See https://github.com/apache/commons-io/commit/6a78ef8903ef7c2c785b8d0cc08a150d1e2ba818 and https://issues.apache.org/jira/browse/IO-666

Hoping that this helps with #11121 but not certain for now. Nevertheless, this change can't hurt.