### PR TITLE
Bump yaml and json config repo plugins to latest versions

### DIFF
--- a/buildSrc/dependency-check-suppress.xml
+++ b/buildSrc/dependency-check-suppress.xml
@@ -263,14 +263,4 @@
     <cve>CVE-2023-35887</cve>
   </suppress>
 
-  <suppress until="2023-10-01Z">
-    <notes><![CDATA[
-    Time-limited suppression of issue from yamlbeans via the yaml config repo plugin )gocd-yaml-config-plugin.jar). There is no fixed version
-    released at time of writing, see https://github.com/EsotericSoftware/yamlbeans/pull/164#issuecomment-1702397167
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.esotericsoftware\.yamlbeans/yamlbeans@.*$</packageUrl>
-    <cve>CVE-2023-24620</cve>
-    <cve>CVE-2023-24621</cve>
-  </suppress>
-
 </suppressions>

--- a/tw-go-plugins/build.gradle
+++ b/tw-go-plugins/build.gradle
@@ -41,16 +41,16 @@ def dependencies = [
   new GithubArtifact(
     user: 'tomzo',
     repo: 'gocd-yaml-config-plugin',
-    tagName: 'v0.14.2-305',
-    asset: 'yaml-config-plugin-0.14.2-305.jar',
-    checksum: 'b48951ac8044fa86736cfe3d3e26e0b87940b68bbbb8d6da310fb3ec76c19136'
+    tagName: 'v0.14.3-321',
+    asset: 'yaml-config-plugin-0.14.3-321.jar',
+    checksum: 'f2c92ef8f5255ff0f6528944302e2a3b4980b6b963afbd391d15c66618a1bc5b'
   ),
   new GithubArtifact(
     user: 'tomzo',
     repo: 'gocd-json-config-plugin',
-    tagName: 'v0.6.1-165',
-    asset: 'json-config-plugin-0.6.1-165.jar',
-    checksum: '0ac7ad48a617520012022e01424457f6bf1ba50b36ec3040c863027f05d6403d'
+    tagName: 'v0.6.1-173',
+    asset: 'json-config-plugin-0.6.1-173.jar',
+    checksum: '2f5b62a89eda05dbd4f913b30562cb2792cc3c8e386428d0bf41ccdfbd901275'
   ),
   new GithubArtifact(
     user: 'gocd',


### PR DESCRIPTION
Includes patches to nested dependencies.

See
- https://github.com/tomzo/gocd-yaml-config-plugin/releases/tag/v0.14.3-321
- https://github.com/tomzo/gocd-json-config-plugin/releases/tag/v0.6.1-173