### PR TITLE
Build most linux container images as multi-arch including arm64

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
@@ -73,15 +73,8 @@ trait DistroBehavior {
     [Architecture.x64]
   }
 
-  Architecture dockerTargetArchitecture(boolean ignoreLocalArchitecture) {
-    if (ignoreLocalArchitecture) {
-      return supportedArchitectures.first()
-    } else if (Architecture.current() in supportedArchitectures) {
-      return Architecture.current()
-    } else {
-       throw new RuntimeException("Local architecture ${Architecture.current()} is not supported by distro $this (supports $supportedArchitectures).\n" +
-         "Pass -PdockerBuildIgnoreLocalArch to build for non-native target arch anyway.")
-    }
+  Architecture getDockerVerifyArchitecture() {
+    Architecture.current() in supportedArchitectures ? Architecture.current(): supportedArchitectures.first()
   }
 
   Map<String, String> getEnvironmentVariables(DistroVersion distroVersion) {

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -22,4 +22,20 @@ subprojects {
   apply plugin: 'base'
 }
 
+tasks.register('initializeBuildx') {
+  doFirst {
+    // Need to do once before everything (not in parallel) see https://github.com/docker/buildx/issues/344
+    def builderName = 'gocd-builder'
+    logger.lifecycle("Initializing docker buildx builder [$builderName]...")
+
+    project.exec { commandLine = ['docker', 'buildx', 'version'] }
+    project.exec {
+      commandLine = ['docker', 'buildx', 'rm', '--force', '--keep-state', builderName]
+      ignoreExitValue = true
+    }
+    project.exec { commandLine = ['docker', 'buildx', 'create', '--use', '--name', builderName] }
+    project.exec { commandLine = ['docker', 'buildx', 'inspect', '--bootstrap', builderName] }
+  }
+}
+
 assemble.dependsOn(subprojects.tasks*.getByName('assemble'))

--- a/docker/gocd-agent/build.gradle
+++ b/docker/gocd-agent/build.gradle
@@ -42,6 +42,7 @@ subprojects {
   DistroVersion distroVersion = distro.getVersion(distroVersionOnProject)
 
   task docker(type: BuildDockerImageTask) { BuildDockerImageTask task ->
+    task.dependsOn ':docker:initializeBuildx'
     assemble.dependsOn(task)
 
     if (project.hasProperty('dockerBuildLocalZip')) {
@@ -170,9 +171,11 @@ task generateManifest() {
     def meta = []
     subprojects.tasks*.getByName('docker').forEach { BuildDockerImageTask dockerTask ->
       meta << [
-        file     : "${dockerTask.imageTarFile.name}.gz",
+        file     : "${dockerTask.imageTarFile.name}",
+        format   : 'oci',
         imageName: dockerTask.dockerImageName,
-        tag      : dockerTask.imageTag
+        tag      : dockerTask.imageTag,
+        platforms: dockerTask.supportedPlatforms
       ]
     }
 

--- a/docker/gocd-server/build.gradle
+++ b/docker/gocd-server/build.gradle
@@ -42,6 +42,7 @@ subprojects {
   DistroVersion distroVersion = distro.getVersion(distroVersionOnProject)
 
   project.tasks.create("docker", BuildDockerImageTask.class) { BuildDockerImageTask task ->
+    task.dependsOn ':docker:initializeBuildx'
     assemble.dependsOn(task)
 
     if (project.hasProperty('dockerBuildLocalZip')) {
@@ -155,9 +156,11 @@ task generateManifest() {
     def meta = []
     subprojects.tasks*.getByName('docker').forEach { BuildDockerImageTask dockerTask ->
       meta << [
-        file     : "${dockerTask.imageTarFile.name}.gz",
+        file     : "${dockerTask.imageTarFile.name}",
+        format   : 'oci',
         imageName: dockerTask.dockerImageName,
-        tag      : dockerTask.imageTag
+        tag      : dockerTask.imageTag,
+        platforms: dockerTask.supportedPlatforms
       ]
     }
 


### PR DESCRIPTION
- Alpine is excluded for now, due to issues with Tanuki wrapper requiring glibc to work on Alpine, and alpine-glibc packages not being available.
- Requires docker buildx plugin to be installed (cleaner errors if not available would probably be useful)
- Built tarballs for all images are changed to OCI format/layout. Since layers are already gzipped here, we remove the additional gzipping which adds little value but adds complexity
- Archived tarballs cannot be directly docker loaded as docker load only understands its native format. Needs a tool like regclient/regctl to export as docker format for docker load so this logic needs incorporation into later steps (functional tests, code signing and docker hub push)
- Currently, only the native build platform image is sanity-checked by starting it now when building multiple archs. Starting cross-platform via emulation seems unreliable most of the time - at least locally.

Related tasks downstream
- [x] Validate arm64 images with functional tests on their native platform 
  - https://github.com/gocd/ruby-functional-tests/commit/892b38f6f68a3a6103e3369a0e7c00cc45884603  (and some subsequent fixes)
- [x] Ensure codesigning and docker hub pushes work with OCI image tarballs
  - https://github.com/gocd/codesigning/commit/a600550e673d6644b68b676f1fd7dcd44cf36648