### PR TITLE
Improve errors logged to assist when a database migration is locked

### DIFF
--- a/db-support/db-migration/build.gradle
+++ b/db-support/db-migration/build.gradle
@@ -50,6 +50,8 @@ dependencies {
   testRuntimeOnly project.deps.junit5Engine
   testImplementation project.deps.assertJ
   testImplementation project.deps.assertJ_DB
+  testImplementation project.deps.mockitoCore
+  testImplementation project.deps.mockitoJunit5
 
   testImplementation project.deps.testcontainers
   testImplementation project.deps.testcontainersJdbc

--- a/db-support/db-migration/src/test/java/com/thoughtworks/go/server/database/migration/AbstractMigratorIntegrationTest.java
+++ b/db-support/db-migration/src/test/java/com/thoughtworks/go/server/database/migration/AbstractMigratorIntegrationTest.java
@@ -26,7 +26,7 @@ import java.sql.SQLException;
 import static org.assertj.db.api.Assertions.assertThat;
 
 public abstract class AbstractMigratorIntegrationTest {
-    protected void migrate(JdbcDatabaseContainer container, String listTableQuery, String username, String password) throws SQLException {
+    protected void migrate(JdbcDatabaseContainer<?> container, String listTableQuery, String username, String password) throws SQLException {
         Source source = new Source(container.getJdbcUrl(), username, password);
         assertThat(new Request(source, listTableQuery))
                 .hasNumberOfRows(0);

--- a/db-support/db-migration/src/test/java/com/thoughtworks/go/server/database/migration/DatabaseMigratorTest.java
+++ b/db-support/db-migration/src/test/java/com/thoughtworks/go/server/database/migration/DatabaseMigratorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.database.migration;
+
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.exception.LiquibaseException;
+import liquibase.exception.LockException;
+import org.h2.jdbc.JdbcConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DatabaseMigratorTest {
+    @TempDir
+    private Path tempDir;
+    @Mock
+    private Liquibase liquibase;
+    private DatabaseMigrator migrator;
+
+    @BeforeEach
+    void setUp() {
+        this.migrator = new DatabaseMigrator() {
+            @Override
+            Liquibase newLiquibaseFor(Database database) {
+                return liquibase;
+            }
+        };
+    }
+
+    @Test
+    public void shouldRunMigrationOnRequestedConnection() throws Exception {
+
+        try (MockedStatic<DataMigrationRunner> migration = mockStatic(DataMigrationRunner.class)) {
+            Connection connection = dummyH2Connection();
+            migrator.migrate(connection);
+
+            verify(liquibase).update(assertArg(Contexts::isEmpty));
+            migration.verify(() -> DataMigrationRunner.run(connection));
+        }
+    }
+
+    @Test
+    public void shouldRaiseWrappedLockExceptionWhenDatabaseLocked() throws Exception {
+
+        try (MockedStatic<DataMigrationRunner> migration = mockStatic(DataMigrationRunner.class)) {
+            doThrow(new LockException("Database locked")).when(liquibase).update(assertArg(Contexts::isEmpty));
+
+            assertThatThrownBy(() -> migrator.migrate(dummyH2Connection()))
+                .isExactlyInstanceOf(SQLException.class)
+                .hasMessageContaining("Unable to migrate the database, as it is currently locked.")
+                .hasRootCauseExactlyInstanceOf(LockException.class)
+                .hasRootCauseMessage("Database locked");
+
+            migration.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    public void shouldRaiseWrappedExceptionForOtherErrors() throws Exception {
+
+        try (MockedStatic<DataMigrationRunner> migration = mockStatic(DataMigrationRunner.class)) {
+            doThrow(new LiquibaseException("Liquibase error")).when(liquibase).update(assertArg(Contexts::isEmpty));
+
+            assertThatThrownBy(() -> migrator.migrate(dummyH2Connection()))
+                .isExactlyInstanceOf(SQLException.class)
+                .hasMessageContaining("Unable to migrate the database")
+                .hasRootCauseExactlyInstanceOf(LiquibaseException.class)
+                .hasRootCauseMessage("Liquibase error");
+
+            migration.verifyNoInteractions();
+        }
+    }
+
+    private JdbcConnection dummyH2Connection() throws SQLException {
+        return new JdbcConnection("jdbc:h2:" + tempDir.resolve("testdb"), new Properties());
+    }
+}


### PR DESCRIPTION
Try to make it easier for folks to recover from issues such as #12038.