### PR TITLE
Correct ability to override env vars for dockerd in dind image

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-agent/dockerd-sudo
+++ b/buildSrc/src/main/resources/gocd-docker-agent/dockerd-sudo
@@ -1,3 +1,3 @@
 
-Defaults    env_reset
+Defaults    env_keep += "DOCKERD_ADDITIONAL_ARGS DOCKERD_MAX_WAIT_SECS"
 go ALL=(ALL) NOPASSWD: /run-docker-daemon.sh

--- a/buildSrc/src/main/resources/gocd-docker-agent/run-docker-daemon.sh
+++ b/buildSrc/src/main/resources/gocd-docker-agent/run-docker-daemon.sh
@@ -17,7 +17,7 @@
 $(which dind) dockerd --host=unix:///var/run/docker.sock ${DOCKERD_ADDITIONAL_ARGS:-'--host=tcp://localhost:2375'} > /var/log/dockerd.log 2>&1 &
 
 waited=0
-until [ $waited -gt ${DOCKERD_MAX_WAIT_SECS:-30} ] || docker stats --no-stream; do
+until [ $waited -ge ${DOCKERD_MAX_WAIT_SECS:-30} ] || docker stats --no-stream; do
   sleep 1
   ((waited++))
 done


### PR DESCRIPTION
Follow-up to #11406, correcting the ability to override from within sudo