### PR TITLE
Poll for successful container start-up when verifying images

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -31,4 +31,5 @@ dependencies {
   implementation project.deps.gradleDownload
   implementation project.deps.grolifant
   implementation project.deps.freemarker
+  implementation project.deps.resilience4jRetry
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -89,6 +89,7 @@ final Map<String, String> libraries = [
   postgresql          : 'org.postgresql:postgresql:42.7.3',
   quartz              : 'org.quartz-scheduler:quartz:2.3.2',
   rack                : 'org.jruby.rack:jruby-rack:1.1.22',
+  resilience4jRetry   : 'io.github.resilience4j:resilience4j-retry:2.2.0',
   semanticVersion     : 'de.skuzzle:semantic-version:2.1.1',
   servletApi          : 'jakarta.servlet:jakarta.servlet-api:4.0.4', // Should be compatible with Jetty and Spring implementations
   slf4jBom            : 'org.slf4j:slf4j-bom:2.0.13',

--- a/docker/gocd-agent/build.gradle
+++ b/docker/gocd-agent/build.gradle
@@ -3,7 +3,10 @@ import com.thoughtworks.go.build.docker.Distro
 import com.thoughtworks.go.build.docker.DistroVersion
 import com.thoughtworks.go.build.docker.ImageType
 import groovy.json.JsonOutput
-import org.apache.tools.ant.util.TeeOutputStream
+import io.github.resilience4j.retry.Retry
+import io.github.resilience4j.retry.RetryConfig
+
+import java.time.Duration
 
 /*
  * Copyright 2024 Thoughtworks, Inc.
@@ -103,18 +106,19 @@ subprojects {
     }
 
     // test image
-    task.verifyHelper = { boolean isNative ->
-      def cleanContainer = {     // remove the container
+    task.verifyHelper = {
+      def cleanContainer = { OutputStream errorStream = System.err ->
         project.exec {
           workingDir = project.rootProject.projectDir
           commandLine = ["docker", "rm", "--force", docker.dockerImageName]
           standardOutput = System.out
-          errorOutput = System.err
+          errorOutput = errorStream
         }
       }
 
+      cleanContainer.call(OutputStream.nullOutputStream()) // Clean-up after any previous aborted runs
+
       // daemonize the container
-      cleanContainer.call() // Clean-up after any previous aborted runs
       project.exec {
         def additionalFlags = distro == Distro.docker ? ["--privileged"] : []
         workingDir = project.rootProject.projectDir
@@ -123,45 +127,20 @@ subprojects {
         errorOutput = System.err
       }
 
-      // Need to wait for start. Would be better to have some polling mechanism here with a timeout.
-      def sleep = isNative ? 5000 : 10000
-      logger.lifecycle("\nWaiting ${sleep}ms for ${isNative ? 'native' : 'emulated'} container to start...")
-      Thread.sleep(sleep)
-      logger.lifecycle("Should be started now...")
-
-      // run a `ps aux`
-      ByteArrayOutputStream psOutput = new ByteArrayOutputStream()
-      project.exec {
-        workingDir = project.rootProject.projectDir
-        commandLine = ["docker", "exec", docker.dockerImageName, "ps", "aux"]
-        standardOutput = new TeeOutputStream(psOutput, System.out)
-        errorOutput = new TeeOutputStream(psOutput, System.err)
-        ignoreExitValue = true
-      }
-
-      ByteArrayOutputStream containerOutput = new ByteArrayOutputStream()
-      project.exec {
-        workingDir = project.rootProject.projectDir
-        commandLine = ["docker", "logs", docker.dockerImageName]
-        standardOutput = containerOutput
-        errorOutput = containerOutput
-        ignoreExitValue = true
-      }
-
-      // remove the container
-      cleanContainer.call()
-
-      // assert if process was running
-      def expectedProcess = "lib/agent-bootstrapper.jar -serverUrl http://localhost:8153/go"
-      def expectedOutput = /Connect to localhost:8153.*Connection refused/
-      def processList = psOutput.toString()
-      def containerLog = containerOutput.toString()
-
-      if (!processList.contains(expectedProcess)) {
-        throw new GradleException("Expected process output to contain [${expectedProcess}], but was: [${processList}]\n\nContainer output:\n${containerOutput.toString()}")
-      }
-      if (!(containerLog =~ expectedOutput)) {
-        throw new GradleException("Agent process was up, but expected container output to match /${expectedOutput}/. Was: \n${containerOutput.toString()}")
+      def start = System.currentTimeMillis()
+      try {
+        Retry.of("wait-for-container-to-start",
+          RetryConfig.custom().maxAttempts(20).waitDuration(Duration.ofMillis(500)).failAfterMaxAttempts(true).build()
+        ).executeRunnable {
+          task.verifyProcessInContainerStarted(
+            "lib/agent-bootstrapper.jar -serverUrl http://localhost:8153/go",
+            /Connect to localhost:8153.*Connection refused/
+          )
+        }
+      } finally {
+        logger.lifecycle("Took ${System.currentTimeMillis() - start} ms to verify [${docker.dockerImageName}] container started.")
+        // remove the container
+        cleanContainer.call()
       }
     }
   }

--- a/docker/gocd-server/build.gradle
+++ b/docker/gocd-server/build.gradle
@@ -3,7 +3,10 @@ import com.thoughtworks.go.build.docker.Distro
 import com.thoughtworks.go.build.docker.DistroVersion
 import com.thoughtworks.go.build.docker.ImageType
 import groovy.json.JsonOutput
-import org.apache.tools.ant.util.TeeOutputStream
+import io.github.resilience4j.retry.Retry
+import io.github.resilience4j.retry.RetryConfig
+
+import java.time.Duration
 
 /*
  * Copyright 2024 Thoughtworks, Inc.
@@ -94,18 +97,19 @@ subprojects {
     }
 
     // test image
-    task.verifyHelper = { boolean isNative ->
-      def cleanContainer = {     // remove the container
+    task.verifyHelper = {
+      def cleanContainer = { OutputStream errorStream = System.err ->
         project.exec {
           workingDir = project.rootProject.projectDir
           commandLine = ["docker", "rm", "--force", docker.dockerImageName]
           standardOutput = System.out
-          errorOutput = System.err
+          errorOutput = errorStream
         }
       }
 
+      cleanContainer.call(OutputStream.nullOutputStream()) // Clean-up after any previous aborted runs
+
       // daemonize the container
-      cleanContainer.call() // Clean-up after any previous aborted runs
       project.exec {
         workingDir = project.rootProject.projectDir
         commandLine = ["docker", "run", "-d", "--name", docker.dockerImageName, docker.imageNameWithTag]
@@ -113,39 +117,20 @@ subprojects {
         errorOutput = System.err
       }
 
-      // Need to wait for start. Would be better to have some polling mechanism here with a timeout.
-      def sleep = isNative ? 10000 : 15000
-      logger.lifecycle("\nWaiting ${sleep}ms for ${isNative ? 'native' : 'emulated'} container to start...")
-      Thread.sleep(sleep)
-      logger.lifecycle("Should be started now...")
-
-      // run a `ps aux`
-      ByteArrayOutputStream psOutput = new ByteArrayOutputStream()
-      project.exec {
-        workingDir = project.rootProject.projectDir
-        commandLine = ["docker", "exec", docker.dockerImageName, "ps", "aux"]
-        standardOutput = new TeeOutputStream(psOutput, System.out)
-        errorOutput = new TeeOutputStream(psOutput, System.err)
-        ignoreExitValue = true
-      }
-
-      ByteArrayOutputStream containerOutput = new ByteArrayOutputStream()
-      project.exec {
-        workingDir = project.rootProject.projectDir
-        commandLine = ["docker", "logs", docker.dockerImageName]
-        standardOutput = containerOutput
-        errorOutput = containerOutput
-        ignoreExitValue = true
-      }
-
-      // remove the container
-      cleanContainer.call()
-
-      // assert if process was running
-      def expectedProcess = "lib/go.jar"
-      def processList = psOutput.toString()
-      if (!processList.contains(expectedProcess)) {
-        throw new GradleException("Expected process output to contain ${expectedProcess}, but was: [${processList}]\n\nContainer output:\n${containerOutput.toString()}")
+      def start = System.currentTimeMillis()
+      try {
+        Retry.of("wait-for-container-to-start",
+          RetryConfig.custom().maxAttempts(30).waitDuration(Duration.ofMillis(500)).failAfterMaxAttempts(true).build()
+        ).executeRunnable {
+          task.verifyProcessInContainerStarted(
+            "lib/go.jar",
+            /GoCD server started successfully/
+          )
+        }
+      } finally {
+        logger.lifecycle("Took ${System.currentTimeMillis() - start} ms to verify [${docker.dockerImageName}] container started.")
+        // remove the container
+        cleanContainer.call()
       }
     }
   }

--- a/server/src/main/java/com/thoughtworks/go/server/GoServer.java
+++ b/server/src/main/java/com/thoughtworks/go/server/GoServer.java
@@ -60,6 +60,7 @@ public class GoServer {
             LOG.error("ERROR: Failed to start GoCD server.", exceptionAtServerStart);
             throw new RuntimeException("Failed to start GoCD server.", exceptionAtServerStart);
         }
+        LOG.info("GoCD server started successfully.");
     }
 
     AppServer configureServer() throws Exception {


### PR DESCRIPTION
Avoid static sleeps by keep trying every 500ms up to max attempts to give faster feedback. Also validates the server has started more reliably using log output.