### PR TITLE
Ensure the go user is within the correct dind image group for socket access

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -229,7 +229,10 @@ enum Distro implements DistroBehavior {
 
     @Override
     List<String> getCreateUserAndGroupCommands() {
-      return alpine.getCreateUserAndGroupCommands()
+      return alpine.getCreateUserAndGroupCommands() +
+        [
+          'adduser go docker' // Add user to the docker group used to control access to the Docker daemon unix socket
+        ]
     }
 
     @Override


### PR DESCRIPTION
Fixes #12765 

Addresses regression caused by change in upstream image at https://github.com/docker-library/docker/pull/462