### PR TITLE
Make Gradle dev prepare leaner by not including test code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -632,15 +632,25 @@ task allDependencies {
   description = "Print dependency tree of all projects"
 }
 
-task compileAll { compileAllTask ->
-  group LifecycleBasePlugin.BUILD_GROUP
+private allCompileTasks(Closure<Boolean> include = { t -> true }) {
   allprojects.collect { Project prj ->
-    compileAll.dependsOn(prj.getTasks().withType(JavaCompile))
-    compileAll.dependsOn(prj.getTasks().withType(GroovyCompile))
+    prj.afterEvaluate {
+      compileAll.dependsOn(prj.getTasks().withType(JavaCompile).findAll(include))
+      compileAll.dependsOn(prj.getTasks().withType(GroovyCompile).findAll(include))
+    }
   }
 }
 
-task prepare(dependsOn: compileAll)
+
+task compileAll { compileAllTask ->
+  group LifecycleBasePlugin.BUILD_GROUP
+  allCompileTasks()
+}
+
+task prepare {
+  group LifecycleBasePlugin.BUILD_GROUP
+  allCompileTasks { Task task -> !task.name.toLowerCase().contains('test') && !task.project.path.toLowerCase().contains('test') }
+}
 
 task sparkTest { thisTask ->
   group LifecycleBasePlugin.VERIFICATION_GROUP

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/ExecuteUnderRailsTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/ExecuteUnderRailsTask.groovy
@@ -34,8 +34,7 @@ class ExecuteUnderRailsTask extends JavaExec {
 
   ExecuteUnderRailsTask() {
     super()
-    dependsOn(project.railsTasksDefaultDependsOn)
-    dependsOn(':server:pathingJar')
+    dependsOn(':server:initializeRailsGems', ':server:cleanDb', ':server:createJRubyBinstubs', ':server:pathingJar')
 
     originalEnv = new LinkedHashMap<String, Object>(environment)
     workingDir = project.railsRoot

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -170,17 +170,6 @@ project.ext.railsSystemProperties = [
   'jdk.net.URLClassPath.disableClassPathURLCheck': true
 ]
 
-project.ext.railsTasksDefaultDependsOn = [
-  ':server:initializeRailsGems',
-  ':server:cleanDb',
-  ':server:createJRubyBinstubs',
-  project.sourceSets.main.runtimeClasspath,
-  project.sourceSets.test.runtimeClasspath,
-  project.configurations.spark,
-  project.sourceSets.sharedTest.runtimeClasspath,
-  project.sourceSets.fastUnitTest.runtimeClasspath
-]
-
 project.ext.jrubyexec = { Closure<JavaExecSpec> cl ->
   try {
     project.javaexec { JavaExecSpec javaExecSpec ->
@@ -282,7 +271,7 @@ dependencies {
     implementation project.deps.commonsFileUpload
   }
   implementation project.deps.aspectj
-  implementation project.deps.urlrewrite
+  implementation files('lib/urlrewritefilter-4.0.5-SNAPSHOT.jar')
 
   implementation project.deps.freemarker
   implementation project.deps.guava

--- a/server/rails.gradle
+++ b/server/rails.gradle
@@ -25,7 +25,7 @@ import org.gradle.internal.jvm.Jvm
 
 task pathingJar(type: Jar) {
   archiveClassifier = 'pathing'
-  dependsOn(project.railsTasksDefaultDependsOn)
+  dependsOn(project.railsClasspath, project.configurations.compileClasspath)
 
   doFirst {
     manifest {


### PR DESCRIPTION
When doing a prepare for local dev, there's no need to compile all the test code - and this takes ages. Probably not necessary to compile all production code either, but let's leave that there.

Also clean up dependencies on rails tasks so they are bit easier to grok.