### PR TITLE
Lock google-protobuf at < 3.25.0

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile
@@ -14,6 +14,7 @@ platforms :jruby do
     # See https://github.com/sass/sassc-ruby/pull/233
     gem 'sassc', github: 'sass/sassc-ruby', ref: 'refs/pull/233/head'
     gem 'sassc-embedded'
+    gem 'google-protobuf', '< 3.25.0'
 
     gem 'js-routes'
     gem 'ts_routes'

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -85,16 +85,10 @@ GEM
     date (3.3.4-java)
     diff-lcs (1.5.0)
     erubi (1.12.0)
-    ffi (1.16.3-java)
-    ffi-compiler (1.0.1)
-      ffi (>= 1.0.0)
-      rake
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (3.25.1-java)
-      ffi (~> 1)
-      ffi-compiler (~> 1)
-    google-protobuf (3.25.1-x86_64-linux)
+    google-protobuf (3.24.4-java)
+    google-protobuf (3.24.4-x86_64-linux)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     js-routes (1.4.14)
@@ -231,6 +225,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  google-protobuf (< 3.25.0)
   js-routes
   rails
   rails-controller-testing


### PR DESCRIPTION
Currently google-protobuf requires a native compile via ffi-compiler on Windows under JRuby which requires additional work on Windows build agents, see https://github.com/protocolbuffers/protobuf/issues/14611

Locking for now to prevent accidental transitive upgrades until we are read.