### PR TITLE
Remove subversion & mercurial from container images

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -49,7 +49,7 @@ enum Distro implements DistroBehavior {
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
       return [
         // procps is needed for tanuki wrapper shell script
-        'apk add --no-cache git mercurial subversion openssh-client bash curl procps'
+        'apk add --no-cache git openssh-client bash curl procps'
       ]
     }
 
@@ -117,7 +117,7 @@ enum Distro implements DistroBehavior {
     @Override
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
       return [
-        "${pkgFor(v)} install -y git-core mercurial subversion openssh-clients bash unzip procps-ng coreutils-single glibc-langpack-en ${v.lessThan(9) ? ' curl' : ' curl-minimal'}",
+        "${pkgFor(v)} install -y git-core openssh-clients bash unzip procps-ng coreutils-single glibc-langpack-en ${v.lessThan(9) ? ' curl' : ' curl-minimal'}",
         "${pkgFor(v)} clean all",
         "rm -rf /var/cache/yum /var/cache/dnf",
       ]
@@ -153,7 +153,7 @@ enum Distro implements DistroBehavior {
     @Override
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
       return [
-        'DEBIAN_FRONTEND=noninteractive apt-get install -y git-core subversion mercurial openssh-client bash unzip curl ca-certificates locales procps coreutils',
+        'DEBIAN_FRONTEND=noninteractive apt-get install -y git-core openssh-client bash unzip curl ca-certificates locales procps coreutils',
         'DEBIAN_FRONTEND=noninteractive apt-get clean all',
         'rm -rf /var/lib/apt/lists/*',
         'echo \'en_US.UTF-8 UTF-8\' > /etc/locale.gen && /usr/sbin/locale-gen'

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -153,7 +153,7 @@ enum Distro implements DistroBehavior {
     @Override
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
       return [
-        'DEBIAN_FRONTEND=noninteractive apt-get install -y git-core subversion mercurial openssh-client bash unzip curl ca-certificates locales procps sysvinit-utils coreutils',
+        'DEBIAN_FRONTEND=noninteractive apt-get install -y git-core subversion mercurial openssh-client bash unzip curl ca-certificates locales procps coreutils',
         'DEBIAN_FRONTEND=noninteractive apt-get clean all',
         'rm -rf /var/lib/apt/lists/*',
         'echo \'en_US.UTF-8 UTF-8\' > /etc/locale.gen && /usr/sbin/locale-gen'

--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -29,14 +29,9 @@ enum PackageType {
 
       // for basic stuff like `ls`, `id`
       fpmArgs += ['--depends', 'coreutils']
-      // for `pidof`
-      fpmArgs += ['--depends', 'sysvinit-utils']
 
       // for `ps`
       fpmArgs += ['--depends', 'procps']
-
-      // for `su`
-      fpmArgs += ['--depends', 'login']
 
       // HACK: for debian packages :(, since manifests cannot contain fine grained ownership
       def tmpDir = project.file("${project.buildDir}/tmp")


### PR DESCRIPTION
All of the current container images (server and agent) include both subversion and mercurial, which GoCD does have support for.

However, these SCMs are very infrequently used, and including them does bring in a lot of other dependencies, including perl and python, increasing the security/attack surface area of the images.

This change removes these by default, leaving only git included by default in the images. Users who need these SCMs are suggested to build their own images which layer on the required SCMs.

This is estimated to reduce the image size by ~60MB (uncompressed), but will update these with the end results after official builds.