### PR TITLE
Avoid asset hashes changing when content doesn't change

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/config/loaders/static-assets-loader.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/config/loaders/static-assets-loader.ts
@@ -24,7 +24,7 @@ export function getStaticAssetsLoader(configOptions: ConfigOptions): webpack.Rul
       {
         loader: "file-loader",
         options: {
-          name: configOptions.production ? "[name]-[hash].[ext]" : "[name].[ext]",
+          name: configOptions.production ? "[name]-[contenthash].[ext]" : "[name].[ext]",
           outputPath: configOptions.production ? "media/" : "fonts/",
           esModule: false
         }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/config/plugins.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/config/plugins.ts
@@ -69,10 +69,8 @@ export function plugins(configOptions: ConfigOptions): webpack.Plugin[] {
 
   if (configOptions.production) {
     plugins.push(new MiniCssExtractPlugin({
-                                            // Options similar to the same options in webpackOptions.output
-                                            // both options are optional
-                                            filename: "[name]-[hash].css",
-                                            chunkFilename: "[id]-[hash].css",
+                                            filename: "[name]-[contenthash].css",
+                                            chunkFilename: "[id]-[contenthash].css",
                                             ignoreOrder: true
                                           }) as unknown as webpack.Plugin);
   } else {


### PR DESCRIPTION
We don't need to have the hashes change just because the build is re-run, it makes comparisons harder and reduces reproducibility and effectively of caching. Also prepares for Webpack 5.