### PR TITLE
Include arm64 wrapper binaries in deb and rpm packages

### DIFF
--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -279,12 +279,14 @@ def configureLinuxPackage(DefaultTask packageTask, InstallerType installerType, 
       project.copy {
         into "${buildRoot}/usr/share/${installerType.baseName}/wrapper"
         from("${extractDeltaPack.outputs.files.singleFile}/wrapper-delta-pack-${project.versions.tanuki}/bin") {
-          include 'wrapper-linux-x86-*'
+          include 'wrapper-linux-x86-64*'
+          include 'wrapper-linux-arm-64*'
         }
 
         from("${extractDeltaPack.outputs.files.singleFile}/wrapper-delta-pack-${project.versions.tanuki}/lib") {
           include 'wrapper.jar'
-          include 'libwrapper-linux-x86-*'
+          include 'libwrapper-linux-x86-64*'
+          include 'libwrapper-linux-arm-64*'
         }
       }
 


### PR DESCRIPTION
Although the JVM bundled is currently an x64 one, if we include the arm wrapper packages folks can override the JRE to their own arm64 one, in lieu of providing proper arch-specific packages.

Unfortunately the current packages are marked as noarch/all arch despite not actually being as such, so requires us to publish multiple packages :-(