### PR TITLE
Fix console log menu scroll pinning

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/build_detail_page.js
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/build_detail_page.js
@@ -150,7 +150,7 @@
       $(".content_wrapper_outer").toggleClass("full-screen");
       $(window).trigger($.Event("resetPinOnScroll"), [{
         calcRequiredScroll: function () {
-          return $(".console-area").offset().top - $("#header").outerHeight(true) - $(".page_header").outerHeight(true);
+          return $(".console-area").offset().top - $(".page_header").outerHeight(true);
         }
       }]);
     });

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/console_log_tailing.js
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/console_log_tailing.js
@@ -81,7 +81,7 @@
     $(".console-area").on('consoleCompleted consoleUpdated consoleInteraction', function () {
       $(window).trigger($.Event("resetPinOnScroll"), [{
         calcRequiredScroll: function () {
-          return $(".console-area").offset().top - $("#header").outerHeight(true) - $(".page_header").outerHeight(true);
+          return $(".console-area").offset().top - $(".page_header").outerHeight(true);
         }
       }]);
     });


### PR DESCRIPTION
Fixes #12220

There appears to be no id="header" element in these pages. In old JQuery `2.2.4` `$("#header").outerHeight(true)` always evaluated to `null`, and was treated as 0 for the calculation, however in JQuery `3.7.x` (which we upgraded to in GoCD `23.4.0`) it returns `undefined` which makes the calculation evaluation to `NaN`, breaking the whole functionality.