### PR TITLE
Use stable buildkit rootless image

### DIFF
--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -34,7 +34,7 @@ tasks.register('initializeBuildx') {
         commandLine = ['docker', 'buildx', 'rm', '--force', '--keep-state', builderName]
         ignoreExitValue = true
       }
-      project.exec { commandLine = ['docker', 'buildx', 'create', '--use', '--name', builderName, '--driver-opt', 'image=moby/buildkit:rootless'] }
+      project.exec { commandLine = ['docker', 'buildx', 'create', '--use', '--name', builderName, '--driver-opt', 'image=moby/buildkit:buildx-stable-1-rootless'] }
       project.exec { commandLine = ['docker', 'buildx', 'inspect', '--bootstrap', builderName] }
     }
   }


### PR DESCRIPTION
Previously was essentially using latest `rootless` image. 0.17.0 seems to have an issue right now on our hosts so switching back to a stable image