### PR TITLE
Improve error logging during agent token acquisition failures

### DIFF
--- a/agent-common/src/main/java/com/thoughtworks/go/agent/common/launcher/AgentProcessParent.java
+++ b/agent-common/src/main/java/com/thoughtworks/go/agent/common/launcher/AgentProcessParent.java
@@ -23,5 +23,5 @@ public interface AgentProcessParent {
     int run(
             @Deprecated //launcherVersion is unused, but keeping it around because the bootstrapper has this contract with the agent launcher
                     String launcherVersion,
-            String launcherMd5, ServerUrlGenerator urlGenerator, Map<String, String> env, Map context);
+            String launcherMd5, ServerUrlGenerator urlGenerator, Map<String, String> env, Map<String, String> context);
 }

--- a/agent-process-launcher/src/main/java/com/thoughtworks/go/agent/AgentProcessParentImpl.java
+++ b/agent-process-launcher/src/main/java/com/thoughtworks/go/agent/AgentProcessParentImpl.java
@@ -44,9 +44,9 @@ public class AgentProcessParentImpl implements AgentProcessParent {
     static final String GO_AGENT_STDOUT_LOG = "go-agent-stdout.log";
 
     @Override
-    public int run(String launcherVersion, String launcherMd5, ServerUrlGenerator urlGenerator, Map<String, String> env, Map context) {
+    public int run(String launcherVersion, String launcherMd5, ServerUrlGenerator urlGenerator, Map<String, String> env, Map<String, String> context) {
         int exitValue = 0;
-        LOG.info("Agent is version: {}", CurrentGoCDVersion.getInstance().fullVersion());
+        LOG.info("Agent launcher is version: {}", CurrentGoCDVersion.getInstance().fullVersion());
         String[] command = new String[]{};
 
         try {
@@ -105,12 +105,11 @@ public class AgentProcessParentImpl implements AgentProcessParent {
     private void removeShutdownHook(Shutdown shutdownHook) {
         try {
             Runtime.getRuntime().removeShutdownHook(shutdownHook);
-        } catch (Exception e) {
+        } catch (Exception ignore) {
         }
     }
 
-    private String[] agentInvocationCommand(String agentMD5, String launcherMd5, String agentPluginsZipMd5, String tfsImplMd5, Map<String, String> env, Map context,
-                                            // the port is kept for backward compatibility to ensure that old bootstrappers are able to launch new agents
+    private String[] agentInvocationCommand(String agentMD5, String launcherMd5, String agentPluginsZipMd5, String tfsImplMd5, Map<String, String> env, Map<String, String> context,
                                             Map<String, String> extraProperties) {
         AgentBootstrapperArgs bootstrapperArgs = AgentBootstrapperArgs.fromProperties(context);
 
@@ -133,9 +132,9 @@ public class AgentProcessParentImpl implements AgentProcessParent {
         commandSnippets.add(property(GoConstants.AGENT_JAR_MD5, agentMD5));
         commandSnippets.add(property(GoConstants.GIVEN_AGENT_LAUNCHER_JAR_MD5, launcherMd5));
         commandSnippets.add(property(GoConstants.TFS_IMPL_MD5, tfsImplMd5));
-        commandSnippets.add(property(GoConstants.AGENT_BOOTSTRAPPER_VERSION, (String) context.getOrDefault(GoConstants.AGENT_BOOTSTRAPPER_VERSION, "UNKNOWN")));
-        commandSnippets.add("-jar");
+        commandSnippets.add(property(GoConstants.AGENT_BOOTSTRAPPER_VERSION, context.getOrDefault(GoConstants.AGENT_BOOTSTRAPPER_VERSION, "UNKNOWN")));
 
+        commandSnippets.add("-jar");
         commandSnippets.add(Downloader.AGENT_BINARY);
 
         commandSnippets.add("-serverUrl");

--- a/agent/src/main/java/com/thoughtworks/go/agent/service/AgentUpgradeService.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/service/AgentUpgradeService.java
@@ -15,9 +15,9 @@
  */
 package com.thoughtworks.go.agent.service;
 
+import com.thoughtworks.go.agent.URLService;
 import com.thoughtworks.go.agent.common.ssl.GoAgentServerHttpClient;
 import com.thoughtworks.go.util.SystemEnvironment;
-import com.thoughtworks.go.agent.URLService;
 import org.apache.http.Header;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -96,7 +96,7 @@ public class AgentUpgradeService {
             validateMd5(tfsImplMd5, response, AGENT_TFS_SDK_MD5_HEADER, "tfs-impl jar");
             updateExtraProperties(response.getFirstHeader(AGENT_EXTRA_PROPERTIES_HEADER));
         } catch (IOException ioe) {
-            String message = String.format("[Agent Upgrade] Couldn't connect to: %s: %s", urlService.getAgentLatestStatusUrl(), ioe.toString());
+            String message = String.format("[Agent Upgrade] Couldn't connect to: %s: %s", urlService.getAgentLatestStatusUrl(), ioe);
             LOGGER.error(message);
             LOGGER.debug(message, ioe);
             throw ioe;

--- a/agent/src/main/java/com/thoughtworks/go/agent/service/SslInfrastructureService.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/service/SslInfrastructureService.java
@@ -15,12 +15,12 @@
  */
 package com.thoughtworks.go.agent.service;
 
+import com.thoughtworks.go.agent.URLService;
 import com.thoughtworks.go.agent.common.ssl.GoAgentServerHttpClient;
 import com.thoughtworks.go.config.AgentAutoRegistrationProperties;
 import com.thoughtworks.go.config.AgentRegistry;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 import com.thoughtworks.go.util.SystemUtil;
-import com.thoughtworks.go.agent.URLService;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -99,7 +99,7 @@ public class SslInfrastructureService {
                 getTokenIfNecessary();
                 registered = remoteRegistrationRequester.requestRegistration(hostName, agentAutoRegistrationProperties);
             } catch (Exception e) {
-                LOGGER.error("[Agent Registration] There was a problem registering with the GoCD server.", e);
+                LOGGER.error("[Agent Registration] There was a problem registering with the GoCD server.");
                 throw e;
             }
 


### PR DESCRIPTION
- Avoid duplicating stack trace logging
- Avoid logging massive HTML content when servers/reverse proxies are returning it during startup (includes 503 GoCD starting page)