### PR TITLE
Update Tanuki wrapper license keys

### DIFF
--- a/installers/include/wrapper-license-linux-go-agent.conf
+++ b/installers/include/wrapper-license-linux-go-agent.conf
@@ -6,13 +6,12 @@
 # wrapper.app.parameter.1=/usr/share/go-agent/lib/agent-bootstrapper.jar
 
 wrapper.license.type=DEV
-wrapper.license.id=202305310000010
+wrapper.license.id=202403190000005
 wrapper.license.licensee=ThoughtWorks
 wrapper.license.group=Go
 wrapper.license.dev_application=GoCD Agent On Linux
 wrapper.license.features=64bit
-wrapper.license.key.0=4844-0af0-665c-88f0
-wrapper.license.key.1=54d1-8ca5-fc04-80fc
-wrapper.license.key.2=59e4-7b00-7e92-3e0d
-wrapper.license.key.3=adb7-3173-227c-d524
-wrapper.license.key.4=5a91-3471-7a16-ca11
+wrapper.license.key.1=dab6-33bf-d978-d9ec
+wrapper.license.key.2=032f-d28a-bf15-d17c
+wrapper.license.key.3=ebae-ad54-86c9-6d25
+wrapper.license.key.4=cc3d-6bb6-63a1-4fef

--- a/installers/include/wrapper-license-linux-go-server.conf
+++ b/installers/include/wrapper-license-linux-go-server.conf
@@ -6,13 +6,12 @@
 # wrapper.app.parameter.1=/usr/share/go-server/lib/go.jar
 
 wrapper.license.type=DEV
-wrapper.license.id=202305310000011
+wrapper.license.id=202403190000004
 wrapper.license.licensee=ThoughtWorks
 wrapper.license.group=Go
 wrapper.license.dev_application=GoCD Server On Linux
 wrapper.license.features=64bit
-wrapper.license.key.0=4844-0af0-665c-88f0
-wrapper.license.key.1=e6b8-05e5-9315-0dd9
-wrapper.license.key.2=20f3-8766-dc3c-7de5
-wrapper.license.key.3=0784-7c49-af90-6f36
-wrapper.license.key.4=458a-4cc2-ad2f-7437
+wrapper.license.key.1=18f4-fc2b-904b-fb84
+wrapper.license.key.2=4cac-3361-2945-85e1
+wrapper.license.key.3=6241-ecdf-8362-5ebb
+wrapper.license.key.4=47f0-88ec-a131-4309

--- a/installers/include/wrapper-license-relative-path-go-agent.conf
+++ b/installers/include/wrapper-license-relative-path-go-agent.conf
@@ -6,13 +6,12 @@
 # wrapper.app.parameter.1=lib/agent-bootstrapper.jar
 
 wrapper.license.type=DEV
-wrapper.license.id=202305310000009
+wrapper.license.id=202403190000006
 wrapper.license.licensee=ThoughtWorks
 wrapper.license.group=Go
 wrapper.license.dev_application=GoCD Agent
 wrapper.license.features=64bit
-wrapper.license.key.0=4844-0af0-665c-88f0
-wrapper.license.key.1=2ed3-f3da-ae97-5b84
-wrapper.license.key.2=a4ab-d252-7365-bdd6
-wrapper.license.key.3=9005-ca4e-d859-4649
-wrapper.license.key.4=9ca7-ad7f-33ea-a3a2
+wrapper.license.key.1=aa8d-c303-f788-235d
+wrapper.license.key.2=5058-96a6-539c-fe30
+wrapper.license.key.3=3c3c-ceef-dd84-8e7b
+wrapper.license.key.4=e1b1-139c-6945-baf1

--- a/installers/include/wrapper-license-relative-path-go-server.conf
+++ b/installers/include/wrapper-license-relative-path-go-server.conf
@@ -6,13 +6,12 @@
 # wrapper.app.parameter.1=lib/go.jar
 
 wrapper.license.type=DEV
-wrapper.license.id=202305310000008
+wrapper.license.id=202403190000007
 wrapper.license.licensee=ThoughtWorks
 wrapper.license.group=Go
 wrapper.license.dev_application=GoCD Server
 wrapper.license.features=64bit
-wrapper.license.key.0=4844-0af0-665c-88f0
-wrapper.license.key.1=629b-5715-aa45-4f1b
-wrapper.license.key.2=e1b9-8b23-e3cb-bf7a
-wrapper.license.key.3=5a3b-e6bc-87c0-5cc7
-wrapper.license.key.4=f031-f6f4-0ad2-5b0b
+wrapper.license.key.1=c66a-c135-7a03-2727
+wrapper.license.key.2=580a-d7a3-3374-80b5
+wrapper.license.key.3=f17e-6e51-b286-3612
+wrapper.license.key.4=4f4c-f586-1c7d-37f6


### PR DESCRIPTION
These will work on new releases of the Standard Edition until 2025-06-03. Hopefully a new Community Edition we can use is released by then, with support for 64-bit Windows and a FOSS distribution exception.