### PR TITLE
Upgrade OWASP Dependency check to v9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,29 +157,19 @@ project.ext.packaging = [
 
 dependencyCheck {
   failBuildOnCVSS = 1
-  cve {
-    def baseUrl
+  skipConfigurations = ['pmd']
+  suppressionFile = rootProject.file('buildSrc/dependency-check-suppress.xml').toPath().toString()
 
-    if (System.getenv().containsKey("GO_SERVER_URL")) {
-      baseUrl = "https://nexus.gocd.io/repository/nvd-nist"
-    } else {
-      baseUrl = "https://nvd.nist.gov/feeds"
-    }
-
-    urlModified = "${baseUrl}/json/cve/1.1/nvdcve-1.1-modified.json.gz"
-    urlBase = "${baseUrl}/json/cve/1.1/nvdcve-1.1-%d.json.gz"
+  nvd {
+    apiKey = System.getenv().getOrDefault("NVD_API_KEY", "")
   }
 
   analyzers {
     bundleAuditEnabled = false // Currently there is a separate bundle audit security check job independent of Gradle
     nodeAudit.yarnEnabled = false // Doesn't work correctly with Yarn 3+ https://github.com/jeremylong/DependencyCheck/issues/4894
     assemblyEnabled = false
-    retirejs {
-      filterNonVulnerable = true
-    }
+    retirejs.filterNonVulnerable = true // Reduces effort/memory processing retirejs results
   }
-  skipConfigurations = ['pmd']
-  suppressionFile = rootProject.file('buildSrc/dependency-check-suppress.xml').toPath().toString()
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -164,6 +164,12 @@ dependencyCheck {
     apiKey = System.getenv().getOrDefault("NVD_API_KEY", "")
   }
 
+  if (System.getenv().containsKey("GO_SERVER_URL")) {
+    data {
+      directory = "${rootProject.layout.buildDirectory.get()}/dependency-check-data"
+    }
+  }
+
   analyzers {
     bundleAuditEnabled = false // Currently there is a separate bundle audit security check job independent of Gradle
     nodeAudit.yarnEnabled = false // Doesn't work correctly with Yarn 3+ https://github.com/jeremylong/DependencyCheck/issues/4894

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ import com.github.jk1.license.render.JsonReportRenderer
 import com.github.jk1.license.task.ReportTask
 import com.thoughtworks.go.build.AdoptiumVersion
 import com.thoughtworks.go.build.InstallerType
+import de.undercouch.gradle.tasks.download.Download
 import nl.javadude.gradle.plugins.license.License
 import org.apache.tools.ant.filters.FixCrLfFilter
 import org.gradle.plugins.ide.idea.model.IdeaLanguageLevel
@@ -154,29 +155,6 @@ project.ext.packaging = [
     build  : 9
   )
 ]
-
-dependencyCheck {
-  failBuildOnCVSS = 1
-  skipConfigurations = ['pmd']
-  suppressionFile = rootProject.file('buildSrc/dependency-check-suppress.xml').toPath().toString()
-
-  nvd {
-    apiKey = System.getenv().getOrDefault("NVD_API_KEY", "")
-  }
-
-  if (System.getenv().containsKey("GO_SERVER_URL")) {
-    data {
-      directory = "${rootProject.layout.buildDirectory.get()}/dependency-check-data"
-    }
-  }
-
-  analyzers {
-    bundleAuditEnabled = false // Currently there is a separate bundle audit security check job independent of Gradle
-    nodeAudit.yarnEnabled = false // Doesn't work correctly with Yarn 3+ https://github.com/jeremylong/DependencyCheck/issues/4894
-    assemblyEnabled = false
-    retirejs.filterNonVulnerable = true // Reduces effort/memory processing retirejs results
-  }
-}
 
 allprojects {
   apply plugin: 'idea'
@@ -713,6 +691,78 @@ static List<String> getTestClassesForTask(List<String> testsToRun) {
     .collect(Collectors.toList())
 }
 
+dependencyCheck {
+  failBuildOnCVSS = 1
+  skipConfigurations = ['pmd']
+  suppressionFile = rootProject.file('buildSrc/dependency-check-suppress.xml').toPath().toString()
+
+  nvd {
+    apiKey = System.getenv("NVD_API_KEY") ?: ""
+  }
+
+  analyzers {
+    bundleAuditEnabled = false // Currently there is a separate bundle audit security check job independent of Gradle
+    nodeAudit.yarnEnabled = false // Doesn't work correctly with Yarn 3+ https://github.com/jeremylong/DependencyCheck/issues/4894
+    assemblyEnabled = false
+    retirejs.filterNonVulnerable = true // Reduces effort/memory processing retirejs results
+  }
+}
+
+if (System.getenv().containsKey("GO_SERVER_URL")) {
+  dependencyCheck {
+    data {
+      directory = "${layout.buildDirectory.get()}/dependency-check-data"
+    }
+  }
+
+  tasks.register('downloadDependencyCheckCache', Download) {
+    src 'https://nexus.gocd.io/repository/cache/dependency-check-data.zip'
+    dest layout.buildDirectory.file('dependency-check-data.zip')
+    onlyIfModified true
+  }
+
+  tasks.register('unzipDependencyCheckCache', Copy) {
+    dependsOn downloadDependencyCheckCache
+    from zipTree(downloadDependencyCheckCache.dest)
+    into layout.buildDirectory.dir("dependency-check-data")
+    def copyDetails = []
+    eachFile { copyDetails << it }
+    doLast {
+      copyDetails.each { FileCopyDetails details ->
+        def target = new File(destinationDir, details.path)
+        if (target.exists()) { target.setLastModified(details.lastModified) }
+      }
+    }
+  }
+
+  dependencyCheckUpdate.dependsOn unzipDependencyCheckCache
+  dependencyCheckAnalyze.dependsOn unzipDependencyCheckCache
+  dependencyCheckAggregate.dependsOn unzipDependencyCheckCache
+
+  tasks.register('uploadDependencyCheckCache', Zip) {
+    mustRunAfter dependencyCheckUpdate, dependencyCheckAnalyze, dependencyCheckAggregate
+
+    from layout.buildDirectory.file("dependency-check-data")
+    archiveFileName = "dependency-check-data-updated.zip"
+    destinationDirectory = layout.buildDirectory
+
+    doLast {
+      project.exec {
+        workingDir = projectDir
+        commandLine = [
+          "curl",
+          "-u", "${System.getenv("NEXUS_CACHE_USERNAME")}:${System.getenv("NEXUS_CACHE_PASSWORD")}",
+          "--include",
+          "--upload-file", uploadDependencyCheckCache.archiveFile.get(), 'https://nexus.gocd.io/repository/cache/dependency-check-data.zip'
+        ]
+        standardOutput = System.out
+        errorOutput = System.err
+        ignoreExitValue = true
+      }
+    }
+  }
+}
+
 task newSPA {
   description = "Helper to create a new SPA. Pass `-PspaName=maintenance_mode"
 
@@ -1239,7 +1289,7 @@ task upgradeApi {
           .replace(oldControllerClassSuffix, newControllerClassSuffix)
           .replaceAll("ApiVersion\\.v${currentMaxApiVersion}", "ApiVersion.v${apiVersion}")
       }
-      filter(FixCrLfFilter, eol: FixCrLfFilter.CrLf.UNIX)
+      filter(FixCrLfFilter, eol: FixCrLfFilter.CrLf.newInstance("unix"))
 
       eachFile { FileCopyDetails fcd ->
         List<String> segments = fcd.relativePath.segments

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ import java.util.stream.Collectors
 
 plugins {
   id 'base'
-  id 'org.owasp.dependencycheck' version '8.4.3'
+  id 'org.owasp.dependencycheck' version '9.0.2'
   id 'com.github.hierynomus.license-base' version '0.16.1'
   id 'com.github.jk1.dependency-license-report' version '2.5'
 }


### PR DESCRIPTION
- Upgrades to v9
- Involves switch to use of the NVD API rather than the old data feeds
- To reduce API usage and speed things up, use Nexus to cache the ODC database and artifacts so we are not starting from scratch each time