### PR TITLE
Ensure input streams are buffered when unzipping uploaded artifacts

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/ArtifactsService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ArtifactsService.java
@@ -32,10 +32,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.util.zip.ZipInputStream;
 
 import static com.thoughtworks.go.util.SystemEnvironment.ARTIFACT_COPY_BUFFER_SIZE;
@@ -43,7 +40,7 @@ import static java.lang.String.format;
 
 @Service
 public class ArtifactsService implements ArtifactUrlReader {
-    public static final Logger LOGGER = LoggerFactory.getLogger(ArtifactsService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactsService.class);
     public static final String LOG_XML_NAME = "log.xml";
     private final ArtifactsDirHolder artifactsDirHolder;
     private final ZipUtil zipUtil;
@@ -80,7 +77,7 @@ public class ArtifactsService implements ArtifactUrlReader {
         try {
             LOGGER.trace("Saving file [{}]", destPath);
             if (shouldUnzip) {
-                zipUtil.unzip(new ZipInputStream(stream), dest);
+                zipUtil.unzip(new ZipInputStream(IOUtils.buffer(stream, bufferSize)), dest);
             } else {
                 try (FileOutputStream out = FileUtils.openOutputStream(dest, true)) {
                     IOUtils.copy(stream, out, bufferSize);


### PR DESCRIPTION
Currently these streams are generally coming from Spring/Jetty from `MultipartFile`s. It seems they are generally handed off to disk by Spring/Jetty (probably due to size of upload) and thus `FileInputStream`s which are not buffered. We buffer explicitly in other cases so let's buffer here too.

On slower disks this might make quite a big difference. Local testing on a super-fast SSD (for read+write) even shows marked difference in speed when buffering the input stream (20-25% faster) so I'd expect this to potentially be even more marked on higher latency setups where one side is not a bottleneck.

May address #11121 