### PR TITLE
Allow dind image to be correctly verified

### DIFF
--- a/docker/gocd-agent/build.gradle
+++ b/docker/gocd-agent/build.gradle
@@ -116,8 +116,9 @@ subprojects {
       // daemonize the container
       cleanContainer.call() // Clean-up after any previous aborted runs
       project.exec {
+        def additionalFlags = distro == Distro.docker ? ["--privileged"] : []
         workingDir = project.rootProject.projectDir
-        commandLine = ["docker", "run", "-e", "GO_SERVER_URL=http://localhost:8153/go", "-d", "--name", docker.dockerImageName, docker.imageNameWithTag]
+        commandLine = ["docker", "run", "-e", "GO_SERVER_URL=http://localhost:8153/go", "-d", "--name", docker.dockerImageName] + additionalFlags + [docker.imageNameWithTag] as List<String>
         standardOutput = System.out
         errorOutput = System.err
       }


### PR DESCRIPTION
Another follow-up to #11406 - unfortunately cannot verify this locally due to only having arm64 hardware.