### PR TITLE
Include hidden files within artifact listings by default

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -143,6 +143,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static final GoSystemProperty<String> APP_SERVER = new CachedProperty<>(new GoStringSystemProperty("app.server", JETTY9));
     public static final GoSystemProperty<String> GO_LANDING_PAGE = new GoStringSystemProperty("go.landing.page", "/pipelines");
 
+    public static final GoSystemProperty<Boolean> ARTIFACT_VIEW_INCLUDE_ALL_FILES = new GoBooleanSystemProperty("go.view-artifacts.include-all", true);
     public static final GoSystemProperty<Boolean> FETCH_ARTIFACT_AUTO_SUGGEST = new GoBooleanSystemProperty("go.fetch-artifact.auto-suggest", true);
     public static final GoSystemProperty<Boolean> GO_FETCH_ARTIFACT_TEMPLATE_AUTO_SUGGEST = new GoBooleanSystemProperty("go.fetch-artifact.template.auto-suggest", true);
 

--- a/common/src/main/java/com/thoughtworks/go/util/DirectoryReader.java
+++ b/common/src/main/java/com/thoughtworks/go/util/DirectoryReader.java
@@ -25,8 +25,10 @@ import java.io.File;
 import java.io.FileFilter;
 import java.util.Arrays;
 
+import static com.thoughtworks.go.util.SystemEnvironment.ARTIFACT_VIEW_INCLUDE_ALL_FILES;
+
 public class DirectoryReader {
-    private URLService urlService;
+    private final URLService urlService;
     private final JobIdentifier jobIdentifier;
 
     private static final FileFilter VISIBLE_NON_SERIALIZED_FILES = new FileFilter() {
@@ -56,7 +58,7 @@ public class DirectoryReader {
         if (rootFolder == null) {
             return entries;
         }
-        File[] files = rootFolder.listFiles(VISIBLE_NON_SERIALIZED_FILES);
+        File[] files = rootFolder.listFiles(ARTIFACT_VIEW_INCLUDE_ALL_FILES.getValue() ? file -> true : VISIBLE_NON_SERIALIZED_FILES);
 
         if (files == null) {
             return entries;

--- a/common/src/test/java/com/thoughtworks/go/util/DirectoryReaderTest.java
+++ b/common/src/test/java/com/thoughtworks/go/util/DirectoryReaderTest.java
@@ -20,7 +20,11 @@ import com.thoughtworks.go.domain.FolderDirectoryEntry;
 import com.thoughtworks.go.domain.JobIdentifier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,9 +36,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 
+@ExtendWith(SystemStubsExtension.class)
 public class DirectoryReaderTest {
     @TempDir
     File testFolder;
+
+    @SystemStub
+    SystemProperties systemProperties;
+
     private JobIdentifier jobIdentifier;
     private String folderRoot;
 
@@ -123,15 +132,17 @@ public class DirectoryReaderTest {
     }
 
     @Test
-    public void shouldNotContainSerializedObjectFile() throws Exception {
+    public void shouldNotContainSerializedObjectFileWhenConfigured() throws Exception {
         String filename = ".log200806041535.xml.ser";
         TestFileUtil.createTestFile(testFolder, filename);
         DirectoryReader reader = new DirectoryReader(jobIdentifier);
-        List<DirectoryEntry> entries = reader.listEntries(testFolder, folderRoot);
-        assertThat(entries.size(), is(0));
+        assertThat((reader.listEntries(testFolder, folderRoot)).size(), is(1));
+        systemProperties.set(SystemEnvironment.ARTIFACT_VIEW_INCLUDE_ALL_FILES.propertyName(), false);
+        assertThat((reader.listEntries(testFolder, folderRoot)).size(), is(0));
     }
 
-    @Test public void shouldKeepRootsInUrl() throws Exception {
+    @Test
+    public void shouldKeepRootsInUrl() throws Exception {
         File b = TestFileUtil.createTestFolder(testFolder, "b");
         TestFileUtil.createTestFile(b, "c.xml");
         List<DirectoryEntry> entries = new DirectoryReader(jobIdentifier).listEntries(b, folderRoot + "/b");


### PR DESCRIPTION
- fixes #11399 

Not sure why the old code was like this. When artifacts are downloaded as zips the hidden files are included. This looks like legacy code, but will keep a flag here in case we need to restore the old behaviour.