### PR TITLE
Add Debian 12 / Bookworm container image variants

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -209,6 +209,7 @@ enum Distro implements DistroBehavior {
       return [ // See https://endoflife.date/debian
         new DistroVersion(version: '10', releaseName: 'buster-slim', eolDate: parseDate('2024-06-01')),
         new DistroVersion(version: '11', releaseName: 'bullseye-slim', eolDate: parseDate('2026-06-30')),
+        new DistroVersion(version: '12', releaseName: 'bookworm-slim', eolDate: parseDate('2028-06-10')),
       ]
     }
   },


### PR DESCRIPTION
See https://www.debian.org/releases/bookworm/ and https://endoflife.date/debian