### PR TITLE
Add Alpine 3.18 support

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -29,6 +29,7 @@ enum Distro implements DistroBehavior {
         new DistroVersion(version: '3.15', releaseName: '3.15', eolDate: parseDate('2023-11-01')),
         new DistroVersion(version: '3.16', releaseName: '3.16', eolDate: parseDate('2024-05-23')),
         new DistroVersion(version: '3.17', releaseName: '3.17', eolDate: parseDate('2024-11-22')),
+        new DistroVersion(version: '3.18', releaseName: '3.18', eolDate: parseDate('2025-05-09')),
       ]
     }
 

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -263,6 +263,7 @@ enum Distro implements DistroBehavior {
       return alpine.getInstallPrerequisitesCommands(v) +
         [
           'apk add --no-cache sudo',
+          'apk del --purge btrfs-progs', // btrfs is installed by Docker, but requires udev, which causes issues with OSHI on alpine. Dont think we need btrfs here?
         ]
     }
 
@@ -279,7 +280,7 @@ enum Distro implements DistroBehavior {
     @Override
     List<DistroVersion> getSupportedVersions() {
       return [
-        new DistroVersion(version: 'dind', releaseName: '23.0.6-dind-alpine3.17', eolDate: parseDate('2099-01-01'))
+        new DistroVersion(version: 'dind', releaseName: 'dind', eolDate: parseDate('2099-01-01'))
       ]
     }
   }

--- a/settings-docker.gradle
+++ b/settings-docker.gradle
@@ -30,4 +30,4 @@ Distro.values().each { distro ->
 }
 
 include ":docker:gocd-server:${Distro.centos.projectName(Distro.centos.getVersion('9'))}"
-include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.17'))}"
+include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.18'))}"


### PR DESCRIPTION
- Fixes #11561 issue with DIND images on Alpine 3.18
- Adds Alpine 3.18 agent images
- Changes server to default to Alpine 3.18