### PR TITLE
Improve jetty server tests to avoid initialization issue

### DIFF
--- a/jetty9/src/main/java/com/thoughtworks/go/server/Jetty9Server.java
+++ b/jetty9/src/main/java/com/thoughtworks/go/server/Jetty9Server.java
@@ -30,7 +30,6 @@ import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.util.resource.Resource;
-import org.eclipse.jetty.webapp.JettyWebXmlConfiguration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
 import org.eclipse.jetty.webapp.WebXmlConfiguration;
@@ -226,8 +225,7 @@ public class Jetty9Server extends AppServer {
 
         context.setConfigurationClasses(new String[]{
             WebInfConfiguration.class.getCanonicalName(),
-            WebXmlConfiguration.class.getCanonicalName(),
-            JettyWebXmlConfiguration.class.getCanonicalName()
+            WebXmlConfiguration.class.getCanonicalName()
         });
         context.setContextPath(systemEnvironment.getWebappContextPath());
 

--- a/server/src/main/webapp/WEB-INF/web.xml
+++ b/server/src/main/webapp/WEB-INF/web.xml
@@ -118,7 +118,7 @@
     <param-value>30000000</param-value>
   </context-param>
 
-  <!-- DelegatingServlet below loads this servlet and delegates to it, the source is in PROJECT_ROOT/rack_hack. Default ant task for this project runs tests, packages a jar, and deploys to the correct localivy directory(it always overwrites becuase there is no version) -->
+  <!-- DelegatingServlet below loads this servlet and delegates to it, the source is in PROJECT_ROOT/rack_hack. -->
   <context-param>
     <param-name>delegate.servlet.name</param-name>
     <param-value>org.jruby.rack.RackServlet</param-value>


### PR DESCRIPTION
Validate that the assets context initializer actually fires. If it doesn't, we end up in a bizarre world of pain.