### PR TITLE
Ensure background threads are named

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/common/settings/PluginSettingsMetadataLoader.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/common/settings/PluginSettingsMetadataLoader.java
@@ -35,7 +35,7 @@ import static com.thoughtworks.go.plugin.domain.common.PluginConstants.PLUGGABLE
 public class PluginSettingsMetadataLoader implements PluginChangeListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(PluginSettingsMetadataLoader.class);
     private final List<GoPluginExtension> extensions;
-    private PluginSettingsMetadataStore metadataStore = PluginSettingsMetadataStore.getInstance();
+    private final PluginSettingsMetadataStore metadataStore = PluginSettingsMetadataStore.getInstance();
 
     @Autowired
     public PluginSettingsMetadataLoader(List<GoPluginExtension> extensions, PluginManager pluginManager) {
@@ -59,7 +59,7 @@ public class PluginSettingsMetadataLoader implements PluginChangeListener {
         List<ExtensionSettingsInfo> allMetadata = findSettingsAndViewOfAllExtensionsIn(pluginId);
         List<ExtensionSettingsInfo> validMetadata = allSettingsAndViewPairsWhichAreValid(allMetadata);
 
-        if (validMetadata.size() == 0) {
+        if (validMetadata.isEmpty()) {
             LOGGER.warn("Failed to fetch plugin settings metadata for plugin {}. Maybe the plugin does not implement plugin settings and view?", pluginId);
             LOGGER.warn("Plugin: {} - Metadata load info: {}", pluginId, allMetadata);
             LOGGER.warn("Not all plugins are required to implement the request above. This error may be safe to ignore.");
@@ -96,7 +96,7 @@ public class PluginSettingsMetadataLoader implements PluginChangeListener {
         return allMetadata.stream().filter(ExtensionSettingsInfo::settingsAndViewAreValid).collect(Collectors.toList());
     }
 
-    private class ExtensionSettingsInfo {
+    private static class ExtensionSettingsInfo {
         private final String extensionName;
         private final String errorMessage;
         private final PluginSettingsConfiguration configuration;

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitor.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitor.java
@@ -96,7 +96,6 @@ public class DefaultPluginJarLocationMonitor implements PluginJarLocationMonitor
             throw new IllegalStateException("Cannot start the monitor multiple times.");
         }
         monitorThread = new PluginLocationMonitorThread(bundledPluginDirectory, externalPluginDirectory, pluginJarChangeListeners, systemEnvironment);
-        monitorThread.setDaemon(true);
     }
 
     @Override
@@ -115,6 +114,7 @@ public class DefaultPluginJarLocationMonitor implements PluginJarLocationMonitor
         try {
             monitorThread.join();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
         monitorThread = null;
     }
@@ -165,6 +165,8 @@ public class DefaultPluginJarLocationMonitor implements PluginJarLocationMonitor
                                            File externalPluginDirectory,
                                            List<WeakReference<PluginJarChangeListener>> pluginJarChangeListener,
                                            SystemEnvironment systemEnvironment) {
+            super("goPluginLocationMonitor");
+            setDaemon(true);
             this.bundledPluginDirectory = bundledPluginDirectory;
             this.externalPluginDirectory = externalPluginDirectory;
             this.pluginJarChangeListener = pluginJarChangeListener;
@@ -209,9 +211,9 @@ public class DefaultPluginJarLocationMonitor implements PluginJarLocationMonitor
             return new DoOnAllListeners(pluginJarChangeListener);
         }
 
-        private void waitForMonitorInterval(int interval) {
+        private void waitForMonitorInterval(int intervalSeconds) {
             try {
-                Thread.sleep(interval * 1000);
+                Thread.sleep(intervalSeconds * 1000L);
             } catch (InterruptedException e) {
                 this.interrupt();
             }

--- a/server/src/main/java/com/thoughtworks/go/server/service/ArtifactsDiskCleaner.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ArtifactsDiskCleaner.java
@@ -53,7 +53,7 @@ public class ArtifactsDiskCleaner extends DiskSpaceChecker {
                 LOGGER.error("Artifact disk cleanup task aborted. Error encountered: '{}'", e.getMessage());//logging not tested
                 throw new RuntimeException(e);
             }
-        });
+        }, "goArtifactsDiskCleaner");
         cleaner.start();
     }
 
@@ -98,7 +98,7 @@ public class ArtifactsDiskCleaner extends DiskSpaceChecker {
     @Override
     protected long limitInMb() {
         ServerConfig serverConfig = goConfigService.serverConfig();
-        return serverConfig.isArtifactPurgingAllowed() ? new Double(serverConfig.getPurgeStart() * GoConstants.MEGABYTES_IN_GIGABYTE).longValue() : Integer.MAX_VALUE;
+        return serverConfig.isArtifactPurgingAllowed() ? Double.valueOf(serverConfig.getPurgeStart() * GoConstants.MEGABYTES_IN_GIGABYTE).longValue() : Integer.MAX_VALUE;
     }
 
     @Override


### PR DESCRIPTION
Makes it a lot easier to debug things from logs with named threads. Couple seem to have been missed here. Might be a rogue thread pool or two somewhere still with generic names.

