### PR TITLE
Add almalinux 9 based GoCD agent image to replace CentOS Stream

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -139,6 +139,37 @@ enum Distro implements DistroBehavior {
     }
   },
 
+  almalinux {
+    @Override
+    Set<Architecture> getSupportedArchitectures() {
+      [Architecture.x64, Architecture.aarch64]
+    }
+
+    @Override
+    List<String> getBaseImageUpdateCommands(DistroVersion v) {
+      return [
+        "echo 'fastestmirror=1' >> /etc/dnf/dnf.conf",
+        "echo 'install_weak_deps=False' >> /etc/dnf/dnf.conf",
+        "microdnf upgrade -y",
+      ]
+    }
+
+    @Override
+    List<String> getInstallPrerequisitesCommands(DistroVersion v) {
+      return [
+        "microdnf install -y git-core openssh-clients bash unzip curl-minimal procps-ng coreutils-single glibc-langpack-en tar",
+        "microdnf clean all",
+        "rm -rf var/cache/dnf",
+      ]
+    }
+    @Override
+    List<DistroVersion> getSupportedVersions() {
+      return [ // See https://endoflife.date/almalinux
+        new DistroVersion(version: '9', releaseName: '9-minimal', eolDate: parseDate('2032-05-31')),
+      ]
+    }
+  },
+
   debian {
     @Override
     Set<Architecture> getSupportedArchitectures() {

--- a/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
@@ -17,7 +17,7 @@
 # Please file any issues or PRs at https://github.com/gocd/gocd
 ###############################################################################################
 
-FROM curlimages/curl:latest as gocd-agent-unzip
+FROM curlimages/curl:latest AS gocd-agent-unzip
 USER root
 ARG TARGETARCH
 ARG UID=1000

--- a/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
@@ -17,7 +17,7 @@
 # Please file any issues or PRs at https://github.com/gocd/gocd
 ###############################################################################################
 
-FROM curlimages/curl:latest as gocd-server-unzip
+FROM curlimages/curl:latest AS gocd-server-unzip
 USER root
 ARG TARGETARCH
 ARG UID=1000


### PR DESCRIPTION
Fixes #12805 (if we decide to go ahead with it)

Replaces the old CentOS Stream image removed in `24.2.0` with a cleaner and security-patched RHEL-equivalent in Alma linux

Currently pending a bit more engagement or discussion on the linked issue, and/or our own decision on whether this would be sufficiently useful.