### PR TITLE
Revert "Bump org.ysb33r.gradle:grolifant-herd from 2.0.0 to 2.1.0"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -52,7 +52,7 @@ final Map<String, String> libraries = [
   felix               : 'org.apache.felix:org.apache.felix.framework:7.0.5',
   freemarker          : 'org.freemarker:freemarker:2.3.32',
   gradleDownload      : 'de.undercouch:gradle-download-task:5.5.0',
-  grolifant           : 'org.ysb33r.gradle:grolifant-herd:2.1.0',
+  grolifant           : 'org.ysb33r.gradle:grolifant-herd:2.0.0',
   gson                : 'com.google.code.gson:gson:2.10.1',
   guava               : 'com.google.guava:guava:32.1.3-jre',
   h2                  : 'com.h2database:h2:1.4.200',


### PR DESCRIPTION
Reverts gocd/gocd#12341 

This broke compiles somehow.