### PR TITLE
Allow caniuse DB update by force transforming class properties

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/.babelrc
+++ b/server/src/main/webapp/WEB-INF/rails/.babelrc
@@ -30,5 +30,8 @@
         "pragma": "m"
       }
     ]
-  ]
+  ],
+  // Workaround for "Module parse failed: Unexpected token" on class properties.
+  // Likely can be removed with Webpack 5.
+  "plugins": ["@babel/plugin-transform-class-properties"]
 }

--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -129,7 +129,6 @@
   "resolutions": {
     "chokidar@npm:2.1.8/glob-parent": "^5.1.2",
     "webpack@npm:4.47.0/terser-webpack-plugin": "^4.2.3",
-    "caniuse-lite": "1.0.30001538",
     "jasmine-browser-runner@^2.3.0": "patch:jasmine-browser-runner@npm%3A2.3.0#./.yarn/patches/jasmine-browser-runner-npm-2.3.0-40f5d8899b.patch"
   },
   "packageManager": "yarn@3.6.4"

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -3501,10 +3501,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:1.0.30001538":
-  version: 1.0.30001538
-  resolution: "caniuse-lite@npm:1.0.30001538"
-  checksum: 94c5d55757a339c7cc175f08a024671e2b4e7c04f130b1015793303d637061347efb6ad84447c3b8137333e742d150b8ad9672716bbf2482646c2e63a56f6c55
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001541":
+  version: 1.0.30001543
+  resolution: "caniuse-lite@npm:1.0.30001543"
+  checksum: 1a65c8b0b93913b6241c7d66e1e1f3ea0f194f7e140eefe500512641c2eb4df285991ec9869a1ba2856ea6f6d21e9f3d7bcd91971b5fb1721e3fa0390feec6f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Follow-up to #12063

The caniuse DB update moved our Safari minimum to v15, which meant Babel no longer tried to transform class properties as a side effect.

Unfortunately this seems to cause other unexplained issues with non-typescript files. Typescript was possibly OK because currently due to similar issues it is still targetting `es5`. Tried force updating terser and acorn but it didn't seem to have any effect, so probably something I am missing.

Better to avoid issues with other transitive dependency updates by transforming these for now to re-look at with Webpack 5 upgrade.

The errors prior were
```
ERROR in ./webpack/models/dashboard/material.js 22:17
Module parse failed: Unexpected token (22:17)
File was processed with these loaders:
 * ./node_modules/thread-loader/dist/cjs.js
 * ./node_modules/cache-loader/dist/cjs.js
 * ./node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
| import { AjaxHelper } from "helpers/ajax_helper";
| export class Material {
>   selectRevision = revision => {
|     this.updateSearchText(revision);
|     this.selection(revision);
 @ ./webpack/models/dashboard/trigger_with_options_info.js 20:0-53 87:15-23
 @ ./spec/webpack/views/dashboard/trigger_with_options/modal_body_spec.js
 @ ./spec/webpack/views sync \.(js|msx|ts|tsx)$
 @ ./spec/webpack/specRoot.js

ERROR in ./webpack/models/dashboard/dashboard_groups.js 41:18
Module parse failed: Unexpected token (41:18)
File was processed with these loaders:
 * ./node_modules/thread-loader/dist/cjs.js
 * ./node_modules/cache-loader/dist/cjs.js
 * ./node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
| }
| class PipelineGroup extends Group {
>   showEmptyGroups = false;
|   show = Stream(false);
|   constructor(data, showEmptyGroups) {
 @ ./webpack/models/dashboard/dashboard.js 21:0-68 24:23-38 25:21-36 34:30-45 35:28-43 38:36-51
 @ ./webpack/single_page_apps/new_dashboard.js

ERROR in ./webpack/views/dashboard/dashboard_groups_widget.js.msx 63:7
Module parse failed: Unexpected token (63:7)
File was processed with these loaders:
 * ./node_modules/thread-loader/dist/cjs.js
 * ./node_modules/cache-loader/dist/cjs.js
 * ./node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
| };
| class Dropdown {
>   show = Stream(false);
|   view(vnode) {
|     const vm = vnode.attrs.vm;
 @ ./webpack/views/dashboard/dashboard_widget.js.msx 23:0-80 80:24-45
 @ ./webpack/single_page_apps/new_dashboard.js
 ```