### PR TITLE
Close pipeline config modals only on "cancel-click" or "ESC"

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks/abstract.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/job/tasks/abstract.tsx
@@ -29,10 +29,11 @@ export abstract class AbstractTaskModal extends Modal {
 
   constructor(onAdd: (t: Task) => Promise<any>, readonly: boolean, disableSave: Stream<boolean> = Stream<boolean>(false)) {
     super(Size.medium);
-    this.onAdd        = onAdd;
-    this.readonlyAttr     = readonly;
-    this.flashMessage = new FlashMessageModel();
-    this.disableSave = disableSave;
+    this.onAdd                    = onAdd;
+    this.readonlyAttr             = readonly;
+    this.flashMessage             = new FlashMessageModel();
+    this.closeModalOnOverlayClick = false;
+    this.disableSave              = disableSave;
   }
 
   abstract getTask(): Task;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stage/add_stage_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stage/add_stage_modal.tsx
@@ -48,9 +48,10 @@ export class AddStageModal extends Modal {
   constructor(stages: NameableSet<Stage>, pipelineConfigSave: () => Promise<any>, flashMessage: FlashMessageModelWithTimeout) {
     super();
 
-    this.stages             = stages;
-    this.pipelineConfigSave = pipelineConfigSave;
-    this.parentFlashMessage = flashMessage;
+    this.stages                   = stages;
+    this.pipelineConfigSave       = pipelineConfigSave;
+    this.parentFlashMessage       = flashMessage;
+    this.closeModalOnOverlayClick = false;
 
     this.stageToCreate = new Stage();
     this.jobToCreate   = new Job();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/jobs/add_job_modal.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/stage/jobs/add_job_modal.tsx
@@ -61,13 +61,14 @@ export class AddJobModal extends Modal {
 
     this.jobToCreate = new Job();
 
-    this.stage                = stage;
-    this.templateConfig       = templateConfig;
-    this.pipelineConfig       = pipelineConfig;
-    this.routeParams          = routeParams;
-    this.ajaxOperationMonitor = ajaxOperationMonitor;
-    this.flashMessage         = flashMessage;
-    this.pipelineConfigSave   = pipelineConfigSave;
+    this.stage                    = stage;
+    this.templateConfig           = templateConfig;
+    this.pipelineConfig           = pipelineConfig;
+    this.routeParams              = routeParams;
+    this.ajaxOperationMonitor     = ajaxOperationMonitor;
+    this.flashMessage             = flashMessage;
+    this.closeModalOnOverlayClick = false;
+    this.pipelineConfigSave       = pipelineConfigSave;
 
     this.jobSettingsTabContent = new JobSettingsTabContent();
 


### PR DESCRIPTION
Some modals on the pipeline config SPA close when you click on the overlay background, but some do not. This makes them consistent, which also mitigates browser inconsistent when you drag to select text and the MouseUp event is "outside" the overlay. To figure out the intended "target" you need to know target of both MouseUp and MouseDown which is a pain. Better to disable this on modals that have text areas folks might be copying+pasting to.

Currently the materials modal doesn't close on clicking the overlay, but the others did allow it.

- Fixes #10669 (in a roundabout way)