### PR TITLE
Fix toggle of show/hide password on modal pages

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/forms/forms.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/forms/forms.scss
@@ -305,9 +305,7 @@ input[type="checkbox"].form-control {
 }
 
 .hide-password {
-  @include icon-after($type: $fa-var-eye-slash, $size: 14px, $top: 1px, $color: $icon-color) {
-    right: 30px;
-  }
+  @include icon-after($type: $fa-var-eye-slash, $size: 14px, $top: 1px, $margin: 3px, $color: $icon-color);
 
   input {
     padding-right: 25px;
@@ -315,9 +313,7 @@ input[type="checkbox"].form-control {
 }
 
 .show-password {
-  @include icon-after($type: $fa-var-eye, $size: 14px, $top: 1px, $color: $icon-color) {
-    right: 30px;
-  }
+  @include icon-after($type: $fa-var-eye, $size: 14px, $top: 1px, $margin: 4px, $color: $icon-color);
 
   input {
     padding-right: 25px;


### PR DESCRIPTION
Fixes #12943

On modals with passwords when the review re-renders the password is auto-hidden as the state is forgotten due to previous implementation hacking with CSS attributes directly. Believe the right way to fix this is to record the state within the control and render off this rather than hacking styles directly. Seems they were predominantly focused/tested on the pipeline config SPA rather than some of the other locations (config repos, possibly others) based on #8261