### PR TITLE
Remove glibc-based zlib from Alpine container mages

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -62,15 +62,11 @@ enum Distro implements DistroBehavior {
       // More detail at https://github.com/adoptium/temurin-build/issues/2688 and https://github.com/adoptium/containers/issues/1
       // Unfortunately, these do not work for GoCD due to the Tanuki Wrapper which does not currently work with musl libc,
       // nor alternate compatibility layers such as libc6-compat or gcompat.
-      //
-      // zlib/libz.so.1 is required by the JRE, and we need a glibc-linked version. Can probably be latest available version.
       return [
-        '# install glibc/zlib for the Tanuki Wrapper, and use by glibc-linked Adoptium JREs',
-        '  apk add --no-cache tzdata --virtual .build-deps curl binutils zstd',
+        '# install glibc for the Tanuki Wrapper, and use by glibc-linked Adoptium JREs',
+        '  apk add --no-cache tzdata --virtual .build-deps curl',
         '  GLIBC_VER="2.34-r0"',
         '  ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download"',
-        '  ZLIB_URL="https://america.archive.pkgbuild.com/packages/z/zlib/zlib-1%3A1.3.1-2-x86_64.pkg.tar.zst"',
-        '  ZLIB_SHA256=4e44ca417663fbdbadd2aa975cb5f56c2fe771ca76bc1462f63760d813fe2458',
         '  curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub',
         '  SGERRAND_RSA_SHA256="823b54589c93b02497f1ba4dc622eaef9c813e6b0f0ebbb2f771e32adf9f4ef2"',
         '  echo "${SGERRAND_RSA_SHA256} */etc/apk/keys/sgerrand.rsa.pub" | sha256sum -c -',
@@ -82,15 +78,9 @@ enum Distro implements DistroBehavior {
         '  apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk',
         '  /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true',
         '  echo "export LANG=$LANG" > /etc/profile.d/locale.sh',
-        '  curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.zst',
-        '  echo "${ZLIB_SHA256} */tmp/libz.tar.zst" | sha256sum -c -',
-        '  mkdir /tmp/libz',
-        '  zstd -d /tmp/libz.tar.zst --output-dir-flat /tmp',
-        '  tar -xf /tmp/libz.tar -C /tmp/libz',
-        '  mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib',
         '  apk del --purge .build-deps glibc-i18n',
-        '  rm -rf /tmp/*.apk /tmp/libz /tmp/libz.tar* /var/cache/apk/*',
-        '# end installing glibc/zlib',
+        '  rm -rf /tmp/*.apk /var/cache/apk/*',
+        '# end installing glibc',
       ] + super.getInstallJavaCommands(project)
     }
   },


### PR DESCRIPTION
Previously system zlib was needed for the JVM, however Eclipse Temurin/Adoptium have changed to use bundled zlib for all runtimes some time in 2023: https://github.com/adoptium/temurin-build/pull/3459

Additionally the version previously used was pre-built by ArchLinux with https://gitlab.archlinux.org/archlinux/devtools/-/merge_requests/188 which needs glibc 2.36.0+ and thus has broken this zlib version whenever it is attempted to be used. (e.g if you try to use glibc AWS SDK layered on top of this image, you will get a crash `/aws/dist/aws: /usr/glibc-compat/lib/libc.so.6: version 'GLIBC_ABI_DT_RELR' not found (required by /usr/glibc-compat/lib/libz.so.1)`)

Since zlib is no longer needed for GoCD, and upgrading to glibc `2.36` is still not easy, this should go. Users will need to BYO glibc-zlib if they are relying on it (or better yet, use apk/musl-based tools or statically linked binaries).