### PR TITLE
Improve performance of agents API responses and dashboard stage modal

### DIFF
--- a/api/api-agents-v7/src/main/java/com/thoughtworks/go/apiv7/agents/representers/AgentsRepresenter.java
+++ b/api/api-agents-v7/src/main/java/com/thoughtworks/go/apiv7/agents/representers/AgentsRepresenter.java
@@ -26,13 +26,13 @@ import java.util.Collection;
 import java.util.Map;
 
 public class AgentsRepresenter {
-    public static void toJSON(OutputWriter writer, Map<AgentInstance, Collection<EnvironmentConfig>> agentInstanceCollectionMap, SecurityService securityService, Username username) {
+    public static void toJSON(OutputWriter writer, Map<AgentInstance, Collection<EnvironmentConfig>> agentToEnvironments, SecurityService securityService, Username username) {
         writer.addLinks(
                 outputLinkWriter -> outputLinkWriter
                         .addLink("self", Routes.AgentsAPI.BASE)
                         .addAbsoluteLink("doc", Routes.AgentsAPI.DOC))
                 .addChild("_embedded", embeddedWriter -> embeddedWriter.addChildList("agents",
-                        agentsWriter -> agentInstanceCollectionMap.forEach((key, value) -> agentsWriter.addChild(agentWriter -> AgentRepresenter.toJSON(agentWriter, key, value, securityService, username))))
+                        agentsWriter -> agentToEnvironments.forEach((agent, env) -> agentsWriter.addChild(agentWriter -> AgentRepresenter.toJSON(agentWriter, agent, env, securityService, username))))
                 );
     }
 }

--- a/api/api-agents-v7/src/main/java/com/thoughtworks/go/apiv7/agents/representers/EnvironmentsRepresenter.java
+++ b/api/api-agents-v7/src/main/java/com/thoughtworks/go/apiv7/agents/representers/EnvironmentsRepresenter.java
@@ -45,7 +45,7 @@ public class EnvironmentsRepresenter {
                 .collect(Collectors.toSet())
                 .stream()
                 .sorted()
-                .collect(Collectors.toList());
+                .toList();
 
         for (String envName : sortedEnvNames) {
             EnvironmentConfig envConfig = envConfigs.find(new CaseInsensitiveString(envName));

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentsConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentsConfig.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.domain.BaseCollection;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.EnvironmentPipelineMatcher;
 import com.thoughtworks.go.domain.EnvironmentPipelineMatchers;
+import com.thoughtworks.go.util.Pair;
 
 import java.util.*;
 
@@ -142,20 +143,22 @@ public class EnvironmentsConfig extends BaseCollection<EnvironmentConfig> implem
         return this.stream()
                 .filter(envConfig -> envConfig.hasAgent(uuid))
                 .map(envConfig -> str(envConfig.name()))
-                .collect(toCollection(HashSet::new));
+                .collect(toSet());
     }
 
-    public Set<EnvironmentConfig> getAgentEnvironments(String uuid) {
-        return this.stream().filter(envConfig -> envConfig.hasAgent(uuid)).collect(toSet());
+    public List<EnvironmentConfig> getAgentEnvironments(String uuid) {
+        return this.stream().filter(envConfig -> envConfig.hasAgent(uuid)).collect(toList());
+    }
+
+    public Map<String, List<EnvironmentConfig>> getAgentEnvironmentsByUuid() {
+        return this.stream()
+            .flatMap(env  -> env.getAgents().stream().map(agent -> Pair.pair(agent.getUuid(), env)))
+                .collect(groupingBy(Pair::first, mapping(Pair::last, toList())));
     }
 
     public boolean hasEnvironmentNamed(CaseInsensitiveString environmentName) {
         EnvironmentConfig environmentConfig = find(environmentName);
         return environmentConfig != null;
-    }
-
-    public void removeAgentFromAllEnvironments(String uuid) {
-        this.forEach(envConfig -> envConfig.removeAgent(uuid));
     }
 
     public EnvironmentsConfig getLocal() {

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/EnvironmentsConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/EnvironmentsConfigTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -305,37 +305,22 @@ class EnvironmentsConfigTest {
 
         @Test
         void shouldFindEnvironmentConfigsForAgent() {
-            Set<EnvironmentConfig> environmentConfigs = envsConfig.getAgentEnvironments("agent-one");
+            List<EnvironmentConfig> environmentConfigs = envsConfig.getAgentEnvironments("agent-one");
             assertThat(environmentConfigs, hasItem(basicEnvConfig));
             assertThat(environmentConfigs, hasSize(1));
         }
 
         @Test
-        void shouldRemoveAgentFromAllEnvironments() {
-            BasicEnvironmentConfig env2 = new BasicEnvironmentConfig(new CaseInsensitiveString("prod"));
-            env2.addPipeline(new CaseInsensitiveString("test"));
-            env2.addAgent("agent-one");
-            env2.addAgent("agent-two");
-            envsConfig.add(env2);
+        void shouldMapAgentsToEnvironments() {
+            EnvironmentConfig secondEnv = new BasicEnvironmentConfig(new CaseInsensitiveString("prod"));
+            secondEnv.addAgent("agent-one");
+            secondEnv.addAgent("agent-two");
+            envsConfig.add(secondEnv);
 
-            BasicEnvironmentConfig env3 = new BasicEnvironmentConfig(new CaseInsensitiveString("dev"));
-            env3.addPipeline(new CaseInsensitiveString("build"));
-            env3.addAgent("agent-two");
-            env3.addAgent("agent-three");
-            envsConfig.add(env3);
-
-            assertThat(envsConfig.get(0).getAgents().size(), is(1));
-            assertThat(envsConfig.get(1).getAgents().size(), is(2));
-            assertThat(envsConfig.getAgentEnvironmentNames("agent-one").size(), is(2));
-
-            envsConfig.removeAgentFromAllEnvironments("agent-one");
-
-            assertThat(envsConfig.get(0).getAgents().size(), is(0));
-            assertThat(envsConfig.get(1).getAgents().size(), is(1));
-            assertThat(envsConfig.get(2).getAgents().size(), is(2));
-            assertThat(envsConfig.getAgentEnvironmentNames("agent-one").size(), is(0));
-            assertThat(envsConfig.getAgentEnvironmentNames("agent-two").size(), is(2));
-            assertThat(envsConfig.getAgentEnvironmentNames("agent-three").size(), is(1));
+            Map<String, List<EnvironmentConfig>> agentEnvironmentsByUuid = envsConfig.getAgentEnvironmentsByUuid();
+            assertThat(agentEnvironmentsByUuid, hasEntry(is("agent-one"), containsInAnyOrder(basicEnvConfig, secondEnv)));
+            assertThat(agentEnvironmentsByUuid, hasEntry(is("agent-two"), containsInAnyOrder(secondEnv)));
+            assertThat(agentEnvironmentsByUuid.keySet(), hasSize(2));
         }
 
         @Test

--- a/server/src/main/java/com/thoughtworks/go/server/service/EnvironmentConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EnvironmentConfigService.java
@@ -42,10 +42,7 @@ import com.thoughtworks.go.util.ClonerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static com.thoughtworks.go.config.CaseInsensitiveString.str;
 import static com.thoughtworks.go.i18n.LocalizedMessage.entityConfigValidationFailed;
@@ -57,14 +54,14 @@ import static java.util.stream.Collectors.toList;
  */
 @Service
 public class EnvironmentConfigService implements ConfigChangedListener, AgentChangeListener {
-    public GoConfigService goConfigService;
+    private static final Cloner cloner = ClonerFactory.instance();
+    private GoConfigService goConfigService;
     private SecurityService securityService;
     private EntityHashingService entityHashingService;
     private AgentService agentService;
 
     private EnvironmentsConfig environments;
     private EnvironmentPipelineMatchers matchers;
-    private static final Cloner cloner = ClonerFactory.instance();
 
     public EnvironmentConfigService() {
     }
@@ -147,8 +144,12 @@ public class EnvironmentConfigService implements ConfigChangedListener, AgentCha
         return environments.getAgentEnvironmentNames(uuid);
     }
 
-    public Set<EnvironmentConfig> getAgentEnvironments(String uuid) {
+    public List<EnvironmentConfig> getAgentEnvironments(String uuid) {
         return environments.getAgentEnvironments(uuid);
+    }
+
+    public Map<String, List<EnvironmentConfig>> getAgentEnvironmentsByUuid() {
+        return environments.getAgentEnvironmentsByUuid();
     }
 
     public EnvironmentConfig getEnvironmentConfig(String envName) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
@@ -260,18 +260,18 @@ class EnvironmentConfigServiceTest {
         EnvironmentsConfig envConfigs = environments("uat", "prod");
         environmentConfigService.syncEnvironments(envConfigs);
 
-        Set<EnvironmentConfig> envConfigSet = environmentConfigService.getAgentEnvironments("uat-agent");
-        assertThat(envConfigSet.size(), is(1));
-        assertTrue(envConfigSet.contains(envConfigs.named(new CaseInsensitiveString("uat"))));
+        List<EnvironmentConfig> envsForAgent = environmentConfigService.getAgentEnvironments("uat-agent");
+        assertThat(envsForAgent.size(), is(1));
+        assertTrue(envsForAgent.contains(envConfigs.named(new CaseInsensitiveString("uat"))));
 
-        envConfigSet = environmentConfigService.getAgentEnvironments("prod-agent");
-        assertThat(envConfigSet.size(), is(1));
-        assertTrue(envConfigSet.contains(envConfigs.named(new CaseInsensitiveString("prod"))));
+        envsForAgent = environmentConfigService.getAgentEnvironments("prod-agent");
+        assertThat(envsForAgent.size(), is(1));
+        assertTrue(envsForAgent.contains(envConfigs.named(new CaseInsensitiveString("prod"))));
 
-        envConfigSet = environmentConfigService.getAgentEnvironments(OMNIPRESENT_AGENT);
-        assertThat(envConfigSet.size(), is(2));
-        assertTrue(envConfigSet.contains(envConfigs.named(new CaseInsensitiveString("uat"))));
-        assertTrue(envConfigSet.contains(envConfigs.named(new CaseInsensitiveString("prod"))));
+        envsForAgent = environmentConfigService.getAgentEnvironments(OMNIPRESENT_AGENT);
+        assertThat(envsForAgent.size(), is(2));
+        assertTrue(envsForAgent.contains(envConfigs.named(new CaseInsensitiveString("uat"))));
+        assertTrue(envsForAgent.contains(envConfigs.named(new CaseInsensitiveString("prod"))));
     }
 
     @Nested

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceIntegrationTest.java
@@ -27,7 +27,6 @@ import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
-import com.thoughtworks.go.server.util.UuidGenerator;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,11 +68,9 @@ public class EnvironmentConfigServiceIntegrationTest {
     @Autowired
     private ConfigRepoService configRepoService;
     @Autowired
-    private UuidGenerator uuidGenerator;
-    @Autowired
     private DatabaseAccessHelper dbHelper;
 
-    private GoConfigFileHelper configHelper = new GoConfigFileHelper();
+    private final GoConfigFileHelper configHelper = new GoConfigFileHelper();
 
 
     @BeforeEach
@@ -159,11 +156,10 @@ public class EnvironmentConfigServiceIntegrationTest {
     }
 
     @Test
-    public void shouldUpdateExistingEnvironment_ForNewUpdateEnvironmentMethod() throws Exception {
+    public void shouldUpdateExistingEnvironment_ForNewUpdateEnvironmentMethod() {
         BasicEnvironmentConfig uat = environmentConfig("uat");
         goConfigService.addPipeline(PipelineConfigMother.createPipelineConfig("foo", "dev", "job"), "foo-grp");
         goConfigService.addPipeline(PipelineConfigMother.createPipelineConfig("bar", "dev", "job"), "foo-grp");
-        Username user = Username.ANONYMOUS;
         uat.addPipeline(new CaseInsensitiveString("foo"));
         uat.addEnvironmentVariable("env-one", "ONE");
         uat.addEnvironmentVariable("env-two", "TWO");
@@ -272,7 +268,7 @@ public class EnvironmentConfigServiceIntegrationTest {
     }
 
     @Test
-    public void shouldPatchAnEnvironment() throws Exception {
+    public void shouldPatchAnEnvironment() {
         String environmentName = "env";
 
         BasicEnvironmentConfig env = environmentConfig(environmentName);


### PR DESCRIPTION
Avoids putting `EnvironmentConfig`s into `HashSet`s - computing hashes and equality on this is extremely expensive, iterating all pipelines etc and causing a kind of `O(n^2*m)` type of problem. 

It's also not necessary for the purpose of these APIs; a list is perfectly fine and uniqueness should be ensured elsewhere - the old set equality for these complex objects with a deep equality check would not have been gaurateeing this.

Furthermore, for the massive index API, a single Map can be built in one pass, rather than building many Lists. Downside with new algorithm is that if there are many environments in configuration mapped to agents which no longer exist, it might theoretically be less efficient than separately searching only for the relevant agents.

Should fix issue reported at https://groups.google.com/g/go-cd/c/c1n1Aq7hG1k which is especially prevalent if you have 
* many pipelines mapped to a given environment
* many agents mapped to that same environment