### PR TITLE
Clean up Jetty configuration for 9.4.52

### DIFF
--- a/buildSrc/.trivyignore
+++ b/buildSrc/.trivyignore
@@ -8,12 +8,6 @@
 # and https://github.com/jruby/jruby/pull/7867 for removing the noise.
 CVE-2023-33201
 
-# org.eclipse.jetty:jetty-xml (go.jar)
-# https://github.com/advisories/GHSA-58qw-p7qm-5rvh
-#
-# GoCD is not vulnerable since it does not use XmlParser on user input
-GHSA-58qw-p7qm-5rvh
-
 # org.springframework:spring-core (go.jar) Fixed: 5.2.22.RELEASE, 5.3.20.RELEASE
 # https://avd.aquasec.com/nvd/2022/cve-2022-22971/
 #

--- a/jetty9/src/main/java/com/thoughtworks/go/server/AssetsContextHandler.java
+++ b/jetty9/src/main/java/com/thoughtworks/go/server/AssetsContextHandler.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 
 public class AssetsContextHandler extends ContextHandler {
     private final AssetsHandler handler;
-    private SystemEnvironment systemEnvironment;
+    private final SystemEnvironment systemEnvironment;
 
     public AssetsContextHandler(SystemEnvironment systemEnvironment) {
         super(systemEnvironment.getWebappContextPath() + "/assets");
@@ -53,7 +53,7 @@ public class AssetsContextHandler extends ContextHandler {
     }
 
     class AssetsHandler extends AbstractHandler {
-        private ResourceHandler resourceHandler = new ResourceHandler();
+        private final ResourceHandler resourceHandler = new ResourceHandler();
 
         private AssetsHandler() {
             resourceHandler.setCacheControl("max-age=31536000,public");

--- a/jetty9/src/main/java/com/thoughtworks/go/server/AssetsContextHandlerInitializer.java
+++ b/jetty9/src/main/java/com/thoughtworks/go/server/AssetsContextHandlerInitializer.java
@@ -21,17 +21,13 @@ import org.eclipse.jetty.webapp.WebAppContext;
 
 import java.io.IOException;
 
-public class AssetsContextHandlerInitializer implements LifeCycle.Listener{
-    private AssetsContextHandler assetsContextHandler;
-    private WebAppContext webAppContext;
+public class AssetsContextHandlerInitializer implements LifeCycle.Listener {
+    private final AssetsContextHandler assetsContextHandler;
+    private final WebAppContext webAppContext;
 
-    public AssetsContextHandlerInitializer(AssetsContextHandler assetsContextHandler, WebAppContext webAppContext){
+    public AssetsContextHandlerInitializer(AssetsContextHandler assetsContextHandler, WebAppContext webAppContext) {
         this.assetsContextHandler = assetsContextHandler;
         this.webAppContext = webAppContext;
-    }
-
-    @Override
-    public void lifeCycleStarting(LifeCycle event) {
     }
 
     @Override
@@ -41,17 +37,5 @@ public class AssetsContextHandlerInitializer implements LifeCycle.Listener{
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    @Override
-    public void lifeCycleFailure(LifeCycle event, Throwable cause) {
-    }
-
-    @Override
-    public void lifeCycleStopping(LifeCycle event) {
-    }
-
-    @Override
-    public void lifeCycleStopped(LifeCycle event) {
     }
 }

--- a/jetty9/src/main/java/com/thoughtworks/go/server/Jetty9Server.java
+++ b/jetty9/src/main/java/com/thoughtworks/go/server/Jetty9Server.java
@@ -17,7 +17,6 @@ package com.thoughtworks.go.server;
 
 import com.thoughtworks.go.server.util.GoPlainSocketConnector;
 import com.thoughtworks.go.util.SystemEnvironment;
-import org.apache.commons.io.FileUtils;
 import org.eclipse.jetty.deploy.App;
 import org.eclipse.jetty.deploy.DeploymentManager;
 import org.eclipse.jetty.deploy.providers.WebAppProvider;
@@ -31,7 +30,6 @@ import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.webapp.JettyWebXmlConfiguration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
 import org.eclipse.jetty.webapp.WebXmlConfiguration;
@@ -45,16 +43,19 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.util.Objects;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public class Jetty9Server extends AppServer {
-    protected static String JETTY_XML_LOCATION_IN_JAR = "/defaultFiles/config";
-    private static final String JETTY_XML = "jetty.xml";
-    private static final String JETTY_CONFIG_VERSION = "jetty-v9.4.48.v20220622";
-    private Server server;
-    private WebAppContext webAppContext;
+    static String JETTY_XML_LOCATION_IN_JAR = "/defaultFiles/config";
+    static final String JETTY_CONFIG_VERSION = "jetty-config-gocd-v9";
     private static final Logger LOG = LoggerFactory.getLogger(Jetty9Server.class);
+    private static final String JETTY_XML = "jetty.xml";
+    private final Server server;
+    private WebAppContext webAppContext;
     private final DeploymentManager deploymentManager;
 
     public Jetty9Server(SystemEnvironment systemEnvironment) {
@@ -76,11 +77,11 @@ public class Jetty9Server extends AppServer {
         ContextHandlerCollection handlers = new ContextHandlerCollection();
         deploymentManager.setContexts(handlers);
 
-        createWebAppContext();
+        webAppContext = createWebAppContext();
 
         JettyCustomErrorPageHandler errorHandler = new JettyCustomErrorPageHandler();
         webAppContext.setErrorHandler(errorHandler);
-        webAppContext.setGzipHandler(gzipHandler());
+        webAppContext.insertHandler(gzipHandler());
         server.addBean(errorHandler);
         server.addBean(deploymentManager);
 
@@ -95,30 +96,30 @@ public class Jetty9Server extends AppServer {
     static GzipHandler gzipHandler() {
         GzipHandler gzipHandler = new GzipHandler();
         gzipHandler.addIncludedMimeTypes(
-                "application/javascript",
-                "application/json",
-                "application/vnd.go.cd.v1+json",
-                "application/vnd.go.cd.v2+json",
-                "application/vnd.go.cd.v3+json",
-                "application/vnd.go.cd.v4+json",
-                "application/vnd.go.cd.v5+json",
-                "application/vnd.go.cd.v6+json",
-                "application/vnd.go.cd.v7+json",
-                "application/vnd.go.cd.v8+json",
-                "application/vnd.go.cd.v9+json",
-                "application/xhtml+xml",
-                "image/svg+xml",
-                "text/css",
-                "text/html",
-                "text/plain",
-                "text/xml"
+            "application/javascript",
+            "application/json",
+            "application/vnd.go.cd.v1+json",
+            "application/vnd.go.cd.v2+json",
+            "application/vnd.go.cd.v3+json",
+            "application/vnd.go.cd.v4+json",
+            "application/vnd.go.cd.v5+json",
+            "application/vnd.go.cd.v6+json",
+            "application/vnd.go.cd.v7+json",
+            "application/vnd.go.cd.v8+json",
+            "application/vnd.go.cd.v9+json",
+            "application/xhtml+xml",
+            "image/svg+xml",
+            "text/css",
+            "text/html",
+            "text/plain",
+            "text/xml"
         );
         gzipHandler.addIncludedMethods("HEAD",
-                "GET",
-                "POST",
-                "PUT",
-                "PATCH",
-                "DELETE");
+            "GET",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE");
         return gzipHandler;
     }
 
@@ -167,7 +168,7 @@ public class Jetty9Server extends AppServer {
         if (systemEnvironment.useCompressedJs()) {
             AssetsContextHandler assetsContextHandler = new AssetsContextHandler(systemEnvironment);
             deploymentManager.addApp(new App(deploymentManager, webAppProvider, "assetsHandler", assetsContextHandler));
-            webAppContext.addLifeCycleListener(new AssetsContextHandlerInitializer(assetsContextHandler, webAppContext));
+            webAppContext.addEventListener(new AssetsContextHandlerInitializer(assetsContextHandler, webAppContext));
         }
 
         deploymentManager.addApp(new App(deploymentManager, webAppProvider, "realApp", webAppContext));
@@ -195,20 +196,20 @@ public class Jetty9Server extends AppServer {
             configuration.configure(server);
         } else {
             String message = String.format(
-                    "No custom jetty configuration (%s) found, using defaults.",
-                    jettyConfig.getAbsolutePath());
+                "No custom jetty configuration (%s) found, using defaults.",
+                jettyConfig.getAbsolutePath());
             LOG.info(message);
         }
     }
 
     protected void replaceJettyXmlIfItBelongsToADifferentVersion(File jettyConfig) throws IOException {
-        if (FileUtils.readFileToString(jettyConfig, UTF_8).contains(JETTY_CONFIG_VERSION)) return;
+        if (Files.readString(jettyConfig.toPath(), UTF_8).contains(JETTY_CONFIG_VERSION)) return;
         replaceFileWithPackagedOne(jettyConfig);
     }
 
     private void replaceFileWithPackagedOne(File jettyConfig) {
-        try (InputStream inputStream = getClass().getResourceAsStream(JETTY_XML_LOCATION_IN_JAR + "/" + jettyConfig.getName())) {
-            FileUtils.copyInputStreamToFile(inputStream, systemEnvironment.getJettyConfigFile());
+        try (InputStream inputStream = Objects.requireNonNull(getClass().getResourceAsStream(JETTY_XML_LOCATION_IN_JAR + "/" + jettyConfig.getName()))) {
+            Files.copy(inputStream, systemEnvironment.getJettyConfigFile().toPath(), REPLACE_EXISTING);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -219,24 +220,23 @@ public class Jetty9Server extends AppServer {
     }
 
     private WebAppContext createWebAppContext() {
-        webAppContext = new WebAppContext();
-        webAppContext.setDefaultsDescriptor(GoWebXmlConfiguration.configuration(getWarFile()));
+        WebAppContext context = new WebAppContext();
+        context.setDefaultsDescriptor(GoWebXmlConfiguration.configuration(getWarFile()));
 
-        webAppContext.setConfigurationClasses(new String[]{
-                WebInfConfiguration.class.getCanonicalName(),
-                WebXmlConfiguration.class.getCanonicalName(),
-                JettyWebXmlConfiguration.class.getCanonicalName()
+        context.setConfigurationClasses(new String[]{
+            WebInfConfiguration.class.getCanonicalName(),
+            WebXmlConfiguration.class.getCanonicalName()
         });
-        webAppContext.setContextPath(systemEnvironment.getWebappContextPath());
+        context.setContextPath(systemEnvironment.getWebappContextPath());
 
         // delegate all logging to parent classloader to avoid initialization of loggers in multiple classloaders
-        webAppContext.getSystemClasspathPattern().add("org.apache.log4j.");
-        webAppContext.getSystemClasspathPattern().add("org.slf4j.");
-        webAppContext.getSystemClasspathPattern().add("org.apache.commons.logging.");
+        context.getSystemClasspathPattern().add("org.apache.log4j.");
+        context.getSystemClasspathPattern().add("org.slf4j.");
+        context.getSystemClasspathPattern().add("org.apache.commons.logging.");
 
-        webAppContext.setWar(getWarFile());
-        webAppContext.setParentLoaderPriority(systemEnvironment.getParentLoaderPriority());
-        return webAppContext;
+        context.setWar(getWarFile());
+        context.setParentLoaderPriority(systemEnvironment.getParentLoaderPriority());
+        return context;
     }
 
     public Server getServer() {

--- a/jetty9/src/main/java/com/thoughtworks/go/server/JettyCustomErrorPageHandler.java
+++ b/jetty9/src/main/java/com/thoughtworks/go/server/JettyCustomErrorPageHandler.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import static java.lang.String.valueOf;
 
@@ -32,7 +33,7 @@ public class JettyCustomErrorPageHandler extends ErrorPageErrorHandler {
     private final String fileContents;
 
     public JettyCustomErrorPageHandler() throws IOException {
-        try (InputStream in = getClass().getResourceAsStream("/error.html")) {
+        try (InputStream in = Objects.requireNonNull(getClass().getResourceAsStream("/error.html"))) {
             fileContents = IOUtils.toString(in, StandardCharsets.UTF_8);
         }
     }

--- a/jetty9/src/test/java/com/thoughtworks/go/server/AssetsContextHandlerInitializerTest.java
+++ b/jetty9/src/test/java/com/thoughtworks/go/server/AssetsContextHandlerInitializerTest.java
@@ -17,7 +17,9 @@ package com.thoughtworks.go.server;
 
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
+
 import static org.mockito.Mockito.*;
 
 public class AssetsContextHandlerInitializerTest {

--- a/jetty9/src/test/resources/com/thoughtworks/go/server/config/jetty.xml
+++ b/jetty9/src/test/resources/com/thoughtworks/go/server/config/jetty.xml
@@ -1,79 +1,43 @@
 <?xml version="1.0"?>
-<!-- *
- * Copyright 2023 Thoughtworks, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * -->
+<!--
+  ~ Copyright 2023 Thoughtworks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
-    <!--Do not remove/modify the below line containing jetty version, else all your changes to this file will be reverted.-->
-    <!--jetty-v9.2.3-->
-    <!-- =========================================================== -->
-    <!-- Server Thread Pool                                          -->
-    <!-- =========================================================== -->
-    <Get name="ThreadPool">
-        <Set name="minThreads">20</Set>
-        <Set name="maxThreads">300</Set>
-        <!-- New Jetty QTP does not have these two properties below.
-        <Set name="lowThreads">10</Set>
-        <Set name="SpawnOrShrinkAt">2</Set>
-        -->
-    </Get>
-    <Call name="setAttribute">
-        <Arg>org.eclipse.jetty.server.Request.maxFormContentSize</Arg>
-        <Arg>30000000</Arg>
-    </Call>
 
-    <!--<Call name="addBean">-->
-    <!--<Arg>-->
-    <!--<New class="org.eclipse.jetty.server.LowResourceMonitor">-->
-    <!--<Arg><Ref id="Server"/></Arg>-->
-    <!--<Set name="period"><Property name="lowresources.period" default="1000"/></Set>-->
-    <!--<Set name="lowResourcesIdleTimeout"><Property name="lowresources.lowResourcesIdleTimeout" default="1000"/></Set>-->
-    <!--<Set name="monitorThreads"><Property name="lowresources.monitorThreads" default="true"/></Set>-->
-    <!--<Set name="maxConnections"><Property name="lowresources.maxConnections" default="0"/></Set>-->
-    <!--<Set name="maxMemory"><Property name="lowresources.maxMemory" default="0"/></Set>-->
-    <!--<Set name="maxLowResourcesTime"><Property name="lowresources.maxLowResourcesTime" default="5000"/></Set>-->
-    <!--</New>-->
-    <!--</Arg>-->
-    <!--</Call>-->
+  <!-- Do not remove/modify the below line containing jetty version, else all your changes to this file will be reverted.
+       This is used by the GoCD server to determine whether a breaking change has been made to Jetty config and the
+       user's custom configuration needs to be overridden with that packages.
 
+       See com.thoughtworks.go.server.Jetty9Server#JETTY_CONFIG_VERSION
+  -->
+  <!-- jetty-config-gocd-intentionally-outdated -->
 
-    <!-- =========================================================== -->
-    <!-- Logging                                                     -->
-    <!-- =========================================================== -->
-    <!-- Note: Please create the weblogs directory if not exist -->
-    <!--
-    <Get name="handler">
-        <Call name="addHandler">
-            <Arg>
-                <New class="org.eclipse.jetty.server.handler.RequestLogHandler">
-                    <Set name="requestLog">
-                        <New class="org.eclipse.jetty.server.NCSARequestLog">
-                            <Arg><SystemProperty name="jetty.logs" default="./weblogs"/>/jetty-yyyy_mm_dd.request.log</Arg>
-                            <Set name="filenameDateFormat">yyyy_MM_dd</Set>
-                            <Set name="retainDays">7</Set>
-                            <Set name="append">true</Set>
-                            <Set name="extended">false</Set>
-                            <Set name="logCookies">false</Set>
-                            <Set name="logLatency">false</Set>
-                        </New>
-                    </Set>
-                </New>
-            </Arg>
-        </Call>
-    </Get>
-    -->
+  <!-- =========================================================== -->
+  <!-- Server Thread Pool                                          -->
+  <!-- =========================================================== -->
+
+  <Get name="ThreadPool">
+    <Set name="minThreads">20</Set>
+    <Set name="maxThreads">300</Set>
+  </Get>
+  <Call name="setAttribute">
+    <Arg>org.eclipse.jetty.server.Request.maxFormContentSize</Arg>
+    <Arg>30000000</Arg>
+  </Call>
+
 </Configure>

--- a/server/config/jetty.xml
+++ b/server/config/jetty.xml
@@ -15,39 +15,35 @@
   ~ limitations under the License.
   -->
 
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
-    <!--Do not remove/modify the below line containing jetty version, else all your changes to this file will be reverted.-->
-    <!--jetty-v9.4.48.v20220622-->
-    <!-- =========================================================== -->
-    <!-- Server Thread Pool                                          -->
-    <!-- =========================================================== -->
 
-    <!--<Get name="ThreadPool">-->
-        <!--<Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>-->
-        <!--<Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>-->
-        <!--<Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>-->
-        <!--<Set name="detailedDump">false</Set>-->
-    <!--</Get>-->
+  <!-- Do not remove/modify the below line containing jetty version, else all your changes to this file will be reverted.
+       This is used by the GoCD server to determine whether a breaking change has been made to Jetty config and the
+       user's custom configuration needs to be overridden with that packages.
 
-    <Get name="ThreadPool">
-        <Set name="minThreads">20</Set>
-        <Set name="maxThreads">300</Set>
-        <!-- New Jetty QTP does not have these two properties below.
-        <Set name="lowThreads">10</Set>
-        <Set name="SpawnOrShrinkAt">2</Set>
-        -->
-    </Get>
-    <Call name="setAttribute">
-        <Arg>org.eclipse.jetty.server.Request.maxFormContentSize</Arg>
-        <Arg>30000000</Arg>
-    </Call>
+       See com.thoughtworks.go.server.JettyServer#JETTY_CONFIG_VERSION
+  -->
+  <!-- jetty-config-gocd-v9 -->
+
+  <!-- =========================================================== -->
+  <!-- Server Thread Pool                                          -->
+  <!-- =========================================================== -->
+
+  <Get name="ThreadPool">
+    <Set name="minThreads">20</Set>
+    <Set name="maxThreads">300</Set>
+  </Get>
+  <Call name="setAttribute">
+    <Arg>org.eclipse.jetty.server.Request.maxFormContentSize</Arg>
+    <Arg>30000000</Arg>
+  </Call>
 
     <Call name="addBean">
         <Arg>
             <New class="org.eclipse.jetty.server.LowResourceMonitor">
-                <Arg><Ref id="Server"/></Arg>
+                <Arg><Ref refid="Server"/></Arg>
                 <Set name="period"><Property name="jetty.lowresources.period" default="1000"/></Set>
                 <Set name="lowResourcesIdleTimeout"><Property name="jetty.lowresources.idleTimeout" default="500"/></Set>
                 <Set name="monitorThreads"><Property name="jetty.lowresources.monitorThreads"  default="true"/></Set>

--- a/server/src/main/java/com/thoughtworks/go/server/util/RequestUtils.java
+++ b/server/src/main/java/com/thoughtworks/go/server/util/RequestUtils.java
@@ -15,16 +15,16 @@
  */
 package com.thoughtworks.go.server.util;
 
+import lombok.experimental.UtilityClass;
+
 import javax.servlet.MultipartConfigElement;
 import javax.servlet.http.HttpServletRequest;
 
 import static org.eclipse.jetty.server.Request.MULTIPART_CONFIG_ELEMENT;
 
+@UtilityClass
 public class RequestUtils {
     public static void configureMultipart(HttpServletRequest req) {
         req.setAttribute(MULTIPART_CONFIG_ELEMENT, new MultipartConfigElement(System.getProperty("java.io.tmpdir", "tmp")));
-    }
-
-    private RequestUtils() {
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/web/UrlRewriterIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/web/UrlRewriterIntegrationTest.java
@@ -21,7 +21,6 @@ import com.thoughtworks.go.domain.ServerSiteUrlConfig;
 import com.thoughtworks.go.domain.SiteUrl;
 import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
 import com.thoughtworks.go.server.service.support.toggle.Toggles;
-import com.thoughtworks.go.server.util.ServletHelper;
 import com.thoughtworks.go.util.SslVerificationMode;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.*;
@@ -143,7 +142,6 @@ public class UrlRewriterIntegrationTest {
 
     @BeforeAll
     public static void beforeClass() throws Exception {
-        ServletHelper.init();
         httpUtil = new HttpTestUtil(ctx -> {
             wac = mock(WebApplicationContext.class);
             ctx.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, wac);


### PR DESCRIPTION
Jetty fails to start on 9.4.52 due to stricter jetty.xml parsing backported from 10.x. This backports tidies ups originally intended for our Jetty 10 migration to correct these issues, and removes an unnecessary Jetty configuration customiser that is not in use.

This was unintentionally broken by https://github.com/gocd/gocd/pull/11917
