### PR TITLE
Make plugin location monitor tests faster and more robust

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -509,7 +509,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     }
 
     public long getUnresponsiveJobWarningThreshold() {
-        return Long.parseLong(getPropertyImpl(UNRESPONSIVE_JOB_WARNING_THRESHOLD, "5")) * 60 * 1000;//mins to mills
+        return Long.parseLong(getPropertyImpl(UNRESPONSIVE_JOB_WARNING_THRESHOLD, "5")) * 60 * 1000; // mins to millis
     }
 
     public boolean getParentLoaderPriority() {
@@ -694,6 +694,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public boolean shouldInitializeConfigRepositoriesOnStartup() {
         return INITIALIZE_CONFIG_REPOSITORIES_ON_STARTUP.getValue();
+    }
+
+    public long getPluginLocationMonitorIntervalInMillis() {
+        return SECONDS.toMillis(PLUGIN_LOCATION_MONITOR_INTERVAL_IN_SECONDS.getValue());
     }
 
     public static abstract class GoSystemProperty<T> {

--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/DefaultExternalPluginJarLocationMonitorTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/DefaultExternalPluginJarLocationMonitorTest.java
@@ -22,25 +22,32 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
+import java.time.Duration;
 
 import static com.thoughtworks.go.util.SystemEnvironment.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.mockito.Mockito.*;
 
 @DisabledOnOs(OS.WINDOWS)
+@ExtendWith(MockitoExtension.class)
 class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocationMonitorTest {
 
     private File pluginBundledDir;
     private File pluginExternalDir;
 
     private DefaultPluginJarLocationMonitor monitor;
-    private PluginJarChangeListener changeListener;
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private SystemEnvironment systemEnvironment;
 
     @BeforeEach
@@ -50,19 +57,17 @@ class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefaultPluginJ
         pluginBundledDir = this.tempFolder.newFolder("bundledDir");
         pluginExternalDir = this.tempFolder.newFolder("externalDir");
 
-        systemEnvironment = mock(SystemEnvironment.class);
-        when(systemEnvironment.get(PLUGIN_LOCATION_MONITOR_INTERVAL_IN_SECONDS)).thenReturn(1);
+        when(systemEnvironment.getPluginLocationMonitorIntervalInMillis()).thenReturn(100L);
         when(systemEnvironment.get(PLUGIN_GO_PROVIDED_PATH)).thenReturn(pluginBundledDir.getAbsolutePath());
         when(systemEnvironment.get(PLUGIN_EXTERNAL_PROVIDED_PATH)).thenReturn(pluginExternalDir.getAbsolutePath());
         when(systemEnvironment.get(PLUGIN_WORK_DIR)).thenReturn(pluginWorkDir.getAbsolutePath());
 
-        changeListener = mock(PluginJarChangeListener.class);
         monitor = new DefaultPluginJarLocationMonitor(systemEnvironment);
         monitor.initialize();
     }
 
     @AfterEach
-    void tearDown() throws Exception {
+    void tearDown() {
         monitor.stop();
     }
 
@@ -74,7 +79,7 @@ class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefaultPluginJ
     }
 
     @Test
-    void shouldThrowUpWhenExternalPluginDirectoryCreationFails() throws Exception {
+    void shouldThrowUpWhenExternalPluginDirectoryCreationFails() {
         when(systemEnvironment.get(PLUGIN_EXTERNAL_PROVIDED_PATH)).thenReturn("/xyz");
         assertThatCode(() -> new DefaultPluginJarLocationMonitor(systemEnvironment).initialize())
                 .hasMessage("Failed to create external plugins folder in location /xyz");
@@ -85,10 +90,11 @@ class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefaultPluginJ
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
 
-        copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-plugin-2.jar");
-        waitUntilNextRun(monitor);
+        BundleOrPluginFileDetails plugin2 = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin-2.jar", false);
 
-        verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin-2.jar", false));
+        copyPluginToThePluginDirectory(plugin2);
+
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin2);
         verifyNoMoreInteractions(changeListener);
     }
 
@@ -97,8 +103,10 @@ class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefaultPluginJ
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
 
-        copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-plugin.something-other-than-jar.zip");
-        waitUntilNextRun(monitor);
+        BundleOrPluginFileDetails plugin = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin.something-other-than-jar.zip", false);
+        
+        copyPluginToThePluginDirectory(plugin);
+        assertTimeout(Duration.ofMillis(MONITOR_WAIT_MILLIS), () -> monitor.hasRunAtLeastOnce());
 
         verifyNoMoreInteractions(changeListener);
     }
@@ -107,14 +115,15 @@ class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefaultPluginJ
     void shouldDetectRemovedPluginJar() throws Exception {
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
-        copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-plugin-2.jar");
-        waitUntilNextRun(monitor);
-        verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin-2.jar", false));
 
-        FileUtils.deleteQuietly(new File(pluginExternalDir, "descriptor-aware-test-plugin-2.jar"));
-        waitUntilNextRun(monitor);
+        BundleOrPluginFileDetails plugin2 = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin-2.jar", false);
 
-        verify(changeListener).pluginJarRemoved(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin-2.jar", false));
+        copyPluginToThePluginDirectory(plugin2);
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin2);
+
+        FileUtils.deleteQuietly(plugin2.file());
+
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarRemoved(plugin2);
         verifyNoMoreInteractions(changeListener);
     }
 
@@ -123,16 +132,19 @@ class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefaultPluginJ
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
 
-        copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar");
-        waitUntilNextRun(monitor);
-        verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false));
+        BundleOrPluginFileDetails plugin1 = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin-1.jar", false);
+        BundleOrPluginFileDetails plugin2 = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin-2.jar", false);
+        BundleOrPluginFileDetails plugin3 = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin-3.jar", false);
 
-        copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-2.jar");
-        copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-3.jar");
-        waitUntilNextRun(monitor);
-        verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-2.jar", false));
-        verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-3.jar", false));
-        verifyNoMoreInteractions(changeListener);
+        copyPluginToThePluginDirectory(plugin1);
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin1);
+
+        copyPluginToThePluginDirectory(plugin2);
+        copyPluginToThePluginDirectory(plugin3);
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin2);
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin3);
+
+        verifyNoMoreInteractionsOtherThanPhantomUpdatesFor(plugin1, plugin2, plugin3);
     }
 
     @Test
@@ -140,20 +152,23 @@ class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefaultPluginJ
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
 
-        copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar");
-        copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-2.jar");
-        copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-3.jar");
-        waitUntilNextRun(monitor);
-        verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false));
-        verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-2.jar", false));
-        verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-3.jar", false));
+        BundleOrPluginFileDetails plugin1 = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin-1.jar", false);
+        BundleOrPluginFileDetails plugin2 = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin-2.jar", false);
+        BundleOrPluginFileDetails plugin3 = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin-3.jar", false);
 
-        FileUtils.deleteQuietly(new File(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar"));
-        FileUtils.deleteQuietly(new File(pluginExternalDir, "descriptor-aware-test-external-plugin-2.jar"));
-        waitUntilNextRun(monitor);
-        verify(changeListener).pluginJarRemoved(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false));
-        verify(changeListener).pluginJarRemoved(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-2.jar", false));
-        verifyNoMoreInteractions(changeListener);
+        copyPluginToThePluginDirectory(plugin1);
+        copyPluginToThePluginDirectory(plugin2);
+        copyPluginToThePluginDirectory(plugin3);
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin1);
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin2);
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin3);
+
+        FileUtils.deleteQuietly(plugin1.file());
+        FileUtils.deleteQuietly(plugin2.file());
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarRemoved(plugin1);
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarRemoved(plugin2);
+
+        verifyNoMoreInteractionsOtherThanPhantomUpdatesFor(plugin1, plugin2, plugin3);
     }
 
     @Test
@@ -161,19 +176,17 @@ class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefaultPluginJ
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
 
-        copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar");
-        waitUntilNextRun(monitor);
         BundleOrPluginFileDetails orgExternalFile = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false);
-        verify(changeListener).pluginJarAdded(orgExternalFile);
-
         BundleOrPluginFileDetails newExternalFile = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1-new.jar", false);
+
+        copyPluginToThePluginDirectory(orgExternalFile);
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(orgExternalFile);
+
         FileUtils.moveFile(orgExternalFile.file(), newExternalFile.file());
 
-        waitUntilNextRun(monitor);
-
         InOrder inOrder = inOrder(changeListener);
-        inOrder.verify(changeListener).pluginJarRemoved(orgExternalFile);
-        inOrder.verify(changeListener).pluginJarAdded(newExternalFile);
+        inOrder.verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarRemoved(orgExternalFile);
+        inOrder.verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(newExternalFile);
         verifyNoMoreInteractions(changeListener);
     }
 
@@ -181,14 +194,15 @@ class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefaultPluginJ
     void shouldNotifyListenersOfUpdatesToPluginJars() throws Exception {
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
-        copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin.jar");
-        waitUntilNextRun(monitor);
-        verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin.jar", false));
 
-        updateFileContents(new File(pluginExternalDir, "descriptor-aware-test-external-plugin.jar"));
-        waitUntilNextRun(monitor);
+        BundleOrPluginFileDetails plugin = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin.jar", false);
 
-        verify(changeListener).pluginJarUpdated(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin.jar", false));
+        copyPluginToThePluginDirectory(plugin);
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin);
+
+        updateFileContents(plugin.file());
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarUpdated(plugin);
+
         verifyNoMoreInteractions(changeListener);
     }
 
@@ -197,29 +211,32 @@ class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefaultPluginJ
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
 
-        copyPluginToThePluginDirectory(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar");
-        copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar");
-        waitUntilNextRun(monitor);
+        BundleOrPluginFileDetails bundledPlugin1 = pluginFileDetails(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar", true);
+        BundleOrPluginFileDetails externalPlugin1 = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false);
+
+        copyPluginToThePluginDirectory(bundledPlugin1);
+        copyPluginToThePluginDirectory(externalPlugin1);
         InOrder jarAddedOrder = inOrder(changeListener);
-        jarAddedOrder.verify(changeListener).pluginJarAdded(pluginFileDetails(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar", true));
-        jarAddedOrder.verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false));
+        jarAddedOrder.verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(bundledPlugin1);
+        jarAddedOrder.verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(externalPlugin1);
 
+        verifyNoMoreInteractionsOtherThanPhantomUpdatesFor(bundledPlugin1, externalPlugin1);
 
-        updateFileContents(new File(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar"));
-        updateFileContents(new File(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar"));
-        waitUntilNextRun(monitor);
+        updateFileContents(bundledPlugin1.file());
+        updateFileContents(externalPlugin1.file());
         InOrder jarUpdatedOrder = inOrder(changeListener);
-        jarUpdatedOrder.verify(changeListener).pluginJarUpdated(pluginFileDetails(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar", true));
-        jarUpdatedOrder.verify(changeListener).pluginJarUpdated(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false));
+        jarUpdatedOrder.verify(changeListener, timeout(MONITOR_WAIT_MILLIS).atLeastOnce()).pluginJarUpdated(bundledPlugin1);
+        jarUpdatedOrder.verify(changeListener, timeout(MONITOR_WAIT_MILLIS).atLeastOnce()).pluginJarUpdated(externalPlugin1);
 
-        FileUtils.deleteQuietly(new File(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar"));
-        FileUtils.deleteQuietly(new File(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar"));
-        waitUntilNextRun(monitor);
+        verifyNoMoreInteractionsOtherThanPhantomUpdatesFor(bundledPlugin1, externalPlugin1);
+
+        FileUtils.deleteQuietly(bundledPlugin1.file());
+        FileUtils.deleteQuietly(externalPlugin1.file());
         InOrder jarRemovedOrder = inOrder(changeListener);
-        jarRemovedOrder.verify(changeListener).pluginJarRemoved(pluginFileDetails(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar", true));
-        jarRemovedOrder.verify(changeListener).pluginJarRemoved(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false));
+        jarRemovedOrder.verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarRemoved(bundledPlugin1);
+        jarRemovedOrder.verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarRemoved(externalPlugin1);
 
-        verifyNoMoreInteractions(changeListener);
+        verifyNoMoreInteractionsOtherThanPhantomUpdatesFor(bundledPlugin1, externalPlugin1);
     }
 
     @Test
@@ -227,14 +244,16 @@ class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefaultPluginJ
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
 
-        copyPluginToThePluginDirectory(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar");
-        copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar");
+        BundleOrPluginFileDetails bundledPlugin1 = pluginFileDetails(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar", true);
+        BundleOrPluginFileDetails externalPlugin1 = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false);
+
+        copyPluginToThePluginDirectory(bundledPlugin1);
+        copyPluginToThePluginDirectory(externalPlugin1);
         ArgumentCaptor<BundleOrPluginFileDetails> pluginFileDetailsArgumentCaptor = ArgumentCaptor.forClass(BundleOrPluginFileDetails.class);
-        waitUntilNextRun(monitor);
-        verify(changeListener, times(2)).pluginJarAdded(pluginFileDetailsArgumentCaptor.capture());
+        verify(changeListener, timeout(MONITOR_WAIT_MILLIS).times(2)).pluginJarAdded(pluginFileDetailsArgumentCaptor.capture());
         assertThat(pluginFileDetailsArgumentCaptor.getAllValues().get(0).isBundledPlugin()).isTrue();
         assertThat(pluginFileDetailsArgumentCaptor.getAllValues().get(1).isBundledPlugin()).isFalse();
-        verifyNoMoreInteractions(changeListener);
 
+        verifyNoMoreInteractionsOtherThanPhantomUpdatesFor(bundledPlugin1, externalPlugin1);
     }
 }


### PR DESCRIPTION
These fail sporadically quite often, because file system events are a bit unpredictable, and because of race conditions in assertions. Simplify, speed up and improve these.