### PR TITLE
Correct transitive expectations; avoiding managing activation version

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -118,7 +118,7 @@ task verifyJar(type: VerifyJarTask) {
     "lib": [
       "agent-${project.version}-classes.jar",
       "agent-common-${project.version}.jar",
-      "angus-activation-${project.versions.angusActivation}.jar",
+      "angus-activation-2.0.2.jar",
       "animal-sniffer-annotations-1.9.jar",
       "ant-${project.versions.apacheAnt}.jar",
       "base-${project.version}.jar",
@@ -153,7 +153,7 @@ task verifyJar(type: VerifyJarTask) {
       "istack-commons-runtime-4.1.2.jar",
       "jakarta.activation-api-2.1.3.jar",
       "jakarta.annotation-api-${project.versions.jakartaAnnotation}.jar",
-      "jakarta.xml.bind-api-4.0.1.jar",
+      "jakarta.xml.bind-api-4.0.2.jar",
       "jaxb-core-${project.versions.jaxb}.jar",
       "jaxb-runtime-${project.versions.jaxb}.jar",
       "jcl-over-slf4j-${project.versions.slf4jBom}.jar",

--- a/build-platform/build.gradle
+++ b/build-platform/build.gradle
@@ -34,7 +34,6 @@ dependencies {
   api platform(project.deps.jaxbBom)
 
   constraints {
-    api project.deps.angusActivation
     api project.deps.commonsCodec
     api project.deps.commonsIO
     api project.deps.commonsPool

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -27,7 +27,6 @@ final Map<String, String> libraries = [
   // DO NOT interpolate version variables here because Dependabot is not smart enough to understand those. Dependabot's
   // version parsing is simply regex matching and never actually evaluates a gradle script.
   activeMQ            : 'org.apache.activemq:activemq-broker:5.18.3',
-  angusActivation     : 'org.eclipse.angus:angus-activation:2.0.2', // Compatibility with JAXB and Angus Mail required
   angusMailSmtp       : 'org.eclipse.angus:smtp:2.0.3',
   apacheAnt           : 'org.apache.ant:ant:1.10.14',
   apacheHttpComponents: 'org.apache.httpcomponents:httpclient:4.5.14',
@@ -109,7 +108,6 @@ final Map<String, String> libraries = [
 // Export versions that are needed outside of this file (and elsewhere within)
 final Map<String, String> v = [
   activeMQ            : versionOf(libraries.activeMQ),
-  angusActivation     : versionOf(libraries.angusActivation),
   angusMailSmtp       : versionOf(libraries.angusMailSmtp),
   apacheAnt           : versionOf(libraries.apacheAnt),
   apacheHttpComponents: versionOf(libraries.apacheHttpComponents),


### PR DESCRIPTION
Not necessary to manage the versions explicitly; the Angus SMTP and JAXB projects can generally be trusted to manage this between them.