### PR TITLE
Temporarily switch to fixed curl image version to fix arm64 image builds

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
@@ -17,7 +17,7 @@
 # Please file any issues or PRs at https://github.com/gocd/gocd
 ###############################################################################################
 
-FROM curlimages/curl:latest as gocd-agent-unzip
+FROM curlimages/curl:8.1.1 as gocd-agent-unzip
 USER root
 ARG TARGETARCH
 ARG UID=1000

--- a/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
@@ -17,7 +17,7 @@
 # Please file any issues or PRs at https://github.com/gocd/gocd
 ###############################################################################################
 
-FROM curlimages/curl:latest as gocd-server-unzip
+FROM curlimages/curl:8.1.1 as gocd-server-unzip
 USER root
 ARG TARGETARCH
 ARG UID=1000


### PR DESCRIPTION
`latest` tag (`8.1.2`) has no arm64 images due to https://github.com/curl/curl-container/issues/3

Temporarily lock version to last working version.