### PR TITLE
Avoid UrlRewriter escaping errors when uploading files from agents without path

### DIFF
--- a/server/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/server/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -1154,8 +1154,14 @@
   </rule>
 
   <rule>
-    <name>RESTful Artifacts</name>
-    <from>^/files/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/(.*?)(\?.*)?$</from>
+    <name>RESTful Artifacts without filepath</name>
+    <from>^/files/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/(\?.*)?$</from>
+    <to type="forward">/repository/restful/artifact/%{attribute:_method}/%{attribute:_type}?pipelineName=$1&amp;pipelineCounter=$2&amp;stageName=$3&amp;stageCounter=$4&amp;buildName=$5&amp;filePath=</to>
+  </rule>
+
+  <rule>
+    <name>RESTful Artifacts with filepath</name>
+    <from>^/files/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/(.+?)(\?.*)?$</from>
     <to type="forward">/repository/restful/artifact/%{attribute:_method}/%{attribute:_type}?pipelineName=$1&amp;pipelineCounter=$2&amp;stageName=$3&amp;stageCounter=$4&amp;buildName=$5&amp;filePath=${escape:$6}</to>
   </rule>
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/web/UrlRewriterIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/web/UrlRewriterIntegrationTest.java
@@ -91,6 +91,7 @@ public class UrlRewriterIntegrationTest {
     private static final ResponseAssertion ARTIFACT_API_GET_FILE = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/2/job/tmp/file", HTTP_URL + "/go/repository/restful/artifact/GET/?pipelineName=pipeline&pipelineCounter=1&stageName=stage&stageCounter=2&buildName=job&filePath=tmp%2Ffile", true);
     private static final ResponseAssertion ARTIFACT_API_PUSH_FILE = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/2/job/tmp/file", HTTP_URL + "/go/repository/restful/artifact/POST/?pipelineName=pipeline&pipelineCounter=1&stageName=stage&stageCounter=2&buildName=job&filePath=tmp%2Ffile", METHOD.POST, true);
     private static final ResponseAssertion ARTIFACT_API_PUSH_FILE_AGENT_REMOTING = new ResponseAssertion(HTTP_URL + "/go/remoting/files/pipeline/1/stage/2/job/file%25?attempt=100&buildId=1000", HTTP_URL + "/go/repository/restful/artifact/POST/?pipelineName=pipeline&pipelineCounter=1&stageName=stage&stageCounter=2&buildName=job&filePath=file%25&attempt=100&buildId=1000", METHOD.POST, true);
+    private static final ResponseAssertion ARTIFACT_API_PUSH_FILE_AGENT_REMOTING_NO_PATH = new ResponseAssertion(HTTP_URL + "/go/remoting/files/pipeline/1/stage/2/job/?attempt=100&buildId=1000", HTTP_URL + "/go/repository/restful/artifact/POST/?pipelineName=pipeline&pipelineCounter=1&stageName=stage&stageCounter=2&buildName=job&filePath=&attempt=100&buildId=1000", METHOD.POST, true);
     private static final ResponseAssertion ARTIFACT_API_CHANGE_FILE = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/2/job/file", HTTP_URL + "/go/repository/restful/artifact/PUT/?pipelineName=pipeline&pipelineCounter=1&stageName=stage&stageCounter=2&buildName=job&filePath=file", METHOD.PUT, true);
     private static final ResponseAssertion ARTIFACT_API_CONSOLE_LOG = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/2/job/cruise-output/console.log?startLineNumber=1000", HTTP_URL + "/go/consoleout.json?pipelineName=pipeline&pipelineCounter=1&stageName=stage&stageCounter=2&buildName=job&filePath=cruise-output%2Fconsole.log&startLineNumber=1000");
 
@@ -130,6 +131,7 @@ public class UrlRewriterIntegrationTest {
             ARTIFACT_API_GET_FILE,
             ARTIFACT_API_PUSH_FILE,
             ARTIFACT_API_PUSH_FILE_AGENT_REMOTING,
+            ARTIFACT_API_PUSH_FILE_AGENT_REMOTING_NO_PATH,
             ARTIFACT_API_CHANGE_FILE,
             ARTIFACT_API_CONSOLE_LOG,
             PIPELINES_STAGE_DETAILS,


### PR DESCRIPTION
- fixes #12872

There is an optional parameter for the destination path of the uploaded file/directory which triggers a minor bug within the Url Rewriter. Workaround it by matching two different rules, depending on whether the destination path is included.