### PR TITLE
Make dashboard fudge delays a little longer

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/dashboard_widget_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/dashboard_widget_spec.js
@@ -172,7 +172,7 @@ describe("Dashboard Widget", () => {
     expect(helper.text('.modal-body', body)).toBe('Specify a reason for pausing schedule on pipeline up42');
     helper.q('.reveal input', body).value = pauseCause;
     helper.click('.reveal .primary', body);
-    await helper.delayRedraw(50);
+    await helper.delayRedraw();
 
     expect(helper.text('.pipeline_message')).toContain(responseMessage);
     expect(helper.q('.pipeline_message')).toHaveClass("success");
@@ -202,7 +202,7 @@ describe("Dashboard Widget", () => {
     });
 
     helper.click(helper.qa('.info a').item(1));
-    await helper.delay(50);
+    await helper.delay();
 
     expect(helper.q('.material_changes')).toBeInDOM();
 
@@ -218,7 +218,7 @@ describe("Dashboard Widget", () => {
     });
 
     helper.click(helper.qa('.info a').item(1));
-    await helper.delay(50);
+    await helper.delay();
 
     expect(helper.q('.material_changes')).toBeInDOM();
   });
@@ -245,7 +245,7 @@ describe("Dashboard Widget", () => {
 
     expect(helper.q('.pipeline_locked')).not.toHaveClass('disabled');
     helper.click('.pipeline_locked');
-    await helper.delayRedraw(50);
+    await helper.delayRedraw();
 
     expect(helper.q('.pipeline_message')).toHaveClass("success");
     expect(helper.text('.pipeline_message')).toContain(responseMessage);

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
@@ -150,7 +150,7 @@ describe("Dashboard Pipeline Instance Widget", () => {
     });
 
     helper.click(helper.qa('.info a')[1]);
-    await helper.delayRedraw(50);
+    await helper.delayRedraw();
 
     expect(helper.q('.material_changes')).toBeInDOM();
     expect(helper.q('.comment')).toHaveHtml('<p>Initial commit <a target="story_tracker" href="http://example.com/1234">#1234</a></p>');

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -232,7 +232,7 @@ describe("Dashboard Pipeline Widget", () => {
 
         doRefreshImmediately.and.callFake(() => pipeline.isPaused = false);
         helper.click('.unpause');
-        await helper.delayRedraw(50);
+        await helper.delayRedraw();
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
@@ -256,7 +256,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(doRefreshImmediately).not.toHaveBeenCalled();
 
         helper.click('.unpause');
-        await helper.delayRedraw(50);
+        await helper.delayRedraw();
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
@@ -339,7 +339,7 @@ describe("Dashboard Pipeline Widget", () => {
 
         doRefreshImmediately.and.callFake(() => pipeline.isPaused = true);
         helper.click('.reveal .primary', body);
-        await helper.delayRedraw(50);
+        await helper.delayRedraw();
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
@@ -368,7 +368,7 @@ describe("Dashboard Pipeline Widget", () => {
 
         helper.q('.reveal input', body).value = "test";
         helper.click('.reveal .primary', body);
-        await helper.delayRedraw(50);
+        await helper.delayRedraw();
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
@@ -393,7 +393,7 @@ describe("Dashboard Pipeline Widget", () => {
         pausePopupTextBox.value = "test";
 
         simulateEvent.simulate(pausePopupTextBox, 'keydown', {key: 'Enter'});
-        await helper.delayRedraw(50);
+        await helper.delayRedraw();
 
         expect(helper.q(".reveal", body)).toBeFalsy();
         expect(helper.text('.pipeline_message')).toContain(responseMessage);
@@ -464,7 +464,7 @@ describe("Dashboard Pipeline Widget", () => {
 
         doRefreshImmediately.and.callFake(() => pipeline.isPaused = true);
         helper.click('.reveal .primary', body);
-        await helper.delayRedraw(50);
+        await helper.delayRedraw();
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
@@ -529,7 +529,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(doRefreshImmediately).not.toHaveBeenCalled();
 
         helper.click('.pipeline_locked');
-        await helper.delayRedraw(50);
+        await helper.delayRedraw();
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
@@ -552,7 +552,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(doRefreshImmediately).not.toHaveBeenCalled();
 
         helper.click('.pipeline_locked');
-        await helper.delayRedraw(50);
+        await helper.delayRedraw();
 
         expect(doCancelPolling).toHaveBeenCalled();
         expect(doRefreshImmediately).toHaveBeenCalled();
@@ -642,7 +642,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(pipeline.triggerDisabled()).toBe(false);
 
         helper.click('.play');
-        await helper.delayRedraw(50);
+        await helper.delayRedraw();
 
         expect(pipeline.triggerDisabled()).toBe(true);
 
@@ -663,7 +663,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(pipeline.triggerDisabled()).toBe(false);
 
         helper.click('.play');
-        await helper.delayRedraw(50);
+        await helper.delayRedraw();
 
         expect(pipeline.triggerDisabled()).toBe(false);
 
@@ -766,7 +766,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.q(".reveal", body)).toBeFalsy();
 
         helper.click('.play_with_options');
-        await helper.delay(50);
+        await helper.delay();
 
         expect(helper.q(".reveal", body)).toBeInDOM();
         expect(helper.q('.callout.alert', body)).toBeInDOM();
@@ -787,7 +787,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.q('.pipeline_options-heading', body)).toBeFalsy();
 
         helper.click('.play_with_options');
-        await helper.delay(50);
+        await helper.delay();
 
         expect(helper.q(".reveal", body)).toBeInDOM();
         expect(helper.text('.pipeline_options-heading', body)).toContain('Materials');
@@ -800,7 +800,7 @@ describe("Dashboard Pipeline Widget", () => {
         expect(helper.q('.pipeline_options-heading', body)).toBeFalsy();
 
         helper.click('.play_with_options');
-        await helper.delay(50);
+        await helper.delay();
 
         expect(helper.q(".reveal", body)).toBeInDOM();
         expect(helper.text('.pipeline_options-heading', body)).toContain('Materials');
@@ -820,10 +820,10 @@ describe("Dashboard Pipeline Widget", () => {
         expect(pipeline.triggerDisabled()).toBe(false);
 
         helper.click('.play_with_options');
-        await helper.delay(50);
+        await helper.delay();
 
         helper.click('.modal-buttons .button.save.primary', body);
-        await helper.delayRedraw(50);
+        await helper.delayRedraw();
 
         expect(pipeline.triggerDisabled()).toBe(true);
 
@@ -845,10 +845,10 @@ describe("Dashboard Pipeline Widget", () => {
         expect(pipeline.triggerDisabled()).toBe(false);
 
         helper.click('.play_with_options');
-        await helper.delay(50);
+        await helper.delay();
 
         helper.clickButtonOnActiveModal('.modal-buttons .button.save.primary');
-        await helper.delayRedraw(50);
+        await helper.delayRedraw();
 
         expect(pipeline.triggerDisabled()).toBe(false);
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/spec/test_helper.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/spec/test_helper.tsx
@@ -30,6 +30,7 @@ export function stubAllMethods<T>(keys: Array<keyof T>): T {
 }
 
 export class TestHelper {
+  static DELAY_MS = 70;
   root?: HTMLElement;
 
   constructor(root?: HTMLElement) {
@@ -195,12 +196,12 @@ export class TestHelper {
     m.redraw.sync();
   }
 
-  delay(time: number) {
-    return new Promise((resolve) => setTimeout(resolve, time));
+  delay(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, TestHelper.DELAY_MS));
   }
 
-  async delayRedraw(time: number) {
-    await this.delay(time);
+  async delayRedraw() {
+    await this.delay();
     this.redraw();
   }
 


### PR DESCRIPTION
The 50ms fudge factor test delays to workaround unpredictable JQuery logic are a little short sometimes. Let's increase it a bit.