### PR TITLE
Disable use of udev for the OSHI system information library

### DIFF
--- a/agent/src/main/java/com/thoughtworks/go/agent/service/SystemInfo.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/service/SystemInfo.java
@@ -20,9 +20,12 @@ import com.thoughtworks.go.util.SystemEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import oshi.software.os.OperatingSystem;
+import oshi.util.GlobalConfig;
 import oshi.util.Util;
 
 import java.util.Optional;
+
+import static oshi.util.GlobalConfig.OSHI_OS_LINUX_ALLOWUDEV;
 
 public class SystemInfo {
     private static final Logger LOG = LoggerFactory.getLogger(SystemInfo.class);
@@ -54,6 +57,11 @@ public class SystemInfo {
     }
 
     static oshi.SystemInfo newSystemInfo() {
+        // Allowing OSHI to load information from udev causes issues on Alpine due to use of glibc JVMs,
+        // if the musl udev is installed. Since we don't rely on this hardware info, we can disable it
+        // but better to remove this if Alpine is no longer supported for agents, or we have a more MUSL
+        // Alpine environment.
+        GlobalConfig.set(OSHI_OS_LINUX_ALLOWUDEV, "false");
         return new oshi.SystemInfo();
     }
 

--- a/agent/src/test/java/com/thoughtworks/go/agent/service/SystemInfoTest.java
+++ b/agent/src/test/java/com/thoughtworks/go/agent/service/SystemInfoTest.java
@@ -24,18 +24,26 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.MockedStatic;
+import oshi.util.GlobalConfig;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mockStatic;
+import static oshi.util.GlobalConfig.OSHI_OS_LINUX_ALLOWUDEV;
 
 @ExtendWith(SystemStubsExtension.class)
 class SystemInfoTest {
 
     @SystemStub
     SystemProperties props;
+
+    @Test
+    public void shouldDisableUdevUsage() {
+        SystemInfo.determineOperatingSystemCompleteName();
+        assertThat(GlobalConfig.get(OSHI_OS_LINUX_ALLOWUDEV, true)).isFalse();
+    }
 
     @Test
     public void shouldDefaultJnaTmpDirIfUnset() {

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -221,7 +221,6 @@ enum Distro implements DistroBehavior {
       return alpine.getInstallPrerequisitesCommands(v) +
         [
           'apk add --no-cache sudo',
-          'rm -rf /lib/libudev.so*', // btrfs is installed by Docker, but requires eudev-libs, which causes issues with OSHI JNA libary on Alpine with glibc and JVM crashes. Dont think we need udev as it's only needed by btrfs for multipath support.
         ]
     }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -86,7 +86,7 @@ final Map<String, String> libraries = [
   mysql               : 'com.mysql:mysql-connector-j:8.2.0',
   objenesis           : 'org.objenesis:objenesis:3.3',
   oscache             : 'opensymphony:oscache:2.4.1',
-  oshi                : 'com.github.oshi:oshi-core-java11:6.4.10',
+  oshi                : 'com.github.oshi:oshi-core-java11:6.4.11',
   postgresql          : 'org.postgresql:postgresql:42.7.1',
   quartz              : 'org.quartz-scheduler:quartz:2.3.2',
   rack                : 'org.jruby.rack:jruby-rack:1.1.22',


### PR DESCRIPTION
fixes #12440 

Workaround issue that at its root is due to use of glibc on Alpine, better summarised in #11355 (**TL;DR** - due to current use of the Tanuki Wrapper which does not have musl libc builds).

This uses new capability within OSHI to tell it not to rely on `udev` which likely avoids issue for those building Alpine agent images and adding other libraries/apks which happen to install udev.