### PR TITLE
Add ability to run additional sanity test commands specific to each distro

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -252,6 +252,13 @@ enum Distro implements DistroBehavior {
     Map<String, String> getEnvironmentVariables(DistroVersion v) {
       return alpine.getEnvironmentVariables(v)
     }
+
+    @Override
+    List<List<String>> getAdditionalVerifyCommands() {
+      return [
+        ['docker', 'run', 'hello-world']
+      ]
+    }
   }
 
   static Date parseDate(String date) {

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
@@ -93,4 +93,8 @@ trait DistroBehavior {
     return false
   }
 
+  List<List<String>> getAdditionalVerifyCommands() {
+    []
+  }
+
 }

--- a/docker/gocd-agent/build.gradle
+++ b/docker/gocd-agent/build.gradle
@@ -137,6 +137,15 @@ subprojects {
             /Connect to localhost:8153.*Connection refused/
           )
         }
+
+        distro.additionalVerifyCommands.each { command ->
+          project.exec {
+            workingDir = project.rootProject.projectDir
+            commandLine = ["docker", "exec", docker.dockerImageName] + command
+            standardOutput = System.out
+            errorOutput = System.err
+          }
+        }
       } finally {
         logger.lifecycle("Took ${System.currentTimeMillis() - start} ms to verify [${docker.dockerImageName}] container started.")
         // remove the container

--- a/docker/gocd-server/build.gradle
+++ b/docker/gocd-server/build.gradle
@@ -127,6 +127,15 @@ subprojects {
             /GoCD server started successfully/
           )
         }
+
+        distro.additionalVerifyCommands.each { command ->
+          project.exec {
+            workingDir = project.rootProject.projectDir
+            commandLine = ["docker", "exec", docker.dockerImageName] + command
+            standardOutput = System.out
+            errorOutput = System.err
+          }
+        }
       } finally {
         logger.lifecycle("Took ${System.currentTimeMillis() - start} ms to verify [${docker.dockerImageName}] container started.")
         // remove the container


### PR DESCRIPTION
Fixes #12773

For now sanity checks docker is working for the dind image, but could be extended to sanity check other included things such as git/mercurial etc.