### PR TITLE
Add byte-buddy transitive dependency exclusion

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -750,7 +750,6 @@ task verifyWar(type: VerifyJarTask) {
         "aopalliance-1.0.jar",
         "aspectjweaver-${project.versions.aspectj}.jar",
         "base-${project.version}.jar",
-        "byte-buddy-1.14.9.jar",
         "cloning-${project.versions.cloning}.jar",
         "commandline-${project.version}.jar",
         "common-${project.version}.jar",

--- a/spark/spark-base/build.gradle
+++ b/spark/spark-base/build.gradle
@@ -25,7 +25,9 @@ dependencies {
 
   implementation platform(project.deps.jacksonBom)
   implementation project.deps.jacksonCore
-  implementation project.deps.jacksonDatabind
+  implementation(project.deps.jacksonDatabind) {
+    exclude(module: 'byte-buddy') // Workaround https://github.com/FasterXML/jackson-databind/issues/4428 until Jackson 2.17.1
+  }
   implementation project.deps.springWeb
   implementation project.deps.guava
 


### PR DESCRIPTION
Workaround a minor issue introduced in Jackson `2.17.0` prior to `2.17.1` release.