### PR TITLE
Workaround auto-closing pipeline material dependency stage selection on Chrome <= 120 on MacOS Sonama

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -107,6 +107,8 @@ class DependencySuggestionProvider extends SuggestionProvider {
 }
 
 export class DependencyFields extends MithrilComponent<Attrs, State> {
+  private static readonly EMPTY_ID = "";
+
   oninit(vnode: m.Vnode<Attrs, State>) {
     if (vnode.attrs.disabled) {
       return;
@@ -114,9 +116,7 @@ export class DependencyFields extends MithrilComponent<Attrs, State> {
 
     const mat             = vnode.attrs.material.attributes() as DependencyMaterialAttributes;
     const cache           = vnode.attrs.cache;
-    const EMPTY: Option[] = [{id: "", text: "-"}];
-    vnode.state.stages    = Stream(EMPTY);
-
+    const EMPTY: Option[] = [{id: DependencyFields.EMPTY_ID, text: "-"}];
     vnode.state.provider = new DependencySuggestionProvider(vnode.attrs.cache, vnode.attrs.parentPipelineName);
     vnode.state.stages   = () => mat.pipeline() ? EMPTY.concat(cache.stages(mat.pipeline())) : [];
   }
@@ -130,7 +130,7 @@ export class DependencyFields extends MithrilComponent<Attrs, State> {
                    required={true} readonly={true}/>,
         <SelectField label="Upstream Stage" property={mat.stage} errorText={this.errs(mat, "stage")} required={true}
                      readonly={true}>
-          <SelectFieldOptions selected={mat.stage()} items={vnode.state.stages()}/>
+          <SelectFieldOptions selected={mat.stage() || DependencyFields.EMPTY_ID} items={vnode.state.stages()}/>
         </SelectField>,
       ];
     }
@@ -138,10 +138,10 @@ export class DependencyFields extends MithrilComponent<Attrs, State> {
     return [
       <AutocompleteField label="Upstream Pipeline" property={mat.pipeline} errorText={this.errs(mat, "pipeline")}
                          readonly={vnode.attrs.readonly} autoEvaluate={!vnode.attrs.readonly}
-                         aut required={true} maxItems={25} provider={vnode.state.provider}/>,
+                         required={true} maxItems={25} provider={vnode.state.provider}/>,
       <SelectField label="Upstream Stage" readonly={vnode.attrs.readonly}
                    property={mat.stage} errorText={this.errs(mat, "stage")} required={true}>
-        <SelectFieldOptions selected={mat.stage()} items={vnode.state.stages()}/>
+        <SelectFieldOptions selected={mat.stage() || DependencyFields.EMPTY_ID} items={vnode.state.stages()}/>
       </SelectField>,
       this.advanced(mat, vnode.attrs)
     ];


### PR DESCRIPTION
- Fixes #12305

Default the pipeline dependency stage selection to EMPTY deterministically to workaround an issue in Chromium on MacOS Sonoma/14 where having no selection seems to cause the pop-up selector to close prematurely.

Seems to be due to https://bugs.chromium.org/p/chromium/issues/detail?id=1497774  - fixed in Chrome 121 via https://github.com/chromium/chromium/commit/9aa331b609148d588ce602cec147ec2f61fc09c3 but easy enough to workaround here without relying on the default selection semantics.