### PR TITLE
Fix sass 1.77.7 deprecations of mixed order nested + direct declarations

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_common.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_common.scss
@@ -239,13 +239,12 @@ textarea {
 // new styles
 
 .key-value-pair {
-  @include clearfix;
-
   margin: 0;
   padding: 0;
 
-  dt,
-  .key {
+  @include clearfix;
+
+  dt, .key {
     float: left;
     min-width: 150px;
     clear: left;
@@ -254,8 +253,7 @@ textarea {
     font-size: rem-calc(13px);
   }
 
-  dd,
-  .value {
+  dd, .value {
     float: left;
     position: relative;
     padding-left: 15px;
@@ -276,8 +274,7 @@ textarea {
     margin-right: 20px;
     line-height: 30px;
 
-    dt,
-    .key {
+    dt, .key {
       min-width: 10px;
     }
   }
@@ -289,10 +286,10 @@ ul.key-value-pair {
   padding: 0;
 
   li {
-    @include clearfix;
-
     padding: 5px;
     border-bottom: 1px dashed lighten($border-color, 10%);
+
+    @include clearfix;
 
     &:last-child {
       border: 0;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_dropdown.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_dropdown.scss
@@ -108,12 +108,12 @@ $c-dropdown-bg-hover: $main-nav-link-bg-hover;
 }
 
 .c-down-arrow {
-  @include icon-before($type: angle-down);
-
   position: absolute;
   right: 9px;
   top: 5px;
   cursor: pointer;
   z-index: 6;
   font-size: 15px;
+
+  @include icon-before($type: angle-down);
 }

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_header.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_header.scss
@@ -129,8 +129,6 @@ $menu-hover: #3e3d3d;
     }
 
     &.server-health-summary a {
-      @include icon-before($failed-icon, $margin: 0);
-
       background-color: darken($failed, 20%);
       border-radius: 3px;
       line-height: 25px;
@@ -138,6 +136,8 @@ $menu-hover: #3e3d3d;
       padding-left: 30px;
       padding-right: 11px;
       position: relative;
+
+      @include icon-before($failed-icon, $margin: 0);
 
       &::before {
         position: absolute;
@@ -148,10 +148,10 @@ $menu-hover: #3e3d3d;
     }
 
     &.current-user {
-      @include icon-before($type: user);
-
       padding-left: 10px;
       position: relative;
+
+      @include icon-before($type: user);
 
       &::before {
         position: absolute;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_modal.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_modal.scss
@@ -71,10 +71,10 @@
       }
 
       &.green-check {
-        @include icon-before($type: check, $margin: 0 5px 0 0);
-
         background-color: map-get($foundation-palette, success);
         transition: all 0.5s ease-in-out;
+
+        @include icon-before($type: check, $margin: 0 5px 0 0);
 
         &::before {
           @include animation(fade-in 1s ease-in);

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_notifications.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/shared/_notifications.scss
@@ -96,9 +96,9 @@
   }
 
   .bell {
-    @include icon-before(bell, $color: #fff);
-
     font-size: 18px;
+
+    @include icon-before(bell, $color: #fff);
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/agents.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/agents.scss
@@ -259,11 +259,11 @@ $table-border: #e9edef;
 $icon-color: #647984;
 
 .search-bar {
-  @include icon-before($type: search);
-
   position: relative;
   margin-top: -6px;
   width: 350px;
+
+  @include icon-before($type: search);
 
   &::before {
     position: absolute;
@@ -570,9 +570,9 @@ $arrow-color: #000;
 }
 
 .has-build-details-drop-down {
-  @include icon-after($type: caret-down, $color: $dark-gray);
-
   position: relative;
+
+  @include icon-after($type: caret-down, $color: $dark-gray);
 
   &::after {
     font-size: 10px;
@@ -585,12 +585,12 @@ $arrow-color: #000;
 }
 
 .agent-analytics {
-  @include icon-before($type: chart-bar);
-
   padding: 0;
   font-size: 14px;
   color: #555;
   cursor: pointer;
+
+  @include icon-before($type: chart-bar);
 
   &:hover {
     color: #000;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -82,8 +82,6 @@ body {
 }
 
 .page_header {
-  @include clearfix;
-
   width: 100%;
   align-items: center;
   background: #fff;
@@ -94,6 +92,8 @@ body {
   position: fixed;
   top: 40px;
   z-index: 10;
+
+  @include clearfix;
 }
 
 .page_title {
@@ -247,12 +247,12 @@ body {
 }
 
 .pipeline_header {
-  @include clearfix;
-
   padding: 0 15px 10px 15px;
   margin: 10px 0 0;
   border-radius: 5px 5px 0 0;
   border-bottom: 1px solid $border-color;
+
+  @include clearfix;
 }
 
 .pipeline_name {
@@ -320,8 +320,6 @@ body {
 }
 
 .pipeline_locked {
-  @include icon-before($type: lock);
-
   overflow: hidden;
   width: 25px;
   height: 25px;
@@ -331,6 +329,8 @@ body {
   background: none;
   margin: 0;
   padding: 0;
+
+  @include icon-before($type: lock);
 
   &:focus {
     color: $icon-color;
@@ -349,11 +349,11 @@ body {
 }
 
 .edit_config {
-  @include icon-before($type: gear);
-
   overflow: hidden;
   font-size: $pipeline-icons-size;
   color: $icon-color;
+
+  @include icon-before($type: gear);
 
   &:hover {
     color: $icon-hover-color;
@@ -380,12 +380,12 @@ body {
 }
 
 .pipeline-analytics {
-  @include icon-before($type: chart-bar);
-
   padding: 0;
   font-size: $pipeline-icons-size;
   color: $icon-color;
   cursor: pointer;
+
+  @include icon-before($type: chart-bar);
 
   &:hover {
     color: $icon-hover-color;
@@ -557,10 +557,10 @@ body {
   padding: 0;
 
   .manual_gate {
-    @include icon-before(step-forward, 14px, 0);
-
     padding: 1px 5px;
     cursor: pointer;
+
+    @include icon-before(step-forward, 14px, 0);
 
     &.disabled {
       opacity: 0.5;
@@ -585,17 +585,17 @@ body {
     text-align: center;
 
     &.passed {
-      @include icon-before($passed-icon, $icon-size, 1.5px);
-
       background: $passed;
       color: #fff;
+
+      @include icon-before($passed-icon, $icon-size, 1.5px);
     }
 
     &.failed {
-      @include icon-before($failed-icon, $icon-size, 1.5px);
-
       background: $failed;
       color: #fff;
+
+      @include icon-before($failed-icon, $icon-size, 1.5px);
     }
 
     &.failing {
@@ -620,10 +620,10 @@ body {
     }
 
     &.cancelled {
-      @include icon-before($cancelled-icon, $icon-size, 1.5px);
-
       background: $building;
       color: $dark-gray;
+
+      @include icon-before($cancelled-icon, $icon-size, 1.5px);
     }
   }
 }
@@ -809,11 +809,11 @@ body {
   }
 
   .error-icon {
-    @include icon-before($failed-icon, $margin: 0, $color: #bd0404);
-
     position: relative;
     top: -6px;
     right: -6px;
+
+    @include icon-before($failed-icon, $margin: 0, $color: #bd0404);
   }
 }
 
@@ -977,10 +977,10 @@ $commits-width: 635px;
 }
 
 .search-icon {
-  @include icon-before($type: search);
-
   position: relative;
   margin-top: 3px;
+
+  @include icon-before($type: search);
 
   &::before {
     position: absolute;
@@ -1006,12 +1006,12 @@ $commits-width: 635px;
 }
 
 .search-in-progress {
-  @include icon-before($type: spinner, $margin: 0);
-  @include animation(spin 1s linear infinite);
-
   position: absolute;
   right: -16px;
   top: 10px;
+
+  @include animation(spin 1s linear infinite);
+  @include icon-before($type: spinner, $margin: 0);
 
   &::before {
     @include animation(spin 1s linear infinite);

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_dashboard_view_tabs.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_dashboard_view_tabs.scss
@@ -403,11 +403,11 @@ button {
 }
 
 .icon_edit {
-  @include icon-before($type: pencil);
-
   cursor: pointer;
   color: $icon-color;
   display: none;
+
+  @include icon-before($type: pencil);
 
   .current & {
     color: $go-primary;
@@ -419,8 +419,12 @@ button {
   @include sort-cursor;
   @include grip-icon;
 
-  font-size: 12px;
-  color: #9b9b9b;
+  // stylelint-disable no-duplicate-selectors
+  & {
+    font-size: 12px;
+    color: #9b9b9b;
+  }
+  // stylelint-enable
 
   &:active {
     @include sort-cursor-active;
@@ -428,32 +432,32 @@ button {
 }
 
 .revert {
-  @include icon-before($type: xmark);
-
   position: absolute;
   right: 5px;
   top: 2px;
   cursor: pointer;
+
+  @include icon-before($type: xmark);
 }
 
 .icon_alert {
-  @include icon-before($type: exclamation-circle);
-
   margin-right: 10px;
   font-size: 150%;
   color: map-get($foundation-palette, alert);
+
+  @include icon-before($type: exclamation-circle);
 }
 
 .icon_tabs-list {
-  @include icon-before($type: chevron-down);
-
   font-size: 14px;
+
+  @include icon-before($type: chevron-down);
 }
 
 .dropdown-btn {
-  @include icon-before($type: caret-down);
-
   cursor: pointer;
+
+  @include icon-before($type: caret-down);
 
   &.deny-action {
     cursor: not-allowed;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_personalize_views_editor.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_personalize_views_editor.scss
@@ -85,12 +85,12 @@ $icon-color: #647984;
   z-index: 100;
 
   .close-button {
-    @include icon-before($type: xmark);
-
     position: absolute;
     right: 20px;
     padding: 5px;
     cursor: pointer;
+
+    @include icon-before($type: xmark);
   }
 }
 
@@ -139,10 +139,10 @@ $icon-color: #647984;
   }
 
   .tooltip-hint {
-    @include icon-before($type: question-circle);
-
     vertical-align: middle;
     margin: 0;
+
+    @include icon-before($type: question-circle);
 
     &:hover {
       cursor: pointer;
@@ -373,19 +373,19 @@ $icon-color: #647984;
 }
 
 .overlay-footer {
-  @include clearfix;
-
   display: block;
+
+  @include clearfix;
 }
 
 .btn-delete {
-  @include icon-before($type: trash-can, $margin: 0 10px 0 0, $progress-spinner: true);
-
   float: left;
   background: #fff;
   color: #333;
   border: 1px solid #e9edef;
   transition: $transition;
+
+  @include icon-before($type: trash-can, $margin: 0 10px 0 0, $progress-spinner: true);
 
   &::before {
     color: $icon-color;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/_vsm.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/_vsm.scss
@@ -99,11 +99,11 @@ $btn-default: #d6d5d5;
 .vsm-entity.current.vsm-current-node {
   @extend %node-selection;
 
+  border: 2px solid $primary-color;
+
   &::before {
     color: $primary-color;
   }
-
-  border: 2px solid $primary-color;
 
   &:hover {
     border: 2px solid $primary-color !important;
@@ -194,17 +194,16 @@ $btn-default: #d6d5d5;
 .vsm-other-node {
   @extend %node-selection;
 
+  border: 2px solid $secondary-color;
+  box-shadow: 0 0 2px 2px #ccc;
+
   &::before {
     color: $secondary-color;
   }
 
-  border: 2px solid $secondary-color;
-
   &:hover {
     border: 2px solid $secondary-color !important;
   }
-
-  box-shadow: 0 0 2px 2px #ccc;
 
   &.material {
     &::before {
@@ -323,20 +322,20 @@ $btn-default: #d6d5d5;
 }
 
 .vsm-analytics-panel {
-  @include clearfix;
-
   padding: 10px;
   position: relative;
   display: none;
   background: $analytics-selection-panel-bg;
+
+  @include clearfix;
 }
 
 .analytics-close {
-  @include icon-before("times", $margin: 10, $size: 20px);
-
   width: 20px;
   background: transparent;
   margin-left: 20px;
+
+  @include icon-before("times", $margin: 10, $size: 20px);
 
   &::before {
     color: $icon-color;
@@ -397,12 +396,12 @@ $btn-default: #d6d5d5;
 }
 
 .icon_vsm_analytics {
-  @include icon-before($type: chart-bar);
-
   padding: 0;
   font-size: 15px;
   color: #fff;
   cursor: pointer;
+
+  @include icon-before($type: chart-bar);
 
   &::before {
     margin-right: 10px;

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_build_detail.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/css/_build_detail.scss
@@ -545,29 +545,26 @@ a.collapse-all {
 .sidebar_history .passed .color_code_small {
   height: 14px;
   width: 14px;
+  color: #78c42d;
 
   @include icon-before($passed-icon, 14px, 0);
-
-  color: #78c42d;
 }
 
 .sidebar_history .failed .color_code_small {
   height: 14px;
   width: 14px;
+  color: #fa2d2d;
 
   @include icon-before($failed-icon, 14px, 0);
-
-  color: #fa2d2d;
 }
 
 .sidebar_history .cancelled .color_code_small {
   height: 14px;
   width: 14px;
-
-  @include icon-before(ban, 14px, 0);
-
   color: #ffc11b;
   text-align: center;
+
+  @include icon-before(ban, 14px, 0);
 }
 
 .sidebar_history .cancelled .color_code_small img {
@@ -608,10 +605,9 @@ a.collapse-all {
 
   .compress {
     display: inline;
+    padding: 5px 0;
 
     @include icon-before("compress", $line-height: 1.22em, $margin: 0 5px);
-
-    padding: 5px 0;
   }
 
   .expand {

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/new-theme.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/new-theme.scss
@@ -48,10 +48,10 @@ ul {
 .row {
   margin-left: auto;
   margin-right: auto;
+  max-width: 100%;
 
   @include clearfix;
 
-  max-width: 100%;
 }
 
 .column,
@@ -903,21 +903,21 @@ a.link_as_button.disabled:hover {
   }
 
   &.Passed {
-    @include icon-before($passed-icon, $margin: 0);
-
     color: $passed;
+
+    @include icon-before($passed-icon, $margin: 0);
   }
 
   &.Failed {
-    @include icon-before($failed-icon, $margin: 0);
-
     color: $failed;
+
+    @include icon-before($failed-icon, $margin: 0);
   }
 
   &.Cancelled {
-    @include icon-before($cancelled-icon, $margin: 0);
-
     color: $building;
+
+    @include icon-before($cancelled-icon, $margin: 0);
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/patterns/_forms.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/patterns/_forms.scss
@@ -113,11 +113,11 @@ label.inline {
 }
 
 .form_item_block {
+  padding-bottom: 15px;
+
   &.with-padding-top {
     padding-top: 15px;
   }
-
-  padding-bottom: 15px;
 }
 
 .form_item_block:last-child {

--- a/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/structure/_application.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/stylesheets/structure/_application.scss
@@ -205,9 +205,11 @@ table td {
 .back_to_top {
   @include floating-button($bottom: 120px);
 
-  background: #000 image_url("back-to-top.png") no-repeat center 10px;
-  padding-top: 30px;
-  color: white;
+  & {
+    background: #000 image_url("back-to-top.png") no-repeat center 10px;
+    padding-top: 30px;
+    color: white;
+  }
 }
 
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/buttons/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/buttons/index.scss
@@ -47,24 +47,36 @@
 .btn-cancel {
   @include button($background-color: transparent);
 
-  color: $text-color;
+  // stylelint-disable no-duplicate-selectors
+  & {
+    color: $text-color;
+  }
+  // stylelint-enable
 }
 
 .btn-link {
   @include button($background-color: transparent);
 
-  color: $text-color;
-  padding: 0;
-  text-decoration: underline;
-  line-height: normal;
-  height: auto;
+  // stylelint-disable no-duplicate-selectors
+  & {
+    color: $text-color;
+    padding: 0;
+    text-decoration: underline;
+    line-height: normal;
+    height: auto;
+  }
+  // stylelint-enable
 }
 
 .btn-default {
   @include button($background-color: $white);
 
-  color: $text-color;
-  border: 1px solid $border-color;
+  // stylelint-disable no-duplicate-selectors
+  & {
+    color: $text-color;
+    border: 1px solid $border-color;
+  }
+  // stylelint-enable
 }
 
 .btn-small {
@@ -107,9 +119,9 @@
 }
 
 .icon-doc {
-  @include icon-before($type: $fa-var-file);
-
   margin-right: 10px;
+
+  @include icon-before($type: $fa-var-file);
 
   &::before {
     margin: 5px 10px 5px -5px;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/buttons/wizard_buttons.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/buttons/wizard_buttons.scss
@@ -20,8 +20,12 @@
 .btn-secondary {
   @include button($background-color: $white);
 
-  color: $btn-primary;
-  border: 1px solid $btn-primary;
+  // stylelint-disable no-duplicate-selectors
+  & {
+    color: $btn-primary;
+    border: 1px solid $btn-primary;
+  }
+  // stylelint-enable
 
   &:hover {
     color: $white;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/collapsible_panel/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/collapsible_panel/index.scss
@@ -61,8 +61,6 @@ $collapsible-header-height: 50px;
 }
 
 .collapse-header {
-  @include icon-after($fa-var-angle-right);
-
   position: relative;
   display: flex;
   flex-flow: column wrap;
@@ -70,6 +68,8 @@ $collapsible-header-height: 50px;
   box-sizing: border-box;
   cursor: pointer;
   min-height: $collapsible-header-height;
+
+  @include icon-after($fa-var-angle-right);
 
   @media (min-width: $screen-md) {
     justify-content: space-between;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/config_repos/material_check.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/config_repos/material_check.scss
@@ -83,13 +83,13 @@
 }
 
 @mixin material-check-button-icon($type, $colors: $icon-light-color, $size: 5px) {
+  font-size: 11px;
+
   @include icon-before($type: $type, $color: $colors, $size: 15px, $margin: 0) {
     display: inline-block;
     margin-right: $size;
     @content;
   }
-
-  font-size: 11px;
 }
 
 .material-check-success {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/dropdown/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/dropdown/index.scss
@@ -114,12 +114,12 @@ $c-dropdown-background: #fff;
 }
 
 .c-down-arrow {
-  @include icon-before($type: $fa-var-angle-down);
-
   position: absolute;
   right: 9px;
   top: 5px;
   cursor: pointer;
   z-index: $c-dropdown-arrow-z-index;
   font-size: 15px;
+
+  @include icon-before($type: $fa-var-angle-down);
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/forms/forms.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/forms/forms.scss
@@ -233,13 +233,13 @@ input[type="checkbox"].form-control {
 }
 
 .search-box-wrapper {
+  display: inline-block;
+  position: relative;
+
   @include icon-before($type: $fa-var-search, $size: 14px, $top: 5px, $color: $icon-color) {
     position: absolute;
     left: 10px;
   }
-
-  display: inline-block;
-  position: relative;
 
   .search-box-input {
     padding: 0 10px 0 40px;
@@ -264,13 +264,21 @@ input[type="checkbox"].form-control {
   .quick-add-button {
     @include button($background-color: $btn-secondary);
 
-    border-radius: 0 $global-border-radius $global-border-radius 0;
+    // stylelint-disable no-duplicate-selectors
+    & {
+      border-radius: 0 $global-border-radius $global-border-radius 0;
+    }
+    // stylelint-enable
   }
 
   .search-button {
     @include button($background-color: $btn-secondary);
 
-    border-radius: 0 $global-border-radius $global-border-radius 0;
+    // stylelint-disable no-duplicate-selectors
+    & {
+      border-radius: 0 $global-border-radius $global-border-radius 0;
+    }
+    // stylelint-enable
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/header_icon/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/header_icon/index.scss
@@ -37,9 +37,9 @@ $collapse-icon-size: 25px;
 }
 
 .unknown-icon {
-  @include icon-before($type: $fa-var-question, $color: $icon-light-color, $size: 25px, $margin: 0);
-
   display: block;
+
+  @include icon-before($type: $fa-var-question, $color: $icon-light-color, $size: 25px, $margin: 0);
 }
 
 .no-margin {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/header_panel/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/header_panel/index.scss
@@ -98,11 +98,11 @@ $page-item-padding: 30px;
     }
 
     .value {
-      @include icon-after($fa-var-angle-double-right, $color: $icon-color, $margin: 3px 5px 0 10px);
-
       display: flex;
       font-weight: 600;
       font-size: 15px;
+
+      @include icon-after($fa-var-angle-double-right, $color: $icon-color, $margin: 3px 5px 0 10px);
     }
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.scss
@@ -100,9 +100,9 @@ $console-icon-color: #fff;
 }
 
 .spinner {
-  @include icon-before($type: $fa-var-spinner);
-
   animation: spin 1500ms linear infinite;
+
+  @include icon-before($type: $fa-var-spinner);
 }
 
 @keyframes spin {
@@ -124,9 +124,9 @@ $console-icon-color: #fff;
 }
 
 .minus {
-  @include icon-before($type: $fa-var-minus);
-
   font-size: 7px;
+
+  @include icon-before($type: $fa-var-minus);
 }
 
 .plus {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/materials/test_connection.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/materials/test_connection.scss
@@ -30,13 +30,13 @@
 }
 
 @mixin test-connection-button-icon($type, $colors: $icon-light-color, $size: 5px) {
+  font-size: 11px;
+
   @include icon-before($type: $type, $color: $colors, $size: 15px, $margin: 0) {
     display: inline-block;
     margin-right: $size;
     @content;
   }
-
-  font-size: 11px;
 }
 
 .test-connection-success {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/notification_center/system_notifications.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/notification_center/system_notifications.scss
@@ -39,9 +39,9 @@ $icon-background: #e0dede;
 }
 
 .bell {
-  @include icon-before($fa-var-bell, $color: $header-text-color);
-
   font-size: 18px;
+
+  @include icon-before($fa-var-bell, $color: $header-text-color);
 
   @media (max-width: $screen-md-min) {
     float: left;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/rules/rules.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/rules/rules.scss
@@ -67,14 +67,14 @@
 }
 
 .icon-delete {
-  @include icon-before($type: $fa-var-xmark);
-
   border: none;
   display: inline;
   cursor: pointer;
   width: 22px;
   height: 22px;
   padding: 0;
+
+  @include icon-before($type: $fa-var-xmark);
 
   &::before {
     margin: 0;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/search_box/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/search_box/index.scss
@@ -19,10 +19,10 @@ $icon-color: #647984;
 $border-color: #ccc;
 
 .search-box-wrapper {
-  @include icon-before($type: $fa-var-search, $size: 14px, $top: 5px, $color: $icon-color) ;
-
   display: inline-block;
   position: relative;
+
+  @include icon-before($type: $fa-var-search, $size: 14px, $top: 5px, $color: $icon-color) ;
 
   &::before {
     position: absolute;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_count_widget.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_count_widget.scss
@@ -69,14 +69,18 @@
   @include hover-effect-for-top-menu;
   @include icon-before($fa-var-exclamation-circle, $margin: 0);
 
-  background-color: darken($failed, 20%);
-  display: flex;
-  padding: 5px 10px;
-  border-radius: $global-border-radius;
-  margin: 0 0 20px 0;
-  align-items: center;
-  color: $white;
-  cursor: pointer;
+  // stylelint-disable no-duplicate-selectors
+  & {
+    background-color: darken($failed, 20%);
+    display: flex;
+    padding: 5px 10px;
+    border-radius: $global-border-radius;
+    margin: 0 0 20px 0;
+    align-items: center;
+    color: $white;
+    cursor: pointer;
+  }
+  // stylelint-enable
 
   &::before {
     margin: 1px 10px 0 0;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.scss
@@ -107,11 +107,11 @@
   }
 
   .caret_down_icon {
-    @include icon-before($fa-var-caret-down);
-
     color: $icon-color;
     font-size: 13px;
     display: none;
+
+    @include icon-before($fa-var-caret-down);
 
     @media (min-width: $screen-md) {
       display: inline-block;
@@ -120,12 +120,11 @@
 }
 
 .site-nav_link {
-  @include hover-effect-for-top-menu;
-
-  text-decoration: none;
   text-transform: uppercase;
   font-size: 12px;
   font-weight: 600;
+
+  @include hover-effect-for-top-menu;
 
   @media (min-width: $screen-md) {
     font-size: 11px;
@@ -176,23 +175,22 @@
 }
 
 .site-sub-nav_item {
-  @media (max-width: $screen-md-min) {
-    line-height: normal;
-  }
-
   list-style-type: none;
   float: none;
   padding: 5px 0;
+
+  @media (max-width: $screen-md-min) {
+    line-height: normal;
+  }
 }
 
 .site-sub-nav_link {
-  @include hover-effect-for-top-menu;
-
-  text-decoration: none;
   display: inline-block;
   font-size: 13px;
   position: relative;
   white-space: nowrap;
+
+  @include hover-effect-for-top-menu;
 
   @media (max-width: $screen-md-min) {
     margin-bottom: 10px;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/table/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/table/index.scss
@@ -68,27 +68,27 @@ $draggable-row-color: #e2f7fa;
 }
 
 .sort-button {
-  @include icon-before($fa-var-sort);
-
   margin-left: 2px;
   cursor: pointer;
   color: $icon-color;
+
+  @include icon-before($fa-var-sort);
 }
 
 .sort-button-asc {
-  @include icon-before($fa-var-sort-up);
-
   margin-left: 2px;
   cursor: pointer;
   color: $icon-color;
+
+  @include icon-before($fa-var-sort-up);
 }
 
 .sort-button-desc {
-  @include icon-before($fa-var-sort-down);
-
   margin-left: 2px;
   cursor: pointer;
   color: $icon-color;
+
+  @include icon-before($fa-var-sort-down);
 }
 
 .in-active {
@@ -96,11 +96,10 @@ $draggable-row-color: #e2f7fa;
 }
 
 .drag-icon {
+  font-size: 12px;
+
   @include sort-cursor;
   @include grip-icon;
-
-  font-size: 12px;
-  color: $icon-drag;
 
   &:active {
     @include sort-cursor-active;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.scss
@@ -366,9 +366,9 @@ $dark-gray: #2f4f4f;
 }
 
 .passed {
-  @include icon-before($type: $fa-var-check, $color: $white);
-
   background: $passed;
+
+  @include icon-before($type: $fa-var-check, $color: $white);
 
   &::before {
     position: relative;
@@ -378,9 +378,9 @@ $dark-gray: #2f4f4f;
 }
 
 .failed {
-  @include icon-before($type: $fa-var-exclamation-circle, $color: $white);
-
   background: $failed;
+
+  @include icon-before($type: $fa-var-exclamation-circle, $color: $white);
 
   &::before {
     position: relative;
@@ -390,9 +390,9 @@ $dark-gray: #2f4f4f;
 }
 
 .cancelled {
-  @include icon-before($type: $fa-var-ban);
-
   background: $building;
+
+  @include icon-before($type: $fa-var-ban);
 
   &::before {
     position: relative;
@@ -768,22 +768,22 @@ $dark-gray: #2f4f4f;
 }
 
 .unsorted {
-  @include icon-before($fa-var-sort);
-
   color: $gray;
   margin-left: 2px;
+
+  @include icon-before($fa-var-sort);
 }
 
 .asc {
-  @include icon-before($fa-var-sort-up);
-
   color: $dark-gray;
   margin-left: 2px;
+
+  @include icon-before($fa-var-sort-up);
 }
 
 .desc {
-  @include icon-before($fa-var-sort-down);
-
   color: $dark-gray;
   margin-left: 2px;
+
+  @include icon-before($fa-var-sort-down);
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/edit_pipeline_group.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/edit_pipeline_group.scss
@@ -16,14 +16,14 @@
 @import "../../global/common";
 
 .icon-delete {
-  @include icon-before($type: $fa-var-xmark);
-
   border: none;
   display: inline;
   cursor: pointer;
   width: 22px;
   height: 22px;
   padding: 0;
+
+  @include icon-before($type: $fa-var-xmark);
 
   &::before {
     margin: 0;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_templates/modals.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_templates/modals.scss
@@ -83,14 +83,14 @@
 }
 
 .icon-delete {
-  @include icon-before($type: $fa-var-xmark);
-
   border: none;
   display: inline;
   cursor: pointer;
   width: 22px;
   height: 22px;
   padding: 0;
+
+  @include icon-before($type: $fa-var-xmark);
 
   &::before {
     margin: 0;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/agents/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/agents/index.scss
@@ -24,12 +24,12 @@ $icon-hover-color: #000;
 $dropdown-button-content-z-index: 5;
 
 .agent-status {
-  @include icon-after($type: $fa-var-caret-down, $color: $icon-color);
-
   position: relative;
   text-decoration: none;
   color: $link-color;
   display: block;
+
+  @include icon-after($type: $fa-var-caret-down, $color: $icon-color);
 
   &::after {
     font-size: 10px;
@@ -183,12 +183,12 @@ $dropdown-button-content-z-index: 5;
 }
 
 .agent-analytics a {
-  @include icon-before($type: $fa-var-chart-bar);
-
   padding: 0;
   font-size: 14px;
   color: $icon-color;
   cursor: pointer;
+
+  @include icon-before($type: $fa-var-chart-bar);
 
   &:hover {
     color: $icon-hover-color;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/backup/progress_indicator.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/backup/progress_indicator.scss
@@ -80,10 +80,10 @@
   }
 
   .spinner {
-    @include icon-before($type: $fa-var-spinner);
-
     position: absolute;
     left: -14px;
+
+    @include icon-before($type: $fa-var-spinner);
 
     &::before {
       animation: spin 1500ms linear infinite;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/stages/stages.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/compare/stages/stages.scss
@@ -58,16 +58,16 @@ $icon-size: 10px;
 }
 
 .cancelled {
-  @include icon-before($fa-var-ban, $icon-size, 1px);
-
   color: $black;
   background: transparent url("../../../../../app/assets/images/building.png");
+
+  @include icon-before($fa-var-ban, $icon-size, 1px);
 }
 
 .failed {
-  @include icon-before($fa-var-exclamation-circle, $icon-size, 1px);
-
   background: $failed;
+
+  @include icon-before($fa-var-exclamation-circle, $icon-size, 1px);
 }
 
 .failing {
@@ -75,7 +75,7 @@ $icon-size: 10px;
 }
 
 .passed {
-  @include icon-before($fa-var-check, $icon-size, 1px);
-
   background: $passed;
+
+  @include icon-before($fa-var-check, $icon-size, 1px);
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/defined_structs.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/defined_structs.scss
@@ -43,11 +43,11 @@ $label-color-env: #ffe099;
 }
 
 .spin {
-  @include icon-before($type: $fa-var-spinner, $margin: 0);
-
   display: inline-block;
   margin-right: 10px;
   animation: rotate 1s linear infinite;
+
+  @include icon-before($type: $fa-var-spinner, $margin: 0);
 
   @keyframes rotate {
     from {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos/index.scss
@@ -20,11 +20,11 @@ $error-message-margin-bottom: 40px;
 $input-length-for-rules: 300px;
 
 @mixin header-icon($type, $color) {
+  display: block;
+
   @include icon-before($type: $type, $color: $color, $size: 25px, $margin: 0) {
     text-align: center;
   }
-
-  display: block;
 }
 
 @mixin key-pair-icon($type, $color) {
@@ -34,15 +34,15 @@ $input-length-for-rules: 300px;
 }
 
 .good-modification-icon {
-  @include key-pair-icon($type: $fa-var-check, $color: $success-txt);
-
   margin-right: 10px;
+
+  @include key-pair-icon($type: $fa-var-check, $color: $success-txt);
 }
 
 .error-last-modification-icon {
-  @include key-pair-icon($type: $fa-var-xmark, $color: $failed);
-
   margin-right: 10px;
+
+  @include key-pair-icon($type: $fa-var-xmark, $color: $failed);
 }
 
 // TODO: Why unqualified tag selector? When webpack compiles production bundle,
@@ -64,13 +64,13 @@ code {
 }
 
 @mixin fa-icon($type, $colors: $icon-light-color, $size: 5px) {
+  font-size: 11px;
+
   @include icon-before($type: $type, $color: $colors, $size: 15px, $margin: 0) {
     display: inline-block;
     margin-right: $size;
     @content;
   }
-
-  font-size: 11px;
 }
 
 .config-repo-success-state {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/elastic_agent_configurations/index.scss
@@ -20,11 +20,11 @@ $icon-light-color: #e6e6e6;
 $disabled-text-color: #999;
 
 @mixin header-icon($type, $color) {
+  display: block;
+
   @include icon-before($type: $type, $color: $color, $size: 25px) {
     text-align: center;
   }
-
-  display: block;
 }
 
 .plugin-icon {
@@ -124,12 +124,12 @@ $disabled-text-color: #999;
 }
 
 .cluster-profile-details-header {
-  @include icon-before($type: $fa-var-angle-right, $size: 16px);
-
   position: relative;
   padding-left: 17px;
   cursor: pointer;
   margin: 0 0 20px 0;
+
+  @include icon-before($type: $fa-var-angle-right, $size: 16px);
 
   &::before {
     position: absolute;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss
@@ -61,9 +61,9 @@ $button-color: #2d6ca2;
   }
 
   &.unknown {
-    @include icon-before($type: $fa-var-question, $color: $icon-light-color, $size: 35px, $margin: 0);
-
     background: $white;
+
+    @include icon-before($type: $fa-var-question, $color: $icon-light-color, $size: 35px, $margin: 0);
   }
 }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/package_repositories/index.scss
@@ -20,12 +20,12 @@
 }
 
 .configuration-details-header {
-  @include icon-before($type: $fa-var-angle-right, $size: 16px);
-
   position: relative;
   padding-left: 17px;
   cursor: pointer;
   margin: 0 0 20px 0;
+
+  @include icon-before($type: $fa-var-angle-right, $size: 16px);
 
   &::before {
     position: absolute;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/site_header.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/partials/site_header.scss
@@ -62,6 +62,7 @@
   width: 40px;
   display: inline-block;
   margin: 10px 0 10px 20px;
+  background: url("../../../../app/assets/images/go_logo.svg") no-repeat 0 0;
 
   @media (min-width: $screen-md) {
     margin: 10px 0 10px 0;
@@ -70,8 +71,6 @@
   @media (min-width: $screen-lg) {
     margin-right: 10px;
   }
-
-  background: url("../../../../app/assets/images/go_logo.svg") no-repeat 0 0; // fixme
 }
 
 .site-navigation_left {
@@ -97,10 +96,6 @@ $bar-height: 3px;
 $bar-spacing: 7px;
 
 .navbtn {
-  @media (min-width: $screen-md) {
-    display: none;
-  }
-
   border: none;
   float: right;
   position: absolute;
@@ -111,6 +106,10 @@ $bar-spacing: 7px;
   height: $bar-height + ($bar-spacing * 2);
   cursor: pointer;
   background: transparent;
+
+  @media (min-width: $screen-md) {
+    display: none;
+  }
 }
 
 // responsive menu
@@ -164,10 +163,10 @@ $bar-spacing: 7px;
 }
 
 .need_help {
-  @include hover-effect-for-top-menu;
-
   line-height: 40px;
   display: block;
+
+  @include hover-effect-for-top-menu;
 
   @media (min-width: $screen-md) {
     margin: 0 7px 0 0;
@@ -216,12 +215,16 @@ $bar-spacing: 7px;
 .user_link {
   @include hover-effect-for-top-menu;
 
-  color: $header-text-color;
-  text-decoration: none;
-  padding: 0;
-  line-height: 40px;
-  display: inline-block;
-  font-size: 13px;
+  // stylelint-disable no-duplicate-selectors
+  & {
+    color: $header-text-color;
+    text-decoration: none;
+    padding: 0;
+    line-height: 40px;
+    display: inline-block;
+    font-size: 13px;
+  }
+  // stylelint-enable
 
   @media (min-width: $screen-md) {
     padding: 0 7px;
@@ -274,9 +277,9 @@ $bar-spacing: 7px;
 }
 
 .caret_down_icon {
-  @include icon-before($fa-var-caret-down);
-
   color: $icon-color;
+
+  @include icon-before($fa-var-caret-down);
 }
 
 .user_icon {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/index.scss
@@ -191,29 +191,29 @@ $stage-action-icon-z-index: 1;
 }
 
 .cancelled {
-  @include icon-before($fa-var-ban, $icon-size, 1px);
-
   color: $black;
   background: transparent url("../../../../app/assets/images/building.png") repeat-x;
+
+  @include icon-before($fa-var-ban, $icon-size, 1px);
 }
 
 .failed {
-  @include icon-before($fa-var-exclamation-circle, $icon-size, 1px);
-
   background: $failed;
+
+  @include icon-before($fa-var-exclamation-circle, $icon-size, 1px);
 }
 
 .passed {
-  @include icon-before($fa-var-check, $icon-size, 1px);
-
   background: $passed;
+
+  @include icon-before($fa-var-check, $icon-size, 1px);
 }
 
 .waiting {
-  @include icon-before($fa-var-spinner, $icon-size, 1px);
-
   color: $black;
   background: transparent url("../../../../app/assets/images/building.png") repeat-x;
+
+  @include icon-before($fa-var-spinner, $icon-size, 1px);
 
   &::before {
     animation: spin 1500ms linear infinite;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.scss
@@ -24,17 +24,18 @@
   border-top: 1px solid $line-color;
 
   .summary {
+    line-height: 25px;
+    cursor: pointer;
+    outline: none;
+    font-weight: 600;
+
     @include icon-before(
       $type: $fa-var-chevron-right,
       $color: $text-color,
       $size: 16px,
       $line-height: 25px,
-      $margin: 0 5px);
-
-    line-height: 25px;
-    cursor: pointer;
-    outline: none;
-    font-weight: 600;
+      $margin: 0 5px
+    );
   }
 
   .details {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/roles/index.scss
@@ -146,14 +146,14 @@ input[type="radio"][disabled] + label[for] {
 }
 
 .icon-delete {
-  @include icon-before($type: $fa-var-xmark);
-
   border: none;
   display: inline;
   cursor: pointer;
   width: 22px;
   height: 22px;
   padding: 0;
+
+  @include icon-before($type: $fa-var-xmark);
 
   &::before {
     margin: 0;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/secret_configs/index.scss
@@ -99,14 +99,14 @@
 }
 
 .icon-delete {
-  @include icon-before($type: $fa-var-xmark);
-
   border: none;
   display: inline;
   cursor: pointer;
   width: 22px;
   height: 22px;
   padding: 0;
+
+  @include icon-before($type: $fa-var-xmark);
 
   &::before {
     margin: 0;

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/server-configuration/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/server-configuration/index.scss
@@ -95,13 +95,13 @@
 }
 
 @mixin test-connection-button-icon($type, $colors: $icon-light-color, $size: 5px) {
+  font-size: 11px;
+
   @include icon-before($type: $type, $color: $colors, $size: 15px, $margin: 0) {
     display: inline-block;
     margin-right: $size;
     @content;
   }
-
-  font-size: 11px;
 }
 
 .test-connection-success {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/users/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/users/index.scss
@@ -31,9 +31,9 @@ $selected-table-row: #e2f7fa;
 }
 
 .gocd-role {
-  @include icon-before($type: $fa-var-circle, $color: $go-primary);
-
   display: inline-block;
+
+  @include icon-before($type: $fa-var-circle, $color: $go-primary);
 }
 
 .user-management-header {
@@ -139,15 +139,15 @@ $selected-table-row: #e2f7fa;
 }
 
 .role-gocd {
-  @include icon-before($type: $fa-var-circle, $color: $go-primary);
-
   font-size: 12px;
+
+  @include icon-before($type: $fa-var-circle, $color: $go-primary);
 }
 
 .role-plugin {
-  @include icon-before($type: $fa-var-circle, $color: $warning-txt);
-
   font-size: 12px;
+
+  @include icon-before($type: $fa-var-circle, $color: $warning-txt);
 }
 
 .search-user {


### PR DESCRIPTION
Works around deprecations of mixed declarations as documented at https://sass-lang.com/documentation/breaking-changes/mixed-decls/ by re-ordering where possible, including allowing mixins to be included later in declarations where possible, generally following the recommendations at https://github.com/sass/dart-sass/issues/2276 where declarations are not being overridden by the mixin, or ordering needed to override something from within the mixin.

There are still warnings from within foundation-sites to address, and some stylelint rules temporarily to disable where `& {}` workarounds are needed, usually from one of the two override cases.