### PR TITLE
Improve efficiency and clarity of working with ServerHealthStates

### DIFF
--- a/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/InternalMaterialsControllerV1.java
+++ b/api/api-internal-materials-v1/src/main/java/com/thoughtworks/go/apiv1/internalmaterials/InternalMaterialsControllerV1.java
@@ -102,7 +102,7 @@ public class InternalMaterialsControllerV1 extends ApiController implements Spar
         Map<MaterialConfig, Boolean> materialConfigs = materialConfigService.getMaterialConfigsWithPermissions(currentUsernameString());
         Map<String, Modification> modifications = materialService.getLatestModificationForEachMaterial();
         Collection<MaintenanceModeService.MaterialPerformingMDU> runningMDUs = maintenanceModeService.getRunningMDUs();
-        ServerHealthStates logs = serverHealthService.logs();
+        ServerHealthStates logs = serverHealthService.logsSorted();
         Map<MaterialConfig, MaterialInfo> mergedMap = createMergedMap(materialConfigs, modifications, runningMDUs, logs);
 
         final String etag = etagFor(mergedMap);

--- a/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/InternalMaterialsControllerV1Test.groovy
+++ b/api/api-internal-materials-v1/src/test/groovy/com/thoughtworks/go/apiv1/internalmaterials/InternalMaterialsControllerV1Test.groovy
@@ -113,7 +113,7 @@ class InternalMaterialsControllerV1Test implements SecurityServiceTrait, Control
     void setUp() {
       loginAsUser()
       when(materialConfigConverter.toMaterial(any(MaterialConfig.class))).thenReturn(material)
-      when(serverHealthService.logs()).thenReturn(new ServerHealthStates())
+      when(serverHealthService.logsSorted()).thenReturn(new ServerHealthStates())
     }
 
     @Nested

--- a/api/api-server-health-messages-v1/src/main/java/com/thoughtworks/go/apiv1/serverhealthmessages/ServerHealthMessagesController.java
+++ b/api/api-server-health-messages-v1/src/main/java/com/thoughtworks/go/apiv1/serverhealthmessages/ServerHealthMessagesController.java
@@ -63,7 +63,7 @@ public class ServerHealthMessagesController extends ApiController implements Spa
     }
 
     public String show(Request request, Response response) {
-        ServerHealthStates allLogs = serverHealthService.logs();
+        ServerHealthStates allLogs = serverHealthService.logsSorted();
         String json = jsonizeAsTopLevelArray(request, outputListWriter -> ServerHealthMessagesRepresenter.toJSON(outputListWriter, allLogs));
         String etag = etagFor(json);
 

--- a/common/src/test/java/com/thoughtworks/go/serverhealth/ServerHealthMatcher.java
+++ b/common/src/test/java/com/thoughtworks/go/serverhealth/ServerHealthMatcher.java
@@ -38,7 +38,7 @@ public class ServerHealthMatcher {
 
             @Override
             public boolean matchesSafely(ServerHealthService item) {
-                allLogs = item.logs();
+                allLogs = item.logsSorted();
                 for (ServerHealthState serverHealthState : allLogs) {
                     if (serverHealthState.getType().equals(healthStateType)) {
                         entry = serverHealthState;
@@ -75,7 +75,7 @@ public class ServerHealthMatcher {
 
             @Override
             public boolean matchesSafely(ServerHealthService item) {
-                for (ServerHealthState serverHealthState : item.logs()) {
+                for (ServerHealthState serverHealthState : item.logsSorted()) {
                     if (serverHealthState.getType().equals(healthStateType)) {
                         entry = serverHealthState;
                         return false;

--- a/config/config-server/src/test/java/com/thoughtworks/go/service/ConfigRepositoryGCWarningServiceTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/service/ConfigRepositoryGCWarningServiceTest.java
@@ -49,7 +49,7 @@ public class ConfigRepositoryGCWarningServiceTest {
         when(configRepository.getLooseObjectCount()).thenReturn(20L);
 
         service.checkRepoAndAddWarningIfRequired();
-        List<ServerHealthState> healthStates = serverHealthService.filterByScope(HealthStateScope.forConfigRepo("GC"));
+        List<ServerHealthState> healthStates = serverHealthService.logsSortedForScope(HealthStateScope.forConfigRepo("GC"));
         String message = "Action required: Run 'git gc' on config.git repo";
         String description = "Number of loose objects in your Configuration repository(config.git) has grown beyond " +
                 "the configured threshold. As the size of config repo increases, the config save operations tend to slow down " +
@@ -68,20 +68,20 @@ public class ConfigRepositoryGCWarningServiceTest {
         when(configRepository.getLooseObjectCount()).thenReturn(1L);
 
         service.checkRepoAndAddWarningIfRequired();
-        List<ServerHealthState> healthStates = serverHealthService.filterByScope(HealthStateScope.forConfigRepo("GC"));
+        List<ServerHealthState> healthStates = serverHealthService.logsSortedForScope(HealthStateScope.forConfigRepo("GC"));
         assertThat(healthStates.isEmpty(), is(true));
     }
 
     @Test
     public void shouldRemoteExistingWarningAboutGCIfLooseObjectCountGoesBelowTheSetThreshold() throws Exception {
         serverHealthService.update(ServerHealthState.warning("message", "description", HealthStateType.general(HealthStateScope.forConfigRepo("GC"))));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forConfigRepo("GC")).isEmpty(), is(false));
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forConfigRepo("GC")).isEmpty(), is(false));
 
         when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_LOOSE_OBJECT_WARNING_THRESHOLD)).thenReturn(10L);
         when(configRepository.getLooseObjectCount()).thenReturn(1L);
 
         service.checkRepoAndAddWarningIfRequired();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forConfigRepo("GC")).isEmpty(), is(true));
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forConfigRepo("GC")).isEmpty(), is(true));
     }
 
 }

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
@@ -56,8 +56,7 @@ public class ConfigReposMaterialParseResultManager {
 
         //config repository was parsed, but does not have merge or clone related errors.
         if (result != null && result.isSuccessful()) {
-            HealthStateScope healthStateScope = HealthStateScope.forPartialConfigRepo(fingerprint);
-            List<ServerHealthState> serverHealthStates = serverHealthService.filterByScope(healthStateScope);
+            List<ServerHealthState> serverHealthStates = serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(fingerprint));
             if (!serverHealthStates.isEmpty()) {
                 result.setException(asError(serverHealthStates.get(0)));
 
@@ -94,7 +93,7 @@ public class ConfigReposMaterialParseResultManager {
             PartialConfigParseResult result = entry.getValue();
 
             HealthStateScope scope = HealthStateScope.forPartialConfigRepo(fingerprint);
-            List<ServerHealthState> serverHealthErrors = serverHealthService.filterByScope(scope);
+            List<ServerHealthState> serverHealthErrors = serverHealthService.logsSortedForScope(scope);
 
             if (!serverHealthErrors.isEmpty() || !result.isSuccessful()) {
                 result.setLatestParsedModification(null); // clear modification to allow a reparse to happen
@@ -103,9 +102,9 @@ public class ConfigReposMaterialParseResultManager {
     }
 
     private PartialConfigParseResult checkForMaterialErrors(String fingerprint) {
-        MaterialConfig naterial = configRepoService.findByFingerprint(fingerprint).getRepo();
-        HealthStateScope healthStateScope = HealthStateScope.forMaterialConfig(naterial);
-        List<ServerHealthState> serverHealthStates = serverHealthService.filterByScope(healthStateScope);
+        MaterialConfig material = configRepoService.findByFingerprint(fingerprint).getRepo();
+        HealthStateScope healthStateScope = HealthStateScope.forMaterialConfig(material);
+        List<ServerHealthState> serverHealthStates = serverHealthService.logsSortedForScope(healthStateScope);
 
         return serverHealthStates.isEmpty() ?
                 null :

--- a/server/src/main/java/com/thoughtworks/go/server/materials/MaterialUpdateService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/MaterialUpdateService.java
@@ -41,7 +41,6 @@ import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
-import com.thoughtworks.go.serverhealth.ServerHealthState;
 import com.thoughtworks.go.util.MaterialFingerprintTag;
 import com.thoughtworks.go.util.ProcessManager;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -254,12 +253,7 @@ public class MaterialUpdateService implements GoMessageListener<MaterialUpdateCo
     @Override
     public void onConfigChange(CruiseConfig newCruiseConfig) {
         Set<HealthStateScope> materialScopes = toHealthStateScopes(newCruiseConfig.getAllUniqueMaterials());
-        for (ServerHealthState state : serverHealthService.logs()) {
-            HealthStateScope currentScope = state.getType().getScope();
-            if (currentScope.isForMaterial() && !materialScopes.contains(currentScope)) {
-                serverHealthService.removeByScope(currentScope);
-            }
-        }
+        serverHealthService.removeByScopeMatcher(scope -> scope.isForMaterial() && !materialScopes.contains(scope));
     }
 
     protected EntityConfigChangedListener<PipelineConfig> pipelineConfigChangedListener() {

--- a/server/src/main/java/com/thoughtworks/go/server/service/support/ServerHealthInformationProvider.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/ServerHealthInformationProvider.java
@@ -46,7 +46,7 @@ public class ServerHealthInformationProvider implements ServerInfoProvider {
     @Override
     public Map<String, Object> asJson() {
         LinkedHashMap<String, Object> json = new LinkedHashMap<>();
-        ServerHealthStates allLogs = service.logs();
+        ServerHealthStates allLogs = service.logsSorted();
         json.put("Messages Count", allLogs.size());
 
         ArrayList<Map<String, String>> messages = new ArrayList<>();

--- a/server/src/test-fast/java/com/thoughtworks/go/config/CachedGoPartialsTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/CachedGoPartialsTest.java
@@ -89,8 +89,8 @@ public class CachedGoPartialsTest {
         serverHealthService.update(ServerHealthState.error("err_repo2", "err desc", HealthStateType.general(HealthStateScope.forPartialConfigRepo(configRepo2))));
         partials.removeKnown(configRepo1.getRepo().getFingerprint());
         assertFalse(partials.lastKnownPartials().contains(part1));
-        assertTrue(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(configRepo1)).isEmpty());
-        assertFalse(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(configRepo2)).isEmpty());
+        assertTrue(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(configRepo1)).isEmpty());
+        assertFalse(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(configRepo2)).isEmpty());
     }
 
     @Test
@@ -98,10 +98,10 @@ public class CachedGoPartialsTest {
         serverHealthService.update(ServerHealthState.error("error-repo-1", "error-desc-1", HealthStateType.general(HealthStateScope.forPartialConfigRepo(fingerprintForRepo1))));
         serverHealthService.update(ServerHealthState.error("error-repo-2", "error-desc-2", HealthStateType.general(HealthStateScope.forPartialConfigRepo(fingerprintForRepo2))));
         partials.markAsValid(fingerprintForRepo1, part1);
-        assertTrue(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(fingerprintForRepo1)).isEmpty());
-        assertEquals("error-repo-2", serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(fingerprintForRepo2)).get(0).getMessage());
+        assertTrue(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(fingerprintForRepo1)).isEmpty());
+        assertEquals("error-repo-2", serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(fingerprintForRepo2)).get(0).getMessage());
         partials.markAllKnownAsValid();
-        assertTrue(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(fingerprintForRepo1)).isEmpty());
-        assertTrue(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(fingerprintForRepo2)).isEmpty());
+        assertTrue(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(fingerprintForRepo1)).isEmpty());
+        assertTrue(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(fingerprintForRepo2)).isEmpty());
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
@@ -58,7 +58,7 @@ class ConfigReposMaterialParseResultManagerTest {
 
     @BeforeEach
     void setUp() {
-        lenient().when(serverHealthService.filterByScope(any())).thenReturn(Collections.emptyList());
+        lenient().when(serverHealthService.logsSortedForScope(any())).thenReturn(Collections.emptyList());
         ScmMaterialConfig material = git("http://my.git");
         ConfigRepoConfig configRepoConfig = ConfigRepoConfig.createConfigRepoConfig(material, "myplugin", "id");
         lenient().when(configRepoService.findByFingerprint(anyString())).thenReturn(configRepoConfig);
@@ -72,7 +72,7 @@ class ConfigReposMaterialParseResultManagerTest {
         HealthStateScope scope = HealthStateScope.forPartialConfigRepo(fingerprint);
         ServerHealthState error = ServerHealthState.error("boom", "bang!", HealthStateType.general(scope));
 
-        when(serverHealthService.filterByScope(scope)).thenReturn(List.of(error));
+        when(serverHealthService.logsSortedForScope(scope)).thenReturn(List.of(error));
 
         Modification modification = modificationFor("rev1");
         manager.parseFailed(fingerprint, modification, new Exception());
@@ -107,7 +107,7 @@ class ConfigReposMaterialParseResultManagerTest {
     @Test
     void shouldCheckForErrorsRelatedToConfigRepoMaterialWithtinServerHealthScope() {
         ServerHealthState serverHealthState = ServerHealthState.error("Error Happened!", "Boom!", HealthStateType.general(HealthStateScope.GLOBAL));
-        when(serverHealthService.filterByScope(any())).thenReturn(List.of(serverHealthState));
+        when(serverHealthService.logsSortedForScope(any())).thenReturn(List.of(serverHealthState));
         String fingerprint = "repo1";
 
 
@@ -124,7 +124,7 @@ class ConfigReposMaterialParseResultManagerTest {
     @Test
     void shouldClearGoodModificationInCaseGoodModificationIsSameAsOfLastParsedModificationAsHealthServiceHasErrors() {
         ServerHealthState serverHealthState = ServerHealthState.error("Error Happened!", "Boom!", HealthStateType.general(HealthStateScope.GLOBAL));
-        when(serverHealthService.filterByScope(any())).thenReturn(List.of(serverHealthState));
+        when(serverHealthService.logsSortedForScope(any())).thenReturn(List.of(serverHealthState));
         String fingerprint = "repo1";
 
 
@@ -140,7 +140,7 @@ class ConfigReposMaterialParseResultManagerTest {
     @Test
     void shouldAddAnErrorFromHealthStateWhenNoResultExistsForTheConfigRepo() {
         ServerHealthState serverHealthState = ServerHealthState.error("Error Happened!", "Boom!", HealthStateType.general(HealthStateScope.GLOBAL));
-        when(serverHealthService.filterByScope(any())).thenReturn(List.of(serverHealthState));
+        when(serverHealthService.logsSortedForScope(any())).thenReturn(List.of(serverHealthState));
         String fingerprint = "repo1";
 
         String expectedBeautifiedMessage = String.format("%s\n%s", serverHealthState.getMessage().toUpperCase(), serverHealthState.getDescription());
@@ -152,7 +152,7 @@ class ConfigReposMaterialParseResultManagerTest {
     @Test
     void shouldAddAnErrorFromHealthStateWhenNoResultExistsForTheConfigRepoWithoutAddingModification() {
         ServerHealthState serverHealthState = ServerHealthState.error("Error Happened!", "Boom!", HealthStateType.general(HealthStateScope.GLOBAL));
-        when(serverHealthService.filterByScope(any())).thenReturn(List.of(serverHealthState));
+        when(serverHealthService.logsSortedForScope(any())).thenReturn(List.of(serverHealthState));
         String fingerprint = "repo1";
 
         assertFalse(manager.get(fingerprint).isSuccessful());

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoConfigRepoConfigDataSourceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoConfigRepoConfigDataSourceTest.java
@@ -254,7 +254,7 @@ public class GoConfigRepoConfigDataSourceTest {
 
         assertTrue(repoConfigDataSource.latestParseHasFailedForMaterial(material));
 
-        assertFalse(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(configRepoConfig)).isEmpty());
+        assertFalse(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(configRepoConfig)).isEmpty());
     }
 
     @Test
@@ -268,12 +268,12 @@ public class GoConfigRepoConfigDataSourceTest {
         HealthStateScope scope = HealthStateScope.forPartialConfigRepo(configRepoConfig);
         serverHealthService.update(ServerHealthState.error("Parse failed", "Bad config format", HealthStateType.general(scope)));
         // verify error health
-        assertFalse(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(configRepoConfig)).isEmpty());
+        assertFalse(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(configRepoConfig)).isEmpty());
 
         // now this should fix health
         repoConfigDataSource.onCheckoutComplete(material, folder, getModificationFor("7a8f"));
 
-        assertTrue(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(configRepoConfig)).isEmpty());
+        assertTrue(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(configRepoConfig)).isEmpty());
     }
 
     private class BrokenConfigPlugin implements PartialConfigProvider {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/SCMMaterialSourceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/SCMMaterialSourceTest.java
@@ -243,7 +243,7 @@ public class SCMMaterialSourceTest {
         schedulableMaterialConfigs = Set.of(svnMaterial.config(), gitMaterial.config());
         when(goConfigService.getSchedulableSCMMaterials()).thenReturn(schedulableMaterialConfigs);
         when(materialConfigConverter.toMaterials(schedulableMaterialConfigs)).thenReturn(Set.of(svnMaterial, gitMaterial));
-        when(serverHealthService.logs()).thenReturn(new ServerHealthStates());
+        when(serverHealthService.logsSorted()).thenReturn(new ServerHealthStates());
 
         source.onConfigChange(mock(CruiseConfig.class));
         materials = source.materialsForUpdate();
@@ -258,7 +258,7 @@ public class SCMMaterialSourceTest {
         Set<MaterialConfig> schedulableMaterialConfigs = Set.of(svnMaterial.config(), gitMaterial.config());
         when(goConfigService.getSchedulableSCMMaterials()).thenReturn(schedulableMaterialConfigs);
         when(materialConfigConverter.toMaterials(schedulableMaterialConfigs)).thenReturn(Set.of(svnMaterial, gitMaterial));
-        when(serverHealthService.logs()).thenReturn(new ServerHealthStates());
+        when(serverHealthService.logsSorted()).thenReturn(new ServerHealthStates());
 
         source.onEntityConfigChange(mock(ConfigRepoConfig.class));
         Set<Material> materials = source.materialsForUpdate();
@@ -285,7 +285,7 @@ public class SCMMaterialSourceTest {
         when(goConfigService.getSchedulableSCMMaterials()).thenReturn(schedulableMaterialConfigs);
         when(goConfigService.getCurrentConfig()).thenReturn(mock(CruiseConfig.class));
         when(materialConfigConverter.toMaterials(schedulableMaterialConfigs)).thenReturn(Set.of(svnMaterial, gitMaterial));
-        when(serverHealthService.logs()).thenReturn(new ServerHealthStates());
+        when(serverHealthService.logsSorted()).thenReturn(new ServerHealthStates());
 
         source.pipelineConfigChangedListener().onEntityConfigChange(mock(PipelineConfig.class));
         materials = source.materialsForUpdate();

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/JobInstanceServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/JobInstanceServiceTest.java
@@ -393,11 +393,11 @@ public class JobInstanceServiceTest {
         ServerHealthService serverHealthService = new ServerHealthService();
         serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(HealthStateScope.forJob("p1", "s1", "j1"))));
         serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(HealthStateScope.forJob("p2", "s2", "j2"))));
-        assertThat(serverHealthService.logs().errorCount(), is(2));
+        assertThat(serverHealthService.logsSorted().errorCount(), is(2));
         JobInstanceService jobService = new JobInstanceService(jobInstanceDao, null, jobStatusCache, transactionTemplate, transactionSynchronizationManager, null, null, goConfigService,
             null, serverHealthService);
         jobService.onConfigChange(new BasicCruiseConfig());
-        assertThat(serverHealthService.logs().errorCount(), is(0));
+        assertThat(serverHealthService.logsSorted().errorCount(), is(0));
     }
 
     @Test
@@ -405,13 +405,13 @@ public class JobInstanceServiceTest {
         ServerHealthService serverHealthService = new ServerHealthService();
         serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(HealthStateScope.forJob("p1", "s1", "j1"))));
         serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(HealthStateScope.forJob("p2", "s2", "j2"))));
-        assertThat(serverHealthService.logs().errorCount(), is(2));
+        assertThat(serverHealthService.logsSorted().errorCount(), is(2));
         JobInstanceService jobService = new JobInstanceService(jobInstanceDao, null, jobStatusCache, transactionTemplate, transactionSynchronizationManager, null, null, goConfigService,
             null, serverHealthService);
         JobInstanceService.PipelineConfigChangedListener pipelineConfigChangedListener = jobService.new PipelineConfigChangedListener();
         pipelineConfigChangedListener.onEntityConfigChange(PipelineConfigMother.pipelineConfig("p1", "s_new", new MaterialConfigs(), "j1"));
-        assertThat(serverHealthService.logs().errorCount(), is(1));
-        assertThat(serverHealthService.logs().get(0).getType().getScope().getScope(), is("p2/s2/j2"));
+        assertThat(serverHealthService.logsSorted().errorCount(), is(1));
+        assertThat(serverHealthService.logsSorted().get(0).getType().getScope().getScope(), is("p2/s2/j2"));
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
@@ -180,7 +180,7 @@ public class CachedGoConfigIntegrationTest {
         // And unluckily downstream gets parsed first
         repoConfigDataSource.onCheckoutComplete(downstreamConfigRepo.getRepo(), downstreamExternalConfigRepo, downstreamLatestModification);
         // So parsing fails and proper message is shown:
-        List<ServerHealthState> messageForInvalidMerge = serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(downstreamConfigRepo));
+        List<ServerHealthState> messageForInvalidMerge = serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(downstreamConfigRepo));
         assertThat(messageForInvalidMerge.isEmpty()).isFalse();
         assertThat(messageForInvalidMerge.get(0).getDescription()).contains("tries to fetch artifact from pipeline &quot;pipe1&quot;");
         // and current config is still old
@@ -194,8 +194,8 @@ public class CachedGoConfigIntegrationTest {
         repoConfigDataSource.onCheckoutComplete(configRepo.getRepo(), externalConfigRepo, latestModification);
 
         // now server should be healthy and contain all pipelines
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(configRepo)).isEmpty()).isTrue();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(downstreamConfigRepo)).isEmpty()).isTrue();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(configRepo)).isEmpty()).isTrue();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(downstreamConfigRepo)).isEmpty()).isTrue();
         assertThat(cachedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("pipe1"))).isTrue();
         assertThat(cachedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("downstream"))).isTrue();
     }
@@ -220,7 +220,7 @@ public class CachedGoConfigIntegrationTest {
         repoConfigDataSource.onCheckoutComplete(secondDownstreamConfigRepo.getRepo(), secondDownstreamExternalConfigRepo, secondDownstreamLatestModification);
 
         // So parsing fails and proper message is shown:
-        List<ServerHealthState> messageForInvalidMerge = serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(secondDownstreamConfigRepo));
+        List<ServerHealthState> messageForInvalidMerge = serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(secondDownstreamConfigRepo));
 
         assertThat(messageForInvalidMerge.isEmpty()).isFalse();
         assertThat(messageForInvalidMerge.get(0).getDescription()).contains("tries to fetch artifact from pipeline &quot;downstream&quot;");
@@ -235,7 +235,7 @@ public class CachedGoConfigIntegrationTest {
         repoConfigDataSource.onCheckoutComplete(firstDownstreamConfigRepo.getRepo(), firstDownstreamExternalConfigRepo, firstDownstreamLatestModification);
 
         // and errors are still shown
-        messageForInvalidMerge = serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(firstDownstreamConfigRepo));
+        messageForInvalidMerge = serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(firstDownstreamConfigRepo));
         assertThat(messageForInvalidMerge.isEmpty()).isFalse();
         assertThat(messageForInvalidMerge.get(0).getDescription()).contains("Pipeline 'pipe1' does not exist. It is used from pipeline 'downstream'");
         // and current config is still old
@@ -249,8 +249,8 @@ public class CachedGoConfigIntegrationTest {
 
         // now server should be healthy and contain all pipelines
 
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(firstDownstreamConfigRepo)).isEmpty()).isTrue();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(secondDownstreamConfigRepo)).isEmpty()).isTrue();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(firstDownstreamConfigRepo)).isEmpty()).isTrue();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(secondDownstreamConfigRepo)).isEmpty()).isTrue();
         assertThat(cachedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("pipe1"))).isTrue();
         assertThat(cachedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("downstream"))).isTrue();
         assertThat(cachedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("downstream2"))).isTrue();
@@ -288,7 +288,7 @@ public class CachedGoConfigIntegrationTest {
         assertThat(configWatchList.getCurrentConfigRepos().size()).isEqualTo(1);
 
         repoConfigDataSource.onCheckoutComplete(configRepo.getRepo(), externalConfigRepo, latestModification);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(configRepo)).isEmpty()).isTrue();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(configRepo)).isEmpty()).isTrue();
         assertThat(repoConfigDataSource.latestPartialConfigForMaterial(configRepo.getRepo()).getGroups().findGroup("first").findBy(new CaseInsensitiveString("pipe1"))).isNotNull();
         assertThat(cachedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("pipe1"))).isTrue();
     }
@@ -361,7 +361,7 @@ public class CachedGoConfigIntegrationTest {
     }
 
     private List<ServerHealthState> findMessageFor(final HealthStateType type) {
-        return serverHealthService.logs().stream().filter(element -> element.getType().equals(type)).collect(Collectors.toList());
+        return serverHealthService.logsSorted().stream().filter(element -> element.getType().equals(type)).collect(Collectors.toList());
     }
 
     @Test
@@ -400,7 +400,7 @@ public class CachedGoConfigIntegrationTest {
 
         repoConfigDataSource.onCheckoutComplete(configRepo.getRepo(), externalConfigRepo, latestModification);
 
-        List<ServerHealthState> messageForInvalidMerge = serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(configRepo));
+        List<ServerHealthState> messageForInvalidMerge = serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(configRepo));
 
         assertThat(messageForInvalidMerge.isEmpty()).isFalse();
         assertThat(messageForInvalidMerge.get(0).getDescription().contains("Pipeline 'pipeline_with_no_stage' does not have any stages configured")).isTrue();
@@ -411,12 +411,12 @@ public class CachedGoConfigIntegrationTest {
         ConfigRepoConfig configRepo = configWatchList.getCurrentConfigRepos().get(0);
         checkinPartial("config_repo_with_invalid_partial/bad_partial.gocd.xml");
         repoConfigDataSource.onCheckoutComplete(configRepo.getRepo(), externalConfigRepo, latestModification);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(configRepo)).isEmpty()).isFalse();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(configRepo)).isEmpty()).isFalse();
 
         //fix partial
         deletePartial("bad_partial.gocd.xml");
         repoConfigDataSource.onCheckoutComplete(configRepo.getRepo(), externalConfigRepo, latestModification);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(configRepo)).isEmpty()).isTrue();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(configRepo)).isEmpty()).isTrue();
     }
 
     @Test
@@ -666,7 +666,7 @@ public class CachedGoConfigIntegrationTest {
 
         assertThat(cachedGoConfig.checkConfigFileValid().isValid()).isEqualTo(false);
 
-        List<ServerHealthState> serverHealthStates = serverHealthService.logs();
+        List<ServerHealthState> serverHealthStates = serverHealthService.logsSorted();
         assertThat(serverHealthStates.isEmpty()).isFalse();
         assertThat(serverHealthStates.contains(ServerHealthState.error(GoConfigService.INVALID_CRUISE_CONFIG_XML, "Error on line 1: Content is not allowed in prolog.", HealthStateType.invalidConfig()))).isTrue();
     }
@@ -961,10 +961,10 @@ public class CachedGoConfigIntegrationTest {
         // introduce an invalid change in repo1 so that there is a server health message corresponding to it
         PartialConfig invalidPartialInRepo1Revision2 = PartialConfigMother.invalidPartial("pipeline_in_repo1", new RepoConfigOrigin(repoConfig1, "repo1_r2"));
         partialConfigService.onSuccessPartialConfig(repoConfig1, invalidPartialInRepo1Revision2);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url1 at revision repo1_r2");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty()).isTrue();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url1 at revision repo1_r2");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty()).isTrue();
 
         int countBeforeDeletion = cachedGoConfig.currentConfig().getConfigRepos().size();
         ConfigSaveState configSaveState = cachedGoConfig.writeWithLock(cruiseConfig -> {
@@ -983,8 +983,8 @@ public class CachedGoConfigIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.lastValidPartials().get(0).getOrigin()).getMaterial().getFingerprint().equals(repoConfig2.getRepo().getFingerprint())).isTrue();
         assertThat(cachedGoPartials.lastValidPartials().stream().filter(item -> ((RepoConfigOrigin) item.getOrigin()).getMaterial().getFingerprint().equals(repoConfig1.getRepo().getFingerprint())).findFirst().orElse(null)).isNull();
 
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).isEmpty()).isTrue();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty()).isTrue();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).isEmpty()).isTrue();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty()).isTrue();
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigratorIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigratorIntegrationTest.java
@@ -182,7 +182,7 @@ public class GoConfigMigratorIntegrationTest {
         try {
             loadConfigFileWithContent(ConfigFileFixture.MINIMAL);
             loadConfigFileWithContent("<cruise></cruise>");
-            ServerHealthStates states = serverHealthService.logs();
+            ServerHealthStates states = serverHealthService.logsSorted();
             assertThat(states.size()).isEqualTo(1);
             assertThat(states.get(0).getDescription()).contains("Go encountered an invalid configuration file while starting up. The invalid configuration file has been renamed to &lsquo;");
             assertThat(states.get(0).getDescription()).contains("&rsquo; and a new configuration file has been automatically created using the last good configuration.");

--- a/server/src/test-integration/java/com/thoughtworks/go/config/InvalidConfigMessageRemoverIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/InvalidConfigMessageRemoverIntegrationTest.java
@@ -81,9 +81,9 @@ public class InvalidConfigMessageRemoverIntegrationTest {
         serverHealthService.update(ServerHealthState.warning("Invalid Configuration", "something",HealthStateType.general(HealthStateScope.forInvalidConfig())));
         InvalidConfigMessageRemover remover = new InvalidConfigMessageRemover(goConfigService, serverHealthService);
         remover.initialize();
-        assertThat(serverHealthService.logs().isEmpty(), is(false));
+        assertThat(serverHealthService.logsSorted().isEmpty(), is(false));
         configHelper.addEnvironments("uat"); //Any change to the config file
         cachedGoConfig.forceReload();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forInvalidConfig()).isEmpty(), is(true));
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forInvalidConfig()).isEmpty(), is(true));
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/cronjob/GoDiskSpaceMonitorTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/cronjob/GoDiskSpaceMonitorTest.java
@@ -221,7 +221,7 @@ public class GoDiskSpaceMonitorTest {
     }
 
     private ServerHealthState findByLogType(HealthStateType healthStateType) {
-        for (ServerHealthState serverHealthState : serverHealthService.logs()) {
+        for (ServerHealthState serverHealthState : serverHealthService.logsSorted()) {
             if (serverHealthState.getType().equals(healthStateType)) {
                 return serverHealthState;
             }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerIntegrationTest.java
@@ -152,7 +152,7 @@ public class ConfigMaterialUpdateListenerIntegrationTest {
     private void assertInProgressState() throws InterruptedException {
         HealthStateScope healthStateScope = HealthStateScope.forPartialConfigRepo(material.config().getFingerprint());
         int i = 0;
-        while (serverHealthService.filterByScope(healthStateScope).isEmpty() && goConfigRepoConfigDataSource.getRevisionAtLastAttempt(material.config()) == null) {
+        while (serverHealthService.logsSortedForScope(healthStateScope).isEmpty() && goConfigRepoConfigDataSource.getRevisionAtLastAttempt(material.config()) == null) {
             if (!materialUpdateService.isInProgress(material))
                 fail("should be still in progress");
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
@@ -57,6 +57,9 @@ import com.thoughtworks.go.server.service.result.HttpOperationResult;
 import com.thoughtworks.go.server.service.result.OperationResult;
 import com.thoughtworks.go.server.service.result.ServerHealthStateOperationResult;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
+import com.thoughtworks.go.serverhealth.HealthStateLevel;
+import com.thoughtworks.go.serverhealth.HealthStateType;
+import com.thoughtworks.go.serverhealth.ServerHealthMatcher;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.util.ReflectionUtil;
@@ -283,8 +286,7 @@ public class BuildCauseProducerServiceIntegrationTest {
 
         scheduleHelper.autoSchedulePipelinesWithRealMaterials();
 
-        assertThat(serverHealthService.getLogsAsText(),
-                containsString("GoCD Server has run out of artifacts disk space. Scheduling has been stopped"));
+        assertThat(serverHealthService, ServerHealthMatcher.containsState(HealthStateType.artifactsDiskFull(), HealthStateLevel.ERROR, "GoCD Server has run out of artifacts disk space. Scheduling has been stopped"));
         assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), not(hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME))));
     }
 
@@ -297,8 +299,7 @@ public class BuildCauseProducerServiceIntegrationTest {
         buildCauseProducer.manualProduceBuildCauseAndSave(MINGLE_PIPELINE_NAME, Username.ANONYMOUS, new ScheduleOptions(revisions, environmentVariables, new HashMap<>()),
                 new ServerHealthStateOperationResult());
 
-        assertThat(serverHealthService.getLogsAsText(),
-                containsString("GoCD Server has run out of artifacts disk space. Scheduling has been stopped"));
+        assertThat(serverHealthService, ServerHealthMatcher.containsState(HealthStateType.artifactsDiskFull(), HealthStateLevel.ERROR, "GoCD Server has run out of artifacts disk space. Scheduling has been stopped"));
         assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), not(hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME))));
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
@@ -777,8 +777,8 @@ public class PipelineConfigServiceIntegrationTest {
     public void shouldSaveWhenKnownPartialListIsTheSameAsValidPartialsAndValidationPassesForConfigChanges() {
         PipelineConfig remoteDownstreamPipeline = partialConfig.getGroups().first().getPipelines().get(0);
         assertThat(goConfigService.getCurrentConfig().getAllPipelineNames().contains(remoteDownstreamPipeline.name())).isTrue();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
 
         DependencyMaterialConfig dependencyMaterialForRemotePipelineInConfigCache = goConfigService.getCurrentConfig().getPipelineConfigByName(remoteDownstreamPipeline.name()).materialConfigs().findDependencyMaterial(pipelineConfig.name());
         assertThat(dependencyMaterialForRemotePipelineInConfigCache.getStageName()).isEqualTo(new CaseInsensitiveString("stage"));
@@ -792,16 +792,16 @@ public class PipelineConfigServiceIntegrationTest {
         CruiseConfig currentConfig = goConfigService.getCurrentConfig();
         assertThat(currentConfig.getAllPipelineNames().contains(remoteDownstreamPipeline.name())).isTrue();
         assertThat(currentConfig.getPipelineConfigByName(pipelineConfig.name()).getVariables().contains(new EnvironmentVariableConfig("key", "value"))).isTrue();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
     }
 
     @Test
     public void shouldNotSaveWhenKnownPartialsListIsTheSameAsValidPartialsAndPipelineValidationFailsForConfigChanges() {
         PipelineConfig remoteDownstreamPipeline = partialConfig.getGroups().first().getPipelines().get(0);
         assertThat(goConfigService.getCurrentConfig().getAllPipelineNames().contains(remoteDownstreamPipeline.name())).isTrue();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
 
         DependencyMaterialConfig dependencyMaterialForRemotePipelineInConfigCache = goConfigService.getCurrentConfig().getPipelineConfigByName(remoteDownstreamPipeline.name()).materialConfigs().findDependencyMaterial(pipelineConfig.name());
         assertThat(dependencyMaterialForRemotePipelineInConfigCache.getStageName()).isEqualTo(new CaseInsensitiveString("stage"));
@@ -820,16 +820,16 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(cachedGoPartials.lastKnownPartials().equals(cachedGoPartials.lastValidPartials())).isTrue();
         assertThat(currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).materialConfigs().findDependencyMaterial(pipelineConfig.name()).getStageName()).isEqualTo(new CaseInsensitiveString("stage"));
         assertThat(currentConfig.getPipelineConfigByName(pipelineConfig.name()).getFirstStageConfig().name()).isEqualTo(new CaseInsensitiveString("stage"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
     }
 
     @Test
     public void shouldSaveWhenKnownNotEqualsValidPartialsAndPipelineValidationPassesWhenValidPartialsAreMergedToMain() {
         PipelineConfig remoteDownstreamPipeline = partialConfig.getGroups().first().getPipelines().get(0);
         assertThat(goConfigService.getCurrentConfig().getAllPipelineNames().contains(remoteDownstreamPipeline.name())).isTrue();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
 
         partialConfig = PartialConfigMother.invalidPartial(remoteDownstreamPipeline.name().toString(), new RepoConfigOrigin(repoConfig1, "repo1_r2"));
         partialConfigService.onSuccessPartialConfig(repoConfig1, partialConfig);
@@ -838,10 +838,10 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision()).isEqualTo("repo1_r1");
         assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo1_r1");
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo1_r2");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url at revision repo1_r2");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url at revision repo1_r2");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
 
         String digest = entityHashingService.hashForEntity(pipelineConfig, groupName);
         pipelineConfig.setVariables(new EnvironmentVariablesConfig(List.of(new EnvironmentVariableConfig("key", "value"))));
@@ -855,18 +855,18 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo1_r1");
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo1_r2");
 
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url at revision repo1_r2");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url at revision repo1_r2");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
     }
 
     @Test
     public void shouldSaveWhenKnownNotEqualsValidPartialsAndPipelineValidationFailsWithValidPartialsButPassesWhenKnownPartialsAreMergedToMain() {
         PipelineConfig remoteDownstreamPipeline = partialConfig.getGroups().first().getPipelines().get(0);
         assertThat(goConfigService.getCurrentConfig().getAllPipelineNames().contains(remoteDownstreamPipeline.name())).isTrue();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
 
         final CaseInsensitiveString upstreamStageRenamed = new CaseInsensitiveString("upstream_stage_renamed");
         partialConfig = PartialConfigMother.pipelineWithDependencyMaterial("remote-downstream", new PipelineConfig(pipelineConfig.name(), pipelineConfig.materialConfigs(), new StageConfig(upstreamStageRenamed, new JobConfigs())), new RepoConfigOrigin(repoConfig1, "repo1_r2"));
@@ -877,10 +877,10 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision()).isEqualTo("repo1_r1");
         assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo1_r1");
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo1_r2");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name()));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name()));
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
 
         String digest = entityHashingService.hashForEntity(pipelineConfig, groupName);
         pipelineConfig.getFirstStageConfig().setName(new CaseInsensitiveString("upstream_stage_renamed"));
@@ -897,8 +897,8 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision()).isEqualTo("repo1_r2");
         assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo1_r2");
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo1_r2");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
     }
 
     @Test
@@ -914,10 +914,10 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig2.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo2_r1");
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig2.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo2_r2");
         assertThat(((RepoConfigOrigin) goConfigService.getCurrentConfig().getPipelineConfigByName(new CaseInsensitiveString(independentRemotePipeline)).getOrigin()).getRevision()).isEqualTo("repo2_r1");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size()).isEqualTo(1);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at revision repo2_r2");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size()).isEqualTo(1);
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at revision repo2_r2");
 
         final CaseInsensitiveString upstreamStageRenamed = new CaseInsensitiveString("upstream_stage_renamed");
         partialConfig = PartialConfigMother.pipelineWithDependencyMaterial("remote-downstream", new PipelineConfig(pipelineConfig.name(), pipelineConfig.materialConfigs(), new StageConfig(upstreamStageRenamed, new JobConfigs())), new RepoConfigOrigin(repoConfig1, "repo1_r2"));
@@ -928,12 +928,12 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision()).isEqualTo("repo1_r1");
         assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo1_r1");
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo1_r2");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name()));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size()).isEqualTo(1);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at revision repo2_r2");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name()));
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size()).isEqualTo(1);
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at revision repo2_r2");
 
         String digest = entityHashingService.hashForEntity(pipelineConfig, groupName);
 
@@ -961,12 +961,12 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(new CaseInsensitiveString(independentRemotePipeline)).getOrigin()).getRevision()).isEqualTo("repo2_r1");
         assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig2.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo2_r1");
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig2.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo2_r2");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name()));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size()).isEqualTo(1);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at revision repo2_r2");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name()));
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size()).isEqualTo(1);
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription()).isEqualTo("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores, hyphens and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.\n- For Config Repo: url2 at revision repo2_r2");
     }
 
     @Test
@@ -983,10 +983,10 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision()).isEqualTo("repo1_r1");
         assertThat(((RepoConfigOrigin) cachedGoPartials.getValid(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo1_r1");
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getRepo().getFingerprint()).getOrigin()).getRevision()).isEqualTo("repo1_r2");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name()));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name()));
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
 
         String digest = entityHashingService.hashForEntity(pipelineConfig, groupName);
 
@@ -1013,10 +1013,10 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) currentConfig.getPipelineConfigByName(remoteDownstreamPipeline.name()).getOrigin()).getRevision()).isEqualTo("repo1_r1");
         assertThat(((RepoConfigOrigin) cachedGoPartials.lastValidPartials().get(0).getOrigin()).getRevision()).isEqualTo("repo1_r1");
         assertThat(((RepoConfigOrigin) cachedGoPartials.lastKnownPartials().get(0).getOrigin()).getRevision()).isEqualTo("repo1_r2");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name()));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size()).isEqualTo(1);
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage()).isEqualTo("Invalid Merged Configuration");
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription()).isEqualTo(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at revision repo1_r2)\n- For Config Repo: url at revision repo1_r2", pipelineConfig.name()));
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPartialConfigRepo(repoConfig2))).isEmpty();
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineSchedulerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineSchedulerIntegrationTest.java
@@ -133,7 +133,7 @@ public class PipelineSchedulerIntegrationTest {
         serverHealthService.update(ServerHealthState.failToScheduling(HealthStateType.general(HealthStateScope.forPipeline(PIPELINE_MINGLE)), PIPELINE_MINGLE, "should wait till cleared"));
         pipelineScheduler.manualProduceBuildCauseAndSave(PIPELINE_MINGLE, Username.ANONYMOUS, scheduleOptions, operationResult);
         assertThat(operationResult.message(), operationResult.canContinue(),is(true));
-        Assertions.waitUntil(Timeout.ONE_MINUTE, () -> serverHealthService.filterByScope(HealthStateScope.forPipeline(PIPELINE_MINGLE)).isEmpty());
+        Assertions.waitUntil(Timeout.ONE_MINUTE, () -> serverHealthService.logsSortedForScope(HealthStateScope.forPipeline(PIPELINE_MINGLE)).isEmpty());
         BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(PIPELINE_MINGLE));
 
         EnvironmentVariables overriddenVariables = buildCause.getVariables();
@@ -152,7 +152,7 @@ public class PipelineSchedulerIntegrationTest {
 
     @SuppressWarnings("SameParameterValue")
     private void assertCurrentErrorLogNumberIs(String pipelineName, int number) {
-        List<ServerHealthState> entries = serverHealthService.filterByScope(HealthStateScope.forPipeline(pipelineName));
+        List<ServerHealthState> entries = serverHealthService.logsSortedForScope(HealthStateScope.forPipeline(pipelineName));
         assertThat(entries.toString(), entries.size(), is(number));
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineServiceTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineServiceTest.java
@@ -145,7 +145,7 @@ public class PipelineServiceTest {
     private Pipeline stubPipelineSaveForStatusListener(StageStatusListener stageStatusListener, JobStatusListener jobStatusListener) {
         StageDao stageDao = mock(StageDao.class);
         ServerHealthService serverHealthService = mock(ServerHealthService.class);
-        when(serverHealthService.logs()).thenReturn(new ServerHealthStates());
+        when(serverHealthService.logsSorted()).thenReturn(new ServerHealthStates());
         JobInstanceService jobInstanceService = new JobInstanceService(mock(JobInstanceDao.class), mock(JobResultTopic.class), mock(JobStatusCache.class),
                 actualTransactionTemplate, transactionSynchronizationManager, null, null, goConfigService, null, serverHealthService, jobStatusListener);
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineServiceTriangleDependencyTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineServiceTriangleDependencyTest.java
@@ -168,7 +168,7 @@ public class PipelineServiceTriangleDependencyTest {
     private Pipeline stubPipelineSaveForStatusListener(StageStatusListener stageStatusListener, JobStatusListener jobStatusListener) {
         StageDao stageDao = mock(StageDao.class);
         ServerHealthService serverHealthService = mock(ServerHealthService.class);
-        when(serverHealthService.logs()).thenReturn(new ServerHealthStates());
+        when(serverHealthService.logsSorted()).thenReturn(new ServerHealthStates());
         JobInstanceService jobInstanceService = new JobInstanceService(mock(JobInstanceDao.class), mock(JobResultTopic.class), mock(JobStatusCache.class),
                 actualTransactionTemplate, transactionSynchronizationManager, null, null, goConfigService, null, serverHealthService, jobStatusListener);
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceRunOnAllAgentIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceRunOnAllAgentIntegrationTest.java
@@ -135,7 +135,7 @@ public class ScheduleServiceRunOnAllAgentIntegrationTest {
         } catch (CannotScheduleException e) {
 
         }
-        List<ServerHealthState> stateList = serverHealthService.filterByScope(HealthStateScope.forStage("blahPipeline", "blahStage"));
+        List<ServerHealthState> stateList = serverHealthService.logsSortedForScope(HealthStateScope.forStage("blahPipeline", "blahStage"));
         assertThat(stateList.size(), is(1));
         assertThat(stateList.get(0).getMessage(), is("Failed to trigger stage [blahStage] pipeline [blahPipeline]"));
         assertThat(stateList.get(0).getDescription(), is("Could not find matching agents to run job [job2] of stage [blahStage]."));
@@ -145,7 +145,7 @@ public class ScheduleServiceRunOnAllAgentIntegrationTest {
     public void shouldUpdateServerHealthWhenSchedulePipelineFails() {
         pipelineScheduleQueue.schedule(new CaseInsensitiveString("blahPipeline"), saveMaterials(modifySomeFiles(goConfigService.pipelineConfigNamed(new CaseInsensitiveString("blahPipeline")))));
         scheduleService.autoSchedulePipelinesFromRequestBuffer();
-        List<ServerHealthState> stateList = serverHealthService.filterByScope(HealthStateScope.forStage("blahPipeline", "blahStage"));
+        List<ServerHealthState> stateList = serverHealthService.logsSortedForScope(HealthStateScope.forStage("blahPipeline", "blahStage"));
         assertThat(stateList.size(), is(1));
         assertThat(stateList.get(0).getMessage(), is("Failed to trigger stage [blahStage] pipeline [blahPipeline]"));
         assertThat(stateList.get(0).getDescription(), is("Could not find matching agents to run job [job2] of stage [blahStage]."));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceStageTriggerTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceStageTriggerTest.java
@@ -267,7 +267,7 @@ public class ScheduleServiceStageTriggerTest {
 
     private JobInstanceService jobInstanceService(JobResultTopic jobResultTopic) {
         ServerHealthService serverHealthService = mock(ServerHealthService.class);
-        when(serverHealthService.logs()).thenReturn(new ServerHealthStates());
+        when(serverHealthService.logsSorted()).thenReturn(new ServerHealthStates());
         return new JobInstanceService(jobInstanceDao, jobResultTopic, jobStatusCache, transactionTemplate,
                 transactionSynchronizationManager, null, null, goConfigService, null, serverHealthService);
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduledPipelineLoaderIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduledPipelineLoaderIntegrationTest.java
@@ -263,7 +263,7 @@ public class ScheduledPipelineLoaderIntegrationTest {
         cfg.removeMaterialConfig(cfg.materialConfigs().get(1));
         configHelper.writeConfigFile(cruiseConfig);
 
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPipeline("last")).size(), is(0));
+        assertThat(serverHealthService.logsSortedForScope(HealthStateScope.forPipeline("last")).size(), is(0));
 
         final long jobId = pipeline.getStages().get(0).getJobInstances().get(0).getId();
 
@@ -285,8 +285,8 @@ public class ScheduledPipelineLoaderIntegrationTest {
         assertThat(reloadedJobInstance.getResult(), is(JobResult.Failed));
 
         HealthStateScope scope = HealthStateScope.forJob("last", "stage", "job-one");
-        assertThat(serverHealthService.filterByScope(scope).size(), is(1));
-        ServerHealthState error = serverHealthService.filterByScope(HealthStateScope.forJob("last", "stage", "job-one")).get(0);
+        assertThat(serverHealthService.logsSortedForScope(scope).size(), is(1));
+        ServerHealthState error = serverHealthService.logsSortedForScope(HealthStateScope.forJob("last", "stage", "job-one")).get(0);
         assertThat(error, is(ServerHealthState.error("Cannot load job 'last/" + pipeline.getCounter() + "/stage/1/job-one' because material " + onDirTwo + " was not found in config.", "Job for pipeline 'last/" + pipeline.getCounter() + "/stage/1/job-one' has been failed as one or more material configurations were either changed or removed.", HealthStateType.general(HealthStateScope.forJob("last", "stage", "job-one")))));
         DateTime expiryTime = ReflectionUtil.getField(error, "expiryTime");
         assertThat(expiryTime.toDate().after(currentTime), is(true));


### PR DESCRIPTION
Previous code is especially inefficient, and when you have a large number of errors on the server, the server spends a lot of time in collection processing logic trying to find and remove resolved errors (due to creating new temporary collections over and over).

This uses the collections a little more efficiently, relying on the semantics of modern `ConcurrentMap`s although there is probably a bit of inefficient code still around here.