### PR TITLE
Proxy/cache Tanuki wrapper downloads directly

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -172,7 +172,7 @@ final Map<String, String> v = [
   ztExec              : versionOf(libraries.ztExec),
 
   // misc
-  tanuki              : '3.5.57-st', // https://wrapper.tanukisoftware.com/doc/english/download.jsp#stable
+  tanuki              : '3.5.57', // https://wrapper.tanukisoftware.com/doc/english/download.jsp#stable
   tanukiSha256sum     : '7beb9e2da1ddcad0ca51ce9c325ae41816250d2f924b8590c5643f5b0c32ea37',
   tfsSdk              : '14.139.0', // https://github.com/microsoft/team-explorer-everywhere/releases
   tfsSdkSha256sum     : '744df70f70d28f6039938917ce02b07cbe07a577bdd662a64bb7dffb42512b90',

--- a/installers/tanuki.gradle
+++ b/installers/tanuki.gradle
@@ -23,7 +23,7 @@ private File destFile(String url) {
 }
 
 task downloadTanukiDeltaPack(type: DownloadFile) {
-  def srcUrl = System.getenv("TANUKI_WRAPPER_URL") ?: "https://nexus.gocd.io/repository/s3-mirrors/local/tanuki/wrapper-delta-pack-${project.versions.tanuki}.tar.gz"
+  def srcUrl = System.getenv("TANUKI_WRAPPER_URL") ?: "https://nexus.gocd.io/repository/tanuki-proxy/${project.versions.tanuki}/wrapper-delta-pack-${project.versions.tanuki}-st.tar.gz"
   src srcUrl
   dest destFile(srcUrl)
   checksum project.versions.tanukiSha256sum


### PR DESCRIPTION
No need to manually archive these; adds manual steps for incrementing versions.