### PR TITLE
Correct byte-buddy transitive dependency exclusion 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -365,6 +365,10 @@ subprojects {
             }
           }
         })
+        // Workaround https://github.com/FasterXML/jackson-databind/issues/4428 until Jackson 2.17.1
+        withModule('com.fasterxml.jackson.core:jackson-databind', { details ->
+          details.allVariants { withDependencies { removeAll {it.name == "byte-buddy" } } }
+        })
       }
     }
   }

--- a/plugin-infra/go-plugin-access/build.gradle
+++ b/plugin-infra/go-plugin-access/build.gradle
@@ -30,8 +30,8 @@ dependencies {
   implementation project(path: ':domain', configuration: 'runtimeElements')
   implementation project(path: ':base', configuration: 'runtimeElements')
   implementation project(path: ':config:config-api', configuration: 'runtimeElements')
-  api project.deps.jolt
-  api project.deps.joltJsonUtils
+  implementation project.deps.jolt
+  implementation project.deps.joltJsonUtils
   api project.deps.commonsCollections4
   implementation project.deps.commonsCodec
   implementation project.deps.gson

--- a/spark/spark-base/build.gradle
+++ b/spark/spark-base/build.gradle
@@ -25,9 +25,7 @@ dependencies {
 
   implementation platform(project.deps.jacksonBom)
   implementation project.deps.jacksonCore
-  implementation(project.deps.jacksonDatabind) {
-    exclude(module: 'byte-buddy') // Workaround https://github.com/FasterXML/jackson-databind/issues/4428 until Jackson 2.17.1
-  }
+  implementation project.deps.jacksonDatabind
   implementation project.deps.springWeb
   implementation project.deps.guava
 


### PR DESCRIPTION
Corrects #12619 to handle the multiple places this is coming from, in the Gradle way.