### PR TITLE
Revert "Bump jruby-complete from 9.4.1.0 to 9.4.2.0"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -71,7 +71,7 @@ final Map<String, String> libraries = [
   jgit                : 'org.eclipse.jgit:org.eclipse.jgit:6.5.0.202303070854-r',
   jodaTime            : 'joda-time:joda-time:2.12.2', // joda-time version has to be compatible with the jruby version
   jolt                : 'com.bazaarvoice.jolt:jolt-core:0.1.7',
-  jruby               : 'org.jruby:jruby-complete:9.4.2.0',
+  jruby               : 'org.jruby:jruby-complete:9.4.1.0',
   jsonUnit            : 'net.javacrumbs.json-unit:json-unit-fluent:2.36.1',
   jsoup               : 'org.jsoup:jsoup:1.15.4',
   junit5Bom           : 'org.junit:junit-bom:5.9.2',

--- a/server/src/main/webapp/WEB-INF/rails/.tool-versions
+++ b/server/src/main/webapp/WEB-INF/rails/.tool-versions
@@ -1,2 +1,2 @@
 # Configuration for https://github.com/asdf-vm/asdf as an alternative to jabba, rvm, nvm etc
-ruby jruby-9.4.2.0
+ruby jruby-9.4.1.0


### PR DESCRIPTION
Reverts gocd/gocd#11365

There's some issue installed sass-embedded on Windows which needs investigation :-(

https://build.gocd.org/go/tab/build/detail/build-windows/6284/build-non-server/2/jasmine

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
C:/go/pipelines/build-windows/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/gems/sass-embedded-1.58.3/ext/sass
C:/go/pipelines/build-windows/server/scripts/jruby.bat
-Iuri:classloader:/META-INF/jruby.home/lib/ruby/stdlib -rrubygems
C:/go/pipelines/build-windows/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/gems/rake-13.0.6/exe/rake
RUBYARCHDIR\=C:/go/pipelines/build-windows/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/extensions/universal-java-17/3.1.0/sass-embedded-1.58.3
RUBYLIBDIR\=C:/go/pipelines/build-windows/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/extensions/universal-java-17/3.1.0/sass-embedded-1.58.3
[16364, #<Thread:0xb01cb8d@main run>, #<LoadError: no such file to load --
rake>, ["org/jruby/RubyKernel.java:1057:in `require'",
"uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:85:in
`require'",
"C:/go/pipelines/build-windows/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/gems/rake-13.0.6/exe/rake:25:in
`<main>'"]]
[16364, #<Thread:0xb01cb8d@main run>, #<RuntimeError: CRITICAL:
RUBYGEMS_ACTIVATION_MONITOR.owned?: before false -> after true>,
["uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:167:in
`require'",
"C:/go/pipelines/build-windows/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/gems/rake-13.0.6/lib/rake.rb:29:in
`<main>'", "org/jruby/RubyKernel.java:1057:in `require'",
"uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:160:in
`require'",
"C:/go/pipelines/build-windows/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/gems/rake-13.0.6/exe/rake:25:in
`<main>'"]]
RuntimeError: CRITICAL: RUBYGEMS_ACTIVATION_MONITOR.owned?: before false ->
after true
require at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:167
<main> at
C:/go/pipelines/build-windows/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/gems/rake-13.0.6/exe/rake:25
RuntimeError: CRITICAL: RUBYGEMS_ACTIVATION_MONITOR.owned?: before false ->
after true
require at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:167
<main> at
C:/go/pipelines/build-windows/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/gems/rake-13.0.6/lib/rake.rb:29
  require at org/jruby/RubyKernel.java:1057
require at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:160
<main> at
C:/go/pipelines/build-windows/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/gems/rake-13.0.6/exe/rake:25
LoadError: no such file to load -- rake
  require at org/jruby/RubyKernel.java:1057
require at
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:85
<main> at
C:/go/pipelines/build-windows/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/gems/rake-13.0.6/exe/rake:25

rake failed, exit code 1

Gem files will remain installed in
C:/go/pipelines/build-windows/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/gems/sass-embedded-1.58.3
for inspection.
Results logged to
C:/go/pipelines/build-windows/server/src/main/webapp/WEB-INF/rails/gems/jruby/3.1.0/extensions/universal-java-17/3.1.0/sass-embedded-1.58.3/gem_make.out

uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:102:in
`run'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/rake_builder.rb:28:in
`build'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:171:in
`build_extension'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:205:in
`block in build_extensions'
  org/jruby/RubyArray.java:1987:in `each'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/ext/builder.rb:202:in
`build_extensions'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/installer.rb:843:in
`build_extensions'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/rubygems_gem_installer.rb:72:in
`build_extensions'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/rubygems_gem_installer.rb:28:in
`install'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/source/rubygems.rb:207:in
`install'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/installer/gem_installer.rb:54:in
`install'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/installer/gem_installer.rb:16:in
`install_from_spec'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/installer/parallel_installer.rb:186:in
`do_install'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/installer/parallel_installer.rb:177:in
`block in worker_pool'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/worker.rb:62:in
`apply_func'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/worker.rb:57:in
`block in process_queue'
  org/jruby/RubyKernel.java:1586:in `loop'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/worker.rb:54:in
`process_queue'
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/bundler/worker.rb:91:in
`block in create_threads'

An error occurred while installing sass-embedded (1.58.3), and Bundler cannot
continue.

In Gemfile:
  sassc-embedded was resolved to 1.54.0, which depends on
    sass-embedded
```
