### PR TITLE
Fix import of nant_path from nant config repo tasks

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -187,9 +187,9 @@ public class ConfigConverter {
         if (crTask == null)
             throw new ConfigConvertionException("task cannot be null");
 
-        if (crTask instanceof CRPluggableTask)
+        if (crTask instanceof CRPluggableTask) {
             return toPluggableTask((CRPluggableTask) crTask);
-        else if (crTask instanceof CRBuildTask) {
+        } else if (crTask instanceof CRBuildTask) {
             return toBuildTask((CRBuildTask) crTask);
         } else if (crTask instanceof CRExecTask) {
             return toExecTask((CRExecTask) crTask);
@@ -254,7 +254,9 @@ public class ConfigConverter {
                 buildTask = new AntTask();
                 break;
             case nant:
-                buildTask = new NantTask();
+                NantTask nantTask = new NantTask();
+                nantTask.setNantPath(((CRNantTask)crBuildTask).getNantPath());
+                buildTask = nantTask;
                 break;
             default:
                 throw new RuntimeException(

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -225,6 +225,7 @@ class ConfigConverterTest {
         assertThat(result.getBuildFile()).isEqualTo("nant");
         assertThat(result.getTarget()).isEqualTo("build");
         assertThat(result.workingDirectory()).isEqualTo("src");
+        assertThat(result.getNantPath()).isEqualTo("path");
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/tomzo/gocd-yaml-config-plugin/issues/175

Currently this field just gets ignored, despite its documentation. Export seems fine.