### PR TITLE
Fix mess in CentOS 7 images on arm64

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -106,9 +106,8 @@ enum Distro implements DistroBehavior {
       def commands = [
         "echo 'fastestmirror=1' >> /etc/${pkg == 'yum' ? 'yum' : 'dnf/dnf'}.conf",
         "echo 'install_weak_deps=False' >> /etc/${pkg == 'yum' ? 'yum' : 'dnf/dnf'}.conf",
-        "${pkg} update -y",
+        v.lessThan(8) ? "${pkg} install grubby -y && ${pkg} autoremove -y && ${pkg} remove grubby -y && ${pkg} update -y" : "${pkg} update -y",
         "${pkg} upgrade -y",
-        "rm -rf /*.core /core.*", // Remove this line when CentOS 7 is removed
       ]
 
       String git = gitPackageFor(v)


### PR DESCRIPTION
The CentOS 7 container images are ancient and contain some orphaned unnecessary packages in the base layer. On arm64 this includes an old kernel-core install from an outdated kernel which can only be removed with grubby installed due to what seems like a bug in the remove script. So we add gruuby, autoremove other stuff, then remove grubby before doing a general update.

This also avoids hundreds of MB of dependencies coming down via kernel-core, kernel-modules, linux-firmware etc.
