### PR TITLE
Revert font family naming to be compatible with FontAwesome 4

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_font-awesome-glyphs.scss.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_font-awesome-glyphs.scss.erb
@@ -47,12 +47,12 @@ $fa-font-icons: (
   }
 }
 
-@mixin icon-only($type, $font: "font-awesome") {
-  @if $font == "font-awesome" {
-    font-family: "Font Awesome 6 Free", sans-serif;
+@mixin icon-only($type, $font: "FontAwesome") {
+  @if $font == "FontAwesome" {
+    font-family: $font, sans-serif;
     font-weight: 900;
-  } @else if $font == "font-awesome-brands" {
-    font-family: "Font Awesome 6 Brands", sans-serif;
+  } @else if $font == "FontAwesomeBrands" {
+    font-family: $font, sans-serif;
     font-weight: 400;
   } @else {
     @error "Could not find font family #{$font}";
@@ -61,7 +61,7 @@ $fa-font-icons: (
   @include icon-glyph("fa-var-#{$type}");
 }
 
-@mixin icon($type, $size: auto, $margin: auto, $line-height: 1em, $color: auto, $top: auto, $shadow: none, $font: "font-awesome") {
+@mixin icon($type, $size: auto, $margin: auto, $line-height: 1em, $color: auto, $top: auto, $shadow: none, $font: "FontAwesome") {
   @include icon-only($type: $type, $font: $font);
 
   font-style: normal;
@@ -94,7 +94,7 @@ $fa-font-icons: (
   @include animation(spin 1s linear infinite);
 }
 
-@mixin icon-before($type, $size: auto, $margin: 5px, $line-height: 1em, $color: auto, $top: auto, $shadow: none, $font: "font-awesome", $progress-spinner: false) {
+@mixin icon-before($type, $size: auto, $margin: 5px, $line-height: 1em, $color: auto, $top: auto, $shadow: none, $font: "FontAwesome", $progress-spinner: false) {
   &:before {
     @include icon($type, $size, $margin, $line-height, $color, $top, $shadow, $font: $font);
     @content;
@@ -107,7 +107,7 @@ $fa-font-icons: (
   }
 }
 
-@mixin icon-after($type, $size: auto, $margin: 5px, $line-height: 1em, $color: auto, $top: auto, $shadow: none, $font: "font-awesome", $progress-spinner: false) {
+@mixin icon-after($type, $size: auto, $margin: 5px, $line-height: 1em, $color: auto, $top: auto, $shadow: none, $font: "FontAwesome", $progress-spinner: false) {
   &:after {
     @include icon($type, $size, $margin, $line-height, $color, $top, $shadow, $font: $font);
     @content;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_font-awesome-sprockets.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_font-awesome-sprockets.scss
@@ -20,20 +20,18 @@
 @import "@fortawesome/fontawesome-free/scss/fontawesome";
 
 $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
-$fa-style-family-brands: "#{str-slice($fa-style-family, 1, -5)} Brands";
 
 @include font-face(
-  $font-family: $fa-style-family,
+  $font-family: FontAwesome,
   $file-path: "#{$fa-font-path}/fa-solid-900",
   $file-formats: ("woff2"),
-  $asset-pipeline: true
 ) {
   font-style: normal;
   font-weight: 900;
 }
 
 @include font-face(
-  $font-family: $fa-style-family-brands,
+  $font-family: FontAwesomeBrands,
   $file-path: "#{$fa-font-path}/fa-brands-400",
   $file-formats: ("woff2"),
   $asset-pipeline: true

--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/global.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/global.scss
@@ -97,10 +97,9 @@ p {
 }
 
 $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
-$fa-style-family-brands: "#{str-slice($fa-style-family, 1, -5)} Brands";
 
 @include font-face(
-  $font-family: $fa-style-family,
+  $font-family: FontAwesome,
   $file-path: "#{$fa-font-path}/fa-solid-900",
   $file-formats: ("woff2"),
 ) {
@@ -109,7 +108,7 @@ $fa-style-family-brands: "#{str-slice($fa-style-family, 1, -5)} Brands";
 }
 
 @include font-face(
-  $font-family: $fa-style-family-brands,
+  $font-family: FontAwesomeBrands,
   $file-path: "#{$fa-font-path}/fa-brands-400",
   $file-formats: ("woff2"),
 ) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/global/_fontawesome.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/global/_fontawesome.scss
@@ -16,12 +16,12 @@
 @import "@fortawesome/fontawesome-free/scss/functions";
 @import "@fortawesome/fontawesome-free/scss/variables";
 
-@mixin icon-only($type, $font: "font-awesome") {
-  @if $font == "font-awesome" {
-    font-family: $fa-style-family, sans-serif;
+@mixin icon-only($type, $font: "FontAwesome") {
+  @if $font == "FontAwesome" {
+    font-family: $font, sans-serif;
     font-weight: 900;
-  } @else if $font == "font-awesome-brands" {
-    font-family: "#{str-slice($fa-style-family, 1, -5)} Brands", sans-serif;
+  } @else if $font == "FontAwesomeBrands" {
+    font-family: $font, sans-serif;
     font-weight: 400;
   } @else {
     @error "Could not find font family #{$font}";
@@ -38,7 +38,7 @@
   $color: auto,
   $top: auto,
   $shadow: none,
-  $font: "font-awesome") {
+  $font: "FontAwesome") {
   @include icon-only($type: $type, $font: $font);
 
   font-style: normal;
@@ -79,7 +79,7 @@
   $color: auto,
   $top: auto,
   $shadow: none,
-  $font: "font-awesome",
+  $font: "FontAwesome",
   $progress-spinner: false) {
   &::before {
     @include icon($type, $size, $margin, $line-height, $color, $top, $shadow, $font: $font);
@@ -95,7 +95,7 @@
   $color: auto,
   $top: auto,
   $shadow: none,
-  $font: "font-awesome",
+  $font: "FontAwesome",
   $progress-spinner: false) {
   &::after {
     @include icon($type, $size, $margin, $line-height, $color, $top, $shadow, $font: $font);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.scss
@@ -94,12 +94,12 @@ $maintenance-mode-banner-message-font-size: 17px;
   text-decoration: none;
   margin: 0 3px;
 
-  @mixin footer-icon($icon, $font: "font-awesome") {
+  @mixin footer-icon($icon, $font: "FontAwesome") {
     @include icon-before($type: $icon, $color: $icon-color, $size: 16px, $line-height: 1.5rem, $font: $font);
   }
 
   &.github {
-    @include footer-icon($icon: $fa-var-github, $font: "font-awesome-brands");
+    @include footer-icon($icon: $fa-var-github, $font: "FontAwesomeBrands");
   }
 
   &.forums {


### PR DESCRIPTION
In #11006 Font Awesome was upgraded to v6 which included a split into brands, and also use of the "solid" fonts and weights by default. In this change I earlier changed the font family name to the full canonical name, which was possibly not the right thing to do.

A number of plugins actually rely on GoCD's inclusion of FontAwesome, so changing the font family name breaks these:
https://github.com/search?q=org%3Agocd+%27FontAwesome%27&type=code
https://github.com/search?q=org%3Agocd-contrib+%27FontAwesome%27&type=code

e.g

![image](https://github.com/gocd/gocd/assets/29788154/ac439595-6bb2-45c2-98e4-6d5067877c33)

Since this renaming doesn't seem to have been strictly required, lets go back to the earlier name. Plugins using an icon from the "Brands" set will still need to change, however.