### PR TITLE
Fail Linux package installs if a compatible JRE cannot be found

### DIFF
--- a/installers/linux/shared/partials/_set-jre-location.sh.erb
+++ b/installers/linux/shared/partials/_set-jre-location.sh.erb
@@ -18,9 +18,24 @@
 
     java="$(<%= ENV['JRE_BINARY_LOCATOR'] %>)"
     if [ -n "${java}" ]; then
-      echo "(info) <%= name %> will use the JRE installed at ${java}"
+      echo "(info) Configuring <%= name %> to default to package-provided Java runtime located at '${java}', unless overridden by user."
       sed -ie "s:^\\(wrapper.java.command=\\).*:\\1${java}:" /usr/share/<%= name %>/wrapper-config/wrapper.conf
     else
-      echo "(info) <%= name %> cannot locate a JRE package dependency. Using default 'java' available on the path, unless overridden by user config."
-      echo "(info) Configure user-controlled path to a Java binary using 'wrapper.java.command' in /usr/share/<%= name %>/wrapper-config/wrapper-properties.conf"
+      echo "(warning) <%= name %> cannot locate package-installed Java runtime (may need to install recommended dependencies?). Will look for default or pre-configured Java runtime."
+    fi
+
+    configured_java_command=$(
+      grep -oP '^wrapper.java.command\s*=\s*\K.*' /usr/share/<%= name %>/wrapper-config/wrapper-properties.conf || \
+      grep -oP '^wrapper.java.command\s*=\s*\K.*' /usr/share/<%= name %>/wrapper-config/wrapper.conf
+    )
+
+    if [ -x "$(command -v ${configured_java_command})" ]; then
+      echo "(info) <%= name %> will use the configured Java runtime located at '${configured_java_command}'"
+    else
+      >&2 echo "(error) Current <%= name %> configuration is looking for Java runtime at '${configured_java_command}' but it cannot be found."
+      >&2 echo "(error) <%= name %> cannot locate a Java runtime to use. Please ensure a compatible Java runtime is available by doing one of:"
+      >&2 echo "        - Installing the 'recommended' package dependencies which include a compatible runtime OR"
+      >&2 echo "        - Pre-configuring location of a compatible 'java' executable using 'wrapper.java.command=/path/to/bin/java' in /usr/share/<%= name %>/wrapper-config/wrapper-properties.conf OR"
+      >&2 echo "        - Ensuring a compatible Java runtime is available by default on the PATH"
+      exit 1
     fi


### PR DESCRIPTION
- fixes #13140

Not entirely sure about this change, as it forces the JRE location to be correct (and able to be found by apt/dpkg/dnf) before installing GoCD itself, however this helps deal with cases where the recommended package dependencies are not installed by default on a user's system and they don't notice the warnings. In the much rarer case where the user intends to override the Java location using wrapper-properties.conf they'd need to pre-create that file without having a template/example, which is not ideal.

It also has some weaknesses in not respecting PATH overrides inside wrapper-properties.conf, not respecting go user specific configuration, not validating the correct Java version etc - but the aim is to be better, not perfect.

Let's see how this goes, and revert if it is problematic.