### PR TITLE
Remove EOL Alpine 3.15 container image

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/BuildDockerImageTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/BuildDockerImageTask.groovy
@@ -52,11 +52,11 @@ class BuildDockerImageTask extends DefaultTask {
 
   @TaskAction
   def perform() {
-    if (distroVersion.pastEolGracePeriod) {
+    if (!project.hasProperty("skipDockerBuild") && distroVersion.pastEolGracePeriod) {
       throw new RuntimeException("The image $distro:v$distroVersion.version is unsupported. EOL was ${distroVersion.eolDate}, and GoCD build grace period has passed.")
     }
 
-    if (distroVersion.eol && !distroVersion.continueToBuild) {
+    if (!project.hasProperty("skipDockerBuild") && distroVersion.eol && !distroVersion.continueToBuild) {
       throw new RuntimeException("The image $distro:v$distroVersion.version was EOL on ${distroVersion.eolDate}. Set :continueToBuild option to continue building through the grace period.")
     }
 

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -26,7 +26,6 @@ enum Distro implements DistroBehavior {
     @Override
     List<DistroVersion> getSupportedVersions() {
       return [ // See https://endoflife.date/alpine
-        new DistroVersion(version: '3.15', releaseName: '3.15', eolDate: parseDate('2023-11-01')),
         new DistroVersion(version: '3.16', releaseName: '3.16', eolDate: parseDate('2024-05-23')),
         new DistroVersion(version: '3.17', releaseName: '3.17', eolDate: parseDate('2024-11-22')),
         new DistroVersion(version: '3.18', releaseName: '3.18', eolDate: parseDate('2025-05-09')),


### PR DESCRIPTION
Alpine 3.15 EOLed on 1st November so can remove this now.