### PR TITLE
Force-upgrade version of jasmine used by karma-jasmine to v5

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -129,6 +129,7 @@
   "resolutions": {
     "chokidar@npm:2.1.8/glob-parent": "^5.1.2",
     "webpack@npm:4.47.0/terser-webpack-plugin": "^4.2.3",
+    "karma-jasmine@npm:5.1.0/jasmine-core": "^5.1.1",
     "jasmine-browser-runner@^2.3.0": "patch:jasmine-browser-runner@npm%3A2.3.0#./.yarn/patches/jasmine-browser-runner-npm-2.3.0-40f5d8899b.patch"
   },
   "packageManager": "yarn@4.0.2"

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -6933,13 +6933,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jasmine-core@npm:^4.1.0":
-  version: 4.6.0
-  resolution: "jasmine-core@npm:4.6.0"
-  checksum: 447ec02128414d85db9ced1f881894d59fc54e47e84b5d659aec3c8d2e2c8e707f9d9b9a7d45730cdccdbc2aa628e1ea63ebf3db324c38f03db876168f057a57
-  languageName: node
-  linkType: hard
-
 "jasmine-core@npm:^5.1.1, jasmine-core@npm:~5.1.0":
   version: 5.1.1
   resolution: "jasmine-core@npm:5.1.1"


### PR DESCRIPTION
Force the transitive dependency to latest Jasmine, per https://github.com/karma-runner/karma-jasmine/issues/333#issuecomment-1685072622