### PR TITLE
Minimise further size of CentOS Stream 9 images

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -110,13 +110,12 @@ enum Distro implements DistroBehavior {
         "${pkg} upgrade -y",
       ]
 
-      String git = gitPackageFor(v)
-      commands += "${pkg} install -y ${git} mercurial subversion openssh-clients bash unzip procps" +
-        (v.lessThan(8) ? ' sysvinit-tools coreutils' : ' procps-ng coreutils-single') +
-        (v.lessThan(9) ? ' curl' : ' curl-minimal')
+      commands += "${pkgFor(v)} install -y ${(v.lessThan(8) ? "rh-git227-git-core" : "git-core")} mercurial subversion openssh-clients bash unzip procps" +
+          (v.lessThan(8) ? ' sysvinit-tools coreutils' : ' procps-ng coreutils-single') +
+          (v.lessThan(9) ? ' curl' : ' curl-minimal')
 
       if (v.lessThan(8)) {
-        commands += "cp /opt/rh/${git}/enable /etc/profile.d/${git}.sh"
+        commands += "cp /opt/rh/rh-git227/enable /etc/profile.d/rh-git227.sh"
       }
 
       commands += [
@@ -125,10 +124,6 @@ enum Distro implements DistroBehavior {
       ]
 
       return commands
-    }
-
-    String gitPackageFor(DistroVersion v) {
-      return v.lessThan(8) ? "rh-git227" : "git"
     }
 
     @Override

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
@@ -44,13 +44,17 @@ trait DistroBehavior {
     }) ?: { throw new RuntimeException("Version [${version}] is not defined for this distro.") }()
   }
 
+  List<String> getBaseImageUpdateCommands(DistroVersion v) {
+    throw new RuntimeException("Subclasses must implement!")
+  }
+
   List<String> getCreateUserAndGroupCommands() {
     return [
       'useradd -l -u ${UID} -g root -d /home/go -m go'
     ]
   }
 
-  List<String> getInstallPrerequisitesCommands(DistroVersion distroVersion) {
+  List<String> getInstallPrerequisitesCommands(DistroVersion v) {
     throw new RuntimeException("Subclasses must implement!")
   }
 

--- a/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
@@ -73,9 +73,10 @@ RUN \
   chown ${fileDescriptor.owner}:${fileDescriptor.group} ${filePath} && \
   </#list>
 </#if>
-# add our user and group first to make sure their IDs get assigned consistently,
-# regardless of whatever dependencies get added
-# add user to root group for GoCD to work on openshift
+<#list distro.getBaseImageUpdateCommands(distroVersion) as command>
+  ${command} && \
+</#list>
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 <#list distro.createUserAndGroupCommands as command>
   ${command} && \
 </#list>

--- a/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
@@ -74,9 +74,10 @@ RUN \
   chown ${fileDescriptor.owner}:${fileDescriptor.group} ${filePath} && \
   </#list>
 </#if>
-# add our user and group first to make sure their IDs get assigned consistently,
-# regardless of whatever dependencies get added
-# add user to root group for GoCD to work on openshift
+<#list distro.getBaseImageUpdateCommands(distroVersion) as command>
+  ${command} && \
+</#list>
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 <#list distro.createUserAndGroupCommands as command>
   ${command} && \
 </#list>


### PR DESCRIPTION
- switch to stream9-minimal base image
  - causes switch to microdnf  
  - avoids unnecessarily installing Python
- switch to git-core rather than full git
  - avoids perl and other dependencies coming down 