### PR TITLE
Update README-running-multiple-agents.md

### DIFF
--- a/installers/go-agent/release/README-running-multiple-agents.md
+++ b/installers/go-agent/release/README-running-multiple-agents.md
@@ -53,6 +53,7 @@ Each agent needs to be configured to run in its own separate directory so that e
         # can write to these directories
         chown -R go:go /var/{lib,log}/${AGENT_ID}
         chmod -R 0750 /var/{lib,log}/${AGENT_ID}
+        chmod 0755 /usr/share/${AGENT_ID}
 
         # tweak the scripts and configs to use the correct directories
         sed -i -e "s@go-agent@${AGENT_ID}@g" /usr/share/${AGENT_ID}/bin/go-agent


### PR DESCRIPTION
hello. I use multiple agents in single machine.
when I use version 20.4.0, script worked fine.
but in version 23.4.0, it now doesn't work.

### changes
- change mode of /usr/share/${AGENT_ID} same as /usr/share/go-agent.


### details

i got an error like below when run the go-agent-1/bin/go-agent

```
./go-agent console
-bash: line 1: /usr/share/go-agent-1/bin/go-agent: Permission denied
Failed to access the script using an absolute path. Insufficient permissions may prevent the user "go" from traversing one of the folders. Please check the following permissions:
drwxr-xr-x.  12 root root   144 Dec 15 10:49 /usr
drwxr-xr-x. 108 root root 16384 Jan  2 17:06 /usr/share
drwx------.   4 root root    76 Jan  2 19:05 /usr/share/go-agent-1
drwxr-xr-x.   2 root root    22 Jan  2 18:59 /usr/share/go-agent-1/bin
```

then i check the mode of /usr/share/go-agent and go-agent-1,
i found they have different mode.

```
drwxr-xr-x.   7 root root    76 Jan  2 15:24 go-agent
drwx------.   4 root root    76 Jan  2 19:05 go-agent-1
```

after I set directory's mode, it works fine.