### PR TITLE
Improve SCM Auto Update UX

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -486,7 +486,9 @@ export class PluginFields extends MithrilComponent<PluginAttrs, PluginState> {
     const attrs       = vnode.attrs.material.attributes() as PluggableScmMaterialAttributes;
     const selectedScm = vnode.attrs.scms.find((scm) => scm.id() === attrs.ref());
     if (selectedScm !== undefined) {
-      const scmRepoDetails = selectedScm.configuration().asMap();
+      const scmRepoDetails = new Map([
+        ["Auto Update", selectedScm.autoUpdate() + ""],
+        ...Array.from(selectedScm.configuration().asMap())]);
       return <ConfigurationDetailsWidget header={"SCM Configuration"} dataTestId={"selected-scm-details"}
                                          data={scmRepoDetails}/>;
     }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
@@ -130,7 +130,7 @@ abstract class ScmFields extends MithrilViewComponent<Attrs> {
                    placeholder="A human-friendly label for this material" property={mattrs.name}
                    errorText={this.errs(mattrs, "name")}/>,
 
-        <MaterialAutoUpdateToggle toggle={mattrs.autoUpdate} errors={mattrs.errors()} disabled={vnode.attrs.disabled}/>,
+        <MaterialAutoUpdateToggle toggle={mattrs.autoUpdate} errors={mattrs.errors()} disabled={vnode.attrs.disabled || vnode.attrs.readonly}/>,
 
         <TextField label="Denylist" helpText={DENYLIST_HELP_MESSAGE}
                    property={this.filterValue}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -343,7 +343,8 @@ describe('PluginFieldsSpec', () => {
 
     expect(helper.byTestId('selected-scm-details')).toBeInDOM();
     assertConfigsPresent(helper, 'selected-scm-details', {
-      url: "url"
+      "url":         "url",
+      "auto-update": "Auto Update"
     });
   });
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
@@ -190,7 +190,22 @@ describe("AddPipeline: SCM Material Fields", () => {
     expect(helper.byTestId("test-connection-button")).toBeInDOM();
   });
 
-  function assertLabelledInputsPresent(idsToLabels: {[key: string]: string}) {
+  it("controls are visible but disabled when readonly", () => {
+    const material = new Material("git", new GitMaterialAttributes());
+    helper.mount(() => <GitFields material={material} showLocalWorkingCopyOptions={true} readonly={true}/>);
+
+    assertLabelledInputsPresent({
+      "repository-url": "Repository URL*",
+      "repository-branch": "Repository Branch",
+      "username": "Username",
+      "password": "Password",
+    }, true);
+    assertAutoUpdateControlPresent(true);
+
+    expect(helper.byTestId("test-connection-button")).toBeInDOM();
+  });
+
+  function assertLabelledInputsPresent(idsToLabels: {[key: string]: string}, shouldBeDisabled?: boolean) {
     const keys = Object.keys(idsToLabels);
     expect(keys.length > 0).toBe(true);
 
@@ -198,6 +213,9 @@ describe("AddPipeline: SCM Material Fields", () => {
       expect(helper.byTestId(`form-field-label-${id}`)).toBeInDOM();
       expect(helper.byTestId(`form-field-label-${id}`).textContent!.startsWith(idsToLabels[id])).toBe(true);
       expect(helper.byTestId(`form-field-input-${id}`)).toBeInDOM();
+      if (shouldBeDisabled) {
+        expect(helper.byTestId(`form-field-input-${id}`)).toBeDisabled();
+      }
     }
   }
 
@@ -210,13 +228,18 @@ describe("AddPipeline: SCM Material Fields", () => {
     }
   }
 
-  function assertAutoUpdateControlPresent() {
+  function assertAutoUpdateControlPresent(shouldBeDisabled?: boolean) {
     const control = helper.byTestId('material-auto-update');
 
     expect(control).toBeInDOM();
     expect(helper.textByTestId('form-field-label', control)).toBe('Repository polling behavior:');
     expect(helper.textByTestId('input-field-for-auto', control)).toBe('Regularly fetch updates to this repository');
     expect(helper.textByTestId('input-field-for-manual', control)).toBe('Fetch updates to this repository only on webhook or manual trigger');
+
+    if (shouldBeDisabled) {
+      expect(helper.byTestId('radio-auto')).toBeDisabled();
+      expect(helper.byTestId('radio-manual')).toBeDisabled();
+    }
   }
 
   function assertAutoUpdateControlAbsent() {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/pluggable_scm_widget.tsx
@@ -53,6 +53,7 @@ export class PluggableScmWidget extends MithrilViewComponent<Attrs> {
                                      ["Id", scm.id()],
                                      ["Name", scm.name()],
                                      ["Plugin Id", scm.pluginMetadata().id()],
+                                     ["Auto Update", scm.autoUpdate() + ""],
                                      ...Array.from(scm.configuration().asMap())
                                    ]);
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pluggable_scms/spec/pluggable_scm_widget_spec.tsx
@@ -64,6 +64,8 @@ describe('PluggableScmWidgetSpec', () => {
     expect(helper.textByTestId('key-value-value-name', scmDetails)).toBe(scm.name());
     expect(helper.textByTestId('key-value-key-plugin-id', scmDetails)).toBe('Plugin Id');
     expect(helper.textByTestId('key-value-value-plugin-id', scmDetails)).toBe(scm.pluginMetadata().id());
+    expect(helper.textByTestId('key-value-key-auto-update', scmDetails)).toBe('Auto Update');
+    expect(helper.textByTestId('key-value-value-auto-update', scmDetails)).toBe('true');
     expect(helper.textByTestId('key-value-key-url', scmDetails)).toBe('url');
     expect(helper.textByTestId('key-value-value-url', scmDetails)).toBe('https://github.com/sample/example.git');
 


### PR DESCRIPTION
Correct some minor issues when managing SCMs and autoUpdate
- disabled radio buttons correctly when viewing config repo materials in pipeline config SPA
- displays the value of "Auto Update" for Pluggable SCMs in pipeline config SPA along with other SCM config
- displays the value of "Auto Update" for Pluggable SCMs in the Pluggable SCM admin summary