### PR TITLE
Prefer contenthash to chunkhash in another place

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/config/webpack.config.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/config/webpack.config.ts
@@ -77,7 +77,7 @@ function configuration(env: any, argv: any): webpack.Configuration {
     output: {
       path: configOptions.outputDir,
       publicPath: "/go/assets/webpack/",
-      filename: configOptions.production ? "[name]-[chunkhash].js" : "[name].js"
+      filename: configOptions.production ? "[name]-[contenthash].js" : "[name].js"
     },
     cache: true,
     bail: !argv.watch,


### PR DESCRIPTION
There is still some unpredictability in hashes for scss -> css, but this seems to improve it for js.