### PR TITLE
Revert "Upgrade Gradle to 7.6.1"

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=518a863631feb7452b8f1b3dc2aaee5f388355cc3421bbd0275fbeadd77e84b2
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
-networkTimeout=10000
+distributionSha256Sum=db9c8211ed63f61f60292c69e80d89196f9eb36665e369e7f00ac4cc841c2219
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Reverts gocd/gocd#11333

Sadly memory usage still still seems to be massively increased despite https://github.com/gradle/gradle/issues/23215 being closed in `7.6.1`

`Gradle build daemon has been stopped: JVM garbage collector thrashing and after running out of JVM memory`