### PR TITLE
Build, test and package GoCD with Java 21 LTS by default

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 # Configuration for https://github.com/asdf-vm/asdf as an alternative to jabba, rvm, nvm etc
-java temurin-17.0.11+9
+java temurin-21.0.3+9.0.LTS
 nodejs 20.13.1

--- a/build.gradle
+++ b/build.gradle
@@ -136,13 +136,13 @@ ext {
   targetJavaVersion = 17
 
   // Version of JVM to compile and test using.
-  buildJavaVersion = 17
+  buildJavaVersion = 21
 
   // Version to package with installers and container images by default
   packagedJavaVersion = new AdoptiumVersion(
-    feature: 17,
+    feature: 21,
     interim: 0,    // set to `null` for the first release of a new featureVersion
-    update : 11,   // set to `null` for the first release of a new featureVersion
+    update : 3,    // set to `null` for the first release of a new featureVersion
     patch  : null, // set to `null` for most releases. Patch releases are "exceptional".
     build  : 9
   )
@@ -482,6 +482,7 @@ subprojects {
     systemProperty 'java.io.tmpdir', tmpDir
     systemProperty 'jdk.attach.allowAttachSelf', 'true'
     jvmArgs += testTask.project.name.startsWith("agent") ? InstallerType.agent.jvmModuleOpensArgs : InstallerType.server.jvmModuleOpensArgs
+    jvmArgs += '-XX:+EnableDynamicAgentLoading' // Needed for byte-buddy-agent (and maybe others?) to avoid warnings/errors on Java 21+
 
     doFirst {
       // workaround for https://github.com/unbroken-dome/gradle-testsets-plugin/issues/40

--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -14,14 +14,24 @@
  * limitations under the License.
  */
 
-import com.thoughtworks.go.build.*
+import com.thoughtworks.go.build.Architecture
+import com.thoughtworks.go.build.InstallerMetadataTask
+import com.thoughtworks.go.build.InstallerType
 import groovy.json.JsonOutput
 import org.apache.commons.codec.digest.DigestUtils
 import org.apache.tools.ant.filters.ConcatFilter
 
 enum PackageType {
 
-  deb{
+  deb {
+    String jreBinaryLocation(Project project) {
+      "/usr/lib/jvm/java-${project.packagedJavaVersion.feature}-openjdk-\$(dpkg --print-architecture)/bin/java"
+    }
+
+    String jreDependency(Project project) {
+      "openjdk-${project.packagedJavaVersion.feature}-jre-headless"
+    }
+
     List<String> configureFpm(Project project, File buildRoot, InstallerType installerType) {
       List<String> fpmArgs = []
       fpmArgs += ['-t', 'deb']
@@ -33,7 +43,7 @@ enum PackageType {
       // for `ps`
       fpmArgs += ['--depends', 'procps']
 
-      fpmArgs += ['--depends', 'openjdk-17-jre-headless']
+      fpmArgs += ['--depends', jreDependency(project)]
 
       // HACK: for debian packages :(, since manifests cannot contain fine grained ownership
       def tmpDir = project.file("${project.buildDir}/tmp")
@@ -50,7 +60,15 @@ enum PackageType {
       return fpmArgs
     }
   },
-  rpm{
+  rpm {
+    String jreBinaryLocation(Project project) {
+      "/etc/alternatives/jre_${project.packagedJavaVersion.feature}/bin/java"
+    }
+
+    String jreDependency(Project project) {
+      "java-${project.packagedJavaVersion.feature}-openjdk-headless"
+    }
+
     List<String> configureFpm(Project project, File buildRoot, InstallerType installerType) {
       List<String> fpmArgs = []
 
@@ -63,7 +81,7 @@ enum PackageType {
       // for `ps`
       fpmArgs += ['--depends', 'procps']
 
-      fpmArgs += ['--depends', 'java-17-openjdk-headless']
+      fpmArgs += ['--depends', jreDependency(project)]
 
       fpmArgs += ['--rpm-defattrfile', '0444']
       fpmArgs += ['--rpm-defattrdir', '0755']
@@ -93,7 +111,8 @@ enum PackageType {
     }
   }
 
-  abstract List<String> configureFpm(Project project, File buildRoot, InstallerType installerType);
+  abstract jreBinaryLocation(Project project)
+  abstract List<String> configureFpm(Project project, File buildRoot, InstallerType installerType)
 }
 
 private File destFile(String url) {
@@ -215,13 +234,6 @@ def configureLinuxPackage(DefaultTask packageTask, InstallerType installerType, 
               eachLine = newLines.join('\n')
             }
 
-            if (eachLine == 'wrapper.java.command=java') {
-              // Debian Package post install script sets command depending on the architecture
-              if (packageType == PackageType.rpm) {
-                eachLine = 'wrapper.java.command=/etc/alternatives/jre_17/bin/java'
-              }
-            }
-
             if (eachLine == 'wrapper.jarfile=../lib/wrapper.jar') {
               eachLine = "wrapper.jarfile=/usr/share/${installerType.baseName}/wrapper/wrapper.jar"
             }
@@ -320,6 +332,8 @@ def configureLinuxPackage(DefaultTask packageTask, InstallerType installerType, 
         cmd += packageType.configureFpm(project, buildRoot, installerType)
 
         commandLine = cmd
+
+        environment += ['JRE_BINARY_LOCATION': packageType.jreBinaryLocation(project)]
 
         workingDir "${project.buildDir}/distributions/${packageType}"
 

--- a/installers/linux/deb/after-install.sh.erb
+++ b/installers/linux/deb/after-install.sh.erb
@@ -20,8 +20,7 @@
     # initialize init script symlinks on first install
     /usr/share/<%= name %>/bin/<%= name %> install 2>&1
 
-    arch=$(dpkg --print-architecture)
-    java=/usr/lib/jvm/java-17-openjdk-$arch/bin/java
-    sed -ie "s:^\\(wrapper.java.command=\\).*:\\1$java:" /usr/share/<%= name %>/wrapper-config/wrapper.conf
+    java="<%= ENV['JRE_BINARY_LOCATION'] %>"
+    sed -ie "s:^\\(wrapper.java.command=\\).*:\\1${java}:" /usr/share/<%= name %>/wrapper-config/wrapper.conf
 
     <%= ERB.new(File.read(File.join(install_scripts_dir, 'shared', 'partials', "_#{name}_post_install_message.sh.erb")), trim_mode: '-', eoutvar: "_#{SecureRandom.hex}").result(binding) %>

--- a/installers/linux/rpm/after-install.sh.erb
+++ b/installers/linux/rpm/after-install.sh.erb
@@ -19,4 +19,7 @@
     # initialize init script symlinks on first install
     /usr/share/<%= name %>/bin/<%= name %> install 2>&1
 
+    java="<%= ENV['JRE_BINARY_LOCATION'] %>"
+    sed -ie "s:^\\(wrapper.java.command=\\).*:\\1${java}:" /usr/share/<%= name %>/wrapper-config/wrapper.conf
+
     <%= ERB.new(File.read(File.join(install_scripts_dir, 'shared', 'partials', "_#{name}_post_install_message.sh.erb")), trim_mode: '-', eoutvar: "_#{SecureRandom.hex}").result(binding) %>

--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -221,7 +221,7 @@ GEM
 
 PLATFORMS
   java
-  universal-java-17
+  universal-java-21
   x86_64-linux
 
 DEPENDENCIES

--- a/server/src/main/webapp/WEB-INF/rails/config/initializers/assets.rb
+++ b/server/src/main/webapp/WEB-INF/rails/config/initializers/assets.rb
@@ -27,3 +27,29 @@ Rails.application.config.assets.paths << Rails.root.join("webpack", "rails-share
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+
+# Monkey patch Open3.popen_run to workaround Java 21 issue with JRuby when running sass-embedded as documented at
+# - https://github.com/sass-contrib/sass-embedded-host-ruby/issues/208
+# - https://github.com/jruby/jruby/issues/8235
+# - https://github.com/jruby/jruby/issues/8069
+# - https://bugs.openjdk.org/browse/JDK-8329604
+# Remove for Java 21.0.4 onwards where a fix for Java 23 is backported.
+if ENV["RAILS_ENV"] != "production" or ENV.has_key?("RAILS_GROUPS")
+  require 'fcntl'
+
+  module Open3
+    _popen_run = instance_method(:popen_run)
+    define_method(:popen_run) do |cmd, opts, child_io, parent_io, &block|
+      child_io.each do |io|
+        flags = io.fcntl(Fcntl::F_GETFL)
+        io.fcntl(Fcntl::F_SETFL, flags | (Fcntl::O_NONBLOCK))
+        io.fcntl(Fcntl::F_SETFL, flags & (~Fcntl::O_NONBLOCK))
+      end
+      _popen_run.bind(self).call(cmd, opts, child_io, parent_io, &block)
+    end
+    module_function :popen_run
+    class << self
+      private :popen_run
+    end
+  end
+end


### PR DESCRIPTION
There seem to be no issues with using Java 21 by default at runtime, so let's get this going for build.gocd.org so we can smoke test things.