### PR TITLE
Improve Jetty & Rack logging

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeServer.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeServer.groovy
@@ -58,11 +58,6 @@ class InstallerTypeServer implements InstallerType {
       '-XX:MaxMetaspaceSize=400m',
       '-Duser.language=en',
       '-Duser.country=US',
-      // jruby rack will buffer the output stream in memory, before it writes to disk.
-      // This writing to disk and then sending the contents over an http socket can cause significant performance overhead
-      // so we increase the buffer limit to 30mb.
-      // See org.jruby.rack.servlet.RewindableInputStream
-      '-Djruby.rack.request.size.threshold.bytes=30000000',
     ]
   }
 
@@ -71,7 +66,7 @@ class InstallerTypeServer implements InstallerType {
     [
       '-Dgocd.server.log.dir=/var/log/go-server',
       '-Dcruise.config.dir=/etc/go',
-      '-Dcruise.config.file=/etc/go/cruise-config.xml'
+      '-Dcruise.config.file=/etc/go/cruise-config.xml',
     ]
   }
 

--- a/jetty9/src/main/java/com/thoughtworks/go/server/GoWebXmlConfiguration.java
+++ b/jetty9/src/main/java/com/thoughtworks/go/server/GoWebXmlConfiguration.java
@@ -19,12 +19,12 @@ import java.io.File;
 
 public class GoWebXmlConfiguration {
 
-    private static String webdefaultXml = "WEB-INF/webdefault.xml";
+    private static final String WEB_DEFAULT_XML = "WEB-INF/webdefault.xml";
 
     public static String configuration(String warFile) {
         if (new File(warFile).isDirectory()) {
-            return new File(warFile, webdefaultXml).getPath();
+            return new File(warFile, WEB_DEFAULT_XML).getPath();
         }
-        return "jar:file:" + warFile + "!/" + webdefaultXml;
+        return "jar:file:" + warFile + "!/" + WEB_DEFAULT_XML;
     }
 }

--- a/server/config/jetty.xml
+++ b/server/config/jetty.xml
@@ -67,7 +67,7 @@
                             <Set name="ignorePaths">
                               <Array type="java.lang.String">
                                 <Item>/go/assets/*</Item>
-                                <Item>/go/server/api/server_health_messages</Item>
+                                <Item>/go/api/server_health_messages</Item>
                               </Array>
                             </Set>
                         </New>

--- a/server/src/main/resources/config/logback.xml
+++ b/server/src/main/resources/config/logback.xml
@@ -81,6 +81,9 @@
 
   <!-- Change to INFO to enable request logging -->
   <logger name="org.eclipse.jetty.server.RequestLog" level="WARN"/>
+
+  <!-- Lower default log levels of certain loggers to improve debuggability if something goes wrong -->
+  <logger name="org.jruby.rack.JRubyRack" level="INFO"/>
   <logger name="liquibase.changelog.visitor.UpdateVisitor" level="DEBUG"/>
 
   <!-- make sure this is the last line in the config -->

--- a/server/src/main/webapp/WEB-INF/web.xml
+++ b/server/src/main/webapp/WEB-INF/web.xml
@@ -99,6 +99,15 @@
     <param-value>1</param-value>
   </context-param>
 
+  <!-- jruby rack will buffer the output stream in memory, before it writes to disk.
+  This writing to disk and then sending the contents over an http socket can cause significant performance overhead
+  so we increase the buffer limit to 30mb.
+  See org.jruby.rack.servlet.RewindableInputStream -->
+  <context-param>
+    <param-name>jruby.rack.request.size.maximum.bytes</param-name>
+    <param-value>30000000</param-value>
+  </context-param>
+
   <!-- DelegatingServlet below loads this servlet and delegates to it, the source is in PROJECT_ROOT/rack_hack. Default ant task for this project runs tests, packages a jar, and deploys to the correct localivy directory(it always overwrites becuase there is no version) -->
   <context-param>
     <param-name>delegate.servlet.name</param-name>

--- a/server/src/main/webapp/WEB-INF/web.xml
+++ b/server/src/main/webapp/WEB-INF/web.xml
@@ -99,10 +99,20 @@
     <param-value>1</param-value>
   </context-param>
 
+  <!-- See https://github.com/jruby/jruby-rack#logging -->
+  <context-param>
+    <param-name>jruby.rack.logging</param-name>
+    <param-value>slf4j</param-value>
+  </context-param>
+  <context-param>
+    <param-name>jruby.rack.logging.name</param-name>
+    <param-value>org.jruby.rack.JRubyRack</param-value>
+  </context-param>
+
   <!-- jruby rack will buffer the output stream in memory, before it writes to disk.
   This writing to disk and then sending the contents over an http socket can cause significant performance overhead
   so we increase the buffer limit to 30mb.
-  See org.jruby.rack.servlet.RewindableInputStream -->
+  See org.jruby.rack.servlet.RewindableInputStream and https://github.com/jruby/jruby-rack#jruby-rack-configuration -->
   <context-param>
     <param-name>jruby.rack.request.size.maximum.bytes</param-name>
     <param-value>30000000</param-value>


### PR DESCRIPTION
Not all Rack errors seem to end up being logged in the right place. Configure it to use Slf4j to assist with debugging weird scenarios, while generally cleaning up the configuration.