### PR TITLE
Fix console FontAwesome references

### DIFF
--- a/server/src/main/resources/server_in_maintenance_mode.html
+++ b/server/src/main/resources/server_in_maintenance_mode.html
@@ -61,7 +61,7 @@
       font-size:   11px;
       font-weight: 200;
       color:       #999;
-      font-family: Arial, ​ Helvetica, ​ sans-serif;
+      font-family: Arial, Helvetica, sans-serif;
     }
 
     .clear_float::after {

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_console-log.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_console-log.scss
@@ -89,7 +89,7 @@ $PROGRESS_BAR_BG_SIZE: 70px;
   font-size: 13px;
 
   .fas {
-    font-family: $fa-style-family, sans-serif;
+    font-family: FontAwesome, sans-serif;
     font-weight: 900;
   }
 
@@ -199,7 +199,7 @@ code {
 .log-fs-status {
   &::before {
     @include fa-icon;
-    font-family: $fa-style-family, sans-serif;
+    font-family: FontAwesome, sans-serif;
 
     position: absolute;
     left: -30px;


### PR DESCRIPTION
Follow-up to #11764 correcting issue on console log to use our own font alias