### PR TITLE
Avoid confusing dependencies for plugin API when testing it internally

### DIFF
--- a/build-platform/build.gradle
+++ b/build-platform/build.gradle
@@ -47,9 +47,3 @@ dependencies {
   api enforcedPlatform(project.deps.mockitoBom)
   api enforcedPlatform(project.deps.testcontainersBom)
 }
-
-publishing {
-  publications {
-    maven(MavenPublication)
-  }
-}

--- a/plugin-infra/go-plugin-api-internal/build.gradle
+++ b/plugin-infra/go-plugin-api-internal/build.gradle
@@ -19,17 +19,3 @@ plugins {
 }
 
 description = 'Internal interfaces for GoCD Plugins'
-
-compileJava {
-  // Use older source compatibility for Plugin API consumed by plugins. No need to break this compatibility
-  // for a while yet, so plugins work on older versions.
-  options.release.set(11)
-}
-
-publishing {
-  publications {
-    maven(MavenPublication) {
-      from components.java
-    }
-  }
-}

--- a/plugin-infra/go-plugin-api/build.gradle
+++ b/plugin-infra/go-plugin-api/build.gradle
@@ -58,8 +58,14 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 publishing {
   publications {
-    maven(MavenPublication) {
-      from components.java
+    mavenJava(MavenPublication) {
+      groupId = 'cd.go.plugin'
+
+      versionMapping {
+        usage('java-runtime') {
+          fromResolutionResult()
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Downstream `plugins` test pipeline relies on a local Maven publication which is slightly different to how the official signed artifacts are published. This aligns them by avoiding the internal dependencies to build-platform and api-internal caused by problems in the way things are structured. This avoids test plugins being validated against extra dependencies that "real" plugin API consumers won't have.