### PR TITLE
Fix display of build detail timestamps icon

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_build_detail.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_build_detail.scss
@@ -718,3 +718,7 @@ a.collapse-all {
 .compress {
   display: none;
 }
+
+.timestamps {
+  @include icon-before("clock", $line-height: 1.22em, $margin: 0 5px);
+}

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_build_output_raw.ftlh
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_build_output_raw.ftlh
@@ -18,7 +18,7 @@
     <div>
         <a class="auto-scroll" title="Scroll to bottom">Scroll to end of logs</a>
         <a href="${req.getContextPath()}/files/${presenter.consoleoutLocator}">Raw output</a>
-        <a class='toggle-timestamps' href="#"><i class="fas fa-clock"></i> Timestamps</a>
+        <a class='toggle-timestamps' href="#"><span class="timestamps"></span> Timestamps</a>
         <a class='toggle-folding' href="#" data-collapsed="true"></a>
         <a id="full-screen">
           <span class="expand">Fullscreen</span>


### PR DESCRIPTION
No idea what happened here :-(

Murphy's law - notice a mysteriously missing icon just after release?