### PR TITLE
Prefer use of agent-owned tmpdir for JNA

### DIFF
--- a/agent-bootstrapper/src/main/java/com/thoughtworks/go/agent/bootstrapper/LauncherTempFileHandler.java
+++ b/agent-bootstrapper/src/main/java/com/thoughtworks/go/agent/bootstrapper/LauncherTempFileHandler.java
@@ -27,20 +27,16 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 class LauncherTempFileHandler implements Runnable {
-
+    private static final Logger LOG = LoggerFactory.getLogger(LauncherTempFileHandler.class);
+    private static final String LAUNCHER_TMP_FILE_LIST = ".tmp.file.list";
     private static volatile Thread reaperThread;
-
-    static final String LAUNCHER_TMP_FILE_LIST = ".tmp.file.list";
-
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultAgentLauncherCreatorImpl.class);
-
-    private static final int TEN_MINS = 1000 * 60 * 10;
 
     @Override
     public void run() {
-        while (true) {
+        while (!Thread.currentThread().isInterrupted()) {
             reapFiles();
             sleepForAMoment();
         }
@@ -83,8 +79,9 @@ class LauncherTempFileHandler implements Runnable {
 
     private static void sleepForAMoment() {
         try {
-            Thread.sleep(TEN_MINS);
+            Thread.sleep(TimeUnit.MINUTES.toMillis(10));
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/agent/src/main/java/com/thoughtworks/go/agent/service/SystemInfo.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/service/SystemInfo.java
@@ -15,6 +15,7 @@
  */
 package com.thoughtworks.go.agent.service;
 
+import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +34,7 @@ public class SystemInfo {
 
     static String determineOperatingSystemCompleteName() {
         try {
+            useAgentTmpDirIfNecessary();
             OperatingSystem os = newSystemInfo().getOperatingSystem();
             return String.format("%s %s%s",
                 os.getFamily(),
@@ -42,6 +44,12 @@ public class SystemInfo {
         } catch (Exception e) {
             LOG.warn("Unable to determine OS platform from native, falling back to default", e);
             return new SystemEnvironment().getOperatingSystemFamilyJvmName();
+        }
+    }
+
+    private static void useAgentTmpDirIfNecessary() {
+        if (System.getProperty("jna.tmpdir") == null) {
+            System.setProperty("jna.tmpdir", FileUtil.TMP_PARENT_DIR);
         }
     }
 

--- a/agent/src/test/java/com/thoughtworks/go/agent/service/SystemInfoTest.java
+++ b/agent/src/test/java/com/thoughtworks/go/agent/service/SystemInfoTest.java
@@ -16,17 +16,45 @@
 
 package com.thoughtworks.go.agent.service;
 
+import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 import org.mockito.MockedStatic;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
+
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mockStatic;
 
+@ExtendWith(SystemStubsExtension.class)
 class SystemInfoTest {
+
+    @SystemStub
+    SystemProperties props;
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void shouldDefaultJnaTmpDirIfUnset() {
+        SystemInfo.determineOperatingSystemCompleteName();
+        assertThat(System.getProperty("jna.tmpdir")).isEqualTo(FileUtil.TMP_PARENT_DIR);
+    }
+
+    @Test
+    public void shouldPreserveJnaTmpDirIfSet() {
+        props.set("jna.tmpdir", tempDir.toString());
+        SystemInfo.determineOperatingSystemCompleteName();
+        assertThat(System.getProperty("jna.tmpdir")).isEqualTo(tempDir.toString());
+    }
 
     @Test
     @EnabledOnOs(OS.MAC)


### PR DESCRIPTION
- Fixes #11548 

This is a tweak to workaround an intended side-effect of #11205 which uses the OSHI library (and JNA underneath) to determine OS name, version etc.

This switches the agent to use `<workingDir>/data` for the temporary JNA storage by default, the same tmp dir used for things like unpacking the TFS libraries, downloading new launchers and a few other things within agents. If the user overrides the standard `jna.tmpdir` system property externally, e.g via `AGENT_STARTUP_ARGS`, it will retain what they have set.

This will apply regardless of whether the agent is launched via the agent-bootstrapper or directly.