### PR TITLE
Fix FontAwesome icons on plugin views coupled to old FA CSS

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_font-awesome-sprockets.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/_font-awesome-sprockets.scss
@@ -39,3 +39,14 @@ $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
   font-style: normal;
   font-weight: 400;
 }
+
+// For backward compatibility with old Font Awesome 4 where certain plugins/places use the
+// old CSS prefixes and/or font family names hard-coded in their views. Overrides default font-family names
+// from within @fortawesome/fontawesome-free/scss/core to match how we declare font-faces
+.fa, .fa-classic, .fas, .fa-solid, .far, .fa-regular {
+  font-family: FontAwesome, sans-serif;
+}
+
+.fab, .fa-brands {
+  font-family: FontAwesomeBrands, sans-serif;
+}

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_build_detail.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_build_detail.scss
@@ -718,7 +718,3 @@ a.collapse-all {
 .compress {
   display: none;
 }
-
-.timestamps {
-  @include icon-before("clock", $line-height: 1.22em, $margin: 0 5px);
-}

--- a/server/src/main/webapp/WEB-INF/vm/build_detail/_build_output_raw.ftlh
+++ b/server/src/main/webapp/WEB-INF/vm/build_detail/_build_output_raw.ftlh
@@ -18,7 +18,7 @@
     <div>
         <a class="auto-scroll" title="Scroll to bottom">Scroll to end of logs</a>
         <a href="${req.getContextPath()}/files/${presenter.consoleoutLocator}">Raw output</a>
-        <a class='toggle-timestamps' href="#"><span class="timestamps"></span> Timestamps</a>
+        <a class='toggle-timestamps' href="#"><i class="fas fa-clock"></i> Timestamps</a>
         <a class='toggle-folding' href="#" data-collapsed="true"></a>
         <a id="full-screen">
           <span class="expand">Fullscreen</span>


### PR DESCRIPTION
e.g ECS Plugin "external link" icon below

![image](https://github.com/gocd/gocd/assets/29788154/f1c81122-e0a2-4a38-8fbf-e66727abaaf4)

![image](https://github.com/gocd/gocd/assets/29788154/3a97899b-2e55-4382-967b-eddbb367d0fc)

Some plugins hardcode CSS classes to "fa", others hardcode font-family to "FontAwesome" - both which are implicitly coupled to stylesheets loaded within GoCD views, and not strictly in any contract.

This poses a problem with Font Awesome 6 and its "free" version since the default Font Family is "Font Awesome 6 Free" (was: "FontAwesome") and the icons are typically "solid" (900 weight) rather than what they used to be.

To make this backward compatible we really need to support both the old CSS class and the old font-family name on these views.

Hopefully this addresses it without further compat issues.