### PR TITLE
Bump packaged JDK to 17.0.9+9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,9 +149,9 @@ project.ext.packaging = [
   adoptiumJavaVersion: new AdoptiumVersion(
     feature: 17,
     interim: 0,    // set to `null` for the first release of a new featureVersion
-    update : 8,    // set to `null` for the first release of a new featureVersion
-    patch  : 1,    // set to `null` for most releases. Patch releases are "exceptional".
-    build  : 1
+    update : 9,    // set to `null` for the first release of a new featureVersion
+    patch  : null, // set to `null` for most releases. Patch releases are "exceptional".
+    build  : 9
   )
 ]
 

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/AdoptiumVersion.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/AdoptiumVersion.groovy
@@ -53,9 +53,13 @@ class AdoptiumVersion implements Serializable {
     update == null ? '' : 'U'
   }
 
+  def releaseSuffixHack(OperatingSystem os) {
+    OperatingSystem.windows == os ? '.1' : '' // Temporary hack for JDK 17.0.9 due to Windows builds being delayed
+  }
+
   def toDownloadURLFor(OperatingSystem os, Architecture arch) {
     "https://github.com/adoptium/temurin${feature}-binaries/releases/download/" +
-      "jdk-${urlSafeDisplayVersion()}/" +
+      "jdk-${urlSafeDisplayVersion()}${releaseSuffixHack(os)}/" +
       "OpenJDK${feature}${featureSuffix()}-jre_${arch.canonicalName}_${os.adoptiumAlias}_hotspot_${fileSafeDisplayVersion()}.${os.extension}"
   }
 


### PR DESCRIPTION
https://adoptium.net/temurin/release-notes/?version=jdk-17.0.9+9