### PR TITLE
Fix disappearing second+ stages on VSM view after clicking a stage

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/vsm_renderer.js
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/javascripts/vsm_renderer.js
@@ -523,7 +523,7 @@ Graph_Renderer = function (container) {
           var pipelineName = stageLocatorSplit.pop();
 
           gui += '" style="width:' + ((stagesWidth - (stagesCount * 4)) / stagesCount) + 'px" title="' + stageTitle + '"><a href="#" onclick="window.getStageOverviewFor(\''+ pipelineName + '\',\'' + pipelineCounter + '\',\'' + stageName + '\',\'' + stageCounter + '\',\'' + instance.stages[i].status + '\',\'' + i + '\',\'' + instance.stages.length + '\',\'' + node.can_edit  + '\',\'' + node.template_name +'\')"></a></li>';
-          gui += '<div id="stage-overview-container-for-pipeline-'+ pipelineName + '-' + pipelineCounter + '-stage-' + stageName + '-' + stageCounter +'"/>';
+          gui += '<div id="stage-overview-container-for-pipeline-'+ pipelineName + '-' + pipelineCounter + '-stage-' + stageName + '-' + stageCounter +'"></div>';
         }
       }
       gui += '</ul>';

--- a/spark/spark-spa/src/main/resources/freemarker/analytics/index.ftlh
+++ b/spark/spark-spa/src/main/resources/freemarker/analytics/index.ftlh
@@ -13,4 +13,4 @@
  See the License for the specific language governing permissions and
  limitations under the License.
   -->
-<div class="analytics-container" data-pipeline-list="${pipelines}" />
+<div class="analytics-container" data-pipeline-list="${pipelines}"></div>


### PR DESCRIPTION
`<div>`s cannot be self-closing (despite frameworks misleading you into thinking they can be). This causes the VSM stages to be messed up, and clicking on the summary views causes stages after the first to disappear.

![image](https://github.com/gocd/gocd/assets/29788154/4b284020-4cda-45d6-91dc-e26885632131)

There are a number of these across mithril/JSX but presumably the framework renders these correctly as they don't seem to be causing issues.