### PR TITLE
fix: templates in alphabetical order

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/stage/pipeline_template_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/spec/tabs/pipeline/stage/pipeline_template_widget_spec.tsx
@@ -33,14 +33,16 @@ describe("Pipeline Template Widget", () => {
   afterEach(helper.unmount.bind(helper));
 
   it("should render templates dropdown", () => {
-    mount(["template1"]);
+    mount(["template3", "template1", "Template2"]);
 
     expect(helper.byTestId("form-field-label-template")).toContainText("Template");
 
     expect(helper.byTestId("form-field-input-template")).toBeInDOM();
 
-    expect(helper.qa("option")).toHaveLength(1);
+    expect(helper.qa("option")).toHaveLength(3);
     expect(helper.qa("option")[0]).toContainText("template1");
+    expect(helper.qa("option")[1]).toContainText("Template2");
+    expect(helper.qa("option")[2]).toContainText("template3");
   });
 
   it("should render no templates found message", () => {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stage/pipeline_template_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stage/pipeline_template_widget.tsx
@@ -73,8 +73,10 @@ export class PipelineTemplateWidget extends MithrilComponent<Attrs> {
   templateOptions({attrs}: { attrs: Attrs }) {
     const config = attrs.pipelineConfig;
 
-    const templatesAsOptions = _.map(attrs.templates(), (template: Template) => {
-      return {id: template.name, text: template.name} as Option;
+    const sortedTemplates = _.sortBy(attrs.templates(), (template: Template) => template.name);
+
+    const templatesAsOptions = _.map(sortedTemplates, (template: Template) => {
+      return { id: template.name, text: template.name } as Option;
     });
 
     return <SelectField label="Template"

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stage/pipeline_template_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/clicky_pipeline_config/tabs/pipeline/stage/pipeline_template_widget.tsx
@@ -73,7 +73,7 @@ export class PipelineTemplateWidget extends MithrilComponent<Attrs> {
   templateOptions({attrs}: { attrs: Attrs }) {
     const config = attrs.pipelineConfig;
 
-    const sortedTemplates = _.sortBy(attrs.templates(), (template: Template) => template.name);
+    const sortedTemplates = _.sortBy(attrs.templates(), (template: Template) => template.name.toLocaleLowerCase());
 
     const templatesAsOptions = _.map(sortedTemplates, (template: Template) => {
       return { id: template.name, text: template.name } as Option;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/template_editor_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/template_editor_spec.tsx
@@ -60,6 +60,8 @@ describe("AddPipeline: TemplateEditor", () => {
     const dropdown = helper.byTestId("form-field-input-template");
     expect(dropdown).toBeInDOM();
     expect(helper.qa("option", dropdown).length).toBe(2);
+    expect(helper.qa("option")[0]).toContainText("one");
+    expect(helper.qa("option")[1]).toContainText("two");
 
     helper.clickByTestId("switch-paddle");
     expect(isUsingTemplate()).toBe(false);
@@ -102,7 +104,7 @@ class TestCache extends TemplateCache {
   prime(onComplete: () => void) { onComplete(); }
    // tslint:disable-next-line
   invalidate() {}
-  contents() { return [{name: "one", parameters: ["paramName"]}, {name: "two", parameters: []}]; }
+  contents() { return [{name: "two", parameters: []}, {name: "one", parameters: ["paramName"]}]; }
   failureReason() { return undefined; }
   failed() { return false; }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/template_editor.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/template_editor.tsx
@@ -54,7 +54,7 @@ export class TemplateEditor extends MithrilComponent<Attrs, State> {
     }
 
     this.cache.prime(() => {
-      this.templates(this.cache.contents());
+      this.templates(_.sortBy(this.cache.contents(), (template: Template) => template.name.toLocaleLowerCase()));
     }, () => {
       this.templates([]);
     });


### PR DESCRIPTION
When you have a long list of templates it's hard to find the one you need. Having the list sorted alphabetically helps with this 

![image](https://github.com/gocd/gocd/assets/63352676/025f1208-d9cf-4b11-87f9-34420a577845)

![image](https://github.com/gocd/gocd/assets/63352676/3abbe5e2-10e8-465b-8fe5-f6ce2007d60b)
