### PR TITLE
Fix docker repo publishing when not building images

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/BuildDockerImageTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/BuildDockerImageTask.groovy
@@ -111,14 +111,14 @@ class BuildDockerImageTask extends DefaultTask {
         verifyHelper.call(isNativeVerify)
         logger.lifecycle("\nVerification of ${imageNameWithTag} image on ${distro.dockerVerifyArchitecture} successful.")
       }
-    }
 
-    logger.lifecycle("Cleaning up...")
-    // delete the image, to save space
-    if (!project.hasProperty('dockerBuildKeepImages')) {
-      project.exec {
-        workingDir = project.rootProject.projectDir
-        commandLine = ["docker", "rmi", imageNameWithTag]
+      logger.lifecycle("Cleaning up...")
+      // delete the image, to save space
+      if (!project.hasProperty('dockerBuildKeepImages')) {
+        project.exec {
+          workingDir = project.rootProject.projectDir
+          commandLine = ["docker", "rmi", imageNameWithTag]
+        }
       }
     }
 

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -24,17 +24,19 @@ subprojects {
 
 tasks.register('initializeBuildx') {
   doFirst {
-    // Need to do once before everything (not in parallel) see https://github.com/docker/buildx/issues/344
-    def builderName = 'gocd-builder'
-    logger.lifecycle("Initializing docker buildx builder [$builderName]...")
+    if (!project.hasProperty('skipDockerBuild')) {
+      // Need to do once before everything (not in parallel) see https://github.com/docker/buildx/issues/344
+      def builderName = 'gocd-builder'
+      logger.lifecycle("Initializing docker buildx builder [$builderName]...")
 
-    project.exec { commandLine = ['docker', 'buildx', 'version'] }
-    project.exec {
-      commandLine = ['docker', 'buildx', 'rm', '--force', '--keep-state', builderName]
-      ignoreExitValue = true
+      project.exec { commandLine = ['docker', 'buildx', 'version'] }
+      project.exec {
+        commandLine = ['docker', 'buildx', 'rm', '--force', '--keep-state', builderName]
+        ignoreExitValue = true
+      }
+      project.exec { commandLine = ['docker', 'buildx', 'create', '--use', '--name', builderName] }
+      project.exec { commandLine = ['docker', 'buildx', 'inspect', '--bootstrap', builderName] }
     }
-    project.exec { commandLine = ['docker', 'buildx', 'create', '--use', '--name', builderName] }
-    project.exec { commandLine = ['docker', 'buildx', 'inspect', '--bootstrap', builderName] }
   }
 }
 


### PR DESCRIPTION
When publishing the docker image repos we dont build images, so `skipDockerBuild` is important. Accidental indent issue was introduced here for multi-arch images that this fixes.