### PR TITLE
ui: bumps lru-cache from 7.18.3 to latest

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -36,7 +36,7 @@
     "jquery": "^3.7.0",
     "lodash": "^4.17.21",
     "lodash-inflection": "^1.5.0",
-    "lru-cache": "^7.18.3",
+    "lru-cache": "^10.0.0",
     "mithril": "^2.2.2",
     "moment": "^2.29.4",
     "moment-duration-format": "^2.3.2",

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/time_formatter.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/time_formatter.ts
@@ -15,7 +15,7 @@
  */
 import * as CONSTANTS from "helpers/constants";
 import _ from "lodash";
-import LRUCache from "lru-cache";
+import {LRUCache} from "lru-cache";
 import moment from "moment";
 import "moment-duration-format";
 
@@ -44,14 +44,10 @@ class Cache implements _.MapCache {
   }
 
   delete(key: any) {
-    if (this.lru.has(key)) {
-      this.lru.del(key);
-      return true;
-    }
-    return false;
+    return this.lru.delete(key);
   }
 
-  clear() { this.lru.reset(); }
+  clear() { this.lru.clear(); }
 }
 
 const format = _.memoize((time) => {

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -6039,7 +6039,7 @@ __metadata:
     license-checker: ^25.0.1
     lodash: ^4.17.21
     lodash-inflection: ^1.5.0
-    lru-cache: ^7.18.3
+    lru-cache: ^10.0.0
     mini-css-extract-plugin: ^1.6.2
     mithril: ^2.2.2
     mockdate: ^3.0.5
@@ -7686,6 +7686,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^10.0.0, lru-cache@npm:^9.1.1 || ^10.0.0":
+  version: 10.0.0
+  resolution: "lru-cache@npm:10.0.0"
+  checksum: 18f101675fe283bc09cda0ef1e3cc83781aeb8373b439f086f758d1d91b28730950db785999cd060d3c825a8571c03073e8c14512b6655af2188d623031baf50
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -7704,17 +7711,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^7.18.3, lru-cache@npm:^7.7.1":
+"lru-cache@npm:^7.7.1":
   version: 7.18.3
   resolution: "lru-cache@npm:7.18.3"
   checksum: e550d772384709deea3f141af34b6d4fa392e2e418c1498c078de0ee63670f1f46f5eee746e8ef7e69e1c895af0d4224e62ee33e66a543a14763b0f2e74c1356
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^9.1.1 || ^10.0.0":
-  version: 10.0.0
-  resolution: "lru-cache@npm:10.0.0"
-  checksum: 18f101675fe283bc09cda0ef1e3cc83781aeb8373b439f086f758d1d91b28730950db785999cd060d3c825a8571c03073e8c14512b6655af2188d623031baf50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps [lru-cache](https://github.com/isaacs/node-lru-cache) to latest.

Still has some kind of issue:
```
ERROR in ./node_modules/lru-cache/dist/mjs/index.js 24:15
Module parse failed: Unexpected token (24:15)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|     //@ts-ignore
|     AS = class AbortSignal {
>         onabort;
|         _onabort = [];
|         reason;
 @ ./webpack/helpers/time_formatter.ts 60:18-38
 @ ./webpack/single_page_apps/show_stage_duration_graph_shim.tsx
```

Seems to use https://babeljs.io/docs/babel-plugin-proposal-class-properties in dist output so probably points to some kind of webpack or babel misconfiguration. Maybe re-assess after we can move to webpack 5 in #10852 ?