### PR TITLE
Bump bundled JDK version to 17.0.8+7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ project.ext.packaging = [
   adoptiumJavaVersion: new AdoptiumVersion(
     feature: 17,
     interim: 0,    // set to `null` for the first release of a new featureVersion
-    update : 7,    // set to `null` for the first release of a new featureVersion
+    update : 8,    // set to `null` for the first release of a new featureVersion
     patch  : null, // set to `null` for most releases. Patch releases are "exceptional".
     build  : 7
   )


### PR DESCRIPTION
See https://www.oracle.com/java/technologies/javase/17all-relnotes.html#R17_0_8 for changes at this stage (build number is different, probably due to Oracle specific builds being slightly different to raw openjdk)