### PR TITLE
Tidy linting rules to match as much as possible

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/.eslintrc-old.json
+++ b/server/src/main/webapp/WEB-INF/rails/.eslintrc-old.json
@@ -5,25 +5,9 @@
   "env": {
     "browser": true,
     "amd": true,
-    "es6": true
-  },
-  "globals": {
-    "it": true,
-    "describe": true,
-    "xdescribe": true,
-    "expect": true,
-    "beforeEach": true,
-    "afterEach": true,
-    "afterAll": true,
-    "beforeAll": true,
-    "xit": true,
-    "spyOn": true,
+    "es2018": true,
     "jasmine": true,
-    "angular": true,
-    "module": true
-  },
-  "parserOptions": {
-    "ecmaVersion": 6
+    "jquery": true
   },
   "rules": {
     "arrow-parens": [
@@ -52,6 +36,10 @@
     "quotes": [
       "off"
     ],
+    "indent-legacy": [
+      "error",
+      2
+    ],
     "semi": [
       "error",
       "always"
@@ -68,13 +56,7 @@
     "no-redeclare": [
       "off"
     ],
-    "no-fallthrough": [
-      "off"
-    ],
     "no-cond-assign": [
-      "off"
-    ],
-    "no-useless-escape": [
       "off"
     ]
   }

--- a/server/src/main/webapp/WEB-INF/rails/.eslintrc.json
+++ b/server/src/main/webapp/WEB-INF/rails/.eslintrc.json
@@ -7,7 +7,8 @@
   "env": {
     "browser": true,
     "amd": true,
-    "es6": true
+    "es2018": true,
+    "jasmine": true
   },
   "plugins": [
     "react"
@@ -20,22 +21,10 @@
     }
   },
   "globals": {
-    "it": true,
-    "describe": true,
-    "xdescribe": true,
-    "expect": true,
-    "beforeEach": true,
-    "afterEach": true,
-    "afterAll": true,
-    "beforeAll": true,
-    "xit": true,
-    "spyOn": true,
-    "jasmine": true,
     "angular": true,
     "module": true
   },
   "parserOptions": {
-    "ecmaVersion": 6,
     "ecmaFeatures": {
       "jsx": true
     }
@@ -75,14 +64,9 @@
     "eol-last": [
       "error"
     ],
-    "indent": [
-      "off",
-      {
-        "indent-legacy": [
-          "error",
-          2
-        ]
-      }
+    "indent-legacy": [
+      "error",
+      2
     ],
     "eqeqeq": [
       "error",

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/console_log_socket.js
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/console_log_socket.js
@@ -31,13 +31,13 @@
     function endpointUrl(startLine) {
       var l        = document.location;
       var protocol = l.protocol.replace("http", "ws"), host = l.host, path = [
-        "console-websocket",
-        details.data("pipeline"),
-        details.data("pipeline-counter"),
-        details.data("stage"),
-        details.data("stage-counter"),
-        details.data("build")
-      ].join("/");
+          "console-websocket",
+          details.data("pipeline"),
+          details.data("pipeline-counter"),
+          details.data("stage"),
+          details.data("stage-counter"),
+          details.data("build")
+        ].join("/");
 
       return protocol + "//" + host + context_path(path) + "?startLine=" + startLine;
     }

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/log_output_transformer.js
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/log_output_transformer.js
@@ -163,7 +163,7 @@
     }
 
     function getOnlyCommand(line) {
-      return line.match(/\ (.*?)\n/)[1];
+      return line.match(/ (.*?)\n/)[1];
     }
 
     function appendNewLineIfDoesNotExists(line) {

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/trigger_with_options_info_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/trigger_with_options_info_spec.js
@@ -97,8 +97,8 @@ describe("Dashboard", () => {
         const triggerOptionsJSON = info.getTriggerOptionsJSON();
         expect(triggerOptionsJSON['materials']).toEqual([
           {
-          fingerprint: info.materials[0].fingerprint,
-          revision
+            fingerprint: info.materials[0].fingerprint,
+            revision
           },
           {
             fingerprint: info.materials[1].fingerprint,

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -30,7 +30,7 @@ describe("Dashboard Pipeline Widget", () => {
   const pipelineName = 'up42';
 
   let dashboardViewModel, dashboard, pipelinesJson, dashboardJSON, pipeline, doCancelPolling,
-      doRefreshImmediately;
+    doRefreshImmediately;
   let pipelineInstances;
   const helper = new TestHelper();
 

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/shared/analytics_iframe_widget_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/shared/analytics_iframe_widget_spec.js
@@ -23,9 +23,9 @@ describe("Analytics iFrame Widget", () => {
 
   function newModel(loadedData, loadedView) {
     const data   = Stream(),
-          view   = Stream(),
-          url    = Stream(),
-          errors = Stream();
+      view   = Stream(),
+      url    = Stream(),
+      errors = Stream();
 
     return {
       url, data, view, errors, load: () => {

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/shared/dropdown_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/shared/dropdown_spec.js
@@ -30,14 +30,14 @@ describe('Dropdown widget', () => {
       id:   "cat",
       text: "Cat"
     },
-      {
-        id:   "dog",
-        text: "Dog"
-      },
-      {
-        id:   "rabbit",
-        text: "Rabbit"
-      }
+    {
+      id:   "dog",
+      text: "Dog"
+    },
+    {
+      id:   "rabbit",
+      text: "Rabbit"
+    }
     ]
   };
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/form_helper.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/form_helper.js.msx
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import m from "mithril";
 import $ from "jquery";
 import _ from "lodash";
-import { v4 as uuid4 } from 'uuid';
+import {v4 as uuid4} from 'uuid';
 import Stream from "mithril/stream";
 import {mixins as s} from "helpers/string-plus";
 import 'foundation-sites';
@@ -93,7 +92,7 @@ function wireUpModel(attrs, property = "value", listener = "onchange") {
     attrs[property]          = deleteKeyAndReturnValue(attrs, property, model[attrName]());
 
     const chainedCallback = deleteKeyAndReturnValue(attrs, "onModelUpdate"),
-          onUpdate        = deleteKeyAndReturnValue(attrs, listener, withAttr(property, model[attrName]));
+      onUpdate        = deleteKeyAndReturnValue(attrs, listener, withAttr(property, model[attrName]));
 
     attrs[listener] = ("function" === typeof chainedCallback) ? function chained(e) {
       onUpdate(e);
@@ -110,7 +109,7 @@ function validateModel(model, attrs) {
   }
 
   const performValidations = deleteKeyAndReturnValue(attrs, 'validate', false),
-        attrName           = attrs["attrName"] || attrs["data-prop-name"];
+    attrName           = attrs["attrName"] || attrs["data-prop-name"];
 
   let validationErrors;
 
@@ -148,8 +147,8 @@ export const f = {
       const children = vnode.children;
 
       const end       = deleteKeyAndReturnValue(args, 'end') ? 'end' : null,
-            size      = deleteKeyAndReturnValue(args, 'size', 6),
-            largeSize = deleteKeyAndReturnValue(args, 'largeSize', size);
+        size      = deleteKeyAndReturnValue(args, 'size', 6),
+        largeSize = deleteKeyAndReturnValue(args, 'largeSize', size);
 
       return (
         <div class={compactClasses(args, 'columns', `medium-${size}`, `large-${largeSize}`, end)}
@@ -177,9 +176,9 @@ export const f = {
       const listen = deleteKeyAndReturnValue(args, "listen");
 
       const model            = wireUpModel(args, prop, listen),
-            validationErrors = validateModel(model, args),
-            label            = coerceArray(deleteKeyAndReturnValue(args, "label", []), wrapTextInSpan), // label can be a string or an array
-            contentAfter     = coerceArray(deleteKeyAndReturnValue(args, "contentAfter", []), wrapTextInSpan);
+        validationErrors = validateModel(model, args),
+        label            = coerceArray(deleteKeyAndReturnValue(args, "label", []), wrapTextInSpan), // label can be a string or an array
+        contentAfter     = coerceArray(deleteKeyAndReturnValue(args, "contentAfter", []), wrapTextInSpan);
 
       args["class"]    = compactClasses(args, validationErrors ? "is-invalid-input" : null);
       const labelAttrs = {};
@@ -207,8 +206,8 @@ export const f = {
       wireUpModel(args, prop, listen);
 
       const label        = coerceArray(deleteKeyAndReturnValue(args, "label", []), wrapTextInSpan), // label can be a string or an array
-            labelClass   = deleteKeyAndReturnValue(args, "labelClass", ""),
-            inputElement = <input type="checkbox" {...args} />;
+        labelClass   = deleteKeyAndReturnValue(args, "labelClass", ""),
+        inputElement = <input type="checkbox" {...args} />;
 
       return _.isEmpty(label) ? inputElement : <label class={labelClass}>
         {inputElement}
@@ -222,11 +221,11 @@ export const f = {
       const args = _.assign({}, vnode.attrs); // copy attrs instead of modifying in-place
 
       const model            = wireUpModel(args), // alters args, should be called first
-            validationErrors = validateModel(model, args),
-            items            = coerceArray(unwrapStream(deleteKeyAndReturnValue(args, "items", []))),
-            label            = coerceArray(deleteKeyAndReturnValue(args, "label", []), wrapTextInSpan), // label can be a string or an array
-            contentAfter     = coerceArray(deleteKeyAndReturnValue(args, "contentAfter", []), wrapTextInSpan),
-            selected         = unwrapStream(args.value);
+        validationErrors = validateModel(model, args),
+        items            = coerceArray(unwrapStream(deleteKeyAndReturnValue(args, "items", []))),
+        label            = coerceArray(deleteKeyAndReturnValue(args, "label", []), wrapTextInSpan), // label can be a string or an array
+        contentAfter     = coerceArray(deleteKeyAndReturnValue(args, "contentAfter", []), wrapTextInSpan),
+        selected         = unwrapStream(args.value);
 
       args["class"]    = compactClasses(args, validationErrors ? "is-invalid-input" : null);
       const labelAttrs = {};
@@ -370,10 +369,10 @@ export const f = {
       }
 
       const direction = deleteKeyAndReturnValue(args.tooltip, 'direction', 'bottom'),
-            size      = deleteKeyAndReturnValue(args.tooltip, 'size', 'medium'),
-            content   = deleteKeyAndReturnValue(args.tooltip, 'content', children),
-            clazz     = deleteKeyAndReturnValue(args.tooltip, 'class', null),
-            type      = deleteKeyAndReturnValue(args.tooltip, 'type', 'question-mark');
+        size      = deleteKeyAndReturnValue(args.tooltip, 'size', 'medium'),
+        content   = deleteKeyAndReturnValue(args.tooltip, 'content', children),
+        clazz     = deleteKeyAndReturnValue(args.tooltip, 'class', null),
+        type      = deleteKeyAndReturnValue(args.tooltip, 'type', 'question-mark');
 
       let tooltipId = 'tooltip-';
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/frame.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/frame.js
@@ -21,7 +21,7 @@ const enc = encodeURIComponent;
 
 function paramPresent(win, key, val) {
   const s  = win.location.search,
-        re = new RegExp("undefined" !== typeof val ?
+    re = new RegExp("undefined" !== typeof val ?
           `[&?]${esr(enc(key))}=${esr(enc(val))}(?:&.+)?$` :
           `[&?]${esr(enc(key))}(?:&.+)?$`);
   return "" !== s && s.match(re);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/rails-shared/plugin-endpoint.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/rails-shared/plugin-endpoint.js
@@ -120,31 +120,31 @@
 
   function handleRequestResponse(source, message) {
     var reqId = message.head.reqId,
-         type = message.head.type;
+      type = message.head.type;
 
     switch (type) {
-      case "request":
-        var key = messageKey(message);
+    case "request":
+      var key = messageKey(message);
 
-        if (!key) {
-          err("Request is missing key; debug:", JSON.stringify(message));
-          return;
-        }
+      if (!key) {
+        err("Request is missing key; debug:", JSON.stringify(message));
+        return;
+      }
 
-        if ("function" !== typeof HANDLERS[key]) {
-          err("Don't know how to handle request key:", key);
-          return;
-        }
+      if ("function" !== typeof HANDLERS[key]) {
+        err("Don't know how to handle request key:", key);
+        return;
+      }
 
-        HANDLERS[key](message, new Transport(source, reqId));
-        break;
-      case "response":
-        var req = PENDING_REQUESTS.pop(reqId);
-        req.onComplete(message.body.data, message.body.errors);
-        break;
-      default:
-        err("Don't know how to handle type", type, "; debug:", message);
-        break;
+      HANDLERS[key](message, new Transport(source, reqId));
+      break;
+    case "response":
+      var req = PENDING_REQUESTS.pop(reqId);
+      req.onComplete(message.body.data, message.body.errors);
+      break;
+    default:
+      err("Don't know how to handle type", type, "; debug:", message);
+      break;
     }
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/analytics/global_metrics.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/analytics/global_metrics.js.msx
@@ -29,8 +29,8 @@ export const GlobalMetrics = {
     _.each(vnode.attrs.metrics, (supportedAnalytics, pluginId) => {
       _.each(supportedAnalytics, (sa, idx) => {
         const uid   = Models.uid(idx, pluginId, sa.type, sa.id),
-              title = sa.title,
-              model = Models.modelFor(uid);
+          title = sa.title,
+          model = Models.modelFor(uid);
 
         elements.push(m(AnalyticsiFrameWidget, {model, pluginId, uid, title, init}));
       });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/analytics/pipeline_metrics.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/analytics/pipeline_metrics.js.msx
@@ -67,8 +67,8 @@ export const PipelineMetrics = {
     $.each(vnode.attrs.metrics, (pluginId, supportedAnalytics) => {
       $.each(supportedAnalytics, (idx, sa) => {
         const uid   = Models.uid(idx, pluginId, sa.type, sa.id),
-              title = sa.title,
-              model = Models.modelFor(uid, pipelineParams(currentPipeline));
+          title = sa.title,
+          model = Models.modelFor(uid, pipelineParams(currentPipeline));
 
         elements.push(m(AnalyticsiFrameWidget, {model, pluginId, uid, title, init}));
       });

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/pipeline_analytics_widget.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/pipeline_analytics_widget.js.msx
@@ -15,17 +15,16 @@
  */
 import m from "mithril";
 import Interactions from "models/shared/analytics_interaction_manager";
-import {init} from "rails-shared/plugin-endpoint";
+import AnalyticsEndpoint, {init} from "rails-shared/plugin-endpoint";
 import {Modal} from "views/shared/new_modal";
 import {AnalyticsiFrameWidget} from "views/shared/analytics_iframe_widget";
-import AnalyticsEndpoint from "rails-shared/plugin-endpoint";
 
 const Models                = Interactions.ensure().ns("PipelineMetrics");
 
 function createModal(pluginId, metricId, pipeline) {
   const uid = Models.uid(0, pluginId, "pipeline", metricId),
-      model = Models.modelFor(uid),
-     params = { pipeline_name: pipeline.name }; // eslint-disable-line camelcase
+    model = Models.modelFor(uid),
+    params = { pipeline_name: pipeline.name }; // eslint-disable-line camelcase
 
   model.url(Models.toUrl(uid, params));
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/shared/analytics_iframe_widget.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/shared/analytics_iframe_widget.js.msx
@@ -20,7 +20,7 @@ export const AnalyticsiFrameWidget = function () {
 
   function loadFrameContent(vnode) {
     const iframe    = vnode.dom.querySelector("iframe"),
-          container = vnode.dom;
+      container = vnode.dom;
 
     function beforeLoad() {
       container.classList.add("loading-analytics");

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/shared/schmodal.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/shared/schmodal.js.msx
@@ -62,7 +62,7 @@ const Footer = {
 const Dialog = {
   oncreate(vnode) {
     function removeAnimation() {
-        vnode.dom.classList.remove("adding");
+      vnode.dom.classList.remove("adding");
     }
     vnode.dom.classList.add("adding");
     setTimeout(removeAnimation, 500);


### PR DESCRIPTION
Fix indenting rules on newer code, and allow all code to be es2018 which should be absolutely fine from a browser compatibilty standpoint based on caniuse: https://caniuse.com/?search=es2018