### PR TITLE
Remove reporting of agent "creating properties" in console logs

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/remote/work/BuildWork.java
+++ b/common/src/main/java/com/thoughtworks/go/remote/work/BuildWork.java
@@ -201,8 +201,6 @@ public class BuildWork implements Work {
         String tag = result.isPassed() ? DefaultGoPublisher.JOB_PASS : DefaultGoPublisher.JOB_FAIL;
         goPublisher.reportCompleting(result, tag);
 
-        goPublisher.reportCreatingProperties();
-
         goPublisher.reportBeginToPublishArtifacts();
 
         try {

--- a/common/src/main/java/com/thoughtworks/go/work/DefaultGoPublisher.java
+++ b/common/src/main/java/com/thoughtworks/go/work/DefaultGoPublisher.java
@@ -167,8 +167,4 @@ public class DefaultGoPublisher implements GoPublisher {
     public void reportBeginToPublishArtifacts() {
         reportAction(PUBLISH, "Start to upload");
     }
-
-    public void reportCreatingProperties() {
-        reportAction(NOTICE, "Start to create properties");
-    }
 }


### PR DESCRIPTION
Properties creation was removed a long time ago in 84041df506c00a94ba25a0ad78c54e3780344186 - there's no need to report creation like this anymore, it's misleading and useless.
