### PR TITLE
Fix export to config repo of fetch artifact tasks without pipeline name set

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -807,7 +807,7 @@ public class ConfigConverter {
         CRFetchPluggableArtifactTask crTask = new CRFetchPluggableArtifactTask(
                 null, null, null, task.getStage().toString(),
                 task.getJob().toString(), task.getArtifactId(), configuration);
-        crTask.setPipeline(task.getPipelineName().toString());
+        crTask.setPipeline(Objects.toString(task.getPipelineName(), null));
         commonCRTaskMembers(crTask, task);
         return crTask;
     }
@@ -816,7 +816,7 @@ public class ConfigConverter {
         CRFetchArtifactTask fetchTask = new CRFetchArtifactTask(null, null, null, task.getStage().toString(), task.getJob().toString(), task.getSrc(), null, false);
 
         fetchTask.setDestination(task.getDest());
-        fetchTask.setPipeline(task.getPipelineName().toString());
+        fetchTask.setPipeline(Objects.toString(task.getPipelineName(), null));
         fetchTask.setSourceIsDirectory(!task.isSourceAFile());
 
         commonCRTaskMembers(fetchTask, task);

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -1997,6 +1997,27 @@ class ConfigConverterTest {
     }
 
     @Test
+    void shouldConvertFetchArtifactTaskWhenPipelineIsEmptyToCR() {
+        FetchTask fetchTask = new FetchTask(
+            null,
+            new CaseInsensitiveString("stage"),
+            new CaseInsensitiveString("job"),
+            "src",
+            "dest"
+        );
+        fetchTask.setConditions(new RunIfConfigs(RunIfConfig.FAILED));
+
+        CRFetchArtifactTask result = (CRFetchArtifactTask) configConverter.taskToCRTask(fetchTask);
+
+        assertThat(result.getRunIf()).isEqualTo(CRRunIf.failed);
+        assertThat(result.getDestination()).isEqualTo("dest");
+        assertThat(result.getJob()).isEqualTo("job");
+        assertThat(result.getPipeline()).isNull();
+        assertThat(result.getSource()).isEqualTo("src");
+        assertThat(result.sourceIsDirectory()).isFalse();
+    }
+
+    @Test
     void shouldConvertFetchPluggableArtifactTaskToCRFetchPluggableArtifactTask() {
         FetchPluggableArtifactTask fetchPluggableArtifactTask = new FetchPluggableArtifactTask(
                 new CaseInsensitiveString("upstream"),
@@ -2010,6 +2031,25 @@ class ConfigConverterTest {
         assertThat(result.getRunIf()).isEqualTo(CRRunIf.passed);
         assertThat(result.getJob()).isEqualTo("job");
         assertThat(result.getPipeline()).isEqualTo("upstream");
+        assertThat(result.getStage()).isEqualTo("stage");
+        assertThat(result.getArtifactId()).isEqualTo("artifactId");
+        assertThat(result.getConfiguration().isEmpty()).isTrue();
+    }
+
+    @Test
+    void shouldConvertFetchPluggableArtifactTaskToCRFetchPluggableArtifactTaskWhenPipelineIsNotSet() {
+        FetchPluggableArtifactTask fetchPluggableArtifactTask = new FetchPluggableArtifactTask(
+            null,
+            new CaseInsensitiveString("stage"),
+            new CaseInsensitiveString("job"),
+            "artifactId");
+        fetchPluggableArtifactTask.setConditions(new RunIfConfigs(RunIfConfig.PASSED));
+
+        CRFetchPluggableArtifactTask result = (CRFetchPluggableArtifactTask) configConverter.taskToCRTask(fetchPluggableArtifactTask);
+
+        assertThat(result.getRunIf()).isEqualTo(CRRunIf.passed);
+        assertThat(result.getJob()).isEqualTo("job");
+        assertThat(result.getPipeline()).isNull();
         assertThat(result.getStage()).isEqualTo("stage");
         assertThat(result.getArtifactId()).isEqualTo("artifactId");
         assertThat(result.getConfiguration().isEmpty()).isTrue();


### PR DESCRIPTION
Fixes https://github.com/tomzo/gocd-yaml-config-plugin/issues/155

The pipeline name is optional and if null or empty, will be inferred as "same pipeline as this stage", to make it easier to fetch artifacts from an upstream stage within the same pipeline.

Validated with an export and re-import.