### PR TITLE
Update Tanuki wrapper license keys to renewed term

### DIFF
--- a/installers/include/wrapper-license-linux-go-agent.conf
+++ b/installers/include/wrapper-license-linux-go-agent.conf
@@ -6,14 +6,13 @@
 # wrapper.app.parameter.1=/usr/share/go-agent/lib/agent-bootstrapper.jar
 
 wrapper.license.type=DEV
-wrapper.license.id=202205130000008
+wrapper.license.id=202305310000010
 wrapper.license.licensee=ThoughtWorks
 wrapper.license.group=Go
 wrapper.license.dev_application=GoCD Agent On Linux
 wrapper.license.features=64bit
-wrapper.license.upgrade_term.begin_date=2008-06-03
-wrapper.license.upgrade_term.end_date=2023-06-03
-wrapper.license.key.1=695b-0ff6-399a-d1a6
-wrapper.license.key.2=27a9-4d9f-be26-1374
-wrapper.license.key.3=e06e-0a78-33aa-879f
-wrapper.license.key.4=d99e-356a-3c5a-f40f
+wrapper.license.key.0=4844-0af0-665c-88f0
+wrapper.license.key.1=54d1-8ca5-fc04-80fc
+wrapper.license.key.2=59e4-7b00-7e92-3e0d
+wrapper.license.key.3=adb7-3173-227c-d524
+wrapper.license.key.4=5a91-3471-7a16-ca11

--- a/installers/include/wrapper-license-linux-go-server.conf
+++ b/installers/include/wrapper-license-linux-go-server.conf
@@ -6,14 +6,13 @@
 # wrapper.app.parameter.1=/usr/share/go-server/lib/go.jar
 
 wrapper.license.type=DEV
-wrapper.license.id=202205130000007
+wrapper.license.id=202305310000011
 wrapper.license.licensee=ThoughtWorks
 wrapper.license.group=Go
 wrapper.license.dev_application=GoCD Server On Linux
 wrapper.license.features=64bit
-wrapper.license.upgrade_term.begin_date=2008-06-03
-wrapper.license.upgrade_term.end_date=2023-06-03
-wrapper.license.key.1=94ae-e1cb-1fe9-8446
-wrapper.license.key.2=e41f-0f78-907d-a749
-wrapper.license.key.3=8c84-74bf-828f-cd70
-wrapper.license.key.4=12a0-ef48-ca43-f386
+wrapper.license.key.0=4844-0af0-665c-88f0
+wrapper.license.key.1=e6b8-05e5-9315-0dd9
+wrapper.license.key.2=20f3-8766-dc3c-7de5
+wrapper.license.key.3=0784-7c49-af90-6f36
+wrapper.license.key.4=458a-4cc2-ad2f-7437

--- a/installers/include/wrapper-license-relative-path-go-agent.conf
+++ b/installers/include/wrapper-license-relative-path-go-agent.conf
@@ -6,14 +6,13 @@
 # wrapper.app.parameter.1=lib/agent-bootstrapper.jar
 
 wrapper.license.type=DEV
-wrapper.license.id=202205130000027
+wrapper.license.id=202305310000009
 wrapper.license.licensee=ThoughtWorks
 wrapper.license.group=Go
 wrapper.license.dev_application=GoCD Agent
 wrapper.license.features=64bit
-wrapper.license.upgrade_term.begin_date=2008-06-03
-wrapper.license.upgrade_term.end_date=2023-06-03
-wrapper.license.key.1=26ef-d0ba-3674-c88b
-wrapper.license.key.2=b7ed-6425-0dbe-506a
-wrapper.license.key.3=dade-57bc-462b-346e
-wrapper.license.key.4=97d6-41f5-aba0-f275
+wrapper.license.key.0=4844-0af0-665c-88f0
+wrapper.license.key.1=2ed3-f3da-ae97-5b84
+wrapper.license.key.2=a4ab-d252-7365-bdd6
+wrapper.license.key.3=9005-ca4e-d859-4649
+wrapper.license.key.4=9ca7-ad7f-33ea-a3a2

--- a/installers/include/wrapper-license-relative-path-go-server.conf
+++ b/installers/include/wrapper-license-relative-path-go-server.conf
@@ -6,14 +6,13 @@
 # wrapper.app.parameter.1=lib/go.jar
 
 wrapper.license.type=DEV
-wrapper.license.id=202205130000028
+wrapper.license.id=202305310000008
 wrapper.license.licensee=ThoughtWorks
 wrapper.license.group=Go
 wrapper.license.dev_application=GoCD Server
 wrapper.license.features=64bit
-wrapper.license.upgrade_term.begin_date=2008-06-03
-wrapper.license.upgrade_term.end_date=2023-06-03
-wrapper.license.key.1=2d2c-52a3-4cb8-487c
-wrapper.license.key.2=c47f-250b-362a-5166
-wrapper.license.key.3=94ea-1556-3336-0b24
-wrapper.license.key.4=1cdc-9201-b2ff-04f9
+wrapper.license.key.0=4844-0af0-665c-88f0
+wrapper.license.key.1=629b-5715-aa45-4f1b
+wrapper.license.key.2=e1b9-8b23-e3cb-bf7a
+wrapper.license.key.3=5a3b-e6bc-87c0-5cc7
+wrapper.license.key.4=f031-f6f4-0ad2-5b0b


### PR DESCRIPTION
Enabled upgrade term obfuscation in Tanuki portal since this confuses users.

Still looking at transitioning to the OSS Community license for next release which is dependent on a couple of things
- Availability of 64-bit Windows binaries in the Community Edition
- an OSS-compatible license that allows redistribution _without_ source code modification outside the GPL v2 (since GoCD is Apache 2 license)