### PR TITLE
Fix agent upgrade check md5Header NullPointerExceptions

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/controller/AgentRegistrationController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/AgentRegistrationController.java
@@ -103,12 +103,6 @@ public class AgentRegistrationController {
 
     @RequestMapping(value = "/admin/latest-agent.status", method = {RequestMethod.HEAD, RequestMethod.GET})
     public void checkAgentStatus(HttpServletResponse response) {
-        LOG.debug("Processing '/admin/latest-agent.status' request with values [{}:{}], [{}:{}], [{}:{}], [{}:{}]",
-                SystemEnvironment.AGENT_CONTENT_MD5_HEADER, agentChecksum,
-                SystemEnvironment.AGENT_LAUNCHER_CONTENT_MD5_HEADER, agentLauncherChecksum,
-                SystemEnvironment.AGENT_PLUGINS_ZIP_MD5_HEADER, pluginsZip.md5(),
-                SystemEnvironment.AGENT_TFS_SDK_MD5_HEADER, tfsSdkChecksum);
-
         response.setHeader(SystemEnvironment.AGENT_CONTENT_MD5_HEADER, agentChecksum);
         response.setHeader(SystemEnvironment.AGENT_LAUNCHER_CONTENT_MD5_HEADER, agentLauncherChecksum);
         response.setHeader(SystemEnvironment.AGENT_PLUGINS_ZIP_MD5_HEADER, pluginsZip.md5());

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthenticationFilterChain.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthenticationFilterChain.java
@@ -38,6 +38,7 @@ public class AuthenticationFilterChain extends FilterChainProxy {
         super(FilterChainBuilder.newInstance()
                 // for agent remoting
                 .addFilterChain("/remoting/**", agentAuthenticationFilter)
+                .addFilterChain("/admin/latest-agent.status", assumeAnonymousUserFilter)
 
                 // For API authentication
                 .addFilterChain("/api/config-repository.git/**", invalidateAuthenticationOnSecurityConfigChangeFilter, assumeAnonymousUserFilter, reAuthenticationWithChallenge, basicAuthenticationWithChallengeFilter)


### PR DESCRIPTION
Fixes #4469 

### The Problem

Currently calls to the `/admin/latest-agent.status` API from static agents will trigger a `NullPointerException` like the below, **every 30 minutes**.

```
jvm 1    | 2023-02-18 16:37:13,918 ERROR [scheduler-1] AgentController:99 - [Agent Loop] Error occurred during loop:
jvm 1    | java.lang.NullPointerException: Cannot invoke "org.apache.http.Header.getValue()" because "md5Header" is null
jvm 1    | 	at com.thoughtworks.go.agent.service.AgentUpgradeService.validateMd5(AgentUpgradeService.java:111)
jvm 1    | 	at com.thoughtworks.go.agent.service.AgentUpgradeService.checkForUpgradeAndExtraProperties(AgentUpgradeService.java:84)
jvm 1    | 	at com.thoughtworks.go.agent.service.AgentUpgradeService.checkForUpgradeAndExtraProperties(AgentUpgradeService.java:72)
jvm 1    | 	at com.thoughtworks.go.agent.AgentController.performWork(AgentController.java:85)
```

Eventually, the JVM will start cutting off stacktraces and you will only see

```
jvm 1    | 2023-02-18 16:37:13,918 ERROR [scheduler-1] AgentController:99 - [Agent Loop] Error occurred during loop:
jvm 1    | java.lang.NullPointerException: null
```

This doesn't cause any major problem, because on next attempt things will work again, a new authenticated session will be created and the agent will continue to check for upgrades and get work. But it will cause an unnecessary 10s break in getting work.

### The Root Cause

This is happening every 30 minutes due to `go.security.reauthentication.interval` at https://github.com/gocd/gocd/blob/781bc78dc473cf14715408adf9f2b054b8a814a3/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java#L178 and some logic causing calls to this endpoint having `re-authentication` forced after 30 minutes.

- Currently the agent shares the `HttpClient` between calls to check for agent upgrades (can be anonymous) and calls to the agent APIs (generally require authentication/registration with an `AgentToken`).
- The `JESSIONID` session cookie is shared between different calls made by the agent, so sometimes the agent sends a cookie referring to a session which was earlier authenticated with an `AgentToken`.
- However, during **agent upgrade checks** there is no agent UUID and token sent. Nor the params required to register an agent or acquire an authentication token. It is expected to work anonymously, and the cookie being sent is a side effect of use of a shared client.
- The current authentication filter being applied to `/admin/latest-agent.status` looks like the below, which means calls to this API fall back to `invalidateAuthenticationOnSecurityConfigChangeFilter, reAuthenticationWithRedirectToLoginPage, assumeAnonymousUserFilter, basicAuthenticationWithRedirectToLoginFilter`
https://github.com/gocd/gocd/blob/246aeb95302d3969595e689b2a5c2c2efb1882ac/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthenticationFilterChain.java#L38-L58
- Since `AgentToken` sessions cannot be "re-authenticated", re-authentication fails and the server issues a `302` redirect back to `/go/login`
https://github.com/gocd/gocd/blob/3ec98138e5f309666bca72873cad8e0a7a39783e/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/AbstractReAuthenticationFilter.java#L88-L97

### The "fix"

To resolve this, this change
- tells agent upgrade not to follow redirects. This is the direct cause of the `NullPointerException`s but not the root cause. This is more for future.
- Tells the authentication filter to treat this route as `assumeAnonymousUserFilter`, and not to apply reauthentication, security config change or other filters during authentication. **Authorization** rules applying to the routes [remain unchanged](https://github.com/gocd/gocd/blob/8811f094a79fe822e4cc0188194e4ecd17c4707d/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java#L37-L55).

### Alternatives considered

It also works to tell the `AgentUpgradeService` to ignore cookies. This way it never refers to an existing session and a new "anonymous" session is always created for every call in the agent loop. I started with this approach, but it seemed more of a workaround for incorrect authentication on the server on the route, and would cause many new single-shot sessions to be created and managed by the server. Didn't feel quite right, but maybe safer?

### Advice needed

I'm not 100% sure if this is the right approach here, and the consequences of [AssumeAnonymousUser](https://github.com/gocd/gocd/blob/0f58107c851cf2df6ce7c6902eebde796dc1f742/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/AssumeAnonymousUserFilter.java#L50-L70) if a given client is accessing multiple routes/APIs that have different authentication requirements. It seems to work fine, and be correct though? :-)