### PR TITLE
Build containers using buildkit in rootless mode

### DIFF
--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -34,7 +34,7 @@ tasks.register('initializeBuildx') {
         commandLine = ['docker', 'buildx', 'rm', '--force', '--keep-state', builderName]
         ignoreExitValue = true
       }
-      project.exec { commandLine = ['docker', 'buildx', 'create', '--use', '--name', builderName] }
+      project.exec { commandLine = ['docker', 'buildx', 'create', '--use', '--name', builderName, '--driver-opt', 'image=moby/buildkit:rootless'] }
       project.exec { commandLine = ['docker', 'buildx', 'inspect', '--bootstrap', builderName] }
     }
   }


### PR DESCRIPTION
We shouldn't need root to build, and this avoids issues on some MacOS installs with [respect to colima](https://github.com/abiosoft/colima/issues/764#issuecomment-1670603248). See https://github.com/moby/buildkit/blob/master/docs/rootless.md although since we typically build official images within a CentOS 9 container (docker-out-of-docker 😬) I don't think we will meed to do anything special to allow this to work.