### PR TITLE
Run frontend lints alongside jasmine task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -674,7 +674,6 @@ private void forAllTask(Closure<Task> closure) {
 task allTests { thisTask ->
   group LifecycleBasePlugin.VERIFICATION_GROUP
   description = "Run all tests"
-  dependsOn ':server:lint'
 
   forAllTask { Test eachTestTask ->
     thisTask.dependsOn eachTestTask

--- a/server/jasmine.gradle
+++ b/server/jasmine.gradle
@@ -146,6 +146,7 @@ task downloadChromeDriver(type: DownloaderTask) { thisTask ->
 task jasmineKarma(type: YarnRunTask) {
   description = 'Run new jasmine tests (typescript) via karma'
   dependsOn ':server:yarnInstall'
+  dependsOn ':server:lintNew'
   dependsOn ':server:compileAssetsWebpackDev'
 
   outputs.upToDateWhen { false }
@@ -158,6 +159,7 @@ task jasmineOld(type: YarnRunTask) {
   description = 'Run old jasmine tests (legacy JS) via jasmine-browser-runner'
   dependsOn driverImpl()
   dependsOn ':server:yarnInstall'
+  dependsOn ':server:lintOld'
   dependsOn ':server:compileAssetsRailsTest'
 
   outputs.upToDateWhen { false }
@@ -171,7 +173,7 @@ task jasmineOld(type: YarnRunTask) {
   }
 }
 
-task jasmine(dependsOn: [jasmineKarma, jasmineOld])
+task jasmine(dependsOn: [':server:lint', jasmineKarma, jasmineOld])
 
 task jasmineKarmaServer(type: YarnRunTask) {
   description = 'Run new jasmine tests (typescript) via karma inside a browser'

--- a/server/lint.gradle
+++ b/server/lint.gradle
@@ -42,6 +42,7 @@ task eslintold(type: YarnRunTask) {
 task eslint(type: YarnRunTask) {
   description "Run ESLint"
   dependsOn 'yarnInstall'
+  dependsOn 'generateJSRoutes'
 
   workingDir = project.railsRoot
 
@@ -55,6 +56,7 @@ task eslint(type: YarnRunTask) {
 task tslint(type: YarnRunTask) {
   description "Run TSLint"
   dependsOn 'yarnInstall'
+  dependsOn 'generateJSRoutes'
 
   workingDir = project.railsRoot
 
@@ -64,7 +66,17 @@ task tslint(type: YarnRunTask) {
   source(project.file("${project.railsRoot}/tslint.json"))
 }
 
+task lintNew {
+  description 'Run lint tools on newer js/scss'
+  dependsOn eslint, tslint
+}
+
+task lintOld {
+  description 'Run lint tools on older legacy js/scss'
+  dependsOn stylelintold, eslintold
+}
+
 task lint {
   description 'Run all lint tools'
-  dependsOn stylelintold, eslintold, eslint, tslint
+  dependsOn lintNew, lintOld
 }


### PR DESCRIPTION
Currently this runs duplicated on the divide-and-conquered agent/server unit tests which is confusing as multiple jobs fail. It makes more sense to run this alongside the jasmine tests since they run on JS for both old and new JS, they all depend on yarn install and they now run at the start of the pipeline anyway, for fast feedback.
