### PR TITLE
Bump mybatis-spring from 2.0.7 to 2.1.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -81,7 +81,7 @@ final Map<String, String> libraries = [
   lombok              : 'org.projectlombok:lombok:1.18.26',
   mockitoBom          : 'org.mockito:mockito-bom:5.3.1',
   mybatis             : 'org.mybatis:mybatis:3.5.13',
-  mybatisSpring       : 'org.mybatis:mybatis-spring:2.0.7',
+  mybatisSpring       : 'org.mybatis:mybatis-spring:2.1.1',
   mysql               : 'com.mysql:mysql-connector-j:8.0.33',
   nanohttpd           : 'org.nanohttpd:nanohttpd:2.3.1',
   objenesis           : 'org.objenesis:objenesis:3.3',


### PR DESCRIPTION
https://github.com/mybatis/spring/releases/tag/mybatis-spring-2.1.0

Theoretically neither 2.0.x or 2.1.x are compatible with Spring 4.x but 2.0.x seems fine with our usage. 2.1.x probably will be too, and is at least currently supported.