### PR TITLE
Allow including paused or cancelled pipelines/stages in user dashboard filters

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/DashboardFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/DashboardFilter.java
@@ -29,8 +29,9 @@ public interface DashboardFilter {
 
     String DEFAULT_NAME = "Default";
     String BUILDING_STATE = "building";
+    String CANCELLED_STATE = "cancelled";
     String FAILED_STATE = "failing";
-    Set<String> VALID_STATES = Set.of(BUILDING_STATE, FAILED_STATE);
+    Set<String> VALID_STATES = Set.of(BUILDING_STATE, CANCELLED_STATE, FAILED_STATE);
 
     String name();
 

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/DashboardFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/DashboardFilter.java
@@ -28,10 +28,7 @@ public interface DashboardFilter {
     }
 
     String DEFAULT_NAME = "Default";
-    String BUILDING_STATE = "building";
-    String CANCELLED_STATE = "cancelled";
-    String FAILED_STATE = "failing";
-    Set<String> VALID_STATES = Set.of(BUILDING_STATE, CANCELLED_STATE, FAILED_STATE);
+    Set<String> VALID_STATES = Set.of("paused", "building", "cancelled", "failing");
 
     String name();
 

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidator.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidator.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import static com.thoughtworks.go.server.domain.user.DashboardFilter.*;
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.VALID_STATES;
 
 class FilterValidator {
 
@@ -39,7 +39,7 @@ class FilterValidator {
     static final String MSG_NAME_FORMAT = "Filter name is only allowed to contain letters, numbers, spaces, and punctuation marks";
     static final String MSG_MISSING_NAME = "Missing filter name";
     static final String MSG_NO_DEFAULT_FILTER = "Missing default filter";
-    static final String MSG_INVALID_STATES = "An invalid filter state has been provided. Only " + BUILDING_STATE + " and " + FAILED_STATE + " are supported";
+    static final String MSG_INVALID_STATES = "An invalid filter state has been provided. Only " + String.join(", ", VALID_STATES) + " are supported";
 
     static void validateDefaultIsPresent(Map<String, DashboardFilter> current) {
         if (current.isEmpty()) throw new FilterValidationException(MSG_NO_DEFAULT_FILTER);

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_personalize_views_editor.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_personalize_views_editor.scss
@@ -110,6 +110,20 @@ $icon-color: #647984;
   input {
     margin-bottom: 0;
   }
+
+  label {
+    width: 90px;
+    margin-left: 25px;
+  }
+}
+
+.show-pipelines-selector-groups {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.stage-state-selector {
+  display: flex;
 }
 
 .text-with-tooltip {
@@ -206,14 +220,6 @@ $icon-color: #647984;
 
   &:focus {
     background: #fff;
-  }
-}
-
-.stage-state-selector {
-  display: flex;
-
-  label {
-    margin-left: 25px;
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_personalize_views_editor.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_personalize_views_editor.scss
@@ -18,7 +18,7 @@ $view-top-bg: $section-bg;
 $icon-color: #647984;
 
 .overlay-personalize-editor {
-  width: 650px;
+  width: 600px;
   top: 10vh;
 
   .is-invalid-label {
@@ -104,26 +104,27 @@ $icon-color: #647984;
   border: 1px solid $light-border;
   background: #fff;
   display: flex;
-  padding: 10px 20px;
+  flex-direction: row;
+  padding: 10px 10px;
   border-radius: 3px;
 
   input {
     margin-bottom: 0;
   }
-
-  label {
-    width: 90px;
-    margin-left: 25px;
-  }
 }
 
-.show-pipelines-selector-groups {
+.show-pipelines-selectors {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  margin-bottom: 10px;
 }
 
 .stage-state-selector {
   display: flex;
+  flex-wrap: wrap;
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid $light-border;
 }
 
 .text-with-tooltip {
@@ -175,7 +176,7 @@ $icon-color: #647984;
 .section-label {
   line-height: 25px;
   margin-right: 20px;
-  white-space: nowrap;
+  width: 190px;
 }
 
 .search-pipelines {
@@ -223,10 +224,11 @@ $icon-color: #647984;
   }
 }
 
-.checkbox-help,
-.checkbox-help_label {
+.checkbox-help {
   display: flex;
   align-items: center;
+  margin-right: 25px;
+  min-width: 110px;
 }
 
 .pipeline-search-container {

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_personalize_views_editor.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_personalize_views_editor.scss
@@ -18,7 +18,7 @@ $view-top-bg: $section-bg;
 $icon-color: #647984;
 
 .overlay-personalize-editor {
-  width: 530px;
+  width: 650px;
   top: 10vh;
 
   .is-invalid-label {

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/dashboard_filter_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/dashboard_filter_spec.js
@@ -29,6 +29,7 @@ describe("DashboardFilter", () => {
     beforeEach(() => {
       pipeline = {
         name: null,
+        isPaused: false,
         latestStage: () => stage
       };
     });
@@ -57,6 +58,30 @@ describe("DashboardFilter", () => {
 
       stage = new Stage("Cancelled");
       expect(filter.acceptsStatusOf(pipeline)).toBe(false);
+    });
+
+    it("should filter when pipeline is paused regardless of state", () => {
+      filter = new DashboardFilter({state: ["paused", "building"]});
+
+      pipeline.isPaused = true;
+
+      // Never run
+      expect(filter.acceptsStatusOf(pipeline)).toBe(true);
+
+      stage = new Stage("Building");
+      expect(filter.acceptsStatusOf(pipeline)).toBe(true);
+
+      stage = new Stage("Failing");
+      expect(filter.acceptsStatusOf(pipeline)).toBe(true);
+
+      stage = new Stage("Failed");
+      expect(filter.acceptsStatusOf(pipeline)).toBe(true);
+
+      stage = new Stage("Passing");
+      expect(filter.acceptsStatusOf(pipeline)).toBe(true);
+
+      stage = new Stage("Cancelled");
+      expect(filter.acceptsStatusOf(pipeline)).toBe(true);
     });
 
     it("should filter when state=[building]", () => {

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/dashboard_filter_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/dashboard_filter_spec.js
@@ -23,6 +23,7 @@ describe("DashboardFilter", () => {
       this.isFailed = () => status === "Failed";
       this.isBuilding = () => status === "Building";
       this.isFailing = () => status === "Failing";
+      this.isCancelled = () => status === "Cancelled";
     }
 
     beforeEach(() => {
@@ -38,7 +39,7 @@ describe("DashboardFilter", () => {
       filter = new DashboardFilter({state: ["failing"]});
       expect(filter.acceptsStatusOf(pipeline)).toBe(false);
 
-      filter = new DashboardFilter({state: ["builing"]});
+      filter = new DashboardFilter({state: ["building"]});
       expect(filter.acceptsStatusOf(pipeline)).toBe(false);
 
       filter = new DashboardFilter({state: []});
@@ -52,6 +53,9 @@ describe("DashboardFilter", () => {
       expect(filter.acceptsStatusOf(pipeline)).toBe(true);
 
       stage = new Stage("Passing");
+      expect(filter.acceptsStatusOf(pipeline)).toBe(false);
+
+      stage = new Stage("Cancelled");
       expect(filter.acceptsStatusOf(pipeline)).toBe(false);
     });
 
@@ -69,15 +73,31 @@ describe("DashboardFilter", () => {
 
       stage = new Stage("Passing");
       expect(filter.acceptsStatusOf(pipeline)).toBe(false);
+
+      stage = new Stage("Cancelled");
+      expect(filter.acceptsStatusOf(pipeline)).toBe(false);
     });
 
-    it("should filter when state=[building, failing]", () => {
-      filter = new DashboardFilter({state: ["building", "failing"]});
+    it("should filter when state=[building, failing, cancelled]", () => {
+      filter = new DashboardFilter({state: ["building", "failing", "cancelled"]});
 
       stage = new Stage("Building");
       expect(filter.acceptsStatusOf(pipeline)).toBe(true);
 
       stage = new Stage("Failed");
+      expect(filter.acceptsStatusOf(pipeline)).toBe(true);
+
+      stage = new Stage("Passing");
+      expect(filter.acceptsStatusOf(pipeline)).toBe(false);
+
+      stage = new Stage("Cancelled");
+      expect(filter.acceptsStatusOf(pipeline)).toBe(true);
+    });
+
+    it("should filter when state=[cancelled]", () => {
+      filter = new DashboardFilter({state: ["cancelled"]});
+
+      stage = new Stage("Cancelled");
       expect(filter.acceptsStatusOf(pipeline)).toBe(true);
 
       stage = new Stage("Passing");

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/model/personalize_editor_vm_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/model/personalize_editor_vm_spec.js
@@ -67,7 +67,11 @@ describe("Personalization Editor View Model", () => {
     check(model.failing);
     expect(model.asFilter().state).toEqual(["building", "failing"]);
 
+    check(model.cancelled);
+    expect(model.asFilter().state).toEqual(["building", "cancelled", "failing"]);
+
     uncheck(model.failing);
+    uncheck(model.cancelled);
     expect(model.asFilter().state).toEqual(["building"]);
   });
 
@@ -76,18 +80,22 @@ describe("Personalization Editor View Model", () => {
 
     expect(a.building()).toBe(false);
     expect(a.failing()).toBe(false);
+    expect(a.cancelled()).toBe(false);
 
     const b = vm({state: ["building"]});
     expect(b.building()).toBe(true);
     expect(b.failing()).toBe(false);
+    expect(a.cancelled()).toBe(false);
 
     const c = vm({state: ["failing"]});
     expect(c.building()).toBe(false);
     expect(c.failing()).toBe(true);
+    expect(a.cancelled()).toBe(false);
 
     const d = vm({state: ["building", "failing"]});
     expect(d.building()).toBe(true);
     expect(d.failing()).toBe(true);
+    expect(a.cancelled()).toBe(false);
   });
 });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/dashboard/dashboard_filter.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/dashboard/dashboard_filter.js
@@ -23,6 +23,7 @@ export function DashboardFilter(config) {
       if (!latestStage) { return false; }
       if (latestStage.isBuilding() || latestStage.isFailing()) { return _.includes(config.state, "building"); }
       if (latestStage.isFailed()) { return _.includes(config.state, "failing"); }
+      if (latestStage.isCancelled()) { return _.includes(config.state, "cancelled"); }
       return false;
     }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/dashboard/dashboard_filter.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/dashboard/dashboard_filter.js
@@ -20,6 +20,9 @@ export function DashboardFilter(config) {
     const latestStage = pipeline.latestStage();
 
     if (config.state.length) {
+      if (pipeline.isPaused && _.includes(config.state, "paused")) {
+        return true;
+      }
       if (!latestStage) { return false; }
       if (latestStage.isBuilding() || latestStage.isFailing()) { return _.includes(config.state, "building"); }
       if (latestStage.isFailed()) { return _.includes(config.state, "failing"); }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/models/personalize_editor_vm.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/models/personalize_editor_vm.js
@@ -41,8 +41,9 @@ export function PersonalizeEditorVM(opts) { // opts is usually the current filte
     selectionVM(PipelineListVM.create(pipelinesByGroup, inverted(), opts.pipelines));
   };
 
-  boolToList(this, state, "building");
   boolToList(this, state, "failing");
+  boolToList(this, state, "cancelled");
+  boolToList(this, state, "building");
 
   this.includeNewPipelines = function (value) {
     if (!arguments.length) { return inverted(); }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/models/personalize_editor_vm.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/models/personalize_editor_vm.js
@@ -41,6 +41,7 @@ export function PersonalizeEditorVM(opts) { // opts is usually the current filte
     selectionVM(PipelineListVM.create(pipelinesByGroup, inverted(), opts.pipelines));
   };
 
+  boolToList(this, state, "paused");
   boolToList(this, state, "failing");
   boolToList(this, state, "cancelled");
   boolToList(this, state, "building");

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/personalization_modal_widget.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/personalization_modal_widget.js.msx
@@ -57,10 +57,15 @@ const StageStateCriteria = {
   view(vnode) {
     const vm = vnode.attrs.vm;
 
-    return <span class="stage-state-selector">
+    return <div class="stage-state-selector">
+      <div class="checkbox-help">
+        <f.checkbox name="state" model={vm} attrName="paused" label="Paused" labelClass="checkbox-help_label"/>
+        <Tooltip vm={vm} name="paused-pipelines">Show paused pipelines regardless of their build completion status, among pipelines
+          selected for this view</Tooltip>
+      </div>
       <div class="checkbox-help">
         <f.checkbox name="state" model={vm} attrName="failing" label="Failed" labelClass="checkbox-help_label"/>
-        <Tooltip vm={vm} name="failed-pipelines">Show only pipelines whose last run stage has failed, among pipelines
+        <Tooltip vm={vm} name="failed-pipelines">Show pipelines whose last run stage has failed, among pipelines
           selected for this view</Tooltip>
       </div>
       <div class="checkbox-help">
@@ -73,7 +78,7 @@ const StageStateCriteria = {
         <Tooltip vm={vm} name="building-pipelines">Show only pipelines with jobs which are scheduled or building, among
           pipelines chosen for this view</Tooltip>
       </div>
-    </span>;
+    </div>;
   }
 };
 
@@ -173,19 +178,16 @@ export const PersonalizationModalWidget = {
         <AlertContainer vm={vm}/>
         <FilterNameInput {...vnode.attrs} />
         <div class="show-pipelines">
-          <span class="section-label">Show pipelines:</span>
-          <div class="show-pipelines-selector-groups">
-            <div class="checkbox-help">
-              <f.checkbox name="include-new-pipelines" model={vm} attrName="includeNewPipelines" label="New" labelClass="checkbox-help_label"/>
+          <span className="section-label">Restrict display to pipelines which are:</span>
+          <div class="show-pipelines-selectors">
+            <StageStateCriteria vm={vm}/>
+            <div className="checkbox-help">
+              <f.checkbox name="include-new-pipelines" model={vm} attrName="includeNewPipelines" label="Automatically include newly created pipelines"
+                          labelClass="checkbox-help_label"/>
               <Tooltip vm={vm} name="include-new-pipelines">
-                {"Include pipelines created since this view was last updated"}
+                {"De-selected pipelines below will act as a denylist, so that pipelines created since this view was updated will automatically be included."}
               </Tooltip>
             </div>
-            <div class="checkbox-help">
-              <f.checkbox name="state" model={vm} attrName="paused" label="Paused" labelClass="checkbox-help_label"/>
-              <Tooltip vm={vm} name="paused-pipelines">Show only pipelines which are paused, regardless of their status</Tooltip>
-            </div>
-            <StageStateCriteria vm={vm}/>
           </div>
         </div>
       </div>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/personalization_modal_widget.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/personalization_modal_widget.js.msx
@@ -64,6 +64,11 @@ const StageStateCriteria = {
           selected for this view</Tooltip>
       </div>
       <div class="checkbox-help">
+        <f.checkbox name="state" model={vm} attrName="cancelled" label="Cancelled" labelClass="checkbox-help_label"/>
+        <Tooltip vm={vm} name="cancelled-pipelines">Show only pipelines whose last run stage was cancelled, among pipelines
+          selected for this view</Tooltip>
+      </div>
+      <div className="checkbox-help">
         <f.checkbox name="state" model={vm} attrName="building" label="Building" labelClass="checkbox-help_label"/>
         <Tooltip vm={vm} name="building-pipelines">Show only pipelines with jobs which are scheduled or building, among
           pipelines chosen for this view</Tooltip>
@@ -172,7 +177,7 @@ export const PersonalizationModalWidget = {
           <div class="checkbox-help">
             <f.checkbox name="include-new-pipelines" model={vm} attrName="includeNewPipelines" label="New" labelClass="checkbox-help_label"/>
             <Tooltip vm={vm} name="include-new-pipelines">
-              {"Include pipelines created since this view was last updated "}
+              {"Include pipelines created since this view was last updated"}
             </Tooltip>
           </div>
           <StageStateCriteria vm={vm}/>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/personalization_modal_widget.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/personalization_modal_widget.js.msx
@@ -57,7 +57,7 @@ const StageStateCriteria = {
   view(vnode) {
     const vm = vnode.attrs.vm;
 
-    return <div class="stage-state-selector">
+    return <span class="stage-state-selector">
       <div class="checkbox-help">
         <f.checkbox name="state" model={vm} attrName="failing" label="Failed" labelClass="checkbox-help_label"/>
         <Tooltip vm={vm} name="failed-pipelines">Show only pipelines whose last run stage has failed, among pipelines
@@ -73,7 +73,7 @@ const StageStateCriteria = {
         <Tooltip vm={vm} name="building-pipelines">Show only pipelines with jobs which are scheduled or building, among
           pipelines chosen for this view</Tooltip>
       </div>
-    </div>;
+    </span>;
   }
 };
 
@@ -174,13 +174,19 @@ export const PersonalizationModalWidget = {
         <FilterNameInput {...vnode.attrs} />
         <div class="show-pipelines">
           <span class="section-label">Show pipelines:</span>
-          <div class="checkbox-help">
-            <f.checkbox name="include-new-pipelines" model={vm} attrName="includeNewPipelines" label="New" labelClass="checkbox-help_label"/>
-            <Tooltip vm={vm} name="include-new-pipelines">
-              {"Include pipelines created since this view was last updated"}
-            </Tooltip>
+          <div class="show-pipelines-selector-groups">
+            <div class="checkbox-help">
+              <f.checkbox name="include-new-pipelines" model={vm} attrName="includeNewPipelines" label="New" labelClass="checkbox-help_label"/>
+              <Tooltip vm={vm} name="include-new-pipelines">
+                {"Include pipelines created since this view was last updated"}
+              </Tooltip>
+            </div>
+            <div class="checkbox-help">
+              <f.checkbox name="state" model={vm} attrName="paused" label="Paused" labelClass="checkbox-help_label"/>
+              <Tooltip vm={vm} name="paused-pipelines">Show only pipelines which are paused, regardless of their status</Tooltip>
+            </div>
+            <StageStateCriteria vm={vm}/>
           </div>
-          <StageStateCriteria vm={vm}/>
         </div>
       </div>
 


### PR DESCRIPTION
It's useful to be able to include `Cancelled` and `Paused` pipelines in such filtered views as 
- cancellation can often be considered a failed state when cancelled by the server (e.g due to timeout acquiring an agent, or a stuck build)
- paused pipelines can be a temporary thing and folks forget to unpause them so folks like to have a filtered view to quickly identify these

This does not change the default behaviour and is both backward and forward compatible (i.e if server is rolled back, filters saved with the added state still work, and just ignore the "cancelled" addition to the filter).

![image](https://user-images.githubusercontent.com/29788154/220693153-95a91fc2-1be5-49f6-8a7e-a20035b2e450.png)


**As-is (for reference)**
![image](https://user-images.githubusercontent.com/29788154/220698876-4d2e02d7-97c0-4c44-8deb-4a0c360bbd63.png)


