### PR TITLE
Remove workaround that fixes unnecessary transitive dependencies from Jetty

### DIFF
--- a/development-utility/development-server/build.gradle
+++ b/development-utility/development-server/build.gradle
@@ -30,9 +30,7 @@ dependencies {
   implementation project.deps.jettyJmx
   implementation project.deps.jettyServlets
   implementation project.deps.jettyUtil
-  implementation(project.deps.jettyDeploy) {
-    exclude(module: 'awaitility') // See https://github.com/jetty/jetty.project/issues/10812
-  }
+  implementation project.deps.jettyDeploy
   implementation(project.deps.jettyWebsocket) {
     exclude(module: 'jetty-annotations')
   }

--- a/jetty/build.gradle
+++ b/jetty/build.gradle
@@ -27,16 +27,12 @@ dependencies {
   compileOnly project.deps.jettyJmx
   compileOnly project.deps.jettyServlets
   compileOnly project.deps.jettyUtil
-  compileOnly(project.deps.jettyDeploy) {
-    exclude(module: 'awaitility') // See https://github.com/jetty/jetty.project/issues/10812
-  }
+  compileOnly project.deps.jettyDeploy
   compileOnly(project.deps.jettyWebsocket) {
     exclude(module: 'jetty-annotations')
   }
 
-  testImplementation(project.deps.jettyDeploy) {
-    exclude(module: 'awaitility') // See https://github.com/jetty/jetty.project/issues/10812
-  }
+  testImplementation project.deps.jettyDeploy
   testImplementation project.deps.jettyJmx
   testImplementation(project.deps.jettyWebsocket) {
     exclude(module: 'jetty-annotations')

--- a/server-launcher/build.gradle
+++ b/server-launcher/build.gradle
@@ -61,9 +61,7 @@ dependencies {
   packagingInLibDir project.deps.jettyJmx
   packagingInLibDir project.deps.jettyServlets
   packagingInLibDir project.deps.jettyUtil
-  packagingInLibDir(project.deps.jettyDeploy) {
-    exclude(module: 'awaitility') // See https://github.com/jetty/jetty.project/issues/10812
-  }
+  packagingInLibDir project.deps.jettyDeploy
   packagingInLibDir(project.deps.jettyWebsocket) {
     exclude(module: 'jetty-annotations')
   }


### PR DESCRIPTION
Reverts gocd/gocd#12192