### PR TITLE
Correct display of "cancelled by" for stage runs other than that being viewed

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/ui/StageSummaryModel.java
+++ b/server/src/main/java/com/thoughtworks/go/server/ui/StageSummaryModel.java
@@ -15,19 +15,12 @@
  */
 package com.thoughtworks.go.server.ui;
 
+import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.server.domain.JobDurationStrategy;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
-import com.thoughtworks.go.domain.JobInstance;
-import com.thoughtworks.go.domain.JobInstances;
-import com.thoughtworks.go.domain.JobResult;
-import com.thoughtworks.go.domain.RunDuration;
-import com.thoughtworks.go.domain.Stage;
-import com.thoughtworks.go.domain.StageIdentifier;
-import com.thoughtworks.go.domain.StageState;
-import com.thoughtworks.go.domain.Stages;
-import com.thoughtworks.go.server.domain.JobDurationStrategy;
 
 public class StageSummaryModel {
 
@@ -117,6 +110,10 @@ public class StageSummaryModel {
 
     public StageState getStateForRun(int stageCounter) {
         return stages.byCounter(stageCounter).stageState();
+    }
+
+    public String getCancelledByForRun(int stageCounter) {
+        return stages.byCounter(stageCounter).getCancelledBy();
     }
 
     public List<JobInstanceModel> passedJobs() {

--- a/server/src/main/webapp/WEB-INF/rails/app/views/stages/_other_stage_runs.html.erb
+++ b/server/src/main/webapp/WEB-INF/rails/app/views/stages/_other_stage_runs.html.erb
@@ -5,7 +5,7 @@
             <li>
                 <a href="<%= stage_detail_tab_path_for(:stage_counter => n_in_other_stage_runs, :action => params[:action]) %>">
                     <span style="float:left; margin-right: 10px;">Run: <%= n_in_other_stage_runs %> of <%= @stage.getTotalRuns() %></span>
-                    <%= render :partial=> "stages/stage_result", :locals=>{:scope => {:state=>@stage.getStateForRun(n_in_other_stage_runs)}} %>
+                    <%= render :partial=> "stages/stage_result", :locals=>{:scope => {:state=>@stage.getStateForRun(n_in_other_stage_runs), :cancelledBy=>@stage.getCancelledByForRun(n_in_other_stage_runs)}} %>
                 </a>
             </li>
         <% end %>

--- a/server/src/test-fast/java/com/thoughtworks/go/server/ui/StageSummaryModelTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/ui/StageSummaryModelTest.java
@@ -26,6 +26,7 @@ import static com.thoughtworks.go.helper.StageMother.completedFailedStageInstanc
 import static com.thoughtworks.go.helper.StageMother.custom;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class StageSummaryModelTest {
     private static final JobDurationStrategy JOB_DURATION_STRATEGY = JobDurationStrategy.ALWAYS_ZERO;
@@ -54,6 +55,8 @@ public class StageSummaryModelTest {
         assertThat(stageSummaryModel.getTotalRuns(), is(2));
         assertThat(stageSummaryModel.getStateForRun(1), is(StageState.Failed));
         assertThat(stageSummaryModel.getStateForRun(2), is(StageState.Passed));
+        assertThat(stageSummaryModel.getCancelledByForRun(1), is(nullValue()));
+        assertThat(stageSummaryModel.getCancelledByForRun(2), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
Currently when looking at other runs of a stage, the UI shows "Cancelled by: GoCD" regardless of whom it was actually cancelled by. This change fixes that.

![image](https://github.com/gocd/gocd/assets/29788154/30d1a3af-ee80-442b-90f8-fca2ab936d45)
