### PR TITLE
Revert "Temporarily switch to fixed curl image version to fix arm64 image builds"

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
@@ -17,7 +17,7 @@
 # Please file any issues or PRs at https://github.com/gocd/gocd
 ###############################################################################################
 
-FROM curlimages/curl:8.1.1 as gocd-agent-unzip
+FROM curlimages/curl:latest as gocd-agent-unzip
 USER root
 ARG TARGETARCH
 ARG UID=1000

--- a/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
@@ -17,7 +17,7 @@
 # Please file any issues or PRs at https://github.com/gocd/gocd
 ###############################################################################################
 
-FROM curlimages/curl:8.1.1 as gocd-server-unzip
+FROM curlimages/curl:latest as gocd-server-unzip
 USER root
 ARG TARGETARCH
 ARG UID=1000


### PR DESCRIPTION
Reverts gocd/gocd#11653 - fixed upstream at https://github.com/curl/curl-container/issues/3