### PR TITLE
Fix remaining plugin monitor test stability using atomic FS operations

### DIFF
--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitorTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitorTest.java
@@ -30,7 +30,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
 import java.time.Duration;
-import java.util.List;
 
 import static com.thoughtworks.go.util.SystemEnvironment.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,6 +48,9 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
     @Mock(strictness = Mock.Strictness.LENIENT)
     private SystemEnvironment systemEnvironment;
 
+    @Mock
+    PluginJarChangeListener changeListener;
+
     @Override
     @BeforeEach
     void setUp(@TempDir File tempFolder) throws Exception {
@@ -56,7 +58,7 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
 
         bundledPluginDir = this.tempFolder.newFolder("bundled-plugins");
 
-        when(systemEnvironment.getPluginLocationMonitorIntervalInMillis()).thenReturn(100L);
+        when(systemEnvironment.getPluginLocationMonitorIntervalInMillis()).thenReturn(TEST_MONITOR_INTERVAL_MILLIS);
         when(systemEnvironment.get(PLUGIN_GO_PROVIDED_PATH)).thenReturn(bundledPluginDir.getAbsolutePath());
         when(systemEnvironment.get(PLUGIN_EXTERNAL_PROVIDED_PATH)).thenReturn(this.tempFolder.newFolder("external-plugins").getAbsolutePath());
         when(systemEnvironment.get(PLUGIN_WORK_DIR)).thenReturn(pluginWorkDir.getAbsolutePath());
@@ -79,10 +81,10 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
 
     @Test
     void shouldNotFailIfNoListenerIsPresentWhenAPluginJarIsAdded() throws Exception {
-        copyPluginToThePluginDirectory(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true));
+        addPlugin(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true));
         monitor.start();
 
-        assertTimeout(Duration.ofMillis(MONITOR_WAIT_MILLIS), () -> monitor.hasRunAtLeastOnce());
+        assertTimeout(Duration.ofMillis(TEST_TIMEOUT), () -> monitor.hasRunAtLeastOnce());
 
         verifyNoMoreInteractions(changeListener);
     }
@@ -93,9 +95,9 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
         monitor.start();
 
         BundleOrPluginFileDetails plugin = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true);
-        copyPluginToThePluginDirectory(plugin);
+        addPlugin(plugin);
 
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin);
         verifyNoMoreInteractions(changeListener);
     }
 
@@ -104,9 +106,9 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
 
-        copyPluginToThePluginDirectory(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.something-other-than-jar.zip", true));
+        addPlugin(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.something-other-than-jar.zip", true));
 
-        assertTimeout(Duration.ofMillis(MONITOR_WAIT_MILLIS), () -> monitor.hasRunAtLeastOnce());
+        assertTimeout(Duration.ofMillis(TEST_TIMEOUT), () -> monitor.hasRunAtLeastOnce());
 
         verifyNoMoreInteractions(changeListener);
     }
@@ -118,11 +120,11 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
         BundleOrPluginFileDetails plugin = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true);
 
         monitor.addPluginJarChangeListener(changeListener);
-        copyPluginToThePluginDirectory(plugin);
+        addPlugin(plugin);
         monitor.start();
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin);
 
-        FileUtils.deleteQuietly(plugin.file());
+        deletePlugin(plugin);
 
         verifyNoMoreInteractions(changeListener);
     }
@@ -134,12 +136,12 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
 
         BundleOrPluginFileDetails plugin = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true);
 
-        copyPluginToThePluginDirectory(plugin);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin);
+        addPlugin(plugin);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin);
 
-        FileUtils.deleteQuietly(plugin.file());
+        deletePlugin(plugin);
 
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarRemoved(plugin);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarRemoved(plugin);
         verify(changeListener, never()).pluginJarUpdated(any());
         verifyNoMoreInteractions(changeListener);
     }
@@ -153,16 +155,16 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
         BundleOrPluginFileDetails plugin2 = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-2.jar", true);
         BundleOrPluginFileDetails plugin3 = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-3.jar", true);
 
-        copyPluginToThePluginDirectory(plugin1);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin1);
+        addPlugin(plugin1);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin1);
 
-        copyPluginToThePluginDirectory(plugin2);
-        copyPluginToThePluginDirectory(plugin3);
+        addPlugin(plugin2);
+        addPlugin(plugin3);
 
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin2);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin3);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin2);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin3);
 
-        verifyNoMoreInteractionsOtherThanPhantomUpdatesFor(plugin1, plugin2, plugin3);
+        verifyNoMoreInteractions(changeListener);
     }
 
     @Test
@@ -177,23 +179,19 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
         BundleOrPluginFileDetails plugin2 = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-2.jar", true);
         BundleOrPluginFileDetails plugin3 = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-3.jar", true);
 
-        copyPluginToThePluginDirectory(plugin1);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin1);
-        verify(exceptionRaisingListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin1);
+        addPlugin(plugin1);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin1);
+        verify(exceptionRaisingListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin1);
 
-        copyPluginToThePluginDirectory(plugin2);
-        copyPluginToThePluginDirectory(plugin3);
+        addPlugin(plugin2);
+        addPlugin(plugin3);
 
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin2);
-        verify(exceptionRaisingListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin2);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin3);
-        verify(exceptionRaisingListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin3);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin2);
+        verify(exceptionRaisingListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin2);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin3);
+        verify(exceptionRaisingListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin3);
 
-        verifyNoMoreInteractionsOtherThanPhantomUpdatesFor(plugin1, plugin2, plugin3);
-
-        for (var plugin : List.of(plugin1, plugin2, plugin3)) {
-            verify(exceptionRaisingListener, atMostOnce()).pluginJarUpdated(plugin);
-        }
+        verifyNoMoreInteractions(changeListener);
         verifyNoMoreInteractions(exceptionRaisingListener);
     }
 
@@ -206,19 +204,19 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
         BundleOrPluginFileDetails plugin2 = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-2.jar", true);
         BundleOrPluginFileDetails plugin3 = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-3.jar", true);
 
-        copyPluginToThePluginDirectory(plugin1);
-        copyPluginToThePluginDirectory(plugin2);
-        copyPluginToThePluginDirectory(plugin3);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin1);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin2);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin3);
+        addPlugin(plugin1);
+        addPlugin(plugin2);
+        addPlugin(plugin3);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin1);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin2);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin3);
 
-        FileUtils.deleteQuietly(plugin1.file());
-        FileUtils.deleteQuietly(plugin2.file());
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarRemoved(plugin1);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarRemoved(plugin2);
+        deletePlugin(plugin1);
+        deletePlugin(plugin2);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarRemoved(plugin1);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarRemoved(plugin2);
 
-        verifyNoMoreInteractionsOtherThanPhantomUpdatesFor(plugin1, plugin2, plugin3);
+        verifyNoMoreInteractions(changeListener);
     }
 
     @Test
@@ -229,14 +227,14 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
         BundleOrPluginFileDetails orgFile = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1.jar", true);
         BundleOrPluginFileDetails newFile = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1-new.jar", true);
 
-        copyPluginToThePluginDirectory(orgFile);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(orgFile);
+        addPlugin(orgFile);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(orgFile);
 
         FileUtils.moveFile(orgFile.file(), newFile.file());
 
         InOrder inOrder = inOrder(changeListener);
-        inOrder.verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarRemoved(orgFile);
-        inOrder.verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(newFile);
+        inOrder.verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarRemoved(orgFile);
+        inOrder.verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(newFile);
         verifyNoMoreInteractions(changeListener);
     }
 
@@ -247,11 +245,11 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
 
         BundleOrPluginFileDetails plugin = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true);
 
-        copyPluginToThePluginDirectory(plugin);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin);
+        addPlugin(plugin);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin);
 
-        updateFileContents(plugin.file());
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarUpdated(plugin);
+        updatePlugin(plugin);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarUpdated(plugin);
 
         verifyNoMoreInteractions(changeListener);
     }
@@ -263,8 +261,8 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
 
         BundleOrPluginFileDetails plugin = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true);
 
-        copyPluginToThePluginDirectory(plugin);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin);
+        addPlugin(plugin);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin);
     }
 
     @Test
@@ -273,11 +271,11 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
         monitor.start();
         BundleOrPluginFileDetails plugin = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true);
 
-        copyPluginToThePluginDirectory(plugin);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin);
+        addPlugin(plugin);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin);
 
-        FileUtils.deleteQuietly(plugin.file());
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarRemoved(plugin);
+        deletePlugin(plugin);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarRemoved(plugin);
     }
 
     @Test
@@ -288,19 +286,19 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
         BundleOrPluginFileDetails orgFile = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1.jar", true);
         BundleOrPluginFileDetails newFile = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1-new.jar", true);
 
-        copyPluginToThePluginDirectory(orgFile);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(orgFile);
+        addPlugin(orgFile);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(orgFile);
 
         FileUtils.moveFile(orgFile.file(), newFile.file());
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarRemoved(orgFile);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(newFile);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarRemoved(orgFile);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(newFile);
     }
 
     @Test
     void shouldNotCreatePluginZipIfPluginJarIsNeitherUpdatedNorAddedOrRemoved() {
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
-        assertTimeout(Duration.ofMillis(MONITOR_WAIT_MILLIS), () -> monitor.hasRunAtLeastOnce());
+        assertTimeout(Duration.ofMillis(TEST_TIMEOUT), () -> monitor.hasRunAtLeastOnce());
     }
 
     @Test
@@ -311,13 +309,13 @@ class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJarLocati
         BundleOrPluginFileDetails plugin1 = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1.jar", true);
         BundleOrPluginFileDetails plugin2 = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-2.jar", true);
 
-        copyPluginToThePluginDirectory(plugin1);
-        verify(changeListener, timeout(MONITOR_WAIT_MILLIS)).pluginJarAdded(plugin1);
+        addPlugin(plugin1);
+        verify(changeListener, timeout(TEST_TIMEOUT)).pluginJarAdded(plugin1);
 
         monitor.removePluginJarChangeListener(changeListener);
-        copyPluginToThePluginDirectory(plugin2);
+        addPlugin(plugin2);
         long removed = System.currentTimeMillis();
-        assertTimeout(Duration.ofMillis(MONITOR_WAIT_MILLIS), () -> monitor.hasRunSince(removed));
+        assertTimeout(Duration.ofMillis(TEST_TIMEOUT), () -> monitor.hasRunSince(removed));
 
         verifyNoMoreInteractions(changeListener);
     }


### PR DESCRIPTION
Fixes remaining instability after #12084.

Phantom updates are caused by streaming the test plugin rather than atomically moving it. Fixes this :-)