### PR TITLE
Remove Groovy hack/workaround for Grolifant AbstractDistributionInstaller

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/DownloaderTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/DownloaderTask.groovy
@@ -21,9 +21,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.ysb33r.grolifant.api.core.OperatingSystem
 import org.ysb33r.grolifant.api.core.ProjectOperations
-import org.ysb33r.grolifant.api.v4.downloader.AbstractDistributionInstaller
-import org.ysb33r.grolifant.api.v4.downloader.ArtifactRootVerification
-import org.ysb33r.grolifant.api.v4.downloader.ArtifactUnpacker
+import org.ysb33r.grolifant.api.core.downloader.AbstractDistributionInstaller
 
 class DownloaderTask extends DefaultTask {
   @Input
@@ -51,7 +49,7 @@ class DownloaderTask extends DefaultTask {
   }
 
   private AbstractDistributionInstaller createInstaller() {
-    new GroovyJava16WorkaroundDistributionInstaller(packageName, "download/${packageName}/${packageVersion}", projectOperations) {
+    new AbstractDistributionInstaller(packageName, "download/${packageName}/${packageVersion}", projectOperations) {
 
       @Override
       URI uriFromVersion(String version) {
@@ -61,30 +59,6 @@ class DownloaderTask extends DefaultTask {
       @Override
       protected File verifyDistributionRoot(File distDir) {
         distDir
-      }
-    }
-  }
-
-  /**
-   * Workaround for issues with Java 17 and Groovy-generated dynamic proxies used by Grolifant on Groovy 3.0.9
-   # https://issues.apache.org/jira/browse/GROOVY-10145 has the fix, but currently seems not backported to 3.x.
-   #
-   # This is logged at https://gitlab.com/ysb33rOrg/grolifant/-/issues/82 but likely no fix possible unless
-   */
-  private abstract class GroovyJava16WorkaroundDistributionInstaller extends AbstractDistributionInstaller {
-    GroovyJava16WorkaroundDistributionInstaller(String distributionName, String basePath, ProjectOperations projectOperations) {
-      super(distributionName, basePath, projectOperations)
-      this.artifactRootVerification = new ArtifactRootVerification() {
-        @Override
-        File apply(File unpackedRoot) {
-          return GroovyJava16WorkaroundDistributionInstaller.this.verifyDistributionRoot(unpackedRoot)
-        }
-      }
-      this.artifactUnpacker = new ArtifactUnpacker() {
-        @Override
-        void accept(File source, File destDir) {
-          GroovyJava16WorkaroundDistributionInstaller.this.unpack(source, destDir)
-        }
       }
     }
   }


### PR DESCRIPTION
This is no longer needed on Grolifant 2.0.0+ as was fixed in https://gitlab.com/ysb33rOrg/grolifant/-/issues/82