### PR TITLE
Tell dockerd to only bind TCP/HTTP API to localhost

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-agent/docker-entrypoint.sh
+++ b/buildSrc/src/main/resources/gocd-docker-agent/docker-entrypoint.sh
@@ -58,7 +58,7 @@ setup_autoregister_properties_file() {
 }
 
 if [ -e /run-docker-daemon.sh ]; then
-  sudo /run-docker-daemon.sh
+  try sudo /run-docker-daemon.sh
 fi
 
 AGENT_WORK_DIR="/go"

--- a/buildSrc/src/main/resources/gocd-docker-agent/run-docker-daemon.sh
+++ b/buildSrc/src/main/resources/gocd-docker-agent/run-docker-daemon.sh
@@ -13,6 +13,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# shellcheck disable=SC2086
+$(which dind) dockerd --host=unix:///var/run/docker.sock ${DOCKERD_ADDITIONAL_ARGS:-'--host=tcp://localhost:2375'} > /var/log/dockerd.log 2>&1 &
 
-$(which dind) dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 > /var/log/dockerd.log 2>&1 &
+waited=0
+until [ $waited -gt ${DOCKERD_MAX_WAIT_SECS:-30} ] || docker stats --no-stream; do
+  sleep 1
+  ((waited++))
+done
+# shellcheck disable=SC2181
+if ! docker stats --no-stream; then
+  echo "dockerd startup failed..."
+  cat /var/log/dockerd.log
+  exit 1
+fi
+echo "dockerd started"
 disown


### PR DESCRIPTION
Fixes #11378 

- resolves the 15s delay caused by listening on 0.0.0.0 without TLS
- listens on localhost only which is not perfect, but more secure
- allows user opt-out of all TCP listens, as well as opt-in to more secure config via `DOCKERD_ADDITIONAL_ARGS`
- continues listening on localhost due to possibility some tools/libs can only talk to Docker on TCP, not unix sockets by default to minimise chance of breaking change
- waits `DOCKERD_MAX_WAIT_SECS` (default 30) for the daemon to start (blocking agent startup), exiting if it doesn't, to avoid hidden issues like we had here
  - image sanity tests will fail if the daemon takes 15s to start, as long as we wait for it

