### PR TITLE
Serialize dates deterministically when communication with agents

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -274,6 +274,7 @@ subprojects {
     exclude '**/CommandLine.java'
     exclude '**/StreamPumper.java'
     exclude '**/StreamConsumer.java'
+    exclude '**/RuntimeTypeAdapterFactory*.java'
 
     // used by intellij for type hints when editing ftl files, intellij gets confused if it sees a license header in this file
     exclude '**/freemarker_implicit.ftl'

--- a/common/src/main/java/com/thoughtworks/go/remote/adapter/RuntimeTypeAdapterFactory.java
+++ b/common/src/main/java/com/thoughtworks/go/remote/adapter/RuntimeTypeAdapterFactory.java
@@ -1,20 +1,4 @@
 /*
- * Copyright 2023 Thoughtworks, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
  * Copyright (C) 2011 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,13 +12,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-
-/*
- * This class has been copied from https://github.com/google/gson/blob/master/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+ *
+ * Originally from Gson project. Modifications copyright Thoughtworks and respective GoCD contributors.
+ * This class has been copied from https://github.com/google/gson/blob/main/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
  * since the gson-extras library is not officially released or maintained, refer - https://github.com/google/gson/issues/845
-*/
-
+ */
 package com.thoughtworks.go.remote.adapter;
 
 import com.google.gson.*;
@@ -194,7 +176,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
      * sensitive.
      *
      * @throws IllegalArgumentException if either {@code type} or {@code label}
-     *     have already been registered on this type adapter.
+     *                                  have already been registered on this type adapter.
      */
     public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type, String label) {
         if (type == null || label == null) {
@@ -213,7 +195,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
      * name}. Labels are case sensitive.
      *
      * @throws IllegalArgumentException if either {@code type} or its simple name
-     *     have already been registered on this type adapter.
+     *                                  have already been registered on this type adapter.
      */
     public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type) {
         return registerSubtype(type, type.getSimpleName());
@@ -225,9 +207,9 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
         }
 
         final Map<String, TypeAdapter<?>> labelToDelegate
-                = new LinkedHashMap<>();
+            = new LinkedHashMap<>();
         final Map<Class<?>, TypeAdapter<?>> subtypeToDelegate
-                = new LinkedHashMap<>();
+            = new LinkedHashMap<>();
         for (Map.Entry<String, Class<?>> entry : labelToSubtype.entrySet()) {
             TypeAdapter<?> delegate = gson.getDelegateAdapter(this, TypeToken.get(entry.getValue()));
             labelToDelegate.put(entry.getKey(), delegate);
@@ -235,7 +217,8 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
         }
 
         return new TypeAdapter<R>() {
-            @Override public R read(JsonReader in) throws IOException {
+            @Override
+            public R read(JsonReader in) throws IOException {
                 JsonElement jsonElement = Streams.parse(in);
                 JsonElement labelJsonElement;
                 if (maintainType) {
@@ -246,26 +229,27 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
 
                 if (labelJsonElement == null) {
                     throw new JsonParseException("cannot deserialize " + baseType
-                            + " because it does not define a field named " + typeFieldName);
+                        + " because it does not define a field named " + typeFieldName);
                 }
                 String label = labelJsonElement.getAsString();
                 @SuppressWarnings("unchecked") // registration requires that subtype extends T
                 TypeAdapter<R> delegate = (TypeAdapter<R>) labelToDelegate.get(label);
                 if (delegate == null) {
                     throw new JsonParseException("cannot deserialize " + baseType + " subtype named "
-                            + label + "; did you forget to register a subtype?");
+                        + label + "; did you forget to register a subtype?");
                 }
                 return delegate.fromJsonTree(jsonElement);
             }
 
-            @Override public void write(JsonWriter out, R value) throws IOException {
+            @Override
+            public void write(JsonWriter out, R value) throws IOException {
                 Class<?> srcType = value.getClass();
                 String label = subtypeToLabel.get(srcType);
                 @SuppressWarnings("unchecked") // registration requires that subtype extends T
                 TypeAdapter<R> delegate = (TypeAdapter<R>) subtypeToDelegate.get(srcType);
                 if (delegate == null) {
                     throw new JsonParseException("cannot serialize " + srcType.getName()
-                            + "; did you forget to register a subtype?");
+                        + "; did you forget to register a subtype?");
                 }
                 JsonObject jsonObject = delegate.toJsonTree(value).getAsJsonObject();
 
@@ -278,7 +262,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
 
                 if (jsonObject.has(typeFieldName)) {
                     throw new JsonParseException("cannot serialize " + srcType.getName()
-                            + " because it already defines a field named " + typeFieldName);
+                        + " because it already defines a field named " + typeFieldName);
                 }
                 clone.add(typeFieldName, new JsonPrimitive(label));
 

--- a/common/src/test/java/com/thoughtworks/go/remote/adapter/RuntimeTypeAdapterFactoryTest.java
+++ b/common/src/test/java/com/thoughtworks/go/remote/adapter/RuntimeTypeAdapterFactoryTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally from Gson project. Modifications copyright Thoughtworks and respective GoCD contributors.
+ * This class has been copied from https://github.com/google/gson/blob/main/extras/src/test/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactoryTest.java
+ * since the gson-extras library is not officially released or maintained, refer - https://github.com/google/gson/issues/845
+ */
+
+package com.thoughtworks.go.remote.adapter;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapterFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+public final class RuntimeTypeAdapterFactoryTest {
+
+    @Test
+    public void testRuntimeTypeAdapter() {
+        RuntimeTypeAdapterFactory<BillingInstrument> rta = RuntimeTypeAdapterFactory.of(
+                BillingInstrument.class)
+            .registerSubtype(CreditCard.class);
+        Gson gson = new GsonBuilder()
+            .registerTypeAdapterFactory(rta)
+            .create();
+
+        CreditCard original = new CreditCard("Jesse", 234);
+        assertEquals("{\"type\":\"CreditCard\",\"cvv\":234,\"ownerName\":\"Jesse\"}",
+            gson.toJson(original, BillingInstrument.class));
+        BillingInstrument deserialized = gson.fromJson(
+            "{type:'CreditCard',cvv:234,ownerName:'Jesse'}", BillingInstrument.class);
+        assertEquals("Jesse", deserialized.ownerName);
+        assertTrue(deserialized instanceof CreditCard);
+    }
+
+    @Test
+    public void testRuntimeTypeIsBaseType() {
+        TypeAdapterFactory rta = RuntimeTypeAdapterFactory.of(
+                BillingInstrument.class)
+            .registerSubtype(BillingInstrument.class);
+        Gson gson = new GsonBuilder()
+            .registerTypeAdapterFactory(rta)
+            .create();
+
+        BillingInstrument original = new BillingInstrument("Jesse");
+        assertEquals("{\"type\":\"BillingInstrument\",\"ownerName\":\"Jesse\"}",
+            gson.toJson(original, BillingInstrument.class));
+        BillingInstrument deserialized = gson.fromJson(
+            "{type:'BillingInstrument',ownerName:'Jesse'}", BillingInstrument.class);
+        assertEquals("Jesse", deserialized.ownerName);
+    }
+
+    @Test
+    public void testNullBaseType() {
+        assertThatThrownBy(() -> RuntimeTypeAdapterFactory.of(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void testNullTypeFieldName() {
+        assertThatThrownBy(() -> RuntimeTypeAdapterFactory.of(BillingInstrument.class, null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void testNullSubtype() {
+        RuntimeTypeAdapterFactory<BillingInstrument> rta = RuntimeTypeAdapterFactory.of(
+            BillingInstrument.class);
+        assertThatThrownBy(() -> rta.registerSubtype(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void testNullLabel() {
+        RuntimeTypeAdapterFactory<BillingInstrument> rta = RuntimeTypeAdapterFactory.of(
+            BillingInstrument.class);
+        assertThatThrownBy(() -> rta.registerSubtype(CreditCard.class, null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void testDuplicateSubtype() {
+        RuntimeTypeAdapterFactory<BillingInstrument> rta = RuntimeTypeAdapterFactory.of(
+            BillingInstrument.class);
+        rta.registerSubtype(CreditCard.class, "CC");
+        assertThatThrownBy(() -> rta.registerSubtype(CreditCard.class, "Visa"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("types and labels must be unique");
+    }
+
+    @Test
+    public void testDuplicateLabel() {
+        RuntimeTypeAdapterFactory<BillingInstrument> rta = RuntimeTypeAdapterFactory.of(
+            BillingInstrument.class);
+        rta.registerSubtype(CreditCard.class, "CC");
+        assertThatThrownBy(() -> rta.registerSubtype(BankTransfer.class, "CC"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("types and labels must be unique");
+    }
+
+    @Test
+    public void testDeserializeMissingTypeField() {
+        TypeAdapterFactory billingAdapter = RuntimeTypeAdapterFactory.of(BillingInstrument.class)
+            .registerSubtype(CreditCard.class);
+        Gson gson = new GsonBuilder()
+            .registerTypeAdapterFactory(billingAdapter)
+            .create();
+        assertThatThrownBy(() -> gson.fromJson("{ownerName:'Jesse'}", BillingInstrument.class))
+            .isInstanceOf(JsonParseException.class)
+            .hasMessageContaining("type");
+    }
+
+    @Test
+    public void testDeserializeMissingSubtype() {
+        TypeAdapterFactory billingAdapter = RuntimeTypeAdapterFactory.of(BillingInstrument.class)
+            .registerSubtype(BankTransfer.class);
+        Gson gson = new GsonBuilder()
+            .registerTypeAdapterFactory(billingAdapter)
+            .create();
+        assertThatThrownBy(() -> gson.fromJson("{type:'CreditCard',ownerName:'Jesse'}", BillingInstrument.class))
+            .isInstanceOf(JsonParseException.class)
+            .hasMessageContaining("CreditCard");
+    }
+
+    @Test
+    public void testSerializeMissingSubtype() {
+        TypeAdapterFactory billingAdapter = RuntimeTypeAdapterFactory.of(BillingInstrument.class)
+            .registerSubtype(BankTransfer.class);
+        Gson gson = new GsonBuilder()
+            .registerTypeAdapterFactory(billingAdapter)
+            .create();
+        assertThatThrownBy(() -> gson.toJson(new CreditCard("Jesse", 456), BillingInstrument.class))
+            .isInstanceOf(JsonParseException.class)
+            .hasMessageContaining("type");
+    }
+
+    @Test
+    public void testSerializeCollidingTypeFieldName() {
+        TypeAdapterFactory billingAdapter = RuntimeTypeAdapterFactory.of(BillingInstrument.class, "cvv")
+            .registerSubtype(CreditCard.class);
+        Gson gson = new GsonBuilder()
+            .registerTypeAdapterFactory(billingAdapter)
+            .create();
+        assertThatThrownBy(() -> gson.toJson(new CreditCard("Jesse", 456), BillingInstrument.class))
+            .isInstanceOf(JsonParseException.class)
+            .hasMessageContaining("already defines a field named cvv");
+    }
+
+    @Test
+    public void testSerializeWrappedNullValue() {
+        TypeAdapterFactory billingAdapter = RuntimeTypeAdapterFactory.of(BillingInstrument.class)
+            .registerSubtype(CreditCard.class)
+            .registerSubtype(BankTransfer.class);
+        Gson gson = new GsonBuilder()
+            .registerTypeAdapterFactory(billingAdapter)
+            .create();
+        String serialized = gson.toJson(new BillingInstrumentWrapper(null), BillingInstrumentWrapper.class);
+        BillingInstrumentWrapper deserialized = gson.fromJson(serialized, BillingInstrumentWrapper.class);
+        assertNull(deserialized.instrument);
+    }
+
+    static class BillingInstrumentWrapper {
+        BillingInstrument instrument;
+
+        BillingInstrumentWrapper(BillingInstrument instrument) {
+            this.instrument = instrument;
+        }
+    }
+
+    static class BillingInstrument {
+        private final String ownerName;
+
+        BillingInstrument(String ownerName) {
+            this.ownerName = ownerName;
+        }
+    }
+
+    static class CreditCard extends BillingInstrument {
+        int cvv;
+
+        CreditCard(String ownerName, int cvv) {
+            super(ownerName);
+            this.cvv = cvv;
+        }
+    }
+
+    static class BankTransfer extends BillingInstrument {
+        int bankAccount;
+
+        BankTransfer(String ownerName, int bankAccount) {
+            super(ownerName);
+            this.bankAccount = bankAccount;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #11969

Default GSON serialization has some nondeterminism due to use of default locales and parsers. While this generally should work fine, there are changes made to these default formats in Java 20 and use of NBSP vs space which breaks things. Generally speaking it'd be better to use a standard serialization such as ISO instants with milliseconds anyway, to represent java.util.Date objects.

Ideally we shouldn't need to send `Date`s to agents anyway, but currently the `Modification`s are sent across via `BuildAssignment` and `MaterialRevision`s and this is used in a few places to `getLatestModification` for a material and to change the SCM material to the correct revision, including with pluggable SCMs. This would need a separate look to determine whether this can be avoided.