### PR TITLE
Disable rake task test on Windows

### DIFF
--- a/server/src/test-fast/java/com/thoughtworks/go/remote/work/BuildWorkTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/remote/work/BuildWorkTest.java
@@ -508,6 +508,7 @@ class BuildWorkTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void rakeTest() throws Exception {
         buildWork = getWork(RAKE, PIPELINE_NAME);
         buildWork.doWork(environmentVariableContext, new AgentWorkContext(agentIdentifier, buildRepository, artifactManipulator, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie"), packageRepositoryExtension, scmExtension, taskExtension, null, pluginRequestProcessorRegistry));


### PR DESCRIPTION
This isn't really necessary to run cross-OS. So few folks rely on Ruby/Rake on Windows and this makes it so you don't need to install ruby on Windows for dev