### PR TITLE
Switch from sassc-rails to dartsass-sprockets

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile
@@ -9,12 +9,7 @@ platforms :jruby do
   gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
   group :assets do
-    gem 'sassc-rails'
-    # Switch sassc to be able to use sass-embedded (and dart-sass) rather than libsass.
-    # See https://github.com/sass/sassc-ruby/pull/233
-    gem 'sassc', github: 'sass/sassc-ruby', ref: 'refs/pull/233/head'
-    gem 'sassc-embedded'
-
+    gem 'dartsass-sprockets'
     gem 'js-routes'
     gem 'ts_routes'
   end

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/sass/sassc-ruby.git
-  revision: 244d3dcc8b985e25bab066b296f0f202e43e41ad
-  ref: refs/pull/233/head
-  specs:
-    sassc (2.4.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -81,6 +74,12 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
+    dartsass-sprockets (3.1.0)
+      railties (>= 4.0.0)
+      sassc-embedded (~> 1.69)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     date (3.3.4)
     date (3.3.4-java)
     diff-lcs (1.5.0)
@@ -193,12 +192,6 @@ GEM
       google-protobuf (~> 3.25)
     sassc-embedded (1.69.0)
       sass-embedded (~> 1.69)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -231,14 +224,12 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  dartsass-sprockets
   js-routes
   rails
   rails-controller-testing
   rspec-rails
   rspec_junit_formatter
-  sassc!
-  sassc-embedded
-  sassc-rails
   sprockets-rails
   ts_routes
   tzinfo-data


### PR DESCRIPTION
Avoid having to patch the legacy sassc project by switching directly to a sprockets implementation that can eventually use dartsass. dartsass-sprockets is effectively a sassc-rails fork, which cuts out the sassc middleman. Thus it is still sassc compatible and limited by this fact, however allows us to keep Sprockets compatibility without dependency on a slightly dodgy closed PR.