### PR TITLE
Replace bundled deb/rpm x64 JRE with arch-independent package deps

### DIFF
--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -33,6 +33,8 @@ enum PackageType {
       // for `ps`
       fpmArgs += ['--depends', 'procps']
 
+      fpmArgs += ['--depends', 'openjdk-17-jre-headless']
+
       // HACK: for debian packages :(, since manifests cannot contain fine grained ownership
       def tmpDir = project.file("${project.buildDir}/tmp")
       tmpDir.mkdirs()
@@ -60,6 +62,8 @@ enum PackageType {
 
       // for `ps`
       fpmArgs += ['--depends', 'procps']
+
+      fpmArgs += ['--depends', 'jre-17-openjdk-headless']
 
       fpmArgs += ['--rpm-defattrfile', '0444']
       fpmArgs += ['--rpm-defattrdir', '0755']
@@ -96,22 +100,9 @@ private File destFile(String url) {
   new File(gradle.gradleUserHomeDir, "download-cache/${DigestUtils.md5Hex(url)}/${new File(new URL(url).path).name}")
 }
 
-task downloadLinuxJreChecksum(type: DownloadFile) {
-  src project.packagedJavaVersion.toSha256SumURLFor(OperatingSystem.linux, Architecture.x64)
-  dest destFile(src.toString())
-}
-
-task downloadLinuxJre(type: DownloadFile) {
-  dependsOn downloadLinuxJreChecksum
-  src project.packagedJavaVersion.toDownloadURLFor(OperatingSystem.linux, Architecture.x64)
-  dest destFile(src.toString())
-  checksum = { downloadLinuxJreChecksum.outputs.files.singleFile.getText("utf-8").trim().split(" ").first() }
-}
-
 def configureLinuxPackage(DefaultTask packageTask, InstallerType installerType, PackageType packageType, File buildRoot, Configuration configuration, File destDir) {
   packageTask.with {
     dependsOn configuration
-    dependsOn downloadLinuxJre
     dependsOn extractDeltaPack
     outputs.dir(destDir)
 
@@ -225,7 +216,10 @@ def configureLinuxPackage(DefaultTask packageTask, InstallerType installerType, 
             }
 
             if (eachLine == 'wrapper.java.command=java') {
-              eachLine = "wrapper.java.command=/usr/share/${installerType.baseName}/jre/bin/java"
+              // Debian Package post install script sets command depending on the architecture
+              if (packageType == PackageType.rpm) {
+                eachLine = 'wrapper.java.command=/etc/alternatives/jre_17/bin/java'
+              }
             }
 
             if (eachLine == 'wrapper.jarfile=../lib/wrapper.jar') {
@@ -277,24 +271,6 @@ def configureLinuxPackage(DefaultTask packageTask, InstallerType installerType, 
           include 'libwrapper-linux-arm-64*'
         }
       }
-
-      project.copy {
-        into "${buildRoot}/usr/share/${installerType.baseName}/jre"
-        from(tarTree(downloadLinuxJre.outputs.files.singleFile)) {
-          eachFile { FileCopyDetails fcd ->
-            List<String> segments = fcd.relativePath.segments
-            segments.remove(0)
-            fcd.relativePath = new RelativePath(!fcd.isDirectory(), (segments as String[]))
-            // Remove write access of JRE files for user group `others`.
-            // Perform `&` operation on existing mode with `0775`.
-            // eg. if existing mode is `0777`, the mode will be changed to `0775` after following operation
-            // eg. if existing mode is `0477`, the mode will be changed to `0475` after following operation
-            fcd.setMode(fcd.getMode() & 0775)
-          }
-          includeEmptyDirs = false
-        }
-      }
-
     }
 
     doLast {

--- a/installers/linux/deb/after-install.sh.erb
+++ b/installers/linux/deb/after-install.sh.erb
@@ -20,4 +20,8 @@
     # initialize init script symlinks on first install
     /usr/share/<%= name %>/bin/<%= name %> install 2>&1
 
+    arch=$(dpkg --print-architecture)
+    java=/usr/lib/jvm/java-17-openjdk-$arch/bin/java
+    sed -ie "s:^\\(wrapper.java.command=\\).*:\\1$java:" /usr/share/<%= name %>/wrapper-config/wrapper.conf
+
     <%= ERB.new(File.read(File.join(install_scripts_dir, 'shared', 'partials', "_#{name}_post_install_message.sh.erb")), trim_mode: '-', eoutvar: "_#{SecureRandom.hex}").result(binding) %>


### PR DESCRIPTION
Removed x86 JRE from architecture-independent package. Instead, added dependency on openjdk-17-jre-headless to DEB and dependency on jre-17-openjdk-headless to RPM. Fixes #11354.

Tested installation of go-agent and go-server.

Tested under:
- CentOS Stream 9
- CentOS Stream 8
- CentOS 7
- Ubuntu 22.04
- Ubuntu 20.04
- Debian 12
- Debian 11
- Debian 10

Each OS both in the x86_64 variant and arm64 variant.

Result: all ok except for:
- CentOS Linux 7: jre-17-openjdk-headless not available
- Debian 10: openjdk-17-jre-headless not available
