### PR TITLE
Fix font display consistency across views

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/old_application.js
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/old_application.js
@@ -36,7 +36,7 @@ Ajax.Responders.register({
 function iframeResizer(iframe){
     if (iframe.is(':visible') && iframe.attr('sandbox') === undefined) {
         iframe.contents().find("body").css({margin:0});
-        iframe.contents().find("body > pre").css({whiteSpace:'pre-wrap',margin : 0,fontSize : '12px',fontFamily: 'consolas, monaco, courier', wordWrap:'break-word', '-ms-word-wrap':'break-word', overflow:'hidden'});
+        iframe.contents().find("body > pre").css({whiteSpace:'pre-wrap',margin : 0,fontSize : '12px',fontFamily: 'consolas, monaco, menlo, courier', wordWrap:'break-word', '-ms-word-wrap':'break-word', overflow:'hidden'});
         setTimeout(function(){
             jQuery('iframe').each(function(){
                 iframe.height(iframe.contents().find("body").height());

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_font-awesome-glyphs.scss.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_font-awesome-glyphs.scss.erb
@@ -86,6 +86,7 @@ $fa-font-icons: (
     text-shadow: $shadow;
   }
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 @mixin in-progress-spinner($type: spinner) {

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_fonts.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_fonts.scss
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 @import "font-awesome-sprockets";
-@import "bourbon/core/bourbon";
 
 // Capitalization here needs to match the font file names in vendor/assets/fonts/opensans
 // stylelint-disable value-keyword-case

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/application.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/application.scss
@@ -28,7 +28,7 @@
  *
  */
 
-@import "font-awesome-sprockets";
+@import "fonts";
 @import "shared/go-variables";
 @import "shared/mixins";
 @import "shared/common";

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_console-log.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_console-log.scss
@@ -62,7 +62,7 @@ $PROGRESS_BAR_BG_SIZE: 70px;
 }
 
 .console-log-loading {
-  font-family: Monaco, Consolas, Inconsolata, "Liberation Mono", "Courier New", monospace;
+  font-family: Monaco, Consolas, Inconsolata, Menlo, "Liberation Mono", "Courier New", monospace;
   font-size: 13px;
   line-height: 19px;
   color: #fff;
@@ -85,7 +85,7 @@ $PROGRESS_BAR_BG_SIZE: 70px;
   min-height: calc(100vh - #{$height-of-non-console-log-elements});
   background-color: #333;
   color: white;
-  font-family: Monaco, Consolas, Inconsolata, "Liberation Mono", "Courier New", monospace;
+  font-family: Monaco, Consolas, Inconsolata, Menlo, "Liberation Mono", "Courier New", monospace;
   font-size: 13px;
 
   .fas {

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css_sass/gadgets/_modals.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css_sass/gadgets/_modals.scss
@@ -38,7 +38,6 @@
   position: fixed;
 }
 
-.ui-dialog,
 #MB_window {
   border: 0 solid;
   position: absolute;
@@ -51,7 +50,6 @@
   position: fixed !important;
 }
 
-.ui-dialog,
 #MB_frame_content {
   background-color: #fff;
   border: 2px solid #333;
@@ -61,7 +59,6 @@
   position: relative;
 }
 
-.ui-dialog-titlebar,
 #MB_header {
   background: #333 image_url("g9/backgrounds/bg_glass_gradient.png") repeat-x center center;
   margin: 0;
@@ -76,15 +73,6 @@
   padding-top: 0 !important;
 }
 
-.ui-dialog-content {
-  padding: 15px;
-}
-
-.ui-dialog-title {
-  display: block;
-}
-
-.ui-dialog-title,
 #MB_caption {
   color: #fff;
   font-family: "Helvetica Neue", Arial, Helvetica, sans-serif;
@@ -161,7 +149,6 @@
 }
 
 /* action row and buttons */
-.ui-dialog-buttonpane,
 #MB_content .actions {
   background: #eeeee9 image_url("g9/backgrounds/overlay_modal_action_row.png") repeat-x;
   border-radius: 0;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css_sass/global/_typography.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css_sass/global/_typography.scss
@@ -16,7 +16,7 @@
 pre,
 code,
 .code {
-  font-family: consolas, monaco, courier;
+  font-family: consolas, monaco, menlo, courier;
   color: #333;
   line-height: 20px;
   font-size: 13px;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/new-theme.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/new-theme.scss
@@ -135,7 +135,6 @@ h4 {
   margin-top: 10px;
 }
 
-.ui-dialog-buttonpane,
 #MB_content .actions {
   background-image: none;
   border: 0;
@@ -763,7 +762,6 @@ button.submit {
   font-weight: 600;
 }
 
-.ui-dialog,
 #MB_frame_content {
   background-color: #fff;
   border: 0;
@@ -1168,12 +1166,6 @@ a:visited#link-to-this-page {
   background: linear-gradient(to bottom, #f5f5f5 0%, #f5f5f5 100%) !important;
 }
 
-.ui-dialog-buttonpane {
-  button.submit.primary {
-    color: #fff !important;
-  }
-}
-
 #MB_window {
   border-radius: 3px;
   overflow: visible;
@@ -1206,7 +1198,6 @@ a:visited#link-to-this-page {
   padding: 15px 20px;
 }
 
-.ui-dialog-titlebar,
 #MB_header {
   border-bottom: 2px solid #ccc;
   background: $modal-header-bg;
@@ -1307,7 +1298,6 @@ a:visited.help {
   }
 }
 
-.ui-dialog-title,
 #MB_caption {
   color: #333;
 }

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/vm/_structure_for_old_ui.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/vm/_structure_for_old_ui.scss
@@ -119,7 +119,7 @@ h3 strong {
 pre,
 code,
 #admin-holder-for-admin-config-source-xml textarea {
-  font-family: consolas, monaco, courier;
+  font-family: consolas, monaco, menlo, courier;
   font-size: 13px;
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/app/views/admin/configuration/show.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/admin/configuration/show.html.erb
@@ -36,7 +36,7 @@
               <style>
                 #content_container textarea {
                   cursor: text;
-                  font-family: consolas, monaco, courier, monospace;
+                  font-family: consolas, monaco, menlo, courier, monospace;
                   color: #333;
                   line-height: 20px;
                   font-size: 13px;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/global.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/global.scss
@@ -88,6 +88,8 @@ body {
   color: $body-color;
   text-align: left;
   background-color: $body-bg;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 p {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/global/_fontawesome.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/global/_fontawesome.scss
@@ -68,6 +68,7 @@
   }
 
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 @mixin icon-before(


### PR DESCRIPTION
Fix some minor UI/UX font bugs that are a bit irritating
- Fix Open Sans display on legacy views (Stage Details, Job/Build Details, VSM etc)
- Fix consistency of font smoothing (especially for headers) on MacOS/Firefox
- Fix display of build console logs on IOS Safari by making a decent font selectable (Menlo)
- Remove some minor CSS cruft on the way