### PR TITLE
Temporarily go back to Java 17 on .debs

### DIFF
--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -25,11 +25,13 @@ enum PackageType {
 
   deb {
     String jreBinaryLocation(Project project) {
-      "/usr/lib/jvm/java-${project.packagedJavaVersion.feature}-openjdk-\$(dpkg --print-architecture)/bin/java"
+      // TODO need to revert to ${project.packagedJavaVersion.feature} when Java 21 available for Debian 11/12
+      "/usr/lib/jvm/java-17-openjdk-\$(dpkg --print-architecture)/bin/java"
     }
 
     String jreDependency(Project project) {
-      "openjdk-${project.packagedJavaVersion.feature}-jre-headless"
+      // TODO need to revert to ${project.packagedJavaVersion.feature} when Java 21 available for Debian 11/12
+      "openjdk-17-jre-headless"
     }
 
     List<String> configureFpm(Project project, File buildRoot, InstallerType installerType) {


### PR DESCRIPTION
Java 21 packages are not available for Debian 11/12, even though they exist for Ubuntu 20-24.

Temporarily use Java 17 here until we can add an "OR" dependency and perhaps use `update-alternatives --query java` to figure out dynamically the install path of the one to use.