### PR TITLE
Fix IntelliJ IDEA idea resolution of sharedTest code within server tests

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -38,22 +38,7 @@ sourceSets {
 
 idea {
   module {
-    testSourceDirs += sourceSets.functionalTest.java.srcDirs
-
-
-    // some hax to fudge the intellij xml
-    iml.withXml {
-      def node = it.asNode()
-      def content = node.component.find { it.'@name' == 'NewModuleRootManager' }.content[0]
-      content.sourceFolder.each { sourceFolder ->
-        if (sourceFolder.@url?.endsWith('/resources')) {
-          sourceFolder.attributes().with {
-            boolean isTestSource = (remove('isTestSource') == 'true')
-            put('type', isTestSource ? 'java-test-resource' : 'java-resource')
-          }
-        }
-      }
-    }
+    testSources.from(sourceSets.functionalTest.java.srcDirs)
   }
 }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -328,23 +328,8 @@ jar {
 
 idea {
   module {
-    testSourceDirs += sourceSets.sharedTest.java.srcDirs
-    testSourceDirs += sourceSets.fastUnitTest.java.srcDirs
-    testSourceDirs += sourceSets.integrationTest.java.srcDirs
-
-    // some hax to fudge the intellij xml
-    iml.withXml {
-      def node = it.asNode()
-      def content = node.component.find { it.'@name' == 'NewModuleRootManager' }.content[0]
-      content.sourceFolder.each { sourceFolder ->
-        if (sourceFolder.@url?.endsWith('/resources')) {
-          sourceFolder.attributes().with {
-            boolean isTestSource = (remove('isTestSource') == 'true')
-            put('type', isTestSource ? 'java-test-resource' : 'java-resource')
-          }
-        }
-      }
-    }
+    testSources.from(sourceSets.fastUnitTest.java.srcDirs)
+    testSources.from(sourceSets.integrationTest.java.srcDirs)
   }
 }
 


### PR DESCRIPTION
See https://github.com/gocd/gocd/discussions/11630#discussioncomment-6125295 - the previous designation of sharedTest code as being "test" rather than utility code seems to have confused IntelliJ. Since it is just utilities, it probably doesn't matter whether IDEA considers it test code or not, as long as it's not on the wrong classpaths (which it's not).

Also removed the weird IML hack as this is confusing, brittle and does not seem to be important/required to make things work in IntelliJ. There are likely still issues with running certain tests within IDEA that involve Spring classpath loading (maybe due to resource issues), but that's a separate problem.

Thanks to @JamesMcNee 🫡