### PR TITLE
Revert "ui: bump @shopify/draggable from 1.0.0-beta.12 to 1.0.0 in /server/src/main/webapp/WEB-INF/rails"

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.4.2",
-    "@shopify/draggable": "^1.0.0",
+    "@shopify/draggable": "^1.0.0-beta.12",
     "angular": "file:node-vendor/angular",
     "awesomplete": "^1.1.5",
     "bourbon": "~7.1.0",

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -1691,10 +1691,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shopify/draggable@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@shopify/draggable@npm:1.0.0"
-  checksum: 5f90e28df328cf1ed085985c9f5ca92bca0fbdb35ec580ede5e23d7ec19d11fade3959007a1a318976a315b4b87799fb59f3db82abd1ef6d17f178590bebece5
+"@shopify/draggable@npm:^1.0.0-beta.12":
+  version: 1.0.0-beta.12
+  resolution: "@shopify/draggable@npm:1.0.0-beta.12"
+  checksum: 4641ab8a3ad7402342d4e6ee02c3c5a8c4fdaf89a029efb21518d47e522d51809b7f226e4e18bb657e0be55476bdc1cc96048b0cc79e427aeb1e87dc01b6c958
   languageName: node
   linkType: hard
 
@@ -5827,7 +5827,7 @@ __metadata:
     "@babel/preset-env": ^7.22.20
     "@babel/preset-react": ^7.22.15
     "@fortawesome/fontawesome-free": ^6.4.2
-    "@shopify/draggable": ^1.0.0
+    "@shopify/draggable": ^1.0.0-beta.12
     "@types/awesomplete": ^1.1.12
     "@types/fs-extra": ^11.0.2
     "@types/html-webpack-plugin": ^3.2.7


### PR DESCRIPTION
Reverts gocd/gocd#12020 - this broken something requiring some webpack tweaks.