### PR TITLE
Improve error messages during config repo material validation

### DIFF
--- a/api/api-pipeline-config-v11/src/test/groovy/com/thoughtworks/go/apiv11/pipelineconfig/PipelineConfigControllerV11Test.groovy
+++ b/api/api-pipeline-config-v11/src/test/groovy/com/thoughtworks/go/apiv11/pipelineconfig/PipelineConfigControllerV11Test.groovy
@@ -541,7 +541,7 @@ class PipelineConfigControllerV11Test implements SecurityServiceTrait, Controlle
 
         assertThatResponse()
           .isUnprocessableEntity()
-          .hasJsonMessage("Can not operate on pipeline 'pipeline1' as it is defined remotely in 'https://github.com/config-repos/repo at revision1'.")
+          .hasJsonMessage("Can not operate on pipeline 'pipeline1' as it is defined remotely in 'https://github.com/config-repos/repo at revision revision1'.")
       }
 
       @Test
@@ -747,7 +747,7 @@ class PipelineConfigControllerV11Test implements SecurityServiceTrait, Controlle
         deleteWithApiHeader(controller.controllerPath("/pipeline1"))
         assertThatResponse()
           .isUnprocessableEntity()
-          .hasJsonMessage("Can not operate on pipeline 'pipeline1' as it is defined remotely in 'https://github.com/config-repos/repo at revision1'.")
+          .hasJsonMessage("Can not operate on pipeline 'pipeline1' as it is defined remotely in 'https://github.com/config-repos/repo at revision revision1'.")
       }
     }
   }

--- a/api/api-scms-v4/src/test/groovy/com/thoughtworks/go/apiv4/scms/SCMControllerV4Test.groovy
+++ b/api/api-scms-v4/src/test/groovy/com/thoughtworks/go/apiv4/scms/SCMControllerV4Test.groovy
@@ -724,7 +724,7 @@ class SCMControllerV4Test implements SecurityServiceTrait, ControllerTrait<SCMCo
 
         assertThatResponse()
           .isUnprocessableEntity()
-          .hasJsonMessage("Can not operate on SCM 'foobar' as it is defined remotely in 'https://github.com/config-repos/repo at revision1'.")
+          .hasJsonMessage("Can not operate on SCM 'foobar' as it is defined remotely in 'https://github.com/config-repos/repo at revision revision1'.")
       }
     }
   }
@@ -828,7 +828,7 @@ class SCMControllerV4Test implements SecurityServiceTrait, ControllerTrait<SCMCo
 
         assertThatResponse()
           .isUnprocessableEntity()
-          .hasJsonMessage("Can not operate on SCM 'foobar' as it is defined remotely in 'https://github.com/config-repos/repo at revision1'.")
+          .hasJsonMessage("Can not operate on SCM 'foobar' as it is defined remotely in 'https://github.com/config-repos/repo at revision revision1'.")
       }
     }
   }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/GoConfigInvalidException.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/GoConfigInvalidException.java
@@ -20,16 +20,17 @@ import com.thoughtworks.go.domain.AllConfigErrors;
 import com.thoughtworks.go.domain.ConfigErrors;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 public class GoConfigInvalidException extends RuntimeException {
     private final CruiseConfig cruiseConfig;
-    private List<String> allErrors;
+    private final Set<String> allErrors;
 
     public GoConfigInvalidException(CruiseConfig cruiseConfig, String error) {
         super(error);
-        allErrors = Collections.singletonList(error);
+        allErrors = Set.of(error);
         this.cruiseConfig = cruiseConfig;
     }
 
@@ -45,8 +46,8 @@ public class GoConfigInvalidException extends RuntimeException {
         this.allErrors = extractErrors(errors);
     }
 
-    private static List<String> extractErrors(List<ConfigErrors> errors) {
-        List<String> allErrors = new ArrayList<>();
+    private static Set<String> extractErrors(List<ConfigErrors> errors) {
+        Set<String> allErrors = new LinkedHashSet<>();
         for (ConfigErrors er : errors) {
             allErrors.addAll(er.getAll());
         }
@@ -69,6 +70,6 @@ public class GoConfigInvalidException extends RuntimeException {
     }
 
     public List<String> getAllErrors() {
-        return allErrors;
+        return new ArrayList<>(allErrors);
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/GoConfigInvalidMergeException.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/GoConfigInvalidMergeException.java
@@ -16,7 +16,6 @@
 package com.thoughtworks.go.config.exceptions;
 
 import com.thoughtworks.go.config.CruiseConfig;
-import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.domain.ConfigErrors;
 
 import java.util.ArrayList;
@@ -26,22 +25,16 @@ import static com.thoughtworks.go.config.exceptions.EntityType.RULE_ERROR_PREFIX
 import static java.util.stream.Collectors.toList;
 
 public class GoConfigInvalidMergeException extends GoConfigInvalidException {
-    private List<PartialConfig> partialConfigs;
-
-    public GoConfigInvalidMergeException(CruiseConfig cruiseConfig,
-                                         List<PartialConfig> partialConfigs, List<ConfigErrors> allErrors) {
+    public GoConfigInvalidMergeException(CruiseConfig cruiseConfig, List<ConfigErrors> allErrors) {
         super(cruiseConfig, allErrors);
-        this.partialConfigs = partialConfigs;
     }
 
-    public GoConfigInvalidMergeException(CruiseConfig cruiseConfig,
-                                         List<PartialConfig> partialConfigs, List<ConfigErrors> allErrors, Throwable e) {
+    public GoConfigInvalidMergeException(CruiseConfig cruiseConfig, List<ConfigErrors> allErrors, Throwable e) {
         super(cruiseConfig, allErrors, e);
-        this.partialConfigs = partialConfigs;
     }
 
-    public GoConfigInvalidMergeException(List<PartialConfig> partials, GoConfigInvalidException failed) {
-        this(failed.getCruiseConfig(), partials, failed.getCruiseConfig().getAllErrors(), failed);
+    public GoConfigInvalidMergeException(GoConfigInvalidException failed) {
+        this(failed.getCruiseConfig(), failed.getCruiseConfig().getAllErrors(), failed);
     }
 
     private static String allErrorsToString(List<String> allErrors) {
@@ -79,10 +72,6 @@ public class GoConfigInvalidMergeException extends GoConfigInvalidException {
 
     @Override
     public String getMessage() {
-        return allErrorsToString(getAllErrors());
-    }
-
-    public List<PartialConfig> getPartialConfigs() {
-        return partialConfigs;
+        return allErrorsToString(new ArrayList<>(getAllErrors()));
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/GoConfigInvalidMergeException.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/GoConfigInvalidMergeException.java
@@ -57,12 +57,12 @@ public class GoConfigInvalidMergeException extends GoConfigInvalidException {
 
         if (ruleValidationErrors.isEmpty()) {
             for (int i = 1; i <= allErrors.size(); i++) {
-                b.append(i).append(". ").append(allErrors.get(i - 1)).append(";; \n");
+                b.append(i).append(". ").append(allErrors.get(i - 1)).append("\n");
             }
         } else {
             b.append("I. Rule Validation Errors: \n");
             for (int i = 1; i <= ruleValidationErrors.size(); i++) {
-                b.append('\t').append(i).append(". ").append(ruleValidationErrors.get(i - 1)).append(";; \n");
+                b.append('\t').append(i).append(". ").append(ruleValidationErrors.get(i - 1)).append("\n");
             }
             b.append("\n");
             List<String> configValidationErrors = new ArrayList<>(allErrors);
@@ -70,7 +70,7 @@ public class GoConfigInvalidMergeException extends GoConfigInvalidException {
             b.append("II. Config Validation Errors: \n");
 
             for (int i = 1; i <= configValidationErrors.size(); i++) {
-                b.append('\t').append(i).append(". ").append(configValidationErrors.get(i - 1)).append(";; \n");
+                b.append('\t').append(i).append(". ").append(configValidationErrors.get(i - 1)).append("\n");
             }
         }
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/MaterialConfigs.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/MaterialConfigs.java
@@ -242,9 +242,17 @@ public class MaterialConfigs extends BaseCollection<MaterialConfig> implements V
                 continue;
             }
             MaterialConfigs allMaterialsByFingerPrint = validationContext.getAllMaterialsByFingerPrint(fingerprint);
-            if (allMaterialsByFingerPrint != null && ((ScmMaterialConfig) material).isAutoUpdateStateMismatch(allMaterialsByFingerPrint)) {
+            if (allMaterialsByFingerPrint != null && allMaterialsByFingerPrint.size() > 1 && allMaterialsByFingerPrint.stream().anyMatch(m -> material.isAutoUpdate() != m.isAutoUpdate())) {
                 Map<CaseInsensitiveString, Boolean> pipelinesWithMaterial = validationContext.getPipelineToMaterialAutoUpdateMapByFingerprint(fingerprint);
-                ((ScmMaterialConfig) material).setAutoUpdateMismatchErrorWithPipelines(pipelinesWithMaterial);
+                material.addError(
+                    ScmMaterialConfig.AUTO_UPDATE,
+                    String.format(
+                        "The material of type %s (%s) is used elsewhere with a different value for autoUpdate (poll for changes). Those values should be the same. Pipelines:\n%s",
+                        material.getTypeForDisplay(),
+                        material.getDescription(),
+                        MaterialErrors.autoUpdatePipelineErrorDisplay(pipelinesWithMaterial)
+                    )
+                );
             }
         }
     }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/MaterialErrors.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/MaterialErrors.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.materials;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import lombok.experimental.UtilityClass;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@UtilityClass
+public class MaterialErrors {
+    public static String autoUpdateDisplayStatus(boolean autoUpdate) {
+        return autoUpdate ? "auto update enabled" : "auto update disabled";
+    }
+
+    public static String autoUpdatePipelineErrorDisplay(Map<CaseInsensitiveString, Boolean> pipelineToAutoUpdateValue) {
+        if (pipelineToAutoUpdateValue == null || pipelineToAutoUpdateValue.isEmpty()) {
+            return "";
+        }
+        return pipelineToAutoUpdateValue
+            .entrySet()
+            .stream()
+            .map(e -> String.format(" %s (%s)", e.getKey(), autoUpdateDisplayStatus(e.getValue())))
+            .collect(Collectors.joining(",\n"));
+    }
+}

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/PluggableSCMMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/PluggableSCMMaterialConfig.java
@@ -293,7 +293,7 @@ public class PluggableSCMMaterialConfig extends AbstractMaterialConfig {
             return;
         }
         if (FilenameUtil.isNormalizedDirectoryPathInsideNormalizedParentDirectory(myDirPath, otherSCMMaterialFolder)) {
-            addError(FOLDER, "Invalid Destination Directory. Every material needs a different destination directory and the directories should not be nested.");
+            addError(FOLDER, "Invalid destination directory. Every material needs a different destination directory and the directories should not be nested.");
         }
     }
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
@@ -18,7 +18,6 @@ package com.thoughtworks.go.config.materials;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.preprocessor.SkipParameterResolution;
 import com.thoughtworks.go.config.validation.FilePathTypeValidator;
-import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.FilenameUtil;
 import com.thoughtworks.go.util.command.UrlArgument;
@@ -312,36 +311,6 @@ public abstract class ScmMaterialConfig extends AbstractMaterialConfig implement
                 this.setFilter(null);
             }
         }
-    }
-
-    public boolean isAutoUpdateStateMismatch(MaterialConfigs materialAutoUpdateMap) {
-        if (materialAutoUpdateMap.size() > 1) {
-            for (MaterialConfig otherMaterial : materialAutoUpdateMap) {
-                if (otherMaterial.isAutoUpdate() != this.autoUpdate) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    public void setAutoUpdateMismatchErrorWithPipelines(Map<CaseInsensitiveString, Boolean> pipelinesWithThisMaterial) {
-        String message = format("The material of type %s (%s) is used elsewhere with a different value for autoUpdate (\"Poll for changes\"). Those values should be the same. Pipelines: %s", getTypeForDisplay(), getDescription(), join(pipelinesWithThisMaterial));
-        addError(AUTO_UPDATE, message);
-    }
-
-    private String getAutoUpdateStatus(boolean autoUpdate) {
-        return autoUpdate ? "auto update enabled" : "auto update disabled";
-    }
-
-    private String join(Map<CaseInsensitiveString, Boolean> pipelinesWithThisMaterial) {
-        if (pipelinesWithThisMaterial == null || pipelinesWithThisMaterial.isEmpty()) {
-            return "";
-        }
-        StringBuilder builder = new StringBuilder();
-        pipelinesWithThisMaterial.forEach((key, value) -> builder.append(format("%s (%s),\n ", key, getAutoUpdateStatus(value))));
-
-        return builder.delete(builder.lastIndexOf(","), builder.length()).toString();
     }
 
     public void setDestinationFolderError(String message) {

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
@@ -354,7 +354,7 @@ public abstract class ScmMaterialConfig extends AbstractMaterialConfig implement
             return;
         }
         if (FilenameUtil.isNormalizedDirectoryPathInsideNormalizedParentDirectory(myDirPath, otherSCMMaterialFolder)) {
-            addError(FOLDER, "Invalid Destination Directory. Every material needs a different destination directory and the directories should not be nested.");
+            addError(FOLDER, "Invalid destination directory. Every material needs a different destination directory and the directories should not be nested.");
         }
     }
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/RepoConfigOrigin.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/RepoConfigOrigin.java
@@ -27,11 +27,10 @@ public class RepoConfigOrigin implements ConfigOrigin {
     private ConfigRepoConfig configRepo;
     private String revision;
 
-    public RepoConfigOrigin()
-    {
+    public RepoConfigOrigin() {
     }
-    public RepoConfigOrigin(ConfigRepoConfig configRepo,String revision)
-    {
+
+    public RepoConfigOrigin(ConfigRepoConfig configRepo, String revision) {
         this.configRepo = configRepo;
         this.revision = revision;
     }
@@ -47,7 +46,7 @@ public class RepoConfigOrigin implements ConfigOrigin {
         if (o == null || getClass() != o.getClass()) return false;
         RepoConfigOrigin that = (RepoConfigOrigin) o;
         return Objects.equals(configRepo, that.configRepo) &&
-                Objects.equals(revision, that.revision);
+            Objects.equals(revision, that.revision);
     }
 
     @Override
@@ -70,16 +69,14 @@ public class RepoConfigOrigin implements ConfigOrigin {
     @Override
     public String displayName() {
         MaterialConfig materialConfig = configRepo != null ?
-                configRepo.getRepo() : null;
+            configRepo.getRepo() : null;
         String materialName = materialConfig != null ?
-                    materialConfig.getDisplayName() : "NULL material";
-        return String.format("%s at %s", materialName, revision);
+            materialConfig.getDisplayName() : "NULL material";
+        return String.format("%s at revision %s", materialName, revision);
     }
 
     public MaterialConfig getMaterial() {
-        if(configRepo == null)
-            return  null;
-        return configRepo.getRepo();
+        return configRepo == null ? null : configRepo.getRepo();
     }
 
     public boolean isFromRevision(String revision) {

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/PipelineGroups.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/PipelineGroups.java
@@ -146,7 +146,7 @@ public class PipelineGroups extends BaseCollection<PipelineConfigs> implements V
 
     public void validatePipelineNameUniqueness() {
         List<PipelineConfig> visited = new ArrayList<>();
-        HashMap<CaseInsensitiveString, Set<String>> duplicates = new HashMap<>();
+        Map<CaseInsensitiveString, Set<String>> duplicates = new HashMap<>();
         for (PipelineConfigs group : this) {
             for (PipelineConfig pipeline : group) {
                 for (PipelineConfig visitedPipeline : visited) {

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/scm/SCM.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/scm/SCM.java
@@ -257,12 +257,12 @@ public class SCM implements Serializable, Validatable, ConfigOriginTraceable, Se
     }
 
     public void setConfigAttributes(Object attributes) {
-        Map attributesMap = (Map) attributes;
+        @SuppressWarnings("unchecked") Map<String, String> attributesMap = (Map<String, String>) attributes;
         if (attributesMap.containsKey(SCM_ID)) {
-            id = ((String) attributesMap.get(SCM_ID));
+            id = attributesMap.get(SCM_ID);
         }
         if (attributesMap.containsKey(NAME)) {
-            name = ((String) attributesMap.get(NAME));
+            name = attributesMap.get(NAME);
         }
         this.setAutoUpdate("true".equals(attributesMap.get(AUTO_UPDATE)));
         if (attributesMap.containsKey(PLUGIN_CONFIGURATION)) {

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/MergeCruiseConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/MergeCruiseConfigTest.java
@@ -334,8 +334,8 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
 
         List<ConfigErrors> allErrors = config.validateAfterPreprocess();
         assertThat(allErrors.size(), is(2));
-        assertThat(allErrors.get(0).on("name"), is("You have defined multiple pipelines named 'pipeline-1'. Pipeline names must be unique. Source(s): [http://some.git at 1234fed, cruise-config.xml]"));
-        assertThat(allErrors.get(1).on("name"), is("You have defined multiple pipelines named 'pipeline-1'. Pipeline names must be unique. Source(s): [http://some.git at 1234fed, cruise-config.xml]"));
+        assertThat(allErrors.get(0).on("name"), is("You have defined multiple pipelines named 'pipeline-1'. Pipeline names must be unique. Source(s): [cruise-config.xml, http://some.git at revision 1234fed]"));
+        assertThat(allErrors.get(1).on("name"), is("You have defined multiple pipelines named 'pipeline-1'. Pipeline names must be unique. Source(s): [cruise-config.xml, http://some.git at revision 1234fed]"));
     }
 
     @Test
@@ -348,8 +348,8 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
         List<ConfigErrors> allErrors = merged.validateAfterPreprocess();
         assertThat(remotePart.getGroups().get(0).getPipelines().get(0).errors().size(), is(1));
         assertThat(allErrors.size(), is(2));
-        assertThat(allErrors.get(0).on("name"), is("You have defined multiple pipelines named 'pipeline1'. Pipeline names must be unique. Source(s): [http://some.git at 1234fed, cruise-config.xml]"));
-        assertThat(allErrors.get(1).on("name"), is("You have defined multiple pipelines named 'pipeline1'. Pipeline names must be unique. Source(s): [http://some.git at 1234fed, cruise-config.xml]"));
+        assertThat(allErrors.get(0).on("name"), is("You have defined multiple pipelines named 'pipeline1'. Pipeline names must be unique. Source(s): [cruise-config.xml, http://some.git at revision 1234fed]"));
+        assertThat(allErrors.get(1).on("name"), is("You have defined multiple pipelines named 'pipeline1'. Pipeline names must be unique. Source(s): [cruise-config.xml, http://some.git at revision 1234fed]"));
     }
 
     @Test
@@ -363,8 +363,8 @@ public class MergeCruiseConfigTest extends CruiseConfigTestBase {
 
         List<ConfigErrors> allErrors = cloned.validateAfterPreprocess();
         assertThat(allErrors.size(), is(2));
-        assertThat(allErrors.get(0).on("name"), is("You have defined multiple pipelines named 'pipeline-1'. Pipeline names must be unique. Source(s): [http://some.git at 1234fed, cruise-config.xml]"));
-        assertThat(allErrors.get(1).on("name"), is("You have defined multiple pipelines named 'pipeline-1'. Pipeline names must be unique. Source(s): [http://some.git at 1234fed, cruise-config.xml]"));
+        assertThat(allErrors.get(0).on("name"), is("You have defined multiple pipelines named 'pipeline-1'. Pipeline names must be unique. Source(s): [cruise-config.xml, http://some.git at revision 1234fed]"));
+        assertThat(allErrors.get(1).on("name"), is("You have defined multiple pipelines named 'pipeline-1'. Pipeline names must be unique. Source(s): [cruise-config.xml, http://some.git at revision 1234fed]"));
     }
 
     @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigTest.java
@@ -877,7 +877,7 @@ public class PipelineConfigTest {
     public void shouldReturnConfigRepoOriginDisplayNameWhenOriginIsRemote() {
         PipelineConfig pipelineConfig = new PipelineConfig();
         pipelineConfig.setOrigin(new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "id"), "revision1"));
-        assertThat(pipelineConfig.getOriginDisplayName(), is("AwesomeGitMaterial at revision1"));
+        assertThat(pipelineConfig.getOriginDisplayName(), is("AwesomeGitMaterial at revision revision1"));
     }
 
     @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/MaterialConfigsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/MaterialConfigsTest.java
@@ -417,7 +417,7 @@ Above scenario allowed
         pipelineOne.materialConfigs().validate(ConfigSaveValidationContext.forChain(config));
 
         assertThat(pipelineOne.materialConfigs().get(0).errors().on(ScmMaterialConfig.AUTO_UPDATE),
-                is("The material of type Mercurial (http://url1) is used elsewhere with a different value for autoUpdate (\"Poll for changes\"). Those values should be the same. Pipelines: one (auto update disabled),\n two (auto update enabled)"));
+                is("The material of type Mercurial (http://url1) is used elsewhere with a different value for autoUpdate (poll for changes). Those values should be the same. Pipelines:\n one (auto update disabled),\n two (auto update enabled)"));
     }
 
     @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/MaterialConfigsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/MaterialConfigsTest.java
@@ -217,7 +217,7 @@ Above scenario allowed
 
         pipelineOne.materialConfigs().validate(ConfigSaveValidationContext.forChain(config));
 
-        String conflictingDirMessage = "Invalid Destination Directory. Every material needs a different destination directory and the directories should not be nested.";
+        String conflictingDirMessage = "Invalid destination directory. Every material needs a different destination directory and the directories should not be nested.";
         assertThat(pipelineOne.materialConfigs().get(0).errors().on(ScmMaterialConfig.FOLDER), is(conflictingDirMessage));
         assertThat(pipelineOne.materialConfigs().get(1).errors().on(ScmMaterialConfig.FOLDER), is(conflictingDirMessage));
         assertThat(pipelineOne.materialConfigs().get(2).errors().on(PluggableSCMMaterialConfig.FOLDER), is(conflictingDirMessage));

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/PluggableSCMMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/PluggableSCMMaterialConfigTest.java
@@ -316,7 +316,7 @@ public class PluggableSCMMaterialConfigTest {
         pluggableSCMMaterialConfig.setFolder("f1");
         pluggableSCMMaterialConfig.validateNotSubdirectoryOf("f1/f2");
         assertFalse(pluggableSCMMaterialConfig.errors().isEmpty());
-        assertThat(pluggableSCMMaterialConfig.errors().on(FOLDER), is("Invalid Destination Directory. Every material needs a different destination directory and the directories should not be nested."));
+        assertThat(pluggableSCMMaterialConfig.errors().on(FOLDER), is("Invalid destination directory. Every material needs a different destination directory and the directories should not be nested."));
     }
 
     @Test
@@ -339,7 +339,7 @@ public class PluggableSCMMaterialConfigTest {
     public void shouldFailValidationIfDestinationDirectoryIsNestedAfterNormalization() {
         pluggableSCMMaterialConfig.setFolder("f1/f2/../../f3");
         pluggableSCMMaterialConfig.validateNotSubdirectoryOf("f3/f4");
-        assertThat(pluggableSCMMaterialConfig.errors().on(FOLDER), is("Invalid Destination Directory. Every material needs a different destination directory and the directories should not be nested."));
+        assertThat(pluggableSCMMaterialConfig.errors().on(FOLDER), is("Invalid destination directory. Every material needs a different destination directory and the directories should not be nested."));
     }
 
     @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/ScmMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/ScmMaterialConfigTest.java
@@ -92,7 +92,7 @@ class ScmMaterialConfigTest {
             material.setFolder("f1");
             material.validateNotSubdirectoryOf("f1/f2");
             assertThat(material.errors().isEmpty()).isFalse();
-            assertThat(material.errors().on(FOLDER)).isEqualTo("Invalid Destination Directory. Every material needs a different destination directory and the directories should not be nested.");
+            assertThat(material.errors().on(FOLDER)).isEqualTo("Invalid destination directory. Every material needs a different destination directory and the directories should not be nested.");
         }
 
         @Test
@@ -115,7 +115,7 @@ class ScmMaterialConfigTest {
         void shouldFailValidationIfDestinationDirectoryIsNestedAfterNormalization() {
             material.setFolder("f1/f2/../../f3");
             material.validateNotSubdirectoryOf("f3/f4");
-            assertThat(material.errors().on(FOLDER)).isEqualTo("Invalid Destination Directory. Every material needs a different destination directory and the directories should not be nested.");
+            assertThat(material.errors().on(FOLDER)).isEqualTo("Invalid destination directory. Every material needs a different destination directory and the directories should not be nested.");
         }
 
         @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/merge/MergeOriginConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/merge/MergeOriginConfigTest.java
@@ -15,25 +15,22 @@
  */
 package com.thoughtworks.go.config.merge;
 
-import static com.thoughtworks.go.helper.MaterialConfigsMother.svn;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.FileConfigOrigin;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import org.junit.jupiter.api.Test;
 
+import static com.thoughtworks.go.helper.MaterialConfigsMother.svn;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class MergeOriginConfigTest {
 
     @Test
-    public void shouldShowDisplayName()
-    {
+    public void shouldShowDisplayName() {
         FileConfigOrigin fileConfigOrigin = new FileConfigOrigin();
         RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(svn("http://mysvn", false), "myplugin", "id"), "123");
         MergeConfigOrigin mergeOrigin = new MergeConfigOrigin(fileConfigOrigin, repoConfigOrigin);
-        assertThat(mergeOrigin.displayName(),is("Merged: [ cruise-config.xml; http://mysvn at 123; ]"));
+        assertThat(mergeOrigin.displayName(), is("Merged: [ cruise-config.xml; http://mysvn at revision 123; ]"));
     }
-
-
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigRepoConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigRepoConfigTest.java
@@ -155,7 +155,7 @@ public class ConfigRepoConfigTest extends AbstractRuleAwarePluginProfileTest {
         configRepoConfig.validate(ConfigSaveValidationContext.forChain(cruiseConfig, new BasicPipelineConfigs(), pipeline1));
 
         assertThat(svnInConfigRepo.errors().isEmpty()).isFalse();
-        assertThat(svnInConfigRepo.errors().on("autoUpdate")).isEqualTo("The material of type Subversion (url) is used elsewhere with a different value for autoUpdate (\"Poll for changes\"). All copies of this material must have the same autoUpdate setting or configuration repository must be removed.\n Config Repository: id (auto update disabled).\n Pipelines: badpipe (auto update enabled)");
+        assertThat(svnInConfigRepo.errors().on("autoUpdate")).isEqualTo("The material of type Subversion (url) is used elsewhere with a different value for autoUpdate (poll for changes). All copies of this material must have the same autoUpdate setting or configuration repository must be removed.\nConfig Repository: id (auto update disabled).\nPipelines:\n badpipe (auto update enabled)");
     }
 
     @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/remote/RepoConfigOriginTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/remote/RepoConfigOriginTest.java
@@ -15,28 +15,26 @@
  */
 package com.thoughtworks.go.config.remote;
 
-import static com.thoughtworks.go.helper.MaterialConfigsMother.svn;
 import org.junit.jupiter.api.Test;
 
+import static com.thoughtworks.go.helper.MaterialConfigsMother.svn;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class RepoConfigOriginTest {
 
     @Test
-    public void shouldShowDisplayName()
-    {
+    public void shouldShowDisplayName() {
         RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin(ConfigRepoConfig.createConfigRepoConfig(svn("http://mysvn", false), "myplugin", "id"), "123");
-        assertThat(repoConfigOrigin.displayName(),is("http://mysvn at 123"));
+        assertThat(repoConfigOrigin.displayName(), is("http://mysvn at revision 123"));
     }
 
     // because we don't like null pointer exceptions
     // and empty config like this can happen in tests
     @Test
-    public void shouldShowDisplayNameWhenEmptyConfig()
-    {
+    public void shouldShowDisplayNameWhenEmptyConfig() {
         RepoConfigOrigin repoConfigOrigin = new RepoConfigOrigin();
-        assertThat(repoConfigOrigin.displayName(),is("NULL material at null"));
+        assertThat(repoConfigOrigin.displayName(), is("NULL material at revision null"));
     }
 
 

--- a/config/config-server/src/main/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoader.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoader.java
@@ -129,10 +129,9 @@ public class MagicalGoConfigXmlLoader {
         LOGGER.debug("[Config Save] In validateCruiseConfig: Starting.");
         List<ConfigErrors> allErrors = validate(config);
         if (!allErrors.isEmpty()) {
-            if (config.isLocal())
-                throw new GoConfigInvalidException(config, allErrors);
-            else
-                throw new GoConfigInvalidMergeException(config, config.getMergedPartials(), allErrors);
+            throw config.isLocal()
+                ? new GoConfigInvalidException(config, allErrors)
+                : new GoConfigInvalidMergeException(config, allErrors);
         }
 
         LOGGER.debug("[Config Save] In validateCruiseConfig: Running validate.");

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
@@ -467,7 +467,7 @@ public class MagicalGoConfigXmlLoaderTest {
                         + "    <svn url=\"/hgrepo2\" autoUpdate='false' dest='second'/>\n"
                         + "  </materials>\n";
         MagicalGoConfigXmlLoaderFixture.assertNotValid(
-                "The material of type Subversion (/hgrepo2) is used elsewhere with a different value for autoUpdate (\"Poll for changes\"). Those values should be the same. Pipelines: pipeline (auto update enabled)",
+                "The material of type Subversion (/hgrepo2) is used elsewhere with a different value for autoUpdate (poll for changes). Those values should be the same. Pipelines:\n pipeline (auto update enabled)",
                 noAutoUpdate);
     }
 

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
@@ -108,7 +108,7 @@ import static org.assertj.core.api.Assertions.*;
 @ExtendWith(ResetCipher.class)
 public class MagicalGoConfigXmlLoaderTest {
     private MagicalGoConfigXmlLoader xmlLoader;
-    private static final String INVALID_DESTINATION_DIRECTORY_MESSAGE = "Invalid Destination Directory. Every material needs a different destination directory and the directories should not be nested";
+    private static final String INVALID_DESTINATION_DIRECTORY_MESSAGE = "Invalid destination directory. Every material needs a different destination directory and the directories should not be nested";
     private ConfigCache configCache = new ConfigCache();
     private final SystemEnvironment systemEnvironment = new SystemEnvironment();
     private MagicalGoConfigXmlWriter xmlWriter;

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -363,44 +363,48 @@ public class ConfigConverter {
     }
 
     private PluggableSCMMaterialConfig toPluggableScmMaterialConfig(CRPluggableScmMaterial crPluggableScmMaterial, PartialConfigLoadContext context, SCMs newSCMs) {
-        String id = crPluggableScmMaterial.getScmId();
         CRPluginConfiguration pluginConfig = crPluggableScmMaterial.getPluginConfiguration();
         SCM scmConfig;
 
         if (pluginConfig == null) {
-            scmConfig = getSCMs().find(id);
+            // Without plugin config, we can only find it by ID. Let's try and find it, or fail.
+            scmConfig = Optional.ofNullable(existingServerSCMs().find(crPluggableScmMaterial.getScmId()))
+                .orElseThrow(() -> new ConfigConvertionException(String.format("Failed to find referenced scm '%s'", crPluggableScmMaterial.getScmId())));
         } else {
-            scmConfig = new SCM(id, toPluginConfiguration(pluginConfig), toConfiguration(crPluggableScmMaterial.getConfiguration()));
+            // Plugin configuration exists, let's see if there is a duplicate
+            scmConfig = new SCM(crPluggableScmMaterial.getScmId(), toPluginConfiguration(pluginConfig), toConfiguration(crPluggableScmMaterial.getConfiguration()));
             scmConfig.ensureIdExists();
             scmConfig.setName(crPluggableScmMaterial.getName());
-            if (getSCMs().findDuplicate(scmConfig) == null) {
-                SCM duplicate = newSCMs.findDuplicate(scmConfig);
-                if (duplicate == null) {
-                    newSCMs.add(scmConfig);
-                } else {
-                    scmConfig = duplicate;
-                }
-            } else {
-                scmConfig = getSCMs().findDuplicate(scmConfig);
-                if (scmConfig.getOrigin() instanceof RepoConfigOrigin) {
-                    RepoConfigOrigin origin = (RepoConfigOrigin) scmConfig.getOrigin();
-                    if (origin.getMaterial().equals(context.configMaterial()) && (newSCMs.findDuplicate(scmConfig) == null)) {
-                        newSCMs.add(scmConfig);
+            SCM alreadyKnownToServer = existingServerSCMs().findDuplicate(scmConfig);
+            if (alreadyKnownToServer != null) {
+                // We have a duplicate within the existing SCMs
+                if (alreadyKnownToServer.getOrigin() instanceof RepoConfigOrigin) {
+                    // The duplicate was from a config repo, but it's still a new SCM if it comes from this
+                    // config repo, and we have not already added it
+                    RepoConfigOrigin origin = (RepoConfigOrigin) alreadyKnownToServer.getOrigin();
+                    if (origin.getMaterial().equals(context.configMaterial()) && newSCMs.findDuplicate(alreadyKnownToServer) == null) {
+                        newSCMs.add(alreadyKnownToServer);
                     }
+                }
+                scmConfig = alreadyKnownToServer;
+            } else {
+                // There are no existing SCMs like this on the server, so as long as we haven't tracked one like this already
+                // to add, it's a new one.
+                SCM alreadyInNewScms = newSCMs.findDuplicate(scmConfig);
+                if (alreadyInNewScms != null) {
+                    scmConfig = alreadyInNewScms;
+                } else {
+                    newSCMs.add(scmConfig);
                 }
             }
         }
-
-        if (scmConfig == null)
-            throw new ConfigConvertionException(
-                    String.format("Failed to find referenced scm '%s'", id));
 
         return new PluggableSCMMaterialConfig(toMaterialName(crPluggableScmMaterial.getName()),
                 scmConfig, crPluggableScmMaterial.getDestination(),
                 toFilter(crPluggableScmMaterial.getFilterList()), crPluggableScmMaterial.isWhitelist());
     }
 
-    private SCMs getSCMs() {
+    private SCMs existingServerSCMs() {
         return this.cachedGoConfig.currentConfig().getSCMs();
     }
 
@@ -965,7 +969,7 @@ public class ConfigConverter {
     }
 
     private CRPluggableScmMaterial pluggableScmMaterialConfigToCRPluggableScmMaterial(PluggableSCMMaterialConfig pluggableScmMaterialConfig) {
-        SCMs scms = getSCMs();
+        SCMs scms = existingServerSCMs();
         String id = pluggableScmMaterialConfig.getScmId();
         SCM scmConfig = scms.find(id);
         if (scmConfig == null)

--- a/server/src/main/java/com/thoughtworks/go/config/GoFileConfigDataSource.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoFileConfigDataSource.java
@@ -353,7 +353,7 @@ public class GoFileConfigDataSource {
                         LOGGER.info("Update operation on merged configuration succeeded with old {} LAST VALID partials.", lastValidPartials.size());
                     } catch (GoConfigInvalidException fallbackFailed) {
                         LOGGER.warn("Merged config update operation failed using fallback LAST VALID {} partials. Exception message was: {}", lastValidPartials.size(), fallbackFailed.getMessage(), fallbackFailed);
-                        throw new GoConfigInvalidMergeException(lastValidPartials, fallbackFailed);
+                        throw new GoConfigInvalidMergeException(fallbackFailed);
                     }
                 }
             }
@@ -521,7 +521,7 @@ public class GoFileConfigDataSource {
             LOGGER.debug("Update operation on merged configuration succeeded with old {} LAST VALID partials.", lastValidPartials.size());
         } catch (GoConfigInvalidException fallbackFailed) {
             LOGGER.warn("Merged config update operation failed using fallback LAST VALID {} partials. Exception message was: {}", lastValidPartials.size(), fallbackFailed.getMessage(), fallbackFailed);
-            throw new GoConfigInvalidMergeException(lastValidPartials, fallbackFailed);
+            throw new GoConfigInvalidMergeException(fallbackFailed);
         }
         return goConfigHolder;
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -70,7 +70,6 @@ class ConfigConverterTest {
 
     private CRStage crStage;
     private CRGitMaterial git;
-    private AgentService agentService;
 
     private CRJob buildJob() {
         CRJob crJob = new CRJob("name");
@@ -103,8 +102,7 @@ class ConfigConverterTest {
     void setUp() {
         cachedGoConfig = mock(CachedGoConfig.class);
         context = mock(PartialConfigLoadContext.class);
-        agentService = mock(AgentService.class);
-        configConverter = new ConfigConverter(new GoCipher(), cachedGoConfig, agentService);
+        configConverter = new ConfigConverter(new GoCipher(), cachedGoConfig, mock(AgentService.class));
 
         filter = new ArrayList<>();
         filter.add("filter");
@@ -706,9 +704,8 @@ class ConfigConverterTest {
     @Test
     void shouldConvertP4MaterialWhenEncryptedPassword() throws CryptoException {
         String encryptedPassword = new GoCipher().encrypt("plain-text-password");
-        CRP4Material crp4Material1 = new CRP4Material("name", "folder", false, false, "user", filter, "server:port", "view", true);
-        crp4Material1.setEncryptedPassword(encryptedPassword);
-        CRP4Material crp4Material = crp4Material1;
+        CRP4Material crp4Material = new CRP4Material("name", "folder", false, false, "user", filter, "server:port", "view", true);
+        crp4Material.setEncryptedPassword(encryptedPassword);
 
         P4MaterialConfig p4MaterialConfig =
                 (P4MaterialConfig) configConverter.toMaterialConfig(crp4Material, context, new SCMs());
@@ -839,7 +836,7 @@ class ConfigConverterTest {
     }
 
     @Test
-    void shouldConvertPluggableScmMaterialWithIncludelist() {
+    void shouldConvertPluggableScmMaterialWithIncludeList() {
         SCM myscm = new SCM("scmid", new PluginConfiguration(), new Configuration());
         SCMs scms = new SCMs(myscm);
 
@@ -885,7 +882,7 @@ class ConfigConverterTest {
     }
 
     @Test
-    void shouldConvertPluggableScmMaterialWithADuplicateSCMFingerPrintShouldUseWhatAlreadyExists() {
+    void shouldConvertPluggableScmMaterialWithADuplicateScmFingerprintShouldUseWhatAlreadyExists() {
         Configuration config = new Configuration();
         config.addNewConfigurationWithValue("url", "url", false);
         SCM scm = new SCM("scmid", new PluginConfiguration("plugin_id", "1.0"), config);
@@ -906,7 +903,7 @@ class ConfigConverterTest {
     }
 
     @Test
-    void shouldConvertPluggableScmMaterialWithANewSCMDefinitionWithoutAnSCMID() {
+    void shouldConvertPluggableScmMaterialWithANewScmDefinitionWithoutAnScmId() {
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         cruiseConfig.setSCMs(new SCMs());
         when(cachedGoConfig.currentConfig()).thenReturn(cruiseConfig);
@@ -920,7 +917,7 @@ class ConfigConverterTest {
     }
 
     @Test
-    void shouldConvertPluggableScmMaterialWithADuplicateSCMIDShouldUseWhatAlreadyExists() {
+    void shouldConvertPluggableScmMaterialWithADuplicateScmIdShouldUseWhatAlreadyExists() {
         SCM scm = new SCM("scmid", new PluginConfiguration(), new Configuration());
         scm.setName("noName");
         SCMs scms = new SCMs(scm);
@@ -939,7 +936,7 @@ class ConfigConverterTest {
     }
 
     @Test
-    void shouldConvertPluggableScmMaterialWithNewSCMPluginVersionShouldDefaultToEmptyString() {
+    void shouldConvertPluggableScmMaterialWithNewScmPluginVersionShouldDefaultToEmptyString() {
         SCM s = new SCM("an_id", new PluginConfiguration(), new Configuration());
         s.setName("aname");
         SCMs scms = new SCMs(s);
@@ -1006,7 +1003,7 @@ class ConfigConverterTest {
     }
 
     @Test
-    void shouldConvertToPluggableArtifactConfigWhenConfigrationIsNotPresent() {
+    void shouldConvertToPluggableArtifactConfigWhenConfigurationIsNotPresent() {
         PluggableArtifactConfig pluggableArtifactConfig = (PluggableArtifactConfig) configConverter.toArtifactConfig(new CRPluggableArtifact("id", "storeId", null));
 
         assertThat(pluggableArtifactConfig.getId()).isEqualTo("id");
@@ -1815,10 +1812,7 @@ class ConfigConverterTest {
     }
 
     @Test
-    void shouldMigratePluggableTasktoCR() {
-        ArrayList<CRConfigurationProperty> configs = new ArrayList<>();
-        configs.add(new CRConfigurationProperty("k", "m", null));
-
+    void shouldMigratePluggableTaskToCR() {
         ConfigurationProperty prop = new ConfigurationProperty(new ConfigurationKey("k"), new ConfigurationValue("m"));
         Configuration config = new Configuration(prop);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/PatchEnvironmentCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/PatchEnvironmentCommandTest.java
@@ -35,7 +35,8 @@ import java.util.ArrayList;
 import static com.thoughtworks.go.helper.MaterialConfigsMother.git;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 public class PatchEnvironmentCommandTest {
@@ -201,7 +202,7 @@ public class PatchEnvironmentCommandTest {
         assertFalse(isValid);
 
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        String message = actionFailed + " Pipeline 'remote-pipeline-to-remove' cannot be removed from environment 'Dev' as the association has been defined remotely in [foo/bar.git at latest]";
+        String message = actionFailed + " Pipeline 'remote-pipeline-to-remove' cannot be removed from environment 'Dev' as the association has been defined remotely in [foo/bar.git at revision latest]";
         expectedResult.unprocessableEntity(message);
 
         assertThat(result, is(expectedResult));
@@ -231,7 +232,7 @@ public class PatchEnvironmentCommandTest {
         assertFalse(isValid);
 
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        String message = actionFailed + " Environment variable with name 'remote-env-var-to-remove' cannot be removed from environment 'Dev' as the association has been defined remotely in [foo/bar.git at latest]";
+        String message = actionFailed + " Environment variable with name 'remote-env-var-to-remove' cannot be removed from environment 'Dev' as the association has been defined remotely in [foo/bar.git at revision latest]";
         expectedResult.unprocessableEntity(message);
 
         assertThat(result, is(expectedResult));

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigServiceTest.java
@@ -80,7 +80,7 @@ public class PipelineConfigServiceTest {
         assertThat(pipelineToCanDeleteIt.get(new CaseInsensitiveString("down")), is(new CanDeleteResult(true, "Delete this pipeline.")));
         assertThat(pipelineToCanDeleteIt.get(new CaseInsensitiveString("in_env")), is(new CanDeleteResult(false, "Cannot delete pipeline 'in_env' as it is present in environment 'foo'.")));
         assertThat(pipelineToCanDeleteIt.get(new CaseInsensitiveString("pipeline")), is(new CanDeleteResult(false, "Cannot delete pipeline 'pipeline' as pipeline 'down' depends on it.")));
-        assertThat(pipelineToCanDeleteIt.get(new CaseInsensitiveString("remote")), is(new CanDeleteResult(false, "Cannot delete pipeline 'remote' defined in configuration repository 'url at 1234'.")));
+        assertThat(pipelineToCanDeleteIt.get(new CaseInsensitiveString("remote")), is(new CanDeleteResult(false, "Cannot delete pipeline 'remote' defined in configuration repository 'url at revision 1234'.")));
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
@@ -961,7 +961,7 @@ public class CachedGoConfigIntegrationTest {
         partialConfigService.onSuccessPartialConfig(repoConfig1, invalidPartialInRepo1Revision2);
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n- For Config Repo: url1 at repo1_r2");
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url1 at repo1_r2");
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty()).isTrue();
 
         int countBeforeDeletion = cachedGoConfig.currentConfig().getConfigRepos().size();

--- a/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
@@ -857,7 +857,7 @@ public class CachedGoConfigIntegrationTest {
             public String unmodifiedMd5() {
                 return md5;
             }
-        })).hasMessageContaining(String.format("Stage with name 'stage' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (%s at r1)", upstream, configRepo.getRepo().getDisplayName()));
+        })).hasMessageContaining(String.format("Stage with name 'stage' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (%s at revision r1)", upstream, configRepo.getRepo().getDisplayName()));
     }
 
     @Test
@@ -961,7 +961,7 @@ public class CachedGoConfigIntegrationTest {
         partialConfigService.onSuccessPartialConfig(repoConfig1, invalidPartialInRepo1Revision2);
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url1 at repo1_r2");
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url1 at revision repo1_r2");
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty()).isTrue();
 
         int countBeforeDeletion = cachedGoConfig.currentConfig().getConfigRepos().size();

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoFileConfigDataSourceIntegrationTest.java
@@ -159,7 +159,7 @@ public class GoFileConfigDataSourceIntegrationTest {
 
         assertThatThrownBy(() -> dataSource.forceLoad(new File(systemEnvironment.getCruiseConfigFile())))
                 .isInstanceOf(GoConfigInvalidException.class)
-                .hasMessageContaining("Stage with name 'upstream_stage_original' does not exist on pipeline 'upstream', it is being referred to from pipeline 'remote_downstream' (url at r1)");
+                .hasMessageContaining("Stage with name 'upstream_stage_original' does not exist on pipeline 'upstream', it is being referred to from pipeline 'remote_downstream' (url at revision r1)");
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/config/PartialConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/PartialConfigServiceIntegrationTest.java
@@ -188,7 +188,7 @@ public class PartialConfigServiceIntegrationTest {
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(false));
         ServerHealthState healthStateForInvalidConfigMerge = serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0);
         assertThat(healthStateForInvalidConfigMerge.getMessage(), is("Invalid Merged Configuration"));
-        assertThat(healthStateForInvalidConfigMerge.getDescription(), is("Number of errors: 3+\n1. Pipeline 'p1_repo1' does not exist. It is used from pipeline 'p2_repo2'. \n2. Pipeline with name 'p1_repo1' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at 1) \n3. Pipeline with name 'p3_repo3' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at 1)\n- For Config Repo: url2 at 1"));
+        assertThat(healthStateForInvalidConfigMerge.getDescription(), is("Number of errors: 3+\n1. Pipeline 'p1_repo1' does not exist. It is used from pipeline 'p2_repo2'.\n2. Pipeline with name 'p1_repo1' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at revision 1)\n3. Pipeline with name 'p3_repo3' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at revision 1)\n- For Config Repo: url2 at revision 1"));
         assertThat(healthStateForInvalidConfigMerge.getLogLevel(), is(HealthStateLevel.ERROR));
         assertThat(cachedGoPartials.lastValidPartials().isEmpty(), is(true));
         assertThat(cachedGoPartials.lastKnownPartials().size(), is(1));
@@ -265,7 +265,7 @@ public class PartialConfigServiceIntegrationTest {
         List<ServerHealthState> serverHealthStates = serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1));
         assertThat(serverHealthStates.isEmpty(), is(false));
         assertThat(serverHealthStates.get(0).getLogLevel(), is(HealthStateLevel.ERROR));
-        assertThat(serverHealthStates.get(0).getDescription(), is("Parameter 'param1' is not defined. All pipelines using this parameter directly or via a template must define it.- For Config Repo: url1 at 124"));
+        assertThat(serverHealthStates.get(0).getDescription(), is("Parameter 'param1' is not defined. All pipelines using this parameter directly or via a template must define it.- For Config Repo: url1 at revision 124"));
     }
 
     @Test // See Error #1 from https://github.com/gocd/gocd/issues/8368
@@ -289,7 +289,7 @@ public class PartialConfigServiceIntegrationTest {
                 "\t1. Not allowed to refer to pipeline group 'group'. Check the 'Rules' of this config repository.\n" +
                 "\n" +
                 "II. Config Validation Errors: \n" +
-                "- For Config Repo: url1 at 1"));
+                "- For Config Repo: url1 at revision 1"));
         assertThat(healthStateForInvalidConfigMerge.getLogLevel(), is(HealthStateLevel.ERROR));
 
         cachedGoPartials.clear();
@@ -316,7 +316,7 @@ public class PartialConfigServiceIntegrationTest {
                 "\t1. Not allowed to refer to pipeline group 'group'. Check the 'Rules' of this config repository.\n" +
                 "\n" +
                 "II. Config Validation Errors: \n" +
-                "- For Config Repo: url1 at 1"));
+                "- For Config Repo: url1 at revision 1"));
         assertThat(healthStateForInvalidConfigMerge.getLogLevel(), is(HealthStateLevel.ERROR));
 
         repoConfig1Cloned = createConfigRepoWithDefaultRules(git("url1"), "plugin", "id-1");

--- a/server/src/test-integration/java/com/thoughtworks/go/config/PartialConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/PartialConfigServiceIntegrationTest.java
@@ -188,7 +188,7 @@ public class PartialConfigServiceIntegrationTest {
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(false));
         ServerHealthState healthStateForInvalidConfigMerge = serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0);
         assertThat(healthStateForInvalidConfigMerge.getMessage(), is("Invalid Merged Configuration"));
-        assertThat(healthStateForInvalidConfigMerge.getDescription(), is("Number of errors: 3+\n1. Pipeline 'p1_repo1' does not exist. It is used from pipeline 'p2_repo2'.;; \n2. Pipeline with name 'p1_repo1' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at 1);; \n3. Pipeline with name 'p3_repo3' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at 1);; \n- For Config Repo: url2 at 1"));
+        assertThat(healthStateForInvalidConfigMerge.getDescription(), is("Number of errors: 3+\n1. Pipeline 'p1_repo1' does not exist. It is used from pipeline 'p2_repo2'. \n2. Pipeline with name 'p1_repo1' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at 1) \n3. Pipeline with name 'p3_repo3' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at 1)\n- For Config Repo: url2 at 1"));
         assertThat(healthStateForInvalidConfigMerge.getLogLevel(), is(HealthStateLevel.ERROR));
         assertThat(cachedGoPartials.lastValidPartials().isEmpty(), is(true));
         assertThat(cachedGoPartials.lastKnownPartials().size(), is(1));
@@ -286,7 +286,7 @@ public class PartialConfigServiceIntegrationTest {
         assertThat(healthStateForInvalidConfigMerge.getMessage(), is("Invalid Merged Configuration"));
         assertThat(healthStateForInvalidConfigMerge.getDescription(), is("Number of errors: 1+\n" +
                 "I. Rule Validation Errors: \n" +
-                "\t1. Not allowed to refer to pipeline group 'group'. Check the 'Rules' of this config repository.;; \n" +
+                "\t1. Not allowed to refer to pipeline group 'group'. Check the 'Rules' of this config repository.\n" +
                 "\n" +
                 "II. Config Validation Errors: \n" +
                 "- For Config Repo: url1 at 1"));
@@ -313,7 +313,7 @@ public class PartialConfigServiceIntegrationTest {
         assertThat(healthStateForInvalidConfigMerge.getMessage(), is("Invalid Merged Configuration"));
         assertThat(healthStateForInvalidConfigMerge.getDescription(), is("Number of errors: 1+\n" +
                 "I. Rule Validation Errors: \n" +
-                "\t1. Not allowed to refer to pipeline group 'group'. Check the 'Rules' of this config repository.;; \n" +
+                "\t1. Not allowed to refer to pipeline group 'group'. Check the 'Rules' of this config repository.\n" +
                 "\n" +
                 "II. Config Validation Errors: \n" +
                 "- For Config Repo: url1 at 1"));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
@@ -759,7 +759,7 @@ public class PipelineConfigServiceIntegrationTest {
         pipelineConfigService.updatePipelineConfig(user, pipelineConfig, groupName, digest, result);
 
         assertThat(result.isSuccessful(), is(false));
-        assertThat(pipelineConfig.errors().on("base"), is(String.format("Stage with name 'stage' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r1)", pipelineConfig.name())));
+        assertThat(pipelineConfig.errors().on("base"), is(String.format("Stage with name 'stage' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r1)", pipelineConfig.name())));
         assertThat(result.message(), is(String.format("Validations failed for pipeline '%s'. Error(s): [Validation failed.]. Please correct and resubmit.", pipelineConfig.name())));
     }
 
@@ -851,7 +851,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url at repo1_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url at revision repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
 
         String digest = entityHashingService.hashForEntity(pipelineConfig, groupName);
@@ -868,7 +868,7 @@ public class PipelineConfigServiceIntegrationTest {
 
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url at repo1_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url at revision repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
     }
 
@@ -890,7 +890,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2)\n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
 
         String digest = entityHashingService.hashForEntity(pipelineConfig, groupName);
@@ -928,7 +928,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).isEmpty(), is(true));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at repo2_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at revision repo2_r2"));
 
         final CaseInsensitiveString upstreamStageRenamed = new CaseInsensitiveString("upstream_stage_renamed");
         partialConfig = PartialConfigMother.pipelineWithDependencyMaterial("remote-downstream", new PipelineConfig(pipelineConfig.name(), pipelineConfig.materialConfigs(), new StageConfig(upstreamStageRenamed, new JobConfigs())), new RepoConfigOrigin(repoConfig1, "repo1_r2"));
@@ -941,10 +941,10 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2)\n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at repo2_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at revision repo2_r2"));
 
         String digest = entityHashingService.hashForEntity(pipelineConfig, groupName);
 
@@ -955,7 +955,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(result.message(), is(String.format("Validations failed for pipeline '%s'. " +
                 "Error(s): [Merged update operation failed on VALID 2 partials. Falling back to using LAST KNOWN 2 partials. " +
                 "Exception message was: [Validation failed. Stage with name 'stage' does not exist on pipeline '%s', " +
-                "it is being referred to from pipeline 'remote-downstream' (url at repo1_r1)]" +
+                "it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r1)]" +
                 System.lineSeparator() +
                 "Merged config update operation failed using fallback LAST KNOWN 2 partials. " +
                 "Exception message was: Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods " +
@@ -974,10 +974,10 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig2.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo2_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2)\n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at repo2_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at revision repo2_r2"));
     }
 
     @Test
@@ -996,7 +996,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2)\n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
 
         String digest = entityHashingService.hashForEntity(pipelineConfig, groupName);
@@ -1008,11 +1008,11 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(result.message(), is(String.format("Validations failed for pipeline '%s'. " +
                 "Error(s): [Merged update operation failed on VALID 2 partials. Falling back to using LAST KNOWN 2 partials. " +
                 "Exception message was: [Validation failed. Stage with name 'stage' does not exist on pipeline '%s', " +
-                "it is being referred to from pipeline 'remote-downstream' (url at repo1_r1)]" +
+                "it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r1)]" +
                 System.lineSeparator() +
                 "Merged config update operation failed using fallback LAST KNOWN 2 partials. " +
                 "Exception message was: Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline " +
-                "'%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2)\n]. " +
+                "'%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n]. " +
                 "Please correct and resubmit.", pipelineConfig.name(), pipelineConfig.name(), pipelineConfig.name())));
         currentConfig = goConfigService.getCurrentConfig();
         assertThat(currentConfig.getAllPipelineNames().contains(remoteDownstreamPipeline.name()), is(true));
@@ -1026,7 +1026,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.lastKnownPartials().get(0).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2)\n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
@@ -851,7 +851,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n- For Config Repo: url at repo1_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url at repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
 
         String digest = entityHashingService.hashForEntity(pipelineConfig, groupName);
@@ -868,7 +868,7 @@ public class PipelineConfigServiceIntegrationTest {
 
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n- For Config Repo: url at repo1_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url at repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
     }
 
@@ -890,7 +890,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2)\n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
 
         String digest = entityHashingService.hashForEntity(pipelineConfig, groupName);
@@ -928,7 +928,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).isEmpty(), is(true));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n- For Config Repo: url2 at repo2_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at repo2_r2"));
 
         final CaseInsensitiveString upstreamStageRenamed = new CaseInsensitiveString("upstream_stage_renamed");
         partialConfig = PartialConfigMother.pipelineWithDependencyMaterial("remote-downstream", new PipelineConfig(pipelineConfig.name(), pipelineConfig.materialConfigs(), new StageConfig(upstreamStageRenamed, new JobConfigs())), new RepoConfigOrigin(repoConfig1, "repo1_r2"));
@@ -941,10 +941,10 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2)\n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n- For Config Repo: url2 at repo2_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at repo2_r2"));
 
         String digest = entityHashingService.hashForEntity(pipelineConfig, groupName);
 
@@ -959,7 +959,7 @@ public class PipelineConfigServiceIntegrationTest {
                 System.lineSeparator() +
                 "Merged config update operation failed using fallback LAST KNOWN 2 partials. " +
                 "Exception message was: Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods " +
-                "(however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n]. Please correct and resubmit.", pipelineConfig.name(), pipelineConfig.name())));
+                "(however, it cannot start with a period). The maximum allowed length is 255 characters.\n]. Please correct and resubmit.", pipelineConfig.name(), pipelineConfig.name())));
         assertThat(ErrorCollector.getAllErrors(pipelineConfig).isEmpty(), is(true));
         currentConfig = goConfigService.getCurrentConfig();
         assertThat(currentConfig.getAllPipelineNames().contains(remoteDownstreamPipeline.name()), is(true));
@@ -974,10 +974,10 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig2.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo2_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2)\n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n- For Config Repo: url2 at repo2_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at repo2_r2"));
     }
 
     @Test
@@ -996,7 +996,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2)\n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
 
         String digest = entityHashingService.hashForEntity(pipelineConfig, groupName);
@@ -1012,7 +1012,7 @@ public class PipelineConfigServiceIntegrationTest {
                 System.lineSeparator() +
                 "Merged config update operation failed using fallback LAST KNOWN 2 partials. " +
                 "Exception message was: Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline " +
-                "'%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n]. " +
+                "'%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2)\n]. " +
                 "Please correct and resubmit.", pipelineConfig.name(), pipelineConfig.name(), pipelineConfig.name())));
         currentConfig = goConfigService.getCurrentConfig();
         assertThat(currentConfig.getAllPipelineNames().contains(remoteDownstreamPipeline.name()), is(true));
@@ -1026,7 +1026,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.lastKnownPartials().get(0).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2)\n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
     }
 


### PR DESCRIPTION
- Tidies error messages when validating material destination directories
- Tidies error messages when validating partials from config repos, making them easier to read
- Removes confusing duplicate errors when validating configuration merges
- Makes the de-duplication of pluggable SCMs during ConfigRepo merge a bit easier to reason about