### PR TITLE
Improve agent work pickup speed with an exponential rather than fixed 10s backoff

### DIFF
--- a/agent/src/main/java/com/thoughtworks/go/agent/AgentWorkRetrievalScheduler.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/AgentWorkRetrievalScheduler.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.agent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.PeriodicTrigger;
+import org.springframework.stereotype.Component;
+import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.BackOffExecution;
+
+import javax.annotation.PostConstruct;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class AgentWorkRetrievalScheduler implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(AgentWorkRetrievalScheduler.class);
+
+    private final AgentController controller;
+    private final BackOff backoffStrategy;
+    private final TaskScheduler scheduler;
+
+    @Autowired
+    public AgentWorkRetrievalScheduler(AgentController controller, BackOff backoffStrategy, TaskScheduler scheduler) {
+        this.controller = controller;
+        this.backoffStrategy = backoffStrategy;
+        this.scheduler = scheduler;
+    }
+
+    @PostConstruct
+    public void schedule() {
+        // Schedule constantly, to ensure any unexpected exceptions in the loop don't cause a zombie agent
+        scheduler.schedule(this, new PeriodicTrigger(1, TimeUnit.MILLISECONDS));
+    }
+
+    @Override
+    public void run() {
+        BackOffExecution backOffExecution = backoffStrategy.start();
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                long nextBackOffMillis = backOffExecution.nextBackOff();
+                LOG.debug("[Agent Loop] Waiting {} ms before retrieving next work.", nextBackOffMillis);
+                waitFor(nextBackOffMillis);
+                WorkAttempt result = controller.performWork();
+                LOG.debug("[Agent Loop] Work attempted was {}", result);
+                if (result.shouldResetDelay()) {
+                    backOffExecution = backoffStrategy.start();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    void waitFor(long waitMillis) throws InterruptedException {
+        Thread.sleep(waitMillis);
+    }
+
+}

--- a/agent/src/main/java/com/thoughtworks/go/agent/WorkAttempt.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/WorkAttempt.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.agent;
+
+import com.thoughtworks.go.remote.work.*;
+
+import java.util.Map;
+
+enum WorkAttempt {
+    OK, NOTHING_TO_DO, FAILED;
+
+    private static final Map<Class<? extends Work>, WorkAttempt> WORK_TO_RESULT = Map.of(
+        BuildWork.class, OK,
+        NoWork.class, NOTHING_TO_DO,
+        DeniedAgentWork.class, NOTHING_TO_DO,
+        UnregisteredAgentWork.class, FAILED
+    );
+
+    public static WorkAttempt fromWork(Work work) {
+        return WORK_TO_RESULT.getOrDefault(work.getClass(), OK);
+    }
+
+    boolean shouldResetDelay() {
+        // Reset backoff delays once we have executed real work successfully
+        return OK.equals(this);
+    }
+}

--- a/agent/src/main/resources/agent.properties
+++ b/agent/src/main/resources/agent.properties
@@ -20,3 +20,4 @@ agent.ping.interval=5000
 agent.ping.delay=1500
 agent.get.work.interval=10000
 agent.get.work.delay=1000
+agent.get.work.backOffMultiplier=1.5

--- a/agent/src/main/resources/applicationContext.xml
+++ b/agent/src/main/resources/applicationContext.xml
@@ -70,12 +70,20 @@
   <task:scheduler id="scheduler" pool-size="3"/>
 
   <task:scheduled-tasks scheduler="scheduler">
-    <task:scheduled ref="agentController" method="loop"
-                    initial-delay="${agent.get.work.delay}" fixed-delay="${agent.get.work.interval}"/>
     <task:scheduled ref="agentController" method="ping"
                     initial-delay="${agent.ping.delay}" fixed-delay="${agent.ping.interval}"/>
     <task:scheduled ref="agentController" method="execute"
                     initial-delay="${agent.instruction.delay}" fixed-delay="${agent.instruction.interval}"/>
   </task:scheduled-tasks>
+
+  <bean id="agentWorkScheduler" class="com.thoughtworks.go.agent.AgentWorkRetrievalScheduler">
+    <constructor-arg>
+      <bean class="org.springframework.util.backoff.ExponentialBackOff">
+        <property name="initialInterval" value="${agent.get.work.delay}"/>
+        <property name="maxInterval" value="${agent.get.work.interval}"/>
+        <property name="multiplier" value="${agent.get.work.backOffMultiplier}"/>
+      </bean>
+    </constructor-arg>
+  </bean>
 
 </beans>

--- a/agent/src/main/resources/config/agent-logback.xml
+++ b/agent/src/main/resources/config/agent-logback.xml
@@ -45,6 +45,7 @@
     <appender-ref ref="${gocd.agent.logback.root.appender:-FileAppender}"/>
   </root>
 
+  <logger name="com.thoughtworks.go.agent" level="INFO"/>
   <logger name="org.apache.http.wire" level="ERROR"/>
 
   <!-- make sure this is the last line in the config -->

--- a/agent/src/test/java/com/thoughtworks/go/agent/AgentWorkRetrievalSchedulerTest.java
+++ b/agent/src/test/java/com/thoughtworks/go/agent/AgentWorkRetrievalSchedulerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2023 Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.agent;
+
+import ch.qos.logback.classic.Level;
+import com.thoughtworks.go.util.LogFixture;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.util.backoff.ExponentialBackOff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@MockitoSettings
+class AgentWorkRetrievalSchedulerTest {
+
+    @Mock
+    private AgentController controller;
+
+    @Mock
+    private TaskScheduler taskScheduler;
+
+    @Test
+    void shouldLoopForWorkWithExponentialBackoffs() throws InterruptedException {
+        AgentWorkRetrievalScheduler scheduler = createSchedulerForIterations(exponentialBackOffTwoToTen(), 10);
+
+        when(controller.performWork())
+            .thenReturn(WorkAttempt.FAILED)
+            .thenReturn(WorkAttempt.FAILED)
+            .thenReturn(WorkAttempt.NOTHING_TO_DO)
+            .thenReturn(WorkAttempt.NOTHING_TO_DO)
+            .thenReturn(WorkAttempt.OK)
+            .thenReturn(WorkAttempt.OK)
+            .thenReturn(WorkAttempt.NOTHING_TO_DO);
+
+        try (LogFixture logging = LogFixture.logFixtureFor(AgentWorkRetrievalScheduler.class, Level.DEBUG)) {
+            Thread runner = new Thread(scheduler);
+
+            runner.start();
+            runner.join();
+
+            verify(controller, times(10)).performWork();
+
+            assertThat(logging.getRawMessages().stream().filter(x -> x.startsWith("[Agent Loop] Waiting")))
+                .containsExactly(
+                    "[Agent Loop] Waiting 2 ms before retrieving next work.", // Initial delay
+                    "[Agent Loop] Waiting 4 ms before retrieving next work.", // Failed 1
+                    "[Agent Loop] Waiting 8 ms before retrieving next work.", // Failed 2
+                    "[Agent Loop] Waiting 10 ms before retrieving next work.", // Nothing to do 1 (at maximum)
+                    "[Agent Loop] Waiting 10 ms before retrieving next work.", // Nothing to do 2 (at maximum)
+                    "[Agent Loop] Waiting 2 ms before retrieving next work.", // After OK - reset
+                    "[Agent Loop] Waiting 2 ms before retrieving next work.", // After OK - reset
+                    "[Agent Loop] Waiting 4 ms before retrieving next work.", // Nothing to do
+                    "[Agent Loop] Waiting 8 ms before retrieving next work.", // Nothing to do
+                    "[Agent Loop] Waiting 10 ms before retrieving next work." // Nothing to do
+                );
+        }
+    }
+
+    @Test
+    void shouldLoopForWorkWithInstantMaxBackoff() throws InterruptedException {
+        AgentWorkRetrievalScheduler scheduler = createSchedulerForIterations(instantBackOffTwoToTen(), 9);
+
+        when(controller.performWork())
+            .thenReturn(WorkAttempt.FAILED)
+            .thenReturn(WorkAttempt.FAILED)
+            .thenReturn(WorkAttempt.NOTHING_TO_DO)
+            .thenReturn(WorkAttempt.NOTHING_TO_DO)
+            .thenReturn(WorkAttempt.OK)
+            .thenReturn(WorkAttempt.OK)
+            .thenReturn(WorkAttempt.NOTHING_TO_DO);
+
+        try (LogFixture logging = LogFixture.logFixtureFor(AgentWorkRetrievalScheduler.class, Level.DEBUG)) {
+            Thread runner = new Thread(scheduler);
+
+            runner.start();
+            runner.join();
+
+            verify(controller, times(9)).performWork();
+
+            assertThat(logging.getRawMessages().stream().filter(x -> x.startsWith("[Agent Loop] Waiting")))
+                .containsExactly(
+                    "[Agent Loop] Waiting 2 ms before retrieving next work.", // Initial delay
+                    "[Agent Loop] Waiting 10 ms before retrieving next work.", // Failed 1 (at maximum)
+                    "[Agent Loop] Waiting 10 ms before retrieving next work.", // Failed 2 (at maximum)
+                    "[Agent Loop] Waiting 10 ms before retrieving next work.", // Nothing to do 1 (at maximum)
+                    "[Agent Loop] Waiting 10 ms before retrieving next work.", // Nothing to do 2 (at maximum)
+                    "[Agent Loop] Waiting 2 ms before retrieving next work.", // After OK - reset
+                    "[Agent Loop] Waiting 2 ms before retrieving next work.", // After OK - reset
+                    "[Agent Loop] Waiting 10 ms before retrieving next work.", // Nothing to do (at maximum)
+                    "[Agent Loop] Waiting 10 ms before retrieving next work." // Nothing to do (at maximum)
+                );
+        }
+    }
+
+    @NotNull
+    private AgentWorkRetrievalScheduler createSchedulerForIterations(final ExponentialBackOff backoffStrategy, final int numIterations) {
+        return new AgentWorkRetrievalScheduler(controller, backoffStrategy, taskScheduler) {
+            int iterations;
+
+            @Override
+            void waitFor(long waitMillis) {
+                if (++iterations >= numIterations) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        };
+    }
+
+    private static ExponentialBackOff exponentialBackOffTwoToTen() {
+        ExponentialBackOff backoff = new ExponentialBackOff();
+        backoff.setInitialInterval(2);
+        backoff.setMultiplier(2);
+        backoff.setMaxInterval(10);
+        return backoff;
+    }
+
+    private static ExponentialBackOff instantBackOffTwoToTen() {
+        ExponentialBackOff backoff = new ExponentialBackOff();
+        backoff.setInitialInterval(2);
+        backoff.setMultiplier(10);
+        backoff.setMaxInterval(10);
+        return backoff;
+    }
+}


### PR DESCRIPTION
- Fixes #11215

### Summary

Prior to this change, agents had an initial once-off delay (1s) and then only attempted to get work every 10s after that. During start-up (and transitioning between pieces of work) this caused a lot of unnecessary delay, as it takes two server round trips _after agent registration_ to get a new piece of work - the first where the server doesn't yet know the agent is idle, and the second where it has asynchronously allocated some work.

This change mitigates some of this by
- changing the existing `agent.get.work.delay=1000` to be interpreted as "delay after each piece of work is retrieved" rather than "once-off at agent start"
- does a configurable exponential backoff `agent.get.work.backOffMultiplier=1.5`
- up to maximum wait between get-work-attempts of `agent.get.work.interval=10000`

In other words, each time the agent completes a piece of real work (with success or failure), it resets the wait time to the `agent.get.work.delay`. This has the effect of
- making agents much more responsive to picking up work when they initially start by default (hugely beneficial for elastic agents) (estimated default saving of 7-15s)
- making it **much** faster to transition between pieces of work and the next when there is work waiting on server for an agent (for static agents) 

If the server responds with "no work to do", "agent denied" or some other failure (say a 503 during server restart, or an agent version mismatch), the exponential backoff for trying to get more work will begin, waiting for the "problem" to go away, or work to be available for the agent. With defaults `1s` --> `1.5s` --> `2.25s` --> `3.4s` --> `5.1s` --> `7.6s` --> `10s` --> `10s` etc.

### Downsides

- More calls from agent to server, but not really that many, and checking for work is easy/low cost, happening all in memory.
- Does not address the problem that two "please give me work" calls are required to the server for a new agent, 1 for the agent to tell the server its ready for work, and other to actually give it some work.
- Implementation uses a perma-running task on the scheduler, which is not really good practice, but easiest way to fit into the current convention of Spring usage. To be ultra conservative, if the thread dies for some reason it gets immediately restarted on the scheduler.

### Other options considered

1. Do something on the server so that as soon as the agent is registered it is known as idle and starts to assign work to it, likely before getWork is called. Might lead to issues when server is restarted/upgraded? Not sure.
    - Would be nice, but far more complicated and invasive. This change has value regardless of server side changes, and is agent side only.
2. Have the agent try again nearly immediately on first attempt to get work
    - Things happen on the server asynchronously so it's hard to tell when the work will be ready for the agent. 

### Results

With this change and default settings, testing with the docker-elastic-agents plugin we get something representative like the below

| Section  | Time | Section Elapsed |
| ------------- | ------------- | ------------- |
| Start | 14:52:37.000 | 0 |
| Approx "elastic agent schedule" time  | 14:52:38.860 | 0-5s (unchanged, `cruise.build.assignment.service.interval` poll)  |
| Container started  | 14:52:39.361 | ~500ms (unchanged) |
| Agent binaries downloaded | 14:52:40,808 | ~1.4s (unchanged) | 
| Agent started + registered with server + cookie | 14:52:43,398 | ~2.6s (unchanged) | 
| Got First Work  | 14:52:46,913 | ~3.6s (was ~10-20s depending on luck) |
| TOTAL | | Probably ~7-12s (depending on poll luck, with extra for slow network speeds or slow agent downloads) |

This last step is the bit that is far faster now compared with `22.3.0`. Prior to `22.3.0` the "agent started" time had a big `10s` delay in it after binary download and a `1s` fudge factor sleep thrown in, so this builds on the changes in #10759 