### PR TITLE
Remove core files hanging around bloating CentOS 7 arm64 container image

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -108,6 +108,7 @@ enum Distro implements DistroBehavior {
         "echo 'install_weak_deps=False' >> /etc/${pkg == 'yum' ? 'yum' : 'dnf/dnf'}.conf",
         "${pkg} update -y",
         "${pkg} upgrade -y",
+        "rm -rf *.core core.*", // Remove this line when CentOS 7 is removed
       ]
 
       String git = gitPackageFor(v)


### PR DESCRIPTION
On CentOS 7 the `yum upgrade`s for aarch64 when building on x64 hardware seem to have some QEMU problems causing crashes of something non-critical during the upgrade which isn't logged anywhere and seems to cause no harm, so removing the core files for now.

Example below.
```
core.9670: ELF 64-bit LSB core file x86-64, version 1 (SYSV), SVR4-style, from '.buildkit_qemu_emulator -0 /lib/ld-linux-aarch64.so.1 /lib/ld-linux-aarch64.so.', real uid: 0, effective uid: 0, real gid: 0, effective gid: 0, execfn: '/proc/self/exe', platform: 'x86_64'

qemu_ld-linux-aarch64.so.1_20230310-170425_9670.core: ELF 64-bit LSB core file ARM aarch64, version 1 (SYSV), SVR4-style, from 'ld-linux-aarch64/lib/ld-linux-aarch64.so.1 /bin/sh', real uid: 0, effective uid: 0, real gid: 0, effective gid: 0, execfn: '/lib/ld-linux-aarch64.so.1', platform: 'aarch64'
```
