### PR TITLE
Revert Jetty 9.4.52 upgrade

### DIFF
--- a/buildSrc/.trivyignore
+++ b/buildSrc/.trivyignore
@@ -8,6 +8,12 @@
 # and https://github.com/jruby/jruby/pull/7867 for removing the noise.
 CVE-2023-33201
 
+# org.eclipse.jetty:jetty-xml (go.jar)
+# https://github.com/advisories/GHSA-58qw-p7qm-5rvh
+#
+# GoCD is not vulnerable since it does not use XmlParser on user input
+GHSA-58qw-p7qm-5rvh
+
 # org.springframework:spring-core (go.jar) Fixed: 5.2.22.RELEASE, 5.3.20.RELEASE
 # https://avd.aquasec.com/nvd/2022/cve-2022-22971/
 #

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -67,7 +67,7 @@ final Map<String, String> libraries = [
   jcommander          : 'com.beust:jcommander:1.82',
   jdom                : 'org.jdom:jdom2:2.0.6.1',
   jetBrainsAnnotations: 'org.jetbrains:annotations:24.0.1',
-  jetty               : 'org.eclipse.jetty:jetty-server:9.4.52.v20230823',
+  jetty               : 'org.eclipse.jetty:jetty-server:9.4.51.v20230217',
   jgit                : 'org.eclipse.jgit:org.eclipse.jgit:6.6.0.202305301015-r',
   jodaTime            : 'joda-time:joda-time:2.12.5', // joda-time version has to be compatible with the jruby version
   jolt                : 'com.bazaarvoice.jolt:jolt-core:0.1.8',


### PR DESCRIPTION
Temporarily reverts #11917 (and part of #11918) as it seems to have introduced some unexplained instability that needs further investigation.