### PR TITLE
Bump jquery to 3.6.4 (and foundation-sites to 6.4.3)

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/.stylelintrc.yml
+++ b/server/src/main/webapp/WEB-INF/rails/.stylelintrc.yml
@@ -16,5 +16,11 @@ rules:
 
   # May have been a requirement of old Ruby Sass, to validate if necessary against Dart Sass now.
   color-function-notation: legacy
+
+  selector-pseudo-class-no-unknown:
+    - true
+    - ignorePseudoClasses:
+        - global
+
 ignoreFiles:
 - app/assets/new_stylesheets/_font-awesome-glyphs.scss.erb

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_settings.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_settings.scss
@@ -15,9 +15,14 @@
  */
 @import "../new_stylesheets/shared/go-variables";
 
+// Since it's mainly a 3rd party file, we ignore all lint errors
+// stylelint-disable
+
 //  Foundation for Sites Settings
 //  -----------------------------
+//
 //  Table of Contents:
+//
 //   1. Global
 //   2. Breakpoints
 //   3. The Grid
@@ -31,31 +36,51 @@
 //  11. Button
 //  12. Button Group
 //  13. Callout
-//  14. Close Button
-//  15. Drilldown
-//  16. Dropdown
-//  17. Dropdown Menu
-//  18. Flex Video
-//  19. Forms
-//  20. Label
-//  21. Media Object
-//  22. Menu
-//  23. Meter
-//  24. Off-canvas
-//  25. Orbit
-//  26. Pagination
-//  27. Progress Bar
-//  28. Reveal
-//  29. Slider
-//  30. Switch
-//  31. Table
-//  32. Tabs
-//  33. Thumbnail
-//  34. Title Bar
-//  35. Tooltip
-//  36. Top Bar
+//  14. Card
+//  15. Close Button
+//  16. Drilldown
+//  17. Dropdown
+//  18. Dropdown Menu
+//  19. Flexbox Utilities
+//  20. Forms
+//  21. Label
+//  22. Media Object
+//  23. Menu
+//  24. Meter
+//  25. Off-canvas
+//  26. Orbit
+//  27. Pagination
+//  28. Progress Bar
+//  29. Prototype Arrow
+//  30. Prototype Border-Box
+//  31. Prototype Border-None
+//  32. Prototype Bordered
+//  33. Prototype Display
+//  34. Prototype Font-Styling
+//  35. Prototype List-Style-Type
+//  36. Prototype Overflow
+//  37. Prototype Position
+//  38. Prototype Rounded
+//  39. Prototype Separator
+//  40. Prototype Shadow
+//  41. Prototype Sizing
+//  42. Prototype Spacing
+//  43. Prototype Text-Decoration
+//  44. Prototype Text-Transformation
+//  45. Prototype Text-Utilities
+//  46. Responsive Embed
+//  47. Reveal
+//  48. Slider
+//  49. Switch
+//  50. Table
+//  51. Tabs
+//  52. Thumbnail
+//  53. Title Bar
+//  54. Tooltip
+//  55. Top Bar
+//  56. Xy Grid
 
-@import "foundation-sites/scss/util/util";
+@import "foundation-sites/scss/util/util"; // custom
 
 // 1. Global
 // ---------
@@ -65,10 +90,10 @@ $global-width: rem-calc(1200);
 $global-lineheight: 1.5;
 $foundation-palette: (
   primary: $go-primary, // custom
-  secondary: #777,
+  secondary: #777, // custom
   success: #3adb76,
   warning: #ffae00,
-  alert: #ec5840,
+  alert: #ec5840, // custom
 );
 $light-gray: #e6e6e6;
 $lighter-gray: #f5f5f5; // custom
@@ -76,17 +101,23 @@ $medium-gray: #cacaca;
 $dark-gray: #8a8a8a;
 $black: #0a0a0a;
 $white: #fefefe;
-$body-background: #f4f8f9;
+$body-background: #f4f8f9; // custom
 $body-font-color: $black;
 $body-font-family: "Open Sans", "Helvetica Neue", helvetica, roboto, arial, sans-serif; // custom
 $body-antialiased: true;
 $global-margin: 1rem;
 $global-padding: 1rem;
+$global-position: 1rem;
 $global-weight-normal: normal;
 $global-weight-bold: bold;
 $global-radius: 3px; // custom
+$global-menu-padding: 0.7rem 1rem;
+$global-menu-nested-margin: 1rem;
 $global-text-direction: ltr;
-$global-flexbox: false;
+$global-flexbox: true;
+$global-prototype-breakpoints: false;
+$global-button-cursor: auto;
+$global-color-pick-contrast-tolerance: 0;
 $print-transparent-backgrounds: true;
 
 @include add-foundation-colors;
@@ -101,6 +132,7 @@ $breakpoints: (
   xlarge: 1200px,
   xxlarge: 1440px,
 );
+$print-breakpoint: large;
 $breakpoint-classes: (small medium large);
 
 // 3. The Grid
@@ -113,6 +145,7 @@ $grid-column-gutter: (
   medium: 30px,
 );
 $grid-column-align-edge: true;
+$grid-column-alias: 'columns';
 $block-grid-max: 8;
 
 // 4. Base Typography
@@ -121,34 +154,34 @@ $block-grid-max: 8;
 $header-font-family: $body-font-family;
 $header-font-weight: $global-weight-normal;
 $header-font-style: normal;
-$font-family-monospace: consolas, "Liberation Mono", courier, monospace;
-$header-styles: (
-  small: (
-    "h1": ("font-size": 24),
-    "h2": ("font-size": 20),
-    "h3": ("font-size": 19),
-    "h4": ("font-size": 18),
-    "h5": ("font-size": 17),
-    "h6": ("font-size": 16),
-  ),
-  medium: (
-    "h1": ("font-size": 48),
-    "h2": ("font-size": 40),
-    "h3": ("font-size": 31),
-    "h4": ("font-size": 25),
-    "h5": ("font-size": 20),
-    "h6": ("font-size": 16),
-  ),
-);
+$font-family-monospace: Consolas, 'Liberation Mono', Courier, monospace;
 $header-color: inherit;
 $header-lineheight: 1.4;
 $header-margin-bottom: 0.5rem;
-$header-text-rendering: optimizelegibility;
+$header-styles: (
+  small: (
+    'h1': ('font-size': 24),
+    'h2': ('font-size': 20),
+    'h3': ('font-size': 19),
+    'h4': ('font-size': 18),
+    'h5': ('font-size': 17),
+    'h6': ('font-size': 16),
+  ),
+  medium: (
+    'h1': ('font-size': 48),
+    'h2': ('font-size': 40),
+    'h3': ('font-size': 31),
+    'h4': ('font-size': 25),
+    'h5': ('font-size': 20),
+    'h6': ('font-size': 16),
+  ),
+);
+$header-text-rendering: optimizeLegibility;
 $small-font-size: 80%;
 $header-small-font-color: $medium-gray;
 $paragraph-lineheight: 1.6;
 $paragraph-margin-bottom: 1rem;
-$paragraph-text-rendering: optimizelegibility;
+$paragraph-text-rendering: optimizeLegibility;
 $code-color: $black;
 $code-font-family: $font-family-monospace;
 $code-font-weight: $global-weight-normal;
@@ -176,6 +209,7 @@ $blockquote-padding: rem-calc(9 20 0 19);
 $blockquote-border: 1px solid $medium-gray;
 $cite-font-size: rem-calc(13);
 $cite-color: $dark-gray;
+$cite-pseudo-content: '\2014 \0020';
 $keystroke-font: $font-family-monospace;
 $keystroke-color: $black;
 $keystroke-background: $light-gray;
@@ -200,9 +234,9 @@ $stat-font-size: 2.5rem;
 
 $abide-inputs: true;
 $abide-labels: true;
-$input-background-invalid: map-get($foundation-palette, alert);
-$form-label-color-invalid: map-get($foundation-palette, alert);
-$input-error-color: map-get($foundation-palette, alert);
+$input-background-invalid: get-color(alert);
+$form-label-color-invalid: get-color(alert);
+$input-error-color: get-color(alert);
 $input-error-font-size: rem-calc(12);
 $input-error-font-weight: $global-weight-bold;
 
@@ -211,25 +245,38 @@ $input-error-font-weight: $global-weight-bold;
 
 $accordion-background: $accordion-bg; // custom
 $accordion-plusminus: false; // custom
-$accordion-item-color: foreground($accordion-background, $black); // custom
+$accordion-title-font-size: rem-calc(12);
+$accordion-item-color: $black; // custom
 $accordion-item-background-hover: $accordion-bg-hover; // custom
 $accordion-item-padding: 0 2rem; // custom
 $accordion-content-background: $accordion-bg; // custom
 $accordion-content-border: 0; // custom
-$accordion-content-color: foreground($accordion-content-background, $body-font-color);
+$accordion-content-color: $body-font-color;
 $accordion-content-padding: 1rem;
 
 // 8. Accordion Menu
 // -----------------
 
+$accordionmenu-padding: $global-menu-padding;
+$accordionmenu-nested-margin: $global-menu-nested-margin;
+$accordionmenu-submenu-padding: $accordionmenu-padding;
 $accordionmenu-arrows: true;
 $accordionmenu-arrow-color: $black; // custom
+$accordionmenu-item-background: null;
+$accordionmenu-border: null;
+$accordionmenu-submenu-toggle-background: null;
+$accordion-submenu-toggle-border: $accordionmenu-border;
+$accordionmenu-submenu-toggle-width: 40px;
+$accordionmenu-submenu-toggle-height: $accordionmenu-submenu-toggle-width;
+$accordionmenu-arrow-size: 6px;
 
 // 9. Badge
 // --------
 
 $badge-background: $primary-color;
-$badge-color: foreground($badge-background);
+$badge-color: $white;
+$badge-color-alt: $black;
+$badge-palette: $foundation-palette;
 $badge-padding: 0.3em;
 $badge-minwidth: 2.1em;
 $badge-font-size: 0.6rem;
@@ -244,11 +291,15 @@ $breadcrumbs-item-color-current: $black;
 $breadcrumbs-item-color-disabled: $medium-gray;
 $breadcrumbs-item-margin: 0.75rem;
 $breadcrumbs-item-uppercase: true;
-$breadcrumbs-item-slash: true;
+$breadcrumbs-item-separator: true;
+$breadcrumbs-item-separator-item: '/';
+$breadcrumbs-item-separator-item-rtl: '\\';
+$breadcrumbs-item-separator-color: $medium-gray;
 
 // 11. Button
 // ----------
 
+$button-font-family: inherit;
 $button-padding: 0.5em 1em; // custom
 $button-margin: 0 0 $global-margin 0;
 $button-fill: solid;
@@ -257,21 +308,27 @@ $button-background-hover: scale-color($button-background, $lightness: -15%);
 $button-color: $white;
 $button-color-alt: $black;
 $button-radius: $global-radius;
+$button-hollow-border-width: 1px;
 $button-sizes: (
   tiny: 0.6rem,
   small: 0.75rem,
   default: 0.9rem,
   large: 1.25rem,
 );
+$button-palette: $foundation-palette;
 $button-opacity-disabled: 0.25;
+$button-background-hover-lightness: -20%;
+$button-hollow-hover-lightness: -50%;
+$button-transition: background-color 0.25s ease-out, color 0.25s ease-out;
 
 // 12. Button Group
 // ----------------
 
 $buttongroup-margin: 1rem;
 $buttongroup-spacing: 1px;
-$buttongroup-child-selector: ".button";
+$buttongroup-child-selector: '.button';
 $buttongroup-expand-max: 6;
+$buttongroup-radius-on-each: true;
 
 // 13. Callout
 // -----------
@@ -286,29 +343,56 @@ $callout-font-color-alt: $body-background;
 $callout-radius: $global-radius;
 $callout-link-tint: 30%;
 
-// 14. Close Button
+// 14. Card
+// --------
+
+$card-background: $white;
+$card-font-color: $body-font-color;
+$card-divider-background: $light-gray;
+$card-border: 1px solid $light-gray;
+$card-shadow: none;
+$card-border-radius: $global-radius;
+$card-padding: $global-padding;
+$card-margin-bottom: $global-margin;
+
+// 15. Close Button
 // ----------------
 
 $closebutton-position: right top;
-$closebutton-offset-horizontal: 1rem;
-$closebutton-offset-vertical: 0.5rem;
-$closebutton-size: 2em;
+$closebutton-offset-horizontal: (
+  small: 0.66rem,
+  medium: 1rem,
+);
+$closebutton-offset-vertical: (
+  small: 0.33em,
+  medium: 0.5rem,
+);
+$closebutton-size: (
+  small: 1.5em,
+  medium: 2em,
+);
 $closebutton-lineheight: 1;
 $closebutton-color: $dark-gray;
 $closebutton-color-hover: $black;
 
-// 15. Drilldown
+// 16. Drilldown
 // -------------
 
 $drilldown-transition: transform 0.15s linear;
 $drilldown-arrows: true;
-$drilldown-arrow-color: $primary-color;
+$drilldown-padding: $global-menu-padding;
+$drilldown-nested-margin: 0;
 $drilldown-background: $white;
+$drilldown-submenu-padding: $drilldown-padding;
+$drilldown-submenu-background: $white;
+$drilldown-arrow-color: $primary-color;
+$drilldown-arrow-size: 6px;
 
-// 16. Dropdown
+// 17. Dropdown
 // ------------
 
 $dropdown-padding: 1rem;
+$dropdown-background: $body-background;
 $dropdown-border: 1px solid $medium-gray;
 $dropdown-font-size: 1rem;
 $dropdown-width: 300px;
@@ -319,23 +403,30 @@ $dropdown-sizes: (
   large: 400px,
 );
 
-// 17. Dropdown Menu
+// 18. Dropdown Menu
 // -----------------
 
 $dropdownmenu-arrows: false; // custom
 $dropdownmenu-arrow-color: $anchor-color;
+$dropdownmenu-arrow-size: 6px;
+$dropdownmenu-arrow-padding: 1.5rem;
 $dropdownmenu-min-width: 200px;
 $dropdownmenu-background: $white;
+$dropdownmenu-submenu-background: $dropdownmenu-background;
+$dropdownmenu-padding: $global-menu-padding;
+$dropdownmenu-nested-margin: 0;
+$dropdownmenu-submenu-padding: $dropdownmenu-padding;
 $dropdownmenu-border: 1px solid $medium-gray;
+$dropdown-menu-item-color-active: get-color(primary);
+$dropdown-menu-item-background-active: transparent;
 
-// 18. Flex Video
-// --------------
+// 19. Flexbox Utilities
+// ---------------------
 
-$flexvideo-margin-bottom: rem-calc(16);
-$flexvideo-ratio: 4 by 3;
-$flexvideo-ratio-widescreen: 16 by 9;
+$flex-source-ordering-count: 6;
+$flexbox-responsive-breakpoints: true;
 
-// 19. Forms
+// 20. Forms
 // ---------
 
 $fieldset-border: 1px solid $medium-gray;
@@ -361,45 +452,56 @@ $input-color: $black;
 $input-placeholder-color: $medium-gray;
 $input-font-family: inherit;
 $input-font-size: rem-calc(14); // custom
+$input-font-weight: $global-weight-normal;
+$input-line-height: $global-lineheight;
 $input-background: $white;
 $input-background-focus: $white;
 $input-background-disabled: $light-gray;
 $input-border: 1px solid $medium-gray;
 $input-border-focus: 1px solid $dark-gray;
+$input-padding: $form-spacing / 2;
 $input-shadow: inset 0 1px 2px rgba($black, 0.1);
 $input-shadow-focus: 0 0 5px $medium-gray;
 $input-cursor-disabled: not-allowed;
 $input-transition: box-shadow 0.5s, border-color 0.25s ease-in-out;
 $input-number-spinners: true;
 $input-radius: $global-radius;
+$form-button-radius: $global-radius;
 
-// 20. Label
+// 21. Label
 // ---------
 
 $label-background: $primary-color;
-$label-color: foreground($label-background);
+$label-color: $white;
+$label-color-alt: $black;
+$label-palette: $foundation-palette;
 $label-font-size: 0.8rem;
 $label-padding: 0.33333rem 0.5rem;
 $label-radius: $global-radius;
 
-// 21. Media Object
+// 22. Media Object
 // ----------------
 
 $mediaobject-margin-bottom: $global-margin;
 $mediaobject-section-padding: $global-padding;
 $mediaobject-image-width-stacked: 100%;
 
-// 22. Menu
+// 23. Menu
 // --------
 
 $menu-margin: 0;
-$menu-margin-nested: 1rem;
-$menu-item-padding: 0.7rem 1rem;
+$menu-nested-margin: $global-menu-nested-margin;
+$menu-items-padding: $global-menu-padding;
+$menu-simple-margin: 1rem;
 $menu-item-color-active: $white;
-$menu-item-background-active: map-get($foundation-palette, primary);
+$menu-item-background-active: get-color(primary);
 $menu-icon-spacing: 0.25rem;
+$menu-item-background-hover: $light-gray;
+$menu-state-back-compat: true;
+$menu-centered-back-compat: true;
+$menu-icons-back-compat: true;
 
-// 23. Meter
+// 24. Meter
 // ---------
 
 $meter-height: 1rem;
@@ -409,20 +511,30 @@ $meter-fill-good: $success-color;
 $meter-fill-medium: $warning-color;
 $meter-fill-bad: $alert-color;
 
-// 24. Off-canvas
+// 25. Off-canvas
 // --------------
 
-$offcanvas-size: 250px;
+$offcanvas-sizes: (
+  small: 250px,
+);
+$offcanvas-vertical-sizes: (
+  small: 250px,
+);
 $offcanvas-background: $light-gray;
-$offcanvas-zindex: -1;
+$offcanvas-shadow: 0 0 10px rgba($black, 0.7);
+$offcanvas-inner-shadow-size: 20px;
+$offcanvas-inner-shadow-color: rgba($black, 0.25);
+$offcanvas-overlay-zindex: 11;
+$offcanvas-push-zindex: 12;
+$offcanvas-overlap-zindex: 13;
+$offcanvas-reveal-zindex: 12;
 $offcanvas-transition-length: 0.5s;
 $offcanvas-transition-timing: ease;
 $offcanvas-fixed-reveal: true;
 $offcanvas-exit-background: rgba($white, 0.25);
-$maincontent-class: "off-canvas-content";
-$maincontent-shadow: 0 0 10px rgba($black, 0.5);
+$maincontent-class: 'off-canvas-content';
 
-// 25. Orbit
+// 26. Orbit
 // ---------
 
 $orbit-bullet-background: $medium-gray;
@@ -437,7 +549,7 @@ $orbit-control-background-hover: rgba($black, 0.5);
 $orbit-control-padding: 1rem;
 $orbit-control-zindex: 10;
 
-// 26. Pagination
+// 27. Pagination
 // --------------
 
 $pagination-font-size: rem-calc(14);
@@ -448,13 +560,14 @@ $pagination-item-spacing: rem-calc(1);
 $pagination-radius: $global-radius;
 $pagination-item-background-hover: $light-gray;
 $pagination-item-background-current: $primary-color;
-$pagination-item-color-current: foreground($pagination-item-background-current);
+$pagination-item-color-current: $white;
 $pagination-item-color-disabled: $medium-gray;
 $pagination-ellipsis-color: $black;
 $pagination-mobile-items: false;
+$pagination-mobile-current-item: false;
 $pagination-arrows: true;
 
-// 27. Progress Bar
+// 28. Progress Bar
 // ----------------
 
 $progress-height: 1rem;
@@ -463,7 +576,177 @@ $progress-margin-bottom: $global-margin;
 $progress-meter-background: $primary-color;
 $progress-radius: $global-radius;
 
-// 28. Reveal
+// 29. Prototype Arrow
+// -------------------
+
+$prototype-arrow-directions: (
+  down,
+  up,
+  right,
+  left
+);
+$prototype-arrow-size: 0.4375rem;
+$prototype-arrow-color: $black;
+
+// 30. Prototype Border-Box
+// ------------------------
+
+$prototype-border-box-breakpoints: $global-prototype-breakpoints;
+
+// 31. Prototype Border-None
+// -------------------------
+
+$prototype-border-none-breakpoints: $global-prototype-breakpoints;
+
+// 32. Prototype Bordered
+// ----------------------
+
+$prototype-bordered-breakpoints: $global-prototype-breakpoints;
+$prototype-border-width: rem-calc(1);
+$prototype-border-type: solid;
+$prototype-border-color: $medium-gray;
+
+// 33. Prototype Display
+// ---------------------
+
+$prototype-display-breakpoints: $global-prototype-breakpoints;
+$prototype-display: (
+  inline,
+  inline-block,
+  block,
+  table,
+  table-cell
+);
+
+// 34. Prototype Font-Styling
+// --------------------------
+
+$prototype-font-breakpoints: $global-prototype-breakpoints;
+$prototype-wide-letter-spacing: rem-calc(4);
+$prototype-font-normal: $global-weight-normal;
+$prototype-font-bold: $global-weight-bold;
+
+// 35. Prototype List-Style-Type
+// -----------------------------
+
+$prototype-list-breakpoints: $global-prototype-breakpoints;
+$prototype-style-type-unordered: (
+  disc,
+  circle,
+  square
+);
+$prototype-style-type-ordered: (
+  decimal,
+  lower-alpha,
+  lower-latin,
+  lower-roman,
+  upper-alpha,
+  upper-latin,
+  upper-roman
+);
+
+// 36. Prototype Overflow
+// ----------------------
+
+$prototype-overflow-breakpoints: $global-prototype-breakpoints;
+$prototype-overflow: (
+  visible,
+  hidden,
+  scroll
+);
+
+// 37. Prototype Position
+// ----------------------
+
+$prototype-position-breakpoints: $global-prototype-breakpoints;
+$prototype-position: (
+  static,
+  relative,
+  absolute,
+  fixed
+);
+$prototype-position-z-index: 975;
+
+// 38. Prototype Rounded
+// ---------------------
+
+$prototype-rounded-breakpoints: $global-prototype-breakpoints;
+$prototype-border-radius: rem-calc(3);
+
+// 39. Prototype Separator
+// -----------------------
+
+$prototype-separator-breakpoints: $global-prototype-breakpoints;
+$prototype-separator-align: center;
+$prototype-separator-height: rem-calc(2);
+$prototype-separator-width: 3rem;
+$prototype-separator-background: $primary-color;
+$prototype-separator-margin-top: $global-margin;
+
+// 40. Prototype Shadow
+// --------------------
+
+$prototype-shadow-breakpoints: $global-prototype-breakpoints;
+$prototype-box-shadow: 0 2px 5px 0 rgba(0,0,0,.16),
+0 2px 10px 0 rgba(0,0,0,.12);
+
+// 41. Prototype Sizing
+// --------------------
+
+$prototype-sizing-breakpoints: $global-prototype-breakpoints;
+$prototype-sizing: (
+  width,
+  height
+);
+$prototype-sizes: (
+  25: 25%,
+  50: 50%,
+  75: 75%,
+  100: 100%
+);
+
+// 42. Prototype Spacing
+// ---------------------
+
+$prototype-spacing-breakpoints: $global-prototype-breakpoints;
+$prototype-spacers-count: 3;
+
+// 43. Prototype Text-Decoration
+// -----------------------------
+
+$prototype-decoration-breakpoints: $global-prototype-breakpoints;
+$prototype-text-decoration: (
+  overline,
+  underline,
+  line-through,
+);
+
+// 44. Prototype Text-Transformation
+// ---------------------------------
+
+$prototype-transformation-breakpoints: $global-prototype-breakpoints;
+$prototype-text-transformation: (
+  lowercase,
+  uppercase,
+  capitalize
+);
+
+// 45. Prototype Text-Utilities
+// ----------------------------
+
+$prototype-utilities-breakpoints: $global-prototype-breakpoints;
+$prototype-text-overflow: ellipsis;
+
+// 46. Responsive Embed
+// --------------------
+
+$responsive-embed-margin-bottom: rem-calc(16);
+$responsive-embed-ratios: (
+  default: 4 by 3,
+  widescreen: 16 by 9,
+);
+
+// 47. Reveal
 // ----------
 
 $reveal-background: $white;
@@ -475,7 +758,7 @@ $reveal-radius: $global-radius;
 $reveal-zindex: 1005;
 $reveal-overlay-background: rgba($black, 0.45);
 
-// 29. Slider
+// 48. Slider
 // ----------
 
 $slider-width-vertical: 0.5rem;
@@ -489,7 +772,7 @@ $slider-handle-background: $primary-color;
 $slider-opacity-disabled: 0.25;
 $slider-radius: $global-radius;
 
-// 30. Switch
+// 49. Switch
 // ----------
 
 $switch-background: $medium-gray;
@@ -505,7 +788,7 @@ $switch-paddle-offset: 0.25rem;
 $switch-paddle-radius: $global-radius;
 $switch-paddle-transition: all 0.25s ease-out;
 
-// 31. Table
+// 50. Table
 // ---------
 
 $table-background: $white;
@@ -515,29 +798,36 @@ $table-padding: rem-calc(8 10 10);
 $table-hover-scale: 2%;
 $table-row-hover: darken($table-background, $table-hover-scale);
 $table-row-stripe-hover: darken($table-background, $table-color-scale + $table-hover-scale);
+$table-is-striped: true;
 $table-striped-background: smart-scale($table-background, $table-color-scale);
 $table-stripe: even;
-$table-head-background: smart-scale($table-background, calc($table-color-scale / 2));
+$table-head-background: smart-scale($table-background, $table-color-scale / 2);
+$table-head-row-hover: darken($table-head-background, $table-hover-scale);
 $table-foot-background: smart-scale($table-background, $table-color-scale);
+$table-foot-row-hover: darken($table-foot-background, $table-hover-scale);
 $table-head-font-color: $body-font-color;
+$table-foot-font-color: $body-font-color;
 $show-header-for-stacked: false;
+$table-stack-breakpoint: medium;
 
-// 32. Tabs
+// 51. Tabs
 // --------
 
 $tab-margin: 0;
 $tab-background: $white;
+$tab-color: $primary-color;
 $tab-background-active: $light-gray;
+$tab-active-color: $primary-color;
 $tab-item-font-size: rem-calc(12);
 $tab-item-background-hover: $white;
 $tab-item-padding: 1.25rem 1.5rem;
 $tab-expand-max: 6;
 $tab-content-background: $white;
 $tab-content-border: $light-gray;
-$tab-content-color: foreground($tab-background, $primary-color);
+$tab-content-color: $body-font-color;
 $tab-content-padding: 1rem;
 
-// 33. Thumbnail
+// 52. Thumbnail
 // -------------
 
 $thumbnail-border: solid 4px $white;
@@ -547,7 +837,7 @@ $thumbnail-shadow-hover: 0 0 6px 1px rgba($primary-color, 0.5);
 $thumbnail-transition: box-shadow 200ms ease-out;
 $thumbnail-radius: $global-radius;
 
-// 34. Title Bar
+// 53. Title Bar
 // -------------
 
 $titlebar-background: $black;
@@ -558,25 +848,44 @@ $titlebar-icon-color: $white;
 $titlebar-icon-color-hover: $medium-gray;
 $titlebar-icon-spacing: 0.25rem;
 
-// 35. Tooltip
+// 54. Tooltip
 // -----------
 
+$has-tip-cursor: help;
 $has-tip-font-weight: $global-weight-bold;
 $has-tip-border-bottom: dotted 1px $dark-gray;
 $tooltip-background-color: $black;
 $tooltip-color: $white;
 $tooltip-padding: 0.75rem;
+$tooltip-max-width: 10rem;
 $tooltip-font-size: $small-font-size;
 $tooltip-pip-width: 0.75rem;
 $tooltip-pip-height: $tooltip-pip-width * 0.866;
 $tooltip-radius: $global-radius;
 
-// 36. Top Bar
+// 55. Top Bar
 // -----------
 
 $topbar-padding: 0.5rem;
 $topbar-background: $light-gray;
 $topbar-submenu-background: $topbar-background;
-$topbar-title-spacing: 1rem;
+$topbar-title-spacing: 0.5rem 1rem 0.5rem 0;
 $topbar-input-width: 200px;
 $topbar-unstack-breakpoint: medium;
+
+// 56. Xy Grid
+// -----------
+
+$xy-grid: true;
+$grid-container: $global-width;
+$grid-columns: 12;
+$grid-margin-gutters: (
+  small: 20px,
+  medium: 30px
+);
+$grid-padding-gutters: $grid-margin-gutters;
+$grid-container-padding: $grid-padding-gutters;
+$grid-container-max: $global-width;
+$xy-block-grid-max: 8;
+
+// stylelint-enable

--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -31,7 +31,7 @@
     "core-js": "^3.30.0",
     "filesize": "^10.0.7",
     "font-awesome": "^4.7.0",
-    "foundation-sites": "=6.3.0",
+    "foundation-sites": "=6.4.3",
     "hack-font": "^3.3.0",
     "jquery": "^2.2.4",
     "lodash": "^4.17.21",

--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -33,7 +33,7 @@
     "font-awesome": "^4.7.0",
     "foundation-sites": "=6.4.3",
     "hack-font": "^3.3.0",
-    "jquery": "^2.2.4",
+    "jquery": "^3.6.4",
     "lodash": "^4.17.21",
     "lodash-inflection": "^1.5.0",
     "lru-cache": "^7.18.3",

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipeline_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipeline_spec.js
@@ -26,6 +26,7 @@ describe("Dashboard", () => {
     };
     pipelineJson     = pipelineJsonFor(defaultPauseInfo);
   });
+
   describe('Pipeline Model', () => {
 
     it("should deserialize from json", () => {
@@ -178,30 +179,33 @@ describe("Dashboard", () => {
   });
 
   describe("Pipeline Operations", () => {
+
+    beforeEach(() => {
+      jasmine.Ajax.install();
+    });
+
+    afterEach(() => {
+      jasmine.Ajax.uninstall();
+    });
+
     describe("Unpause", () => {
-      it('should unpause a pipeline with appropriate headers', () => {
-        jasmine.Ajax.withMock(() => {
-          jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipelineJson.name}/unpause`, undefined, 'POST').andReturn({
-            responseText:    JSON.stringify({"message": `Pipeline '${pipelineJson.name}' paused successfully.`}),
-            responseHeaders: {
-              'Content-Type': 'application/vnd.go.cd.v1+json'
-            },
-            status:          200
-          });
-
-          const successCallback = jasmine.createSpy();
-
-          const pipeline = new Pipeline(pipelineJson);
-          pipeline.unpause().then(successCallback);
-
-          expect(successCallback).toHaveBeenCalled();
-
-          const request = jasmine.Ajax.requests.mostRecent();
-          expect(request.method).toBe('POST');
-          expect(request.url).toBe(`/go/api/pipelines/${pipelineJson.name}/unpause`);
-          expect(request.requestHeaders['Accept']).toContain('application/vnd.go.cd.v1+json');
-          expect(request.requestHeaders['X-GoCD-Confirm']).toContain('true');
+      it('should unpause a pipeline with appropriate headers', async () => {
+        jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipelineJson.name}/unpause`, undefined, 'POST').andReturn({
+          responseText: JSON.stringify({"message": `Pipeline '${pipelineJson.name}' paused successfully.`}),
+          responseHeaders: {
+            'Content-Type': 'application/vnd.go.cd.v1+json'
+          },
+          status: 200
         });
+
+        const pipeline = new Pipeline(pipelineJson);
+        await pipeline.unpause();
+
+        const request = jasmine.Ajax.requests.mostRecent();
+        expect(request.method).toBe('POST');
+        expect(request.url).toBe(`/go/api/pipelines/${pipelineJson.name}/unpause`);
+        expect(request.requestHeaders['Accept']).toContain('application/vnd.go.cd.v1+json');
+        expect(request.requestHeaders['X-GoCD-Confirm']).toContain('true');
       });
     });
 
@@ -215,83 +219,66 @@ describe("Dashboard", () => {
         pipelineJson    = pipelineJsonFor(pauseInfo);
       });
 
-      it('should pause a pipeline with appropriate headers', () => {
-        jasmine.Ajax.withMock(() => {
-          const postData = {"pauseCause": "test"};
-          jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipelineJson.name}/pause`, JSON.stringify(postData), 'POST').andReturn({
-            responseText:    JSON.stringify({}),
-            responseHeaders: {
-              'Content-Type': 'application/vnd.go.cd.v1+json'
-            },
-            status:          200
-          });
-
-          const successCallback = jasmine.createSpy();
-
-          const pipeline = new Pipeline(pipelineJson);
-          pipeline.pause(postData).then(successCallback);
-
-          expect(successCallback).toHaveBeenCalled();
-          const request = jasmine.Ajax.requests.mostRecent();
-          expect(request.method).toBe('POST');
-          expect(request.url).toBe(`/go/api/pipelines/${pipelineJson.name}/pause`);
-          expect(request.requestHeaders['Accept']).toContain('application/vnd.go.cd.v1+json');
-          expect(request.requestHeaders['X-GoCD-Confirm']).toContain('true');
+      it('should pause a pipeline with appropriate headers', async () => {
+        const postData = {"pauseCause": "test"};
+        jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipelineJson.name}/pause`, JSON.stringify(postData), 'POST').andReturn({
+          responseText: JSON.stringify({}),
+          responseHeaders: {
+            'Content-Type': 'application/vnd.go.cd.v1+json'
+          },
+          status: 200
         });
+
+        const pipeline = new Pipeline(pipelineJson);
+        await pipeline.pause(postData);
+
+        const request = jasmine.Ajax.requests.mostRecent();
+        expect(request.method).toBe('POST');
+        expect(request.url).toBe(`/go/api/pipelines/${pipelineJson.name}/pause`);
+        expect(request.requestHeaders['Accept']).toContain('application/vnd.go.cd.v1+json');
+        expect(request.requestHeaders['X-GoCD-Confirm']).toContain('true');
       });
     });
 
     describe("Unlock", () => {
-      it('should unlock a pipeline with appropriate headers', () => {
-        jasmine.Ajax.withMock(() => {
-          jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipelineJson.name}/unlock`, undefined, 'POST').andReturn({
-            responseText:    JSON.stringify({"message": `Pipeline '${pipelineJson.name}' unlocked successfully.`}),
-            responseHeaders: {
-              'Content-Type': 'application/vnd.go.cd.v1+json'
-            },
-            status:          200
-          });
-
-          const successCallback = jasmine.createSpy();
-
-          const pipeline = new Pipeline(pipelineJson);
-          pipeline.unlock().then(successCallback);
-
-          expect(successCallback).toHaveBeenCalled();
-
-          const request = jasmine.Ajax.requests.mostRecent();
-          expect(request.method).toBe('POST');
-          expect(request.url).toBe(`/go/api/pipelines/${pipelineJson.name}/unlock`);
-          expect(request.requestHeaders['Accept']).toContain('application/vnd.go.cd.v1+json');
-          expect(request.requestHeaders['X-GoCD-Confirm']).toContain('true');
+      it('should unlock a pipeline with appropriate headers', async () => {
+        jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipelineJson.name}/unlock`, undefined, 'POST').andReturn({
+          responseText: JSON.stringify({"message": `Pipeline '${pipelineJson.name}' unlocked successfully.`}),
+          responseHeaders: {
+            'Content-Type': 'application/vnd.go.cd.v1+json'
+          },
+          status: 200
         });
+
+        const pipeline = new Pipeline(pipelineJson);
+        await pipeline.unlock();
+
+        const request = jasmine.Ajax.requests.mostRecent();
+        expect(request.method).toBe('POST');
+        expect(request.url).toBe(`/go/api/pipelines/${pipelineJson.name}/unlock`);
+        expect(request.requestHeaders['Accept']).toContain('application/vnd.go.cd.v1+json');
+        expect(request.requestHeaders['X-GoCD-Confirm']).toContain('true');
       });
     });
 
     describe("Trigger", () => {
-      it('should Trigger a pipeline with appropriate headers', () => {
-        jasmine.Ajax.withMock(() => {
-          jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipelineJson.name}/schedule`, undefined, 'POST').andReturn({
-            responseText:    JSON.stringify({"message": `Request to schedule pipeline '${pipelineJson.name}' accepted successfully.`}),
-            responseHeaders: {
-              'Content-Type': 'application/vnd.go.cd.v1+json'
-            },
-            status:          200
-          });
-
-          const successCallback = jasmine.createSpy();
-
-          const pipeline = new Pipeline(pipelineJson);
-          pipeline.trigger().then(successCallback);
-
-          expect(successCallback).toHaveBeenCalled();
-
-          const request = jasmine.Ajax.requests.mostRecent();
-          expect(request.method).toBe('POST');
-          expect(request.url).toBe(`/go/api/pipelines/${pipelineJson.name}/schedule`);
-          expect(request.requestHeaders['Accept']).toContain('application/vnd.go.cd.v1+json');
-          expect(request.requestHeaders['X-GoCD-Confirm']).toContain('true');
+      it('should Trigger a pipeline with appropriate headers', async () => {
+        jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipelineJson.name}/schedule`, undefined, 'POST').andReturn({
+          responseText: JSON.stringify({"message": `Request to schedule pipeline '${pipelineJson.name}' accepted successfully.`}),
+          responseHeaders: {
+            'Content-Type': 'application/vnd.go.cd.v1+json'
+          },
+          status: 200
         });
+
+        const pipeline = new Pipeline(pipelineJson);
+        await pipeline.trigger();
+
+        const request = jasmine.Ajax.requests.mostRecent();
+        expect(request.method).toBe('POST');
+        expect(request.url).toBe(`/go/api/pipelines/${pipelineJson.name}/schedule`);
+        expect(request.requestHeaders['Accept']).toContain('application/vnd.go.cd.v1+json');
+        expect(request.requestHeaders['X-GoCD-Confirm']).toContain('true');
       });
     });
   });

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
@@ -103,9 +103,14 @@ describe("Dashboard Pipeline Instance Widget", () => {
       trackingTool:  {link: "http://example.com/${ID}", regex: "#(\\d+)"},
       pipelineName
     }));
+
+    jasmine.Ajax.install();
   });
 
-  afterEach(helper.unmount.bind(helper));
+  afterEach(() => {
+    jasmine.Ajax.uninstall();
+    helper.unmount();
+  });
 
   it("should render instance label", () => {
     expect(helper.text('.pipeline_instance-label')).toContain('Instance: 1');
@@ -135,18 +140,17 @@ describe("Dashboard Pipeline Instance Widget", () => {
     expect(changesLink).toContainText('Changes');
   });
 
-  it("should show changes once changes link is clicked", () => {
+  it("should show changes once changes link is clicked", async () => {
     expect(helper.q('.material_changes')).not.toExist();
 
-    jasmine.Ajax.withMock(() => {
-      jasmine.Ajax.stubRequest(SparkRoutes.buildCausePath(pipelineName, instance.counter), undefined, 'GET').andReturn({
-        responseText:    JSON.stringify(buildCauseJson),
-        responseHeaders: {'Content-Type': 'application/vnd.go.cd.v1+json'},
-        status:          200
-      });
-
-      helper.click(helper.qa('.info a')[1]);
+    jasmine.Ajax.stubRequest(SparkRoutes.buildCausePath(pipelineName, instance.counter), undefined, 'GET').andReturn({
+      responseText: JSON.stringify(buildCauseJson),
+      responseHeaders: {'Content-Type': 'application/vnd.go.cd.v1+json'},
+      status: 200
     });
+
+    helper.click(helper.qa('.info a')[1]);
+    await helper.delayRedraw(50);
 
     expect(helper.q('.material_changes')).toBeInDOM();
     expect(helper.q('.comment')).toHaveHtml('<p>Initial commit <a target="story_tracker" href="http://example.com/1234">#1234</a></p>');

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -36,8 +36,8 @@ describe("Dashboard Pipeline Widget", () => {
 
   beforeEach(() => {
     jasmine.Ajax.install();
-    doCancelPolling      = jasmine.createSpy();
-    doRefreshImmediately = jasmine.createSpy();
+    doCancelPolling      = jasmine.createSpy("doCancelPolling");
+    doRefreshImmediately = jasmine.createSpy("doRefreshImmediately");
     pipelineInstances    = [{
       "_links":       {
         "self": {
@@ -217,7 +217,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.q('.pipeline_message .error')).toBeFalsy();
       });
 
-      it("should unpause a pipeline", () => {
+      it("should unpause a pipeline", async () => {
         const responseMessage = `Pipeline '${pipeline.name}' unpaused successfully.`;
         jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipeline.name}/unpause`, undefined, 'POST').andReturn({
           responseText:    JSON.stringify({"message": responseMessage}),
@@ -232,6 +232,7 @@ describe("Dashboard Pipeline Widget", () => {
 
         doRefreshImmediately.and.callFake(() => pipeline.isPaused = false);
         helper.click('.unpause');
+        await helper.delayRedraw(50);
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
@@ -241,8 +242,8 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.q('.pipeline_message')).toHaveClass("success");
       });
 
-      it("should show error when unpause a pipeline fails", () => {
-        const responseMessage = `Can not unpuase pipeline. Pipeline '${pipeline.name}' is already unpaused.`;
+      it("should show error when unpause a pipeline fails", async () => {
+        const responseMessage = `Can not unpause pipeline. Pipeline '${pipeline.name}' is already unpaused.`;
         jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipeline.name}/unpause`, undefined, 'POST').andReturn({
           responseText:    JSON.stringify({"message": responseMessage}),
           responseHeaders: {
@@ -255,6 +256,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(doRefreshImmediately).not.toHaveBeenCalled();
 
         helper.click('.unpause');
+        await helper.delayRedraw(50);
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
@@ -318,7 +320,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.text('.modal-title', body)).toBe(`Pause pipeline ${pipeline.name}`);
       });
 
-      it("should pause a pipeline", () => {
+      it("should pause a pipeline", async () => {
         const responseMessage = `Pipeline '${pipeline.name}' paused successfully.`;
         jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipeline.name}/pause`, undefined, 'POST').andReturn({
           responseText:    JSON.stringify({"message": responseMessage}),
@@ -337,6 +339,7 @@ describe("Dashboard Pipeline Widget", () => {
 
         doRefreshImmediately.and.callFake(() => pipeline.isPaused = true);
         helper.click('.reveal .primary', body);
+        await helper.delayRedraw(50);
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
@@ -348,7 +351,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.q('.pipeline_message')).toHaveClass("success");
       });
 
-      it("should not pause a pipeline", () => {
+      it("should not pause a pipeline", async () => {
         const responseMessage = `Pipeline '${pipeline.name}' could not be paused.`;
         jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipeline.name}/pause`, undefined, 'POST').andReturn({
           responseText:    JSON.stringify({"message": responseMessage}),
@@ -365,6 +368,7 @@ describe("Dashboard Pipeline Widget", () => {
 
         helper.q('.reveal input', body).value = "test";
         helper.click('.reveal .primary', body);
+        await helper.delayRedraw(50);
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
@@ -373,7 +377,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.q('.pipeline_message')).toHaveClass("error");
       });
 
-      it("should pause pipeline and close popup when enter is pressed inside the pause popup", () => {
+      it("should pause pipeline and close popup when enter is pressed inside the pause popup", async () => {
         const responseMessage = `Pipeline '${pipeline.name}' paused successfully.`;
         jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipeline.name}/pause`, undefined, 'POST').andReturn({
           responseText:    JSON.stringify({"message": responseMessage}),
@@ -389,7 +393,7 @@ describe("Dashboard Pipeline Widget", () => {
         pausePopupTextBox.value = "test";
 
         simulateEvent.simulate(pausePopupTextBox, 'keydown', {key: 'Enter'});
-        m.redraw.sync();
+        await helper.delayRedraw(50);
 
         expect(helper.q(".reveal", body)).toBeFalsy();
         expect(helper.text('.pipeline_message')).toContain(responseMessage);
@@ -429,7 +433,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.text(document.getElementById(tooltipId))).toBe("You do not have permission to pause the pipeline.");
       });
 
-      it('should not show the paused time if it is null', () => {
+      it('should not show the paused time if it is null', async () => {
         pauseInfo = {
           "paused":       false,
           "paused_by":    "admin",
@@ -460,6 +464,7 @@ describe("Dashboard Pipeline Widget", () => {
 
         doRefreshImmediately.and.callFake(() => pipeline.isPaused = true);
         helper.click('.reveal .primary', body);
+        await helper.delayRedraw(50);
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
@@ -510,7 +515,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.q('.pipeline_message .error')).toBeFalsy();
       });
 
-      it("should unlock a pipeline", () => {
+      it("should unlock a pipeline", async () => {
         const responseMessage = `Pipeline '${pipeline.name}' unlocked successfully.`;
         jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipeline.name}/unlock`, undefined, 'POST').andReturn({
           responseText:    JSON.stringify({"message": responseMessage}),
@@ -524,6 +529,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(doRefreshImmediately).not.toHaveBeenCalled();
 
         helper.click('.pipeline_locked');
+        await helper.delayRedraw(50);
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
@@ -532,7 +538,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.q('.pipeline_message')).toHaveClass("success");
       });
 
-      it("should show error when unlocking a pipeline fails", () => {
+      it("should show error when unlocking a pipeline fails", async () => {
         const responseMessage = `Can not unlock pipeline. Some stages of pipeline are in progress.`;
         jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipeline.name}/unlock`, undefined, 'POST').andReturn({
           responseText:    JSON.stringify({"message": responseMessage}),
@@ -546,6 +552,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(doRefreshImmediately).not.toHaveBeenCalled();
 
         helper.click('.pipeline_locked');
+        await helper.delayRedraw(50);
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
@@ -622,7 +629,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(_.isFunction(helper.q('.play').onclick)).toBe(false);
       });
 
-      it("should trigger a pipeline", () => {
+      it("should trigger a pipeline", async () => {
         const responseMessage = `Request for scheduling pipeline '${pipeline.name}' accepted successfully.`;
         jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipeline.name}/schedule`, undefined, 'POST').andReturn({
           responseText:    JSON.stringify({"message": responseMessage}),
@@ -635,6 +642,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(pipeline.triggerDisabled()).toBe(false);
 
         helper.click('.play');
+        await helper.delayRedraw(50);
 
         expect(pipeline.triggerDisabled()).toBe(true);
 
@@ -642,7 +650,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.q('.pipeline_message')).toHaveClass("success");
       });
 
-      it("should show error when triggering a pipeline fails", () => {
+      it("should show error when triggering a pipeline fails", async () => {
         const responseMessage = `Can not trigger pipeline. Some stages of pipeline are in progress.`;
         jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipeline.name}/schedule`, undefined, 'POST').andReturn({
           responseText:    JSON.stringify({"message": responseMessage}),
@@ -655,6 +663,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(pipeline.triggerDisabled()).toBe(false);
 
         helper.click('.play');
+        await helper.delayRedraw(50);
 
         expect(pipeline.triggerDisabled()).toBe(false);
 
@@ -741,7 +750,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(_.isFunction(helper.q('.play_with_options').onclick)).toBe(false);
       });
 
-      it("should show modal to specify trigger options for a pipeline", () => {
+      it("should show modal to specify trigger options for a pipeline", async () => {
         stubTriggerOptions(pipelineName);
 
         expect(helper.q(".reveal", body)).toBeFalsy();
@@ -751,13 +760,13 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.q(".reveal", body)).toBeInDOM();
       });
 
-      it('should render error message in modal when api response parsing fails', () => {
+      it('should render error message in modal when api response parsing fails', async () => {
         stubTriggerOptionsWithInvalidData(pipelineName);
 
         expect(helper.q(".reveal", body)).toBeFalsy();
 
         helper.click('.play_with_options');
-        m.redraw.sync();
+        await helper.delay(50);
 
         expect(helper.q(".reveal", body)).toBeInDOM();
         expect(helper.q('.callout.alert', body)).toBeInDOM();
@@ -770,7 +779,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.text('.modal-title', body)).toBe(`${pipeline.name} - Trigger`);
       });
 
-      it('should show modal appropriately when opened and closed multiple times', () => {
+      it('should show modal appropriately when opened and closed multiple times', async () => {
         stubTriggerOptions(pipelineName);
 
         //open trigger with options modal
@@ -778,6 +787,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.q('.pipeline_options-heading', body)).toBeFalsy();
 
         helper.click('.play_with_options');
+        await helper.delay(50);
 
         expect(helper.q(".reveal", body)).toBeInDOM();
         expect(helper.text('.pipeline_options-heading', body)).toContain('Materials');
@@ -790,12 +800,13 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.q('.pipeline_options-heading', body)).toBeFalsy();
 
         helper.click('.play_with_options');
+        await helper.delay(50);
 
         expect(helper.q(".reveal", body)).toBeInDOM();
         expect(helper.text('.pipeline_options-heading', body)).toContain('Materials');
       });
 
-      it("should trigger a pipeline", () => {
+      it("should trigger a pipeline", async () => {
         stubTriggerOptions(pipelineName);
         const responseMessage = `Request for scheduling pipeline '${pipeline.name}' accepted successfully.`;
         jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipeline.name}/schedule`, undefined, 'POST').andReturn({
@@ -809,8 +820,10 @@ describe("Dashboard Pipeline Widget", () => {
         expect(pipeline.triggerDisabled()).toBe(false);
 
         helper.click('.play_with_options');
+        await helper.delay(50);
 
         helper.click('.modal-buttons .button.save.primary', body);
+        await helper.delayRedraw(50);
 
         expect(pipeline.triggerDisabled()).toBe(true);
 
@@ -818,7 +831,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.q('.pipeline_message')).toHaveClass("success");
       });
 
-      it("should show error when triggering a pipeline fails", () => {
+      it("should show error when triggering a pipeline fails", async () => {
         stubTriggerOptions(pipelineName);
         const responseMessage = `Can not trigger pipeline. Some stages of pipeline are in progress.`;
         jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipeline.name}/schedule`, undefined, 'POST').andReturn({
@@ -832,8 +845,10 @@ describe("Dashboard Pipeline Widget", () => {
         expect(pipeline.triggerDisabled()).toBe(false);
 
         helper.click('.play_with_options');
+        await helper.delay(50);
 
         helper.clickButtonOnActiveModal('.modal-buttons .button.save.primary');
+        await helper.delayRedraw(50);
 
         expect(pipeline.triggerDisabled()).toBe(false);
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/spec/version_updater_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/spec/version_updater_spec.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 import "jasmine-ajax";
+import _ from "lodash";
+import mockDate from "mockdate";
 import {SystemNotifications} from "models/notifications/system_notifications";
 import {Notification} from "models/notifications/system_notifications";
 import {VersionUpdater} from "models/shared/version_updater";
@@ -23,258 +25,248 @@ describe("VersionUpdater", () => {
   describe("update", () => {
     beforeEach(() => {
       localStorage.clear();
+      jasmine.Ajax.install();
     });
 
-    it("should fetch the stale version info", () => {
-      jasmine.Ajax.withMock(() => {
-        jasmine.Ajax.stubRequest("/go/api/version_infos/stale", undefined, "GET").andReturn({
-          responseText: JSON.stringify({}),
-          status: 200
-        });
-
-        jasmine.Ajax.stubRequest("/go/api/version_infos/latest_version", undefined, "GET").andReturn({
-          responseText: JSON.stringify({}),
-          status: 200
-        });
-
-        const thirtyOneMinutesBack = new Date(Date.now() - 31 * 60 * 1000);
-
-        localStorage.setItem("versionCheckInfo", JSON.stringify({last_updated_at: thirtyOneMinutesBack}));
-
-        VersionUpdater.update();
-
-        const request = jasmine.Ajax.requests.at(0);
-
-        expect(request.method).toBe("GET");
-        expect(request.url).toBe("/go/api/version_infos/stale");
-        expect(request.requestHeaders["Content-Type"]).toContain("application/json");
-        expect(request.requestHeaders.Accept).toContain("application/vnd.go.cd.v1+json");
-
-        expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toBeNull();
-      });
+    afterEach(() => {
+      jasmine.Ajax.uninstall();
+      mockDate.reset();
+      localStorage.clear();
     });
 
-    it("should skip updates if update tried in last half hour", () => {
-      jasmine.Ajax.withMock(() => {
-        const twentyNineMinutesBack = new Date(Date.now() - 29 * 60 * 1000);
-
-        localStorage.setItem("versionCheckInfo", JSON.stringify({last_updated_at: twentyNineMinutesBack}));
-
-        VersionUpdater.update();
-
-        expect(jasmine.Ajax.requests.count()).toBe(0);
+    it("should fetch the stale version info", async () => {
+      jasmine.Ajax.stubRequest("/go/api/version_infos/stale", undefined, "GET").andReturn({
+        responseText: JSON.stringify({}),
+        status: 200
       });
+
+      jasmine.Ajax.stubRequest("/go/api/version_infos/latest_version", undefined, "GET").andReturn({
+        responseText: JSON.stringify({}),
+        status: 200
+      });
+
+      const thirtyOneMinutesBack = new Date(Date.now() - 31 * 60 * 1000);
+
+      localStorage.setItem("versionCheckInfo", JSON.stringify({last_updated_at: thirtyOneMinutesBack}));
+
+      await VersionUpdater.update();
+
+      const request = jasmine.Ajax.requests.at(0);
+
+      expect(request.method).toBe("GET");
+      expect(request.url).toBe("/go/api/version_infos/stale");
+      expect(request.requestHeaders["Content-Type"]).toContain("application/json");
+      expect(request.requestHeaders.Accept).toContain("application/vnd.go.cd.v1+json");
+
+      const nots = JSON.parse(localStorage.getItem("system_notifications") as string);
+      expect(_.isNull(nots) ? [] : nots).toHaveLength(0);
+    });
+
+    it("should skip updates if update tried in last half hour", async () => {
+      const twentyNineMinutesBack = new Date(Date.now() - 29 * 60 * 1000);
+
+      localStorage.setItem("versionCheckInfo", JSON.stringify({last_updated_at: twentyNineMinutesBack}));
+
+      await VersionUpdater.update();
+
+      expect(jasmine.Ajax.requests.count()).toBe(0);
     });
 
     //prior to 19.3.0 current_gocd_version wasnt stored in the local storage
-    it("update_check should remove older update system notification on upgrading to 19.3.0", (done) => {
-      jasmine.Ajax.withMock(() => {
-        const twentyNineMinutesBack = new Date(Date.now() - 29 * 60 * 1000);
-        localStorage.setItem("versionCheckInfo", JSON.stringify({last_updated_at: twentyNineMinutesBack}));
+    it("update_check should remove older update system notification on upgrading to 19.3.0", async () => {
+      const twentyNineMinutesBack = new Date(Date.now() - 29 * 60 * 1000);
+      localStorage.setItem("versionCheckInfo", JSON.stringify({last_updated_at: twentyNineMinutesBack}));
 
-        document.body.setAttribute("data-current-gocd-version", "19.3.0-1234");
-        const systemNotifications = new SystemNotifications();
-        systemNotifications.add(new Notification(updateNotificationJSON));
-        SystemNotifications.setNotifications(systemNotifications);
+      document.body.setAttribute("data-current-gocd-version", "19.3.0-1234");
+      const systemNotifications = new SystemNotifications();
+      systemNotifications.add(new Notification(updateNotificationJSON));
+      SystemNotifications.setNotifications(systemNotifications);
 
-        expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(1);
-        (VersionUpdater.update() as Promise<any>).then(() => {
-          expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(0);
-          expect(localStorage.getItem(VersionUpdater.CURRENT_GOCD_VERSION_KEY) as string).toBe("19.3.0-1234");
-          done();
-        });
-      });
+      expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(1);
+      await VersionUpdater.update();
+      expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(0);
+      expect(localStorage.getItem(VersionUpdater.CURRENT_GOCD_VERSION_KEY) as string).toBe("19.3.0-1234");
     });
 
-    it("update_check should remove older update system notification on upgrading from 19.3.0 to 19.4.0", (done) => {
-      jasmine.Ajax.withMock(() => {
-        const twentyNineMinutesBack = new Date(Date.now() - 29 * 60 * 1000);
-        localStorage.setItem("versionCheckInfo", JSON.stringify({last_updated_at: twentyNineMinutesBack}));
+    it("update_check should remove older update system notification on upgrading from 19.3.0 to 19.4.0", async () => {
+      const twentyNineMinutesBack = new Date(Date.now() - 29 * 60 * 1000);
+      localStorage.setItem("versionCheckInfo", JSON.stringify({last_updated_at: twentyNineMinutesBack}));
 
-        document.body.setAttribute("data-current-gocd-version", "19.4.0-1234");
-        localStorage.setItem(VersionUpdater.CURRENT_GOCD_VERSION_KEY, "19.3.0-1234");
-        const systemNotifications = new SystemNotifications();
-        systemNotifications.add(new Notification(updateNotificationJSON));
-        SystemNotifications.setNotifications(systemNotifications);
+      document.body.setAttribute("data-current-gocd-version", "19.4.0-1234");
+      localStorage.setItem(VersionUpdater.CURRENT_GOCD_VERSION_KEY, "19.3.0-1234");
+      const systemNotifications = new SystemNotifications();
+      systemNotifications.add(new Notification(updateNotificationJSON));
+      SystemNotifications.setNotifications(systemNotifications);
 
-        expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(1);
-        (VersionUpdater.update() as Promise<any>).then(() => {
-          expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(0);
-          done();
-        });
-      });
+      expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(1);
+      await VersionUpdater.update();
+      expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(0);
     });
 
-    it("update_check should remove update system notification on downgrading from 19.3.0 to 19.1.0", (done) => {
-      jasmine.Ajax.withMock(() => {
-        const twentyNineMinutesBack = new Date(Date.now() - 29 * 60 * 1000);
-        localStorage.setItem("versionCheckInfo", JSON.stringify({last_updated_at: twentyNineMinutesBack}));
+    it("update_check should remove update system notification on downgrading from 19.3.0 to 19.1.0", async () => {
+      const twentyNineMinutesBack = new Date(Date.now() - 29 * 60 * 1000);
+      localStorage.setItem("versionCheckInfo", JSON.stringify({last_updated_at: twentyNineMinutesBack}));
 
-        document.body.setAttribute("data-current-gocd-version", "19.1.0-1234");
-        localStorage.setItem(VersionUpdater.CURRENT_GOCD_VERSION_KEY, "19.3.0-1234");
-        const systemNotifications = new SystemNotifications();
-        systemNotifications.add(new Notification(updateNotificationJSON));
-        SystemNotifications.setNotifications(systemNotifications);
+      document.body.setAttribute("data-current-gocd-version", "19.1.0-1234");
+      localStorage.setItem(VersionUpdater.CURRENT_GOCD_VERSION_KEY, "19.3.0-1234");
+      const systemNotifications = new SystemNotifications();
+      systemNotifications.add(new Notification(updateNotificationJSON));
+      SystemNotifications.setNotifications(systemNotifications);
 
-        expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(1);
-        (VersionUpdater.update() as Promise<any>).then(() => {
-          expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(0);
-          done();
-        });
-      });
+      expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(1);
+      await VersionUpdater.update();
+      expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(0);
     });
 
-    it("update_check should not remove update system notification on for same GoCD version", () => {
-      jasmine.Ajax.withMock(() => {
-        const twentyNineMinutesBack = new Date(Date.now() - 29 * 60 * 1000);
-        localStorage.setItem("versionCheckInfo", JSON.stringify({last_updated_at: twentyNineMinutesBack}));
+    it("update_check should not remove update system notification on for same GoCD version", async () => {
+      const twentyNineMinutesBack = new Date(Date.now() - 29 * 60 * 1000);
+      localStorage.setItem("versionCheckInfo", JSON.stringify({last_updated_at: twentyNineMinutesBack}));
 
-        document.body.setAttribute("data-current-gocd-version", "19.3.0-1234");
-        localStorage.setItem(VersionUpdater.CURRENT_GOCD_VERSION_KEY, "19.3.0-1234");
-        const systemNotifications = new SystemNotifications();
-        systemNotifications.add(new Notification(updateNotificationJSON));
-        SystemNotifications.setNotifications(systemNotifications);
+      document.body.setAttribute("data-current-gocd-version", "19.3.0-1234");
+      localStorage.setItem(VersionUpdater.CURRENT_GOCD_VERSION_KEY, "19.3.0-1234");
+      const systemNotifications = new SystemNotifications();
+      systemNotifications.add(new Notification(updateNotificationJSON));
+      SystemNotifications.setNotifications(systemNotifications);
 
-        expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(1);
-        VersionUpdater.update();
-        expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(1);
-      });
+      expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(1);
+      await VersionUpdater.update();
+      expect(JSON.parse(localStorage.getItem("system_notifications") as string)).toHaveLength(1);
     });
 
-    it("should skip updates in absence of stale version info and update local storage with last update time", () => {
-      jasmine.Ajax.withMock(() => {
-        jasmine.Ajax.stubRequest("/go/api/version_infos/stale", undefined, "GET").andReturn({
-          responseText: JSON.stringify({}),
-          status: 200
-        });
-
-        jasmine.Ajax.stubRequest("/go/api/version_infos/latest_version", undefined, "GET").andReturn({
-          responseText: JSON.stringify({latest_version: "18.7.0-1234"}),
-          status: 200
-        });
-
-        const myDate = jasmine.createSpyObj("Date", ["getTime"]);
-
-        // @ts-ignore
-        spyOn(window, "Date").and.returnValue(myDate);
-
-        myDate.getTime.and.callFake(() => 123);
-
-        VersionUpdater.update();
-
-        expect(jasmine.Ajax.requests.count()).toBe(2);
-        expect(localStorage.getItem("versionCheckInfo")).toEqual("{\"last_updated_at\":123}");
+    it("should skip updates in absence of stale version info and update local storage with last update time", async () => {
+      jasmine.Ajax.stubRequest("/go/api/version_infos/stale", undefined, "GET").andReturn({
+        responseText: JSON.stringify({}),
+        status: 200
       });
+
+      jasmine.Ajax.stubRequest("/go/api/version_infos/latest_version", undefined, "GET").andReturn({
+        responseText: JSON.stringify({latest_version: "18.7.0-1234"}),
+        status: 200
+      });
+
+      mockDate.set("2015-10-15T04:29:00.000Z");
+
+      await VersionUpdater.update();
+
+      expect(jasmine.Ajax.requests.count()).toBe(2);
+      expect(localStorage.getItem("versionCheckInfo")).toEqual("{\"last_updated_at\":1444883340000}");
     });
 
-    it("should fetch latest version info if can update", () => {
-      jasmine.Ajax.withMock(() => {
-        jasmine.Ajax.stubRequest("/go/api/version_infos/stale", undefined, "GET").andReturn({
-          responseText: JSON.stringify({update_server_url: "update.server.url"}),
-          status: 200
-        });
-
-        jasmine.Ajax.stubRequest("update.server.url", undefined, "GET").andReturn({
-          responseText: JSON.stringify({}),
-          status: 200
-        });
-
-        VersionUpdater.update();
-
-        const request = jasmine.Ajax.requests.at(1);
-
-        expect(request.method).toBe("GET");
-        expect(request.url).toBe("update.server.url");
-        expect(request.requestHeaders.Accept).toContain("application/vnd.update.go.cd.v1+json");
+    it("should fetch latest version info if can update", async () => {
+      jasmine.Ajax.stubRequest("/go/api/version_infos/stale", undefined, "GET").andReturn({
+        responseText: JSON.stringify({update_server_url: "update.server.url"}),
+        status: 200
       });
+
+      jasmine.Ajax.stubRequest("update.server.url", undefined, "GET").andReturn({
+        responseText: JSON.stringify({}),
+        status: 200
+      });
+
+      jasmine.Ajax.stubRequest("/go/api/version_infos/go_server", undefined, "PATCH").andReturn({
+        responseText: JSON.stringify({}),
+        responseHeaders: {
+          "Content-Type": `application/vnd.go.cd.v1+json`
+        },
+        status: 200
+      });
+
+      jasmine.Ajax.stubRequest("/go/api/version_infos/latest_version", undefined, "GET").andReturn({
+        responseText: JSON.stringify({}),
+        status: 200
+      });
+
+      await VersionUpdater.update();
     });
 
-    it("should post the latest version info to server", () => {
-      jasmine.Ajax.withMock(() => {
-        jasmine.Ajax.stubRequest("/go/api/version_infos/stale", undefined, "GET").andReturn({
-          responseText: JSON.stringify({update_server_url: "update.server.url"}),
-          responseHeaders: {
-            "Content-Type": `application/vnd.go.cd.v1+json`,
-          },
-          status: 200
-        });
-
-        jasmine.Ajax.stubRequest("update.server.url", undefined, "GET").andReturn({
-          responseText: JSON.stringify({foo: "bar"}),
-          responseHeaders: {
-            "Content-Type": "application/json"
-          },
-          status: 200
-        });
-
-        jasmine.Ajax.stubRequest("/go/api/version_infos/go_server", undefined, "PATCH").andReturn({
-          responseText: JSON.stringify({}),
-          responseHeaders: {
-            "Content-Type": `application/vnd.go.cd.v1+json`
-          },
-          status: 200
-        });
-
-        const myDate = jasmine.createSpyObj("Date", ["getTime"]);
-
-        // @ts-ignore
-        spyOn(window, "Date").and.returnValue(myDate);
-
-        myDate.getTime.and.callFake(() => 123);
-
-        VersionUpdater.update();
-
-        const request = jasmine.Ajax.requests.at(2);
-
-        expect(request.method).toBe("PATCH");
-        expect(request.url).toBe("/go/api/version_infos/go_server");
-        expect(JSON.parse(request.params)).toEqual({foo: "bar"});
-        expect(request.requestHeaders["Content-Type"]).toContain("application/json");
-        expect(request.requestHeaders.Accept).toContain("application/vnd.go.cd.v1+json");
-        expect(localStorage.getItem("versionCheckInfo")).toEqual("{\"last_updated_at\":123}");
+    it("should post the latest version info to server", async () => {
+      jasmine.Ajax.stubRequest("/go/api/version_infos/stale", undefined, "GET").andReturn({
+        responseText: JSON.stringify({update_server_url: "update.server.url"}),
+        responseHeaders: {
+          "Content-Type": `application/vnd.go.cd.v1+json`,
+        },
+        status: 200
       });
+
+      jasmine.Ajax.stubRequest("update.server.url", undefined, "GET").andReturn({
+        responseText: JSON.stringify({foo: "bar"}),
+        responseHeaders: {
+          "Content-Type": "application/json"
+        },
+        status: 200
+      });
+
+      jasmine.Ajax.stubRequest("/go/api/version_infos/go_server", undefined, "PATCH").andReturn({
+        responseText: JSON.stringify({}),
+        responseHeaders: {
+          "Content-Type": `application/vnd.go.cd.v1+json`
+        },
+        status: 200
+      });
+
+      jasmine.Ajax.stubRequest("/go/api/version_infos/latest_version", undefined, "GET").andReturn({
+        responseText: JSON.stringify({}),
+        status: 200
+      });
+
+      mockDate.set("2015-10-15T04:29:00.000Z");
+
+      await VersionUpdater.update();
+
+      const updateServerRequest = jasmine.Ajax.requests.at(1);
+
+      expect(updateServerRequest.method).toBe("GET");
+      expect(updateServerRequest.url).toBe("update.server.url");
+      expect(updateServerRequest.requestHeaders.Accept).toContain("application/vnd.update.go.cd.v1+json");
+
+      const updateLatestRequest = jasmine.Ajax.requests.at(2);
+
+      expect(updateLatestRequest.method).toBe("PATCH");
+      expect(updateLatestRequest.url).toBe("/go/api/version_infos/go_server");
+      expect(JSON.parse(updateLatestRequest.params)).toEqual({foo: "bar"});
+      expect(updateLatestRequest.requestHeaders["Content-Type"]).toContain("application/json");
+      expect(updateLatestRequest.requestHeaders.Accept).toContain("application/vnd.go.cd.v1+json");
+      expect(localStorage.getItem("versionCheckInfo")).toEqual("{\"last_updated_at\":1444883340000}");
     });
 
-    it("should post update check message in local storage if an update is available", () => {
-      jasmine.Ajax.withMock(() => {
-        jasmine.Ajax.stubRequest("/go/api/version_infos/stale", undefined, "GET").andReturn({
-          responseText: JSON.stringify({update_server_url: "update.server.url"}),
-          status: 200
-        });
-
-        jasmine.Ajax.stubRequest("update.server.url", undefined, "GET").andReturn({
-          responseText: JSON.stringify({}),
-          status: 200
-        });
-
-        jasmine.Ajax.stubRequest("/go/api/version_infos/go_server", undefined, "PATCH").andReturn({
-          responseText: JSON.stringify({}),
-          responseHeaders: {
-            "Content-Type": `application/vnd.go.cd.v1+json`
-          },
-          status: 200
-        });
-
-        jasmine.Ajax.stubRequest("/go/api/version_infos/latest_version", undefined, "GET").andReturn({
-          responseText: JSON.stringify({latest_version: "18.7.0-1234"}),
-          status: 200
-        });
-
-        VersionUpdater.update();
-
-        const request = jasmine.Ajax.requests.at(3);
-        expect(request.method).toBe("GET");
-        expect(request.url).toBe("/go/api/version_infos/latest_version");
-        expect(request.requestHeaders.Accept).toContain("application/vnd.go.cd.v1+json");
-        const notifications = JSON.parse(localStorage.getItem("system_notifications") as string);
-        expect(notifications.length).toBe(1);
-        expect(notifications[0].message).toBe("A new version of GoCD - 18.7.0-1234 is available.");
-        expect(notifications[0].type).toBe("UpdateCheck");
-        expect(notifications[0].link).toBe("https://www.gocd.org/download/");
-        expect(notifications[0].linkText).toBe("Learn more ...");
-        expect(notifications[0].read).toBe(false);
-        expect(notifications[0].id).not.toBeUndefined();
+    it("should post update check message in local storage if an update is available", async () => {
+      jasmine.Ajax.stubRequest("/go/api/version_infos/stale", undefined, "GET").andReturn({
+        responseText: JSON.stringify({update_server_url: "update.server.url"}),
+        status: 200
       });
+
+      jasmine.Ajax.stubRequest("update.server.url", undefined, "GET").andReturn({
+        responseText: JSON.stringify({}),
+        status: 200
+      });
+
+      jasmine.Ajax.stubRequest("/go/api/version_infos/go_server", undefined, "PATCH").andReturn({
+        responseText: JSON.stringify({}),
+        responseHeaders: {
+          "Content-Type": `application/vnd.go.cd.v1+json`
+        },
+        status: 200
+      });
+
+      jasmine.Ajax.stubRequest("/go/api/version_infos/latest_version", undefined, "GET").andReturn({
+        responseText: JSON.stringify({latest_version: "18.7.0-1234"}),
+        status: 200
+      });
+
+      await VersionUpdater.update();
+
+      const request = jasmine.Ajax.requests.at(3);
+      expect(request.method).toBe("GET");
+      expect(request.url).toBe("/go/api/version_infos/latest_version");
+      expect(request.requestHeaders.Accept).toContain("application/vnd.go.cd.v1+json");
+      const notifications = JSON.parse(localStorage.getItem("system_notifications") as string);
+      expect(notifications.length).toBe(1);
+      expect(notifications[0].message).toBe("A new version of GoCD - 18.7.0-1234 is available.");
+      expect(notifications[0].type).toBe("UpdateCheck");
+      expect(notifications[0].link).toBe("https://www.gocd.org/download/");
+      expect(notifications[0].linkText).toBe("Learn more ...");
+      expect(notifications[0].read).toBe(false);
+      expect(notifications[0].id).not.toBeUndefined();
     });
   });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/header_footer_shim.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/header_footer_shim.tsx
@@ -24,36 +24,34 @@ import {SiteFooter} from "views/pages/partials/site_footer";
 import {SiteHeader} from "views/pages/partials/site_header";
 
 $(() => {
-  window.addEventListener("DOMContentLoaded", () => {
-    $(document).foundation();
-    ModalManager.onPageLoad();
-    VersionUpdater.update();
+  $(document).foundation();
+  ModalManager.onPageLoad();
+  VersionUpdater.update();
 
-    const footerData = footerMeta();
-    const headerData = headerMeta();
+  const footerData = footerMeta();
+  const headerData = headerMeta();
 
-    const menuMountPoint = document.getElementById("app-menu");
+  const menuMountPoint = document.getElementById("app-menu");
 
-    if (menuMountPoint) {
-      m.mount(menuMountPoint, {
-        view() {
-          return <SiteHeader {...headerData}/>;
-        }
-      });
-    } else {
-      throw Error("Could not find menu mount point");
-    }
+  if (menuMountPoint) {
+    m.mount(menuMountPoint, {
+      view() {
+        return <SiteHeader {...headerData}/>;
+      }
+    });
+  } else {
+    throw Error("Could not find menu mount point");
+  }
 
-    const footerMountPoint = document.getElementById("app-footer");
+  const footerMountPoint = document.getElementById("app-footer");
 
-    if (footerMountPoint) {
-      m.mount(footerMountPoint, {
-        view() {
-          return <SiteFooter {...footerData}/>;
-        }
-      });
-    } else {
-      throw Error("Could not find footer mount point");
-    }
-  });
+  if (footerMountPoint) {
+    m.mount(footerMountPoint, {
+      view() {
+        return <SiteFooter {...footerData}/>;
+      }
+    });
+  } else {
+    throw Error("Could not find footer mount point");
+  }
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/stage_overview_shim_for_vsm.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/stage_overview_shim_for_vsm.tsx
@@ -23,66 +23,64 @@ import {StageOverview} from "../views/dashboard/stage_overview";
 import {StageOverviewViewModel} from "../views/dashboard/stage_overview/models/stage_overview_view_model";
 
 $(() => {
-  window.addEventListener("DOMContentLoaded", () => {
+  // @ts-ignore
+  window.stageOverviewStateForVSM = state.StageOverviewState;
+
+  function closeStageOverview() {
     // @ts-ignore
-    window.stageOverviewStateForVSM = state.StageOverviewState;
+    const state = window.stageOverviewStateForVSM;
 
-    function closeStageOverview() {
-      // @ts-ignore
-      const state = window.stageOverviewStateForVSM;
+    if (state.model()) {
+      const ele = document.getElementById(`stage-overview-container-for-pipeline-${state.getPipelineName()}-${state.getPipelineCounter()}-stage-${state.getStageName()}-${state.getStageCounter()}`)!;
+      ele.innerHTML = "";
 
-      if (state.model()) {
-        const ele = document.getElementById(`stage-overview-container-for-pipeline-${state.getPipelineName()}-${state.getPipelineCounter()}-stage-${state.getStageName()}-${state.getStageCounter()}`)!;
-        ele.innerHTML = "";
-
-        state.hide();
-      }
+      state.hide();
     }
+  }
 
-    document.getElementById("vsm-container")!.onclick = closeStageOverview;
+  document.getElementById("vsm-container")!.onclick = closeStageOverview;
+
+  // @ts-ignore
+  window.getStageOverviewFor = (pipelineName: string, pipelineCounter: string | number, stageName: string, stageCounter: string | number, status: string, currentStageIndex: string, totalNumberOfStages: string, canEdit: boolean, templateName: string) => {
+    closeStageOverview();
+    const repeatInterval = 9999999;
 
     // @ts-ignore
-    window.getStageOverviewFor = (pipelineName: string, pipelineCounter: string | number, stageName: string, stageCounter: string | number, status: string, currentStageIndex: string, totalNumberOfStages: string, canEdit: boolean, templateName: string) => {
-      closeStageOverview();
-      const repeatInterval = 9999999;
+    window.stageOverviewStateForVSM.show(pipelineName, pipelineCounter, stageName, stageCounter);
+    // @ts-ignore
+    StageOverviewViewModel.initialize(pipelineName, pipelineCounter, stageName, stageCounter, status, repeatInterval).then((result) => window.stageOverviewStateForVSM.model(result));
 
-      // @ts-ignore
-      window.stageOverviewStateForVSM.show(pipelineName, pipelineCounter, stageName, stageCounter);
-      // @ts-ignore
-      StageOverviewViewModel.initialize(pipelineName, pipelineCounter, stageName, stageCounter, status, repeatInterval).then((result) => window.stageOverviewStateForVSM.model(result));
-
-      const stageOverviewContainer = document.getElementById(`stage-overview-container-for-pipeline-${pipelineName}-${pipelineCounter}-stage-${stageName}-${stageCounter}`)!;
-      const stageInstanceFromDashboard = {
-        status
-      };
-
-      // @ts-ignore
-      const totalWidth = new Array(...document.querySelector(`#${CSS.escape(pipelineName)}`).classList).indexOf("current") !== -1 ? 237 : 192;
-      const spaceBetweenStages = 4;
-      const initialLeftPosition = -36;
-
-      const widthOfEachStage = (totalWidth - (4 * +totalNumberOfStages)) / +totalNumberOfStages;
-      const leftPosition = (widthOfEachStage * +currentStageIndex) + (spaceBetweenStages * +currentStageIndex) + (widthOfEachStage/2) + initialLeftPosition;
-      const templateNameFromString = templateName === 'null' ? null : templateName;
-
-      m.mount(stageOverviewContainer, {
-        view(vnode: m.Vnode<{}, {}>): m.Children | void | null {
-          return <StageOverview pipelineName={pipelineName}
-                                canAdminister={canEdit}
-                                pipelineCounter={pipelineCounter}
-                                stageName={stageName}
-                                stageCounter={stageCounter}
-                                stages={[]}
-                                templateName={templateNameFromString}
-                                pollingInterval={repeatInterval}
-                                isDisplayedOnVSMPage={true}
-                                leftPositionForVSMStageOverview={leftPosition}
-                                stageInstanceFromDashboard={stageInstanceFromDashboard}
-                                // @ts-ignore
-                                stageOverviewVM={window.stageOverviewStateForVSM.model}
-                                stageStatus={status}/>;
-        }
-      });
+    const stageOverviewContainer = document.getElementById(`stage-overview-container-for-pipeline-${pipelineName}-${pipelineCounter}-stage-${stageName}-${stageCounter}`)!;
+    const stageInstanceFromDashboard = {
+      status
     };
-  });
+
+    // @ts-ignore
+    const totalWidth = new Array(...document.querySelector(`#${CSS.escape(pipelineName)}`).classList).indexOf("current") !== -1 ? 237 : 192;
+    const spaceBetweenStages = 4;
+    const initialLeftPosition = -36;
+
+    const widthOfEachStage = (totalWidth - (4 * +totalNumberOfStages)) / +totalNumberOfStages;
+    const leftPosition = (widthOfEachStage * +currentStageIndex) + (spaceBetweenStages * +currentStageIndex) + (widthOfEachStage/2) + initialLeftPosition;
+    const templateNameFromString = templateName === 'null' ? null : templateName;
+
+    m.mount(stageOverviewContainer, {
+      view(vnode: m.Vnode<{}, {}>): m.Children | void | null {
+        return <StageOverview pipelineName={pipelineName}
+                              canAdminister={canEdit}
+                              pipelineCounter={pipelineCounter}
+                              stageName={stageName}
+                              stageCounter={stageCounter}
+                              stages={[]}
+                              templateName={templateNameFromString}
+                              pollingInterval={repeatInterval}
+                              isDisplayedOnVSMPage={true}
+                              leftPositionForVSMStageOverview={leftPosition}
+                              stageInstanceFromDashboard={stageInstanceFromDashboard}
+                              // @ts-ignore
+                              stageOverviewVM={window.stageOverviewStateForVSM.model}
+                              stageStatus={status}/>;
+      }
+    });
+  };
 });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/models/personalization_vm.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/models/personalization_vm.js
@@ -63,7 +63,7 @@ export function PersonalizationVM(currentView) {
 
     if (!checksum() || etag !== checksum()) {
       requestPending = true;
-      fetchPersonalization();
+      return fetchPersonalization();
     }
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/foundation_hax.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/foundation_hax.scss
@@ -18,11 +18,14 @@
 @import "../../../../app/assets/new_stylesheets/variables";
 @import "../../../../app/assets/new_stylesheets/shared/go-variables";
 
-// Since it's a 3rd party file, we ignore all lint errors
+// Since it's mainly a 3rd party file, we ignore all lint errors
 // stylelint-disable
+
 //  Foundation for Sites Settings
 //  -----------------------------
+//
 //  Table of Contents:
+//
 //   1. Global
 //   2. Breakpoints
 //   3. The Grid
@@ -36,30 +39,51 @@
 //  11. Button
 //  12. Button Group
 //  13. Callout
-//  14. Close Button
-//  15. Drilldown
-//  16. Dropdown
-//  17. Dropdown Menu
-//  18. Flex Video
-//  19. Forms
-//  20. Label
-//  21. Media Object
-//  22. Menu
-//  23. Meter
-//  24. Off-canvas
-//  25. Orbit
-//  26. Pagination
-//  27. Progress Bar
-//  28. Reveal
-//  29. Slider
-//  30. Switch
-//  31. Table
-//  32. Tabs
-//  33. Thumbnail
-//  34. Title Bar
-//  35. Tooltip
-//  36. Top Bar
-@import "~foundation-sites/scss/util/util";
+//  14. Card
+//  15. Close Button
+//  16. Drilldown
+//  17. Dropdown
+//  18. Dropdown Menu
+//  19. Flexbox Utilities
+//  20. Forms
+//  21. Label
+//  22. Media Object
+//  23. Menu
+//  24. Meter
+//  25. Off-canvas
+//  26. Orbit
+//  27. Pagination
+//  28. Progress Bar
+//  29. Prototype Arrow
+//  30. Prototype Border-Box
+//  31. Prototype Border-None
+//  32. Prototype Bordered
+//  33. Prototype Display
+//  34. Prototype Font-Styling
+//  35. Prototype List-Style-Type
+//  36. Prototype Overflow
+//  37. Prototype Position
+//  38. Prototype Rounded
+//  39. Prototype Separator
+//  40. Prototype Shadow
+//  41. Prototype Sizing
+//  42. Prototype Spacing
+//  43. Prototype Text-Decoration
+//  44. Prototype Text-Transformation
+//  45. Prototype Text-Utilities
+//  46. Responsive Embed
+//  47. Reveal
+//  48. Slider
+//  49. Switch
+//  50. Table
+//  51. Tabs
+//  52. Thumbnail
+//  53. Title Bar
+//  54. Tooltip
+//  55. Top Bar
+//  56. Xy Grid
+
+@import "foundation-sites/scss/util/util"; // custom
 
 // 1. Global
 // ---------
@@ -68,11 +92,11 @@ $global-font-size: 100%;
 $global-width: rem-calc(1200);
 $global-lineheight: 1.5;
 $foundation-palette: (
-  primary: $go-primary,
-  secondary: #777,
+  primary: $go-primary, // custom
+  secondary: #777, // custom
   success: #3adb76,
   warning: #ffae00,
-  alert: #ec5840
+  alert: #ec5840, // custom
 );
 $light-gray: #e6e6e6;
 $lighter-gray: #f5f5f5; // custom
@@ -80,17 +104,23 @@ $medium-gray: #cacaca;
 $dark-gray: #8a8a8a;
 $black: #0a0a0a;
 $white: #fefefe;
-$body-background: #f4f8f9;
+$body-background: #f4f8f9; // custom
 $body-font-color: $black;
 $body-font-family: "Open Sans", "Helvetica Neue", helvetica, roboto, arial, sans-serif; // custom
 $body-antialiased: true;
 $global-margin: 1rem;
 $global-padding: 1rem;
+$global-position: 1rem;
 $global-weight-normal: normal;
 $global-weight-bold: bold;
 $global-radius: 3px; // custom
+$global-menu-padding: 0.7rem 1rem;
+$global-menu-nested-margin: 1rem;
 $global-text-direction: ltr;
-$global-flexbox: false;
+$global-flexbox: true;
+$global-prototype-breakpoints: false;
+$global-button-cursor: auto;
+$global-color-pick-contrast-tolerance: 0;
 $print-transparent-backgrounds: true;
 
 @include add-foundation-colors;
@@ -105,6 +135,7 @@ $breakpoints: (
   xlarge: 1200px,
   xxlarge: 1440px,
 );
+$print-breakpoint: large;
 $breakpoint-classes: (small medium large);
 
 // 3. The Grid
@@ -117,6 +148,7 @@ $grid-column-gutter: (
   medium: 30px,
 );
 $grid-column-align-edge: true;
+$grid-column-alias: 'columns';
 $block-grid-max: 8;
 
 // 4. Base Typography
@@ -125,34 +157,34 @@ $block-grid-max: 8;
 $header-font-family: $body-font-family;
 $header-font-weight: $global-weight-normal;
 $header-font-style: normal;
-$font-family-monospace: consolas, "Liberation Mono", courier, monospace;
-$header-styles: (
-  small: (
-    "h1": ("font-size": 24),
-    "h2": ("font-size": 20),
-    "h3": ("font-size": 19),
-    "h4": ("font-size": 18),
-    "h5": ("font-size": 17),
-    "h6": ("font-size": 16),
-  ),
-  medium: (
-    "h1": ("font-size": 48),
-    "h2": ("font-size": 40),
-    "h3": ("font-size": 31),
-    "h4": ("font-size": 25),
-    "h5": ("font-size": 20),
-    "h6": ("font-size": 16),
-  ),
-);
+$font-family-monospace: Consolas, 'Liberation Mono', Courier, monospace;
 $header-color: inherit;
 $header-lineheight: 1.4;
 $header-margin-bottom: 0.5rem;
-$header-text-rendering: optimizelegibility;
+$header-styles: (
+  small: (
+    'h1': ('font-size': 24),
+    'h2': ('font-size': 20),
+    'h3': ('font-size': 19),
+    'h4': ('font-size': 18),
+    'h5': ('font-size': 17),
+    'h6': ('font-size': 16),
+  ),
+  medium: (
+    'h1': ('font-size': 48),
+    'h2': ('font-size': 40),
+    'h3': ('font-size': 31),
+    'h4': ('font-size': 25),
+    'h5': ('font-size': 20),
+    'h6': ('font-size': 16),
+  ),
+);
+$header-text-rendering: optimizeLegibility;
 $small-font-size: 80%;
 $header-small-font-color: $medium-gray;
 $paragraph-lineheight: 1.6;
 $paragraph-margin-bottom: 1rem;
-$paragraph-text-rendering: optimizelegibility;
+$paragraph-text-rendering: optimizeLegibility;
 $code-color: $black;
 $code-font-family: $font-family-monospace;
 $code-font-weight: $global-weight-normal;
@@ -180,6 +212,7 @@ $blockquote-padding: rem-calc(9 20 0 19);
 $blockquote-border: 1px solid $medium-gray;
 $cite-font-size: rem-calc(13);
 $cite-color: $dark-gray;
+$cite-pseudo-content: '\2014 \0020';
 $keystroke-font: $font-family-monospace;
 $keystroke-color: $black;
 $keystroke-background: $light-gray;
@@ -204,9 +237,9 @@ $stat-font-size: 2.5rem;
 
 $abide-inputs: true;
 $abide-labels: true;
-$input-background-invalid: map-get($foundation-palette, alert);
-$form-label-color-invalid: map-get($foundation-palette, alert);
-$input-error-color: map-get($foundation-palette, alert);
+$input-background-invalid: get-color(alert);
+$form-label-color-invalid: get-color(alert);
+$input-error-color: get-color(alert);
 $input-error-font-size: rem-calc(12);
 $input-error-font-weight: $global-weight-bold;
 
@@ -215,25 +248,38 @@ $input-error-font-weight: $global-weight-bold;
 
 $accordion-background: $accordion-bg; // custom
 $accordion-plusminus: false; // custom
-$accordion-item-color: foreground($accordion-background, $black); // custom
+$accordion-title-font-size: rem-calc(12);
+$accordion-item-color: $black; // custom
 $accordion-item-background-hover: $accordion-bg-hover; // custom
 $accordion-item-padding: 0 2rem; // custom
 $accordion-content-background: $accordion-bg; // custom
 $accordion-content-border: 0; // custom
-$accordion-content-color: foreground($accordion-content-background, $body-font-color);
+$accordion-content-color: $body-font-color;
 $accordion-content-padding: 1rem;
 
 // 8. Accordion Menu
 // -----------------
 
+$accordionmenu-padding: $global-menu-padding;
+$accordionmenu-nested-margin: $global-menu-nested-margin;
+$accordionmenu-submenu-padding: $accordionmenu-padding;
 $accordionmenu-arrows: true;
 $accordionmenu-arrow-color: $black; // custom
+$accordionmenu-item-background: null;
+$accordionmenu-border: null;
+$accordionmenu-submenu-toggle-background: null;
+$accordion-submenu-toggle-border: $accordionmenu-border;
+$accordionmenu-submenu-toggle-width: 40px;
+$accordionmenu-submenu-toggle-height: $accordionmenu-submenu-toggle-width;
+$accordionmenu-arrow-size: 6px;
 
 // 9. Badge
 // --------
 
 $badge-background: $primary-color;
-$badge-color: foreground($badge-background);
+$badge-color: $white;
+$badge-color-alt: $black;
+$badge-palette: $foundation-palette;
 $badge-padding: 0.3em;
 $badge-minwidth: 2.1em;
 $badge-font-size: 0.6rem;
@@ -248,11 +294,15 @@ $breadcrumbs-item-color-current: $black;
 $breadcrumbs-item-color-disabled: $medium-gray;
 $breadcrumbs-item-margin: 0.75rem;
 $breadcrumbs-item-uppercase: true;
-$breadcrumbs-item-slash: true;
+$breadcrumbs-item-separator: true;
+$breadcrumbs-item-separator-item: '/';
+$breadcrumbs-item-separator-item-rtl: '\\';
+$breadcrumbs-item-separator-color: $medium-gray;
 
 // 11. Button
 // ----------
 
+$button-font-family: inherit;
 $button-padding: 0.5em 1em; // custom
 $button-margin: 0 0 $global-margin 0;
 $button-fill: solid;
@@ -261,21 +311,27 @@ $button-background-hover: scale-color($button-background, $lightness: -15%);
 $button-color: $white;
 $button-color-alt: $black;
 $button-radius: $global-radius;
+$button-hollow-border-width: 1px;
 $button-sizes: (
   tiny: 0.6rem,
   small: 0.75rem,
   default: 0.9rem,
   large: 1.25rem,
 );
+$button-palette: $foundation-palette;
 $button-opacity-disabled: 0.25;
+$button-background-hover-lightness: -20%;
+$button-hollow-hover-lightness: -50%;
+$button-transition: background-color 0.25s ease-out, color 0.25s ease-out;
 
 // 12. Button Group
 // ----------------
 
 $buttongroup-margin: 1rem;
 $buttongroup-spacing: 1px;
-$buttongroup-child-selector: ".button";
+$buttongroup-child-selector: '.button';
 $buttongroup-expand-max: 6;
+$buttongroup-radius-on-each: true;
 
 // 13. Callout
 // -----------
@@ -290,29 +346,56 @@ $callout-font-color-alt: $body-background;
 $callout-radius: $global-radius;
 $callout-link-tint: 30%;
 
-// 14. Close Button
+// 14. Card
+// --------
+
+$card-background: $white;
+$card-font-color: $body-font-color;
+$card-divider-background: $light-gray;
+$card-border: 1px solid $light-gray;
+$card-shadow: none;
+$card-border-radius: $global-radius;
+$card-padding: $global-padding;
+$card-margin-bottom: $global-margin;
+
+// 15. Close Button
 // ----------------
 
 $closebutton-position: right top;
-$closebutton-offset-horizontal: 1rem;
-$closebutton-offset-vertical: 0.5rem;
-$closebutton-size: 2em;
+$closebutton-offset-horizontal: (
+  small: 0.66rem,
+  medium: 1rem,
+);
+$closebutton-offset-vertical: (
+  small: 0.33em,
+  medium: 0.5rem,
+);
+$closebutton-size: (
+  small: 1.5em,
+  medium: 2em,
+);
 $closebutton-lineheight: 1;
 $closebutton-color: $dark-gray;
 $closebutton-color-hover: $black;
 
-// 15. Drilldown
+// 16. Drilldown
 // -------------
 
 $drilldown-transition: transform 0.15s linear;
 $drilldown-arrows: true;
-$drilldown-arrow-color: $primary-color;
+$drilldown-padding: $global-menu-padding;
+$drilldown-nested-margin: 0;
 $drilldown-background: $white;
+$drilldown-submenu-padding: $drilldown-padding;
+$drilldown-submenu-background: $white;
+$drilldown-arrow-color: $primary-color;
+$drilldown-arrow-size: 6px;
 
-// 16. Dropdown
+// 17. Dropdown
 // ------------
 
 $dropdown-padding: 1rem;
+$dropdown-background: $body-background;
 $dropdown-border: 1px solid $medium-gray;
 $dropdown-font-size: 1rem;
 $dropdown-width: 300px;
@@ -323,23 +406,30 @@ $dropdown-sizes: (
   large: 400px,
 );
 
-// 17. Dropdown Menu
+// 18. Dropdown Menu
 // -----------------
 
 $dropdownmenu-arrows: false; // custom
 $dropdownmenu-arrow-color: $anchor-color;
+$dropdownmenu-arrow-size: 6px;
+$dropdownmenu-arrow-padding: 1.5rem;
 $dropdownmenu-min-width: 200px;
 $dropdownmenu-background: $white;
+$dropdownmenu-submenu-background: $dropdownmenu-background;
+$dropdownmenu-padding: $global-menu-padding;
+$dropdownmenu-nested-margin: 0;
+$dropdownmenu-submenu-padding: $dropdownmenu-padding;
 $dropdownmenu-border: 1px solid $medium-gray;
+$dropdown-menu-item-color-active: get-color(primary);
+$dropdown-menu-item-background-active: transparent;
 
-// 18. Flex Video
-// --------------
+// 19. Flexbox Utilities
+// ---------------------
 
-$flexvideo-margin-bottom: rem-calc(16);
-$flexvideo-ratio: 4 by 3;
-$flexvideo-ratio-widescreen: 16 by 9;
+$flex-source-ordering-count: 6;
+$flexbox-responsive-breakpoints: true;
 
-// 19. Forms
+// 20. Forms
 // ---------
 
 $fieldset-border: 1px solid $medium-gray;
@@ -365,45 +455,56 @@ $input-color: $black;
 $input-placeholder-color: $medium-gray;
 $input-font-family: inherit;
 $input-font-size: rem-calc(14); // custom
+$input-font-weight: $global-weight-normal;
+$input-line-height: $global-lineheight;
 $input-background: $white;
 $input-background-focus: $white;
 $input-background-disabled: $light-gray;
 $input-border: 1px solid $medium-gray;
 $input-border-focus: 1px solid $dark-gray;
+$input-padding: $form-spacing / 2;
 $input-shadow: inset 0 1px 2px rgba($black, 0.1);
 $input-shadow-focus: 0 0 5px $medium-gray;
 $input-cursor-disabled: not-allowed;
 $input-transition: box-shadow 0.5s, border-color 0.25s ease-in-out;
 $input-number-spinners: true;
 $input-radius: $global-radius;
+$form-button-radius: $global-radius;
 
-// 20. Label
+// 21. Label
 // ---------
 
 $label-background: $primary-color;
-$label-color: foreground($label-background);
+$label-color: $white;
+$label-color-alt: $black;
+$label-palette: $foundation-palette;
 $label-font-size: 0.8rem;
 $label-padding: 0.33333rem 0.5rem;
 $label-radius: $global-radius;
 
-// 21. Media Object
+// 22. Media Object
 // ----------------
 
 $mediaobject-margin-bottom: $global-margin;
 $mediaobject-section-padding: $global-padding;
 $mediaobject-image-width-stacked: 100%;
 
-// 22. Menu
+// 23. Menu
 // --------
 
 $menu-margin: 0;
-$menu-margin-nested: 1rem;
-$menu-item-padding: 0.7rem 1rem;
+$menu-nested-margin: $global-menu-nested-margin;
+$menu-items-padding: $global-menu-padding;
+$menu-simple-margin: 1rem;
 $menu-item-color-active: $white;
-$menu-item-background-active: map-get($foundation-palette, primary);
+$menu-item-background-active: get-color(primary);
 $menu-icon-spacing: 0.25rem;
+$menu-item-background-hover: $light-gray;
+$menu-state-back-compat: true;
+$menu-centered-back-compat: true;
+$menu-icons-back-compat: true;
 
-// 23. Meter
+// 24. Meter
 // ---------
 
 $meter-height: 1rem;
@@ -413,20 +514,30 @@ $meter-fill-good: $success-color;
 $meter-fill-medium: $warning-color;
 $meter-fill-bad: $alert-color;
 
-// 24. Off-canvas
+// 25. Off-canvas
 // --------------
 
-$offcanvas-size: 250px;
+$offcanvas-sizes: (
+  small: 250px,
+);
+$offcanvas-vertical-sizes: (
+  small: 250px,
+);
 $offcanvas-background: $light-gray;
-$offcanvas-zindex: -1;
+$offcanvas-shadow: 0 0 10px rgba($black, 0.7);
+$offcanvas-inner-shadow-size: 20px;
+$offcanvas-inner-shadow-color: rgba($black, 0.25);
+$offcanvas-overlay-zindex: 11;
+$offcanvas-push-zindex: 12;
+$offcanvas-overlap-zindex: 13;
+$offcanvas-reveal-zindex: 12;
 $offcanvas-transition-length: 0.5s;
 $offcanvas-transition-timing: ease;
 $offcanvas-fixed-reveal: true;
 $offcanvas-exit-background: rgba($white, 0.25);
-$maincontent-class: "off-canvas-content";
-$maincontent-shadow: 0 0 10px rgba($black, 0.5);
+$maincontent-class: 'off-canvas-content';
 
-// 25. Orbit
+// 26. Orbit
 // ---------
 
 $orbit-bullet-background: $medium-gray;
@@ -441,7 +552,7 @@ $orbit-control-background-hover: rgba($black, 0.5);
 $orbit-control-padding: 1rem;
 $orbit-control-zindex: 10;
 
-// 26. Pagination
+// 27. Pagination
 // --------------
 
 $pagination-font-size: rem-calc(14);
@@ -452,13 +563,14 @@ $pagination-item-spacing: rem-calc(1);
 $pagination-radius: $global-radius;
 $pagination-item-background-hover: $light-gray;
 $pagination-item-background-current: $primary-color;
-$pagination-item-color-current: foreground($pagination-item-background-current);
+$pagination-item-color-current: $white;
 $pagination-item-color-disabled: $medium-gray;
 $pagination-ellipsis-color: $black;
 $pagination-mobile-items: false;
+$pagination-mobile-current-item: false;
 $pagination-arrows: true;
 
-// 27. Progress Bar
+// 28. Progress Bar
 // ----------------
 
 $progress-height: 1rem;
@@ -467,7 +579,177 @@ $progress-margin-bottom: $global-margin;
 $progress-meter-background: $primary-color;
 $progress-radius: $global-radius;
 
-// 28. Reveal
+// 29. Prototype Arrow
+// -------------------
+
+$prototype-arrow-directions: (
+  down,
+  up,
+  right,
+  left
+);
+$prototype-arrow-size: 0.4375rem;
+$prototype-arrow-color: $black;
+
+// 30. Prototype Border-Box
+// ------------------------
+
+$prototype-border-box-breakpoints: $global-prototype-breakpoints;
+
+// 31. Prototype Border-None
+// -------------------------
+
+$prototype-border-none-breakpoints: $global-prototype-breakpoints;
+
+// 32. Prototype Bordered
+// ----------------------
+
+$prototype-bordered-breakpoints: $global-prototype-breakpoints;
+$prototype-border-width: rem-calc(1);
+$prototype-border-type: solid;
+$prototype-border-color: $medium-gray;
+
+// 33. Prototype Display
+// ---------------------
+
+$prototype-display-breakpoints: $global-prototype-breakpoints;
+$prototype-display: (
+  inline,
+  inline-block,
+  block,
+  table,
+  table-cell
+);
+
+// 34. Prototype Font-Styling
+// --------------------------
+
+$prototype-font-breakpoints: $global-prototype-breakpoints;
+$prototype-wide-letter-spacing: rem-calc(4);
+$prototype-font-normal: $global-weight-normal;
+$prototype-font-bold: $global-weight-bold;
+
+// 35. Prototype List-Style-Type
+// -----------------------------
+
+$prototype-list-breakpoints: $global-prototype-breakpoints;
+$prototype-style-type-unordered: (
+  disc,
+  circle,
+  square
+);
+$prototype-style-type-ordered: (
+  decimal,
+  lower-alpha,
+  lower-latin,
+  lower-roman,
+  upper-alpha,
+  upper-latin,
+  upper-roman
+);
+
+// 36. Prototype Overflow
+// ----------------------
+
+$prototype-overflow-breakpoints: $global-prototype-breakpoints;
+$prototype-overflow: (
+  visible,
+  hidden,
+  scroll
+);
+
+// 37. Prototype Position
+// ----------------------
+
+$prototype-position-breakpoints: $global-prototype-breakpoints;
+$prototype-position: (
+  static,
+  relative,
+  absolute,
+  fixed
+);
+$prototype-position-z-index: 975;
+
+// 38. Prototype Rounded
+// ---------------------
+
+$prototype-rounded-breakpoints: $global-prototype-breakpoints;
+$prototype-border-radius: rem-calc(3);
+
+// 39. Prototype Separator
+// -----------------------
+
+$prototype-separator-breakpoints: $global-prototype-breakpoints;
+$prototype-separator-align: center;
+$prototype-separator-height: rem-calc(2);
+$prototype-separator-width: 3rem;
+$prototype-separator-background: $primary-color;
+$prototype-separator-margin-top: $global-margin;
+
+// 40. Prototype Shadow
+// --------------------
+
+$prototype-shadow-breakpoints: $global-prototype-breakpoints;
+$prototype-box-shadow: 0 2px 5px 0 rgba(0,0,0,.16),
+0 2px 10px 0 rgba(0,0,0,.12);
+
+// 41. Prototype Sizing
+// --------------------
+
+$prototype-sizing-breakpoints: $global-prototype-breakpoints;
+$prototype-sizing: (
+  width,
+  height
+);
+$prototype-sizes: (
+  25: 25%,
+  50: 50%,
+  75: 75%,
+  100: 100%
+);
+
+// 42. Prototype Spacing
+// ---------------------
+
+$prototype-spacing-breakpoints: $global-prototype-breakpoints;
+$prototype-spacers-count: 3;
+
+// 43. Prototype Text-Decoration
+// -----------------------------
+
+$prototype-decoration-breakpoints: $global-prototype-breakpoints;
+$prototype-text-decoration: (
+  overline,
+  underline,
+  line-through,
+);
+
+// 44. Prototype Text-Transformation
+// ---------------------------------
+
+$prototype-transformation-breakpoints: $global-prototype-breakpoints;
+$prototype-text-transformation: (
+  lowercase,
+  uppercase,
+  capitalize
+);
+
+// 45. Prototype Text-Utilities
+// ----------------------------
+
+$prototype-utilities-breakpoints: $global-prototype-breakpoints;
+$prototype-text-overflow: ellipsis;
+
+// 46. Responsive Embed
+// --------------------
+
+$responsive-embed-margin-bottom: rem-calc(16);
+$responsive-embed-ratios: (
+  default: 4 by 3,
+  widescreen: 16 by 9,
+);
+
+// 47. Reveal
 // ----------
 
 $reveal-background: $white;
@@ -479,7 +761,7 @@ $reveal-radius: $global-radius;
 $reveal-zindex: 1005;
 $reveal-overlay-background: rgba($black, 0.45);
 
-// 29. Slider
+// 48. Slider
 // ----------
 
 $slider-width-vertical: 0.5rem;
@@ -493,7 +775,7 @@ $slider-handle-background: $primary-color;
 $slider-opacity-disabled: 0.25;
 $slider-radius: $global-radius;
 
-// 30. Switch
+// 49. Switch
 // ----------
 
 $switch-background: $medium-gray;
@@ -509,7 +791,7 @@ $switch-paddle-offset: 0.25rem;
 $switch-paddle-radius: $global-radius;
 $switch-paddle-transition: all 0.25s ease-out;
 
-// 31. Table
+// 50. Table
 // ---------
 
 $table-background: $white;
@@ -519,29 +801,36 @@ $table-padding: rem-calc(8 10 10);
 $table-hover-scale: 2%;
 $table-row-hover: darken($table-background, $table-hover-scale);
 $table-row-stripe-hover: darken($table-background, $table-color-scale + $table-hover-scale);
+$table-is-striped: true;
 $table-striped-background: smart-scale($table-background, $table-color-scale);
 $table-stripe: even;
-$table-head-background: smart-scale($table-background, calc($table-color-scale / 2));
+$table-head-background: smart-scale($table-background, $table-color-scale / 2);
+$table-head-row-hover: darken($table-head-background, $table-hover-scale);
 $table-foot-background: smart-scale($table-background, $table-color-scale);
+$table-foot-row-hover: darken($table-foot-background, $table-hover-scale);
 $table-head-font-color: $body-font-color;
+$table-foot-font-color: $body-font-color;
 $show-header-for-stacked: false;
+$table-stack-breakpoint: medium;
 
-// 32. Tabs
+// 51. Tabs
 // --------
 
 $tab-margin: 0;
 $tab-background: $white;
+$tab-color: $primary-color;
 $tab-background-active: $light-gray;
+$tab-active-color: $primary-color;
 $tab-item-font-size: rem-calc(12);
 $tab-item-background-hover: $white;
 $tab-item-padding: 1.25rem 1.5rem;
 $tab-expand-max: 6;
 $tab-content-background: $white;
 $tab-content-border: $light-gray;
-$tab-content-color: foreground($tab-background, $primary-color);
+$tab-content-color: $body-font-color;
 $tab-content-padding: 1rem;
 
-// 33. Thumbnail
+// 52. Thumbnail
 // -------------
 
 $thumbnail-border: solid 4px $white;
@@ -551,7 +840,7 @@ $thumbnail-shadow-hover: 0 0 6px 1px rgba($primary-color, 0.5);
 $thumbnail-transition: box-shadow 200ms ease-out;
 $thumbnail-radius: $global-radius;
 
-// 34. Title Bar
+// 53. Title Bar
 // -------------
 
 $titlebar-background: $black;
@@ -562,30 +851,49 @@ $titlebar-icon-color: $white;
 $titlebar-icon-color-hover: $medium-gray;
 $titlebar-icon-spacing: 0.25rem;
 
-// 35. Tooltip
+// 54. Tooltip
 // -----------
 
+$has-tip-cursor: help;
 $has-tip-font-weight: $global-weight-bold;
 $has-tip-border-bottom: dotted 1px $dark-gray;
 $tooltip-background-color: $black;
 $tooltip-color: $white;
 $tooltip-padding: 0.75rem;
+$tooltip-max-width: 10rem;
 $tooltip-font-size: $small-font-size;
 $tooltip-pip-width: 0.75rem;
 $tooltip-pip-height: $tooltip-pip-width * 0.866;
 $tooltip-radius: $global-radius;
 
-// 36. Top Bar
+// 55. Top Bar
 // -----------
 
 $topbar-padding: 0.5rem;
 $topbar-background: $light-gray;
 $topbar-submenu-background: $topbar-background;
-$topbar-title-spacing: 1rem;
+$topbar-title-spacing: 0.5rem 1rem 0.5rem 0;
 $topbar-input-width: 200px;
 $topbar-unstack-breakpoint: medium;
 
+// 56. Xy Grid
+// -----------
+
+$xy-grid: true;
+$grid-container: $global-width;
+$grid-columns: 12;
+$grid-margin-gutters: (
+  small: 20px,
+  medium: 30px
+);
+$grid-padding-gutters: $grid-margin-gutters;
+$grid-container-padding: $grid-padding-gutters;
+$grid-container-max: $global-width;
+$xy-block-grid-max: 8;
+
 @import "~foundation-sites/scss/foundation";
+
+// stylelint-enable
 
 .foundation-form-hax {
   @include foundation-forms;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/spec/test_helper.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/spec/test_helper.tsx
@@ -195,9 +195,13 @@ export class TestHelper {
     m.redraw.sync();
   }
 
-  dump(context?: Element) {
-    // tslint:disable-next-line:no-console
-    console.log((context || this.root!).innerHTML);
+  delay(time: number) {
+    return new Promise((resolve) => setTimeout(resolve, time));
+  }
+
+  async delayRedraw(time: number) {
+    await this.delay(time);
+    this.redraw();
   }
 
   clickByTestId(id: string, context?: Element) {
@@ -206,10 +210,6 @@ export class TestHelper {
 
   byClass(className: string) {
     return this.root!.getElementsByClassName(className)[0];
-  }
-
-  allByClass(className: string) {
-    return this.root!.getElementsByClassName(className);
   }
 
   private _el(selector: string | Element, context?: Element): Element {

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -3943,13 +3943,13 @@ forwarded@0.2.0:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
 
-foundation-sites@=6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/foundation-sites/-/foundation-sites-6.3.0.tgz#19b2d6e5edced8418a4a7b4a1d65287ee1c8d512"
-  integrity sha512-nKnmtMiA0cZaxEOCkiLnVMNHO0EbFBihTeIY8NE+vaFejr0E7qYuXK9tVCBE0RoFRESECg00zTzBPghFNgD03A==
+foundation-sites@=6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/foundation-sites/-/foundation-sites-6.4.3.tgz#ea89eb599badf6f03dd526c51f00bdb942a844f6"
+  integrity sha512-GW7/iYwpgBfmhkrPNP/x5RiokSkdVy9OFwvHpBfIz9u7qkyi4PXdmBrItD4XZxQ2xYLbOv9d//Ye5gHhhS/aEg==
   dependencies:
-    jquery "^2.2.0"
-    what-input "^4.0.3"
+    jquery ">=3.0.0"
+    what-input "^4.1.3"
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -4894,7 +4894,12 @@ jest-worker@^28.1.3:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jquery@^2.2.0, jquery@^2.2.4:
+jquery@>=3.0.0:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.4.tgz#ba065c188142100be4833699852bf7c24dc0252f"
+  integrity sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ==
+
+jquery@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
   integrity sha512-lBHj60ezci2u1v2FqnZIraShGgEXq35qCzMv4lITyHGppTnA13rwR0MgwyNJh9TnDs3aXUvd1xjAotfraMHX/Q==
@@ -8454,7 +8459,7 @@ webpack@^5:
     watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 
-what-input@^4.0.3:
+what-input@^4.1.3:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/what-input/-/what-input-4.3.1.tgz#b8ea7554ba1d9171887c4c6addf28185fec3d31d"
   integrity sha512-7KD71RWNRWI9M08shZ8+n/2UjO5amwsG9PMSXWz0iIlH8H2DVbHE8Z2tW1RqQa0kIwdeqdUIffFz7crDfkcbAw==

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -4894,15 +4894,10 @@ jest-worker@^28.1.3:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jquery@>=3.0.0:
+jquery@>=3.0.0, jquery@^3.6.4:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.4.tgz#ba065c188142100be4833699852bf7c24dc0252f"
   integrity sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ==
-
-jquery@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
-  integrity sha512-lBHj60ezci2u1v2FqnZIraShGgEXq35qCzMv4lITyHGppTnA13rwR0MgwyNJh9TnDs3aXUvd1xjAotfraMHX/Q==
 
 js-sdsl@^4.1.4:
   version "4.4.0"


### PR DESCRIPTION
Upgrades foundation-sites to final version before removal of jquery peer dependency, to focus on the JQuery 3 upgrade and any possible backward compatibility issues.

https://jquery.com/upgrade-guide/3.0/
https://github.com/foundation/foundation-sites/releases/tag/v6.4.0