### PR TITLE
Minor improvements to agent launcher logging redirection

### DIFF
--- a/agent-process-launcher/src/main/java/com/thoughtworks/go/agent/AgentConsoleLogThread.java
+++ b/agent-process-launcher/src/main/java/com/thoughtworks/go/agent/AgentConsoleLogThread.java
@@ -52,17 +52,17 @@ public class AgentConsoleLogThread extends Thread {
                 break;
             }
             try {
-                logConsoleError(reader);
+                logFrom(reader);
                 Thread.sleep(100);
             } catch (Exception e) {
-                System.err.println("Error occured while capturing console output from agent process: ");
+                System.err.println("Error occurred while capturing console output from agent process: ");
                 e.printStackTrace();
                 break;
             }
         }
     }
 
-    private void logConsoleError(final BufferedReader reader) {
+    private void logFrom(final BufferedReader reader) {
         flushedAfterStop = !keepRunning;
         try {
             reader.lines().forEach(agentOutputAppender::write);

--- a/agent-process-launcher/src/main/java/com/thoughtworks/go/agent/AgentOutputAppender.java
+++ b/agent-process-launcher/src/main/java/com/thoughtworks/go/agent/AgentOutputAppender.java
@@ -36,15 +36,12 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 class AgentOutputAppender {
     enum Outstream {
-        STDOUT(ConsoleTarget.SystemOut, "stdout"),
-        STDERR(ConsoleTarget.SystemErr, "stderr");
+        STDOUT(ConsoleTarget.SystemOut),
+        STDERR(ConsoleTarget.SystemErr);
 
         private final ConsoleTarget target;
-        private final String marker;
-
-        Outstream(ConsoleTarget target, String marker) {
+        Outstream(ConsoleTarget target) {
             this.target = target;
-            this.marker = marker;
         }
     }
 
@@ -57,20 +54,16 @@ class AgentOutputAppender {
     void writeTo(Outstream target) {
         ConsoleAppender<ILoggingEvent> appender = new ConsoleAppender<>();
         appender.setTarget(target.target.getName());
-        appender.setEncoder(LogHelper.encoder("%date{ISO8601} [" + target.marker + "] - %msg%n"));
+        appender.setEncoder(LogHelper.encoder("%msg%n"));
         appender.start();
         appenders.add(appender);
     }
 
-    private void write(String message, Exception throwable) {
+    void write(String line) {
         for (OutputStreamAppender<ILoggingEvent> appender : appenders) {
             Logger logger = (Logger) LoggerFactory.getLogger(AgentOutputAppender.class);
-            appender.doAppend(new LoggingEvent("", logger, Level.ERROR, message, throwable, null));
+            appender.doAppend(new LoggingEvent("", logger, Level.INFO, line, null, null));
         }
-    }
-
-    void write(String line) {
-        write(line, null);
     }
 
     void close() {
@@ -79,7 +72,7 @@ class AgentOutputAppender {
 
     private RollingFileAppender<ILoggingEvent> rollingAppender(String file) {
         RollingFileAppender<ILoggingEvent> rollingFileAppender = new RollingFileAppender<>();
-        rollingFileAppender.setEncoder(LogHelper.encoder("%date{ISO8601} - %msg%n"));
+        rollingFileAppender.setEncoder(LogHelper.encoder("%msg%n"));
         rollingFileAppender.setContext(LogHelper.LOGGER_CONTEXT);
         rollingFileAppender.setFile(getEffectiveLogDirectory(file));
         rollingFileAppender.setName(UUID.randomUUID().toString());

--- a/agent-process-launcher/src/main/java/com/thoughtworks/go/agent/AgentProcessParentImpl.java
+++ b/agent-process-launcher/src/main/java/com/thoughtworks/go/agent/AgentProcessParentImpl.java
@@ -47,7 +47,7 @@ public class AgentProcessParentImpl implements AgentProcessParent {
     public int run(String launcherVersion, String launcherMd5, ServerUrlGenerator urlGenerator, Map<String, String> env, Map context) {
         int exitValue = 0;
         LOG.info("Agent is version: {}", CurrentGoCDVersion.getInstance().fullVersion());
-        String command[] = new String[]{};
+        String[] command = new String[]{};
 
         try {
             AgentBootstrapperArgs bootstrapperArgs = AgentBootstrapperArgs.fromProperties(context);

--- a/base/src/main/java/com/thoughtworks/go/logging/LogHelper.java
+++ b/base/src/main/java/com/thoughtworks/go/logging/LogHelper.java
@@ -40,8 +40,8 @@ public class LogHelper {
     }
 
 
-    public static void rollingPolicyForAppender(RollingFileAppender rollingFileAppender, String maxFileSize, String totalSizeCap, int maxHistory) {
-        SizeAndTimeBasedRollingPolicy rollingPolicy = new SizeAndTimeBasedRollingPolicy();
+    public static void rollingPolicyForAppender(RollingFileAppender<?> rollingFileAppender, String maxFileSize, String totalSizeCap, int maxHistory) {
+        SizeAndTimeBasedRollingPolicy<?> rollingPolicy = new SizeAndTimeBasedRollingPolicy<>();
         rollingPolicy.setContext(LOGGER_CONTEXT);
         rollingPolicy.setMaxHistory(maxHistory);
         rollingPolicy.setMaxFileSize(FileSize.valueOf(maxFileSize));


### PR DESCRIPTION
Fixes misleading duplicate timestamps in logs that originate in the agent process, but are logged from the agent launcher, especially when redirecting to console.