### PR TITLE
Properly handle unexpected RuntimeExceptions from secrets plugins

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/exceptions/SecretResolutionFailureException.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/exceptions/SecretResolutionFailureException.java
@@ -24,12 +24,24 @@ public class SecretResolutionFailureException extends RuntimeException {
         super(message);
     }
 
+    public SecretResolutionFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
     public static SecretResolutionFailureException withMissingSecretParams(String secretConfigId, Set<String> secretsToResolve, Set<String> missingSecrets) {
         return new SecretResolutionFailureException(format("Expected plugin to resolve secret param(s) `%s` using secret config `%s` but plugin failed to resolve secret param(s) `%s`. Please make sure that secret(s) with the same name exists in your secret management tool.", csv(secretsToResolve), secretConfigId, csv(missingSecrets)));
     }
 
     public static SecretResolutionFailureException withUnwantedSecretParams(String secretConfigId, Set<String> secretsToResolve, Set<String> unwantedSecrets) {
         return new SecretResolutionFailureException(format("Expected plugin to resolve secret param(s) `%s` using secret config `%s` but plugin sent additional secret param(s) `%s`.", csv(secretsToResolve), secretConfigId, csv(unwantedSecrets)));
+    }
+
+    public static SecretResolutionFailureException withBrokenResolution(String secretConfigId, Set<String> secretsToResolve, Exception cause) {
+        return new SecretResolutionFailureException(format("Expected plugin to resolve secret param(s) `%s` using secret config `%s` but plugin failed to resolve any of the required secrets `%s` due to a plugin issue `%s`. Please check the plugin configuration or dependencies.", csv(secretsToResolve), secretConfigId, csv(secretsToResolve), cause.toString()), cause);
+    }
+
+    public static SecretResolutionFailureException withPluginError(String secretConfigId, Set<String> secretsToResolve, int responseCode, String message) {
+        return new SecretResolutionFailureException(format("Expected plugin to resolve secret param(s) `%s` using secret config `%s` but plugin failed to resolve any of the required secrets `%s` due to a plugin returning error code '%s' with response `%s`.", csv(secretsToResolve), secretConfigId, csv(secretsToResolve), responseCode, message));
     }
 
     private static String csv(Set<String> secretsToResolve) {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsExtensionV1.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsExtensionV1.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.thoughtworks.go.plugin.access.secrets.SecretsPluginConstants.*;
-import static java.lang.String.format;
 
 public class SecretsExtensionV1 implements VersionedSecretsExtension {
     public static final String VERSION = "1.0";
@@ -112,9 +111,9 @@ public class SecretsExtensionV1 implements VersionedSecretsExtension {
                 @Override
                 public void onFailure(int responseCode, String responseBody, String resolvedExtensionVersion) {
                     String errorMessage = secretsMessageConverterV1.getErrorMessageFromResponse(responseBody);
-                    throw new SecretResolutionFailureException(
-                        format("Error looking up secrets, plugin returned error code '%s' with response: '%s'", responseCode, errorMessage));
+                    throw SecretResolutionFailureException.withPluginError(secretConfig.getId(), keys, responseCode, errorMessage);
                 }
             });
     }
+
 }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsExtensionV1Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsExtensionV1Test.java
@@ -145,7 +145,7 @@ public class SecretsExtensionV1Test {
 
             assertThatCode(() -> secretsExtensionV1.lookupSecrets(PLUGIN_ID, secretConfig, new LinkedHashSet<>(List.of("key1", "key2"))))
                     .isInstanceOf(SecretResolutionFailureException.class)
-                    .hasMessage("Error looking up secrets, plugin returned error code '500' with response: 'Error looking up for keys 'key1''");
+                    .hasMessage("Expected plugin to resolve secret param(s) `key1, key2` using secret config `null` but plugin failed to resolve any of the required secrets `key1, key2` due to a plugin returning error code '500' with response `Error looking up for keys 'key1'`.");
         }
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/exceptions/RulesViolationException.java
+++ b/server/src/main/java/com/thoughtworks/go/server/exceptions/RulesViolationException.java
@@ -23,7 +23,7 @@ public class RulesViolationException extends RuntimeException {
     }
 
     public static void throwSecretConfigNotFound(String entityType, String entityName, String secretConfigId) {
-        throw new RulesViolationException(format("%s '%s' is referring to none-existent secret config '%s'.", entityType, entityName, secretConfigId));
+        throw new RulesViolationException(format("%s '%s' is referring to non-existent secret config '%s'.", entityType, entityName, secretConfigId));
     }
 
     public static void throwCannotRefer(String entityType, String entityName, String secretConfigId) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/RulesService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/RulesService.java
@@ -69,7 +69,7 @@ public class RulesService {
                 String secretConfigId = secretParam.getSecretConfigId();
                 SecretConfig secretConfig = goConfigService.getSecretConfigById(secretConfigId);
                 if (secretConfig == null) {
-                    addError(pipelinesWithErrors, pipelineName, format("Pipeline '%s' is referring to none-existent secret config '%s'.", pipelineName, secretConfigId));
+                    addError(pipelinesWithErrors, pipelineName, format("Pipeline '%s' is referring to non-existent secret config '%s'.", pipelineName, secretConfigId));
                 } else if (!secretConfig.canRefer(group.getClass(), group.getGroup())) {
                     addError(pipelinesWithErrors, pipelineName, format("Pipeline '%s' does not have permission to refer to secrets using secret config '%s'", pipelineName, secretConfigId));
                 }
@@ -189,7 +189,7 @@ public class RulesService {
                 .forEach((secretConfigId, secretParam) -> {
                     SecretConfig secretConfig = goConfigService.getSecretConfigById(secretConfigId);
                     if (secretConfig == null) {
-                        addError(pipelinesWithErrors, new CaseInsensitiveString(entityName), format("%s '%s' is referring to none-existent secret config '%s'.", entityNameOrErrorMessagePrefix, entityName, secretConfigId));
+                        addError(pipelinesWithErrors, new CaseInsensitiveString(entityName), format("%s '%s' is referring to non-existent secret config '%s'.", entityNameOrErrorMessagePrefix, entityName, secretConfigId));
                     } else if (!secretConfig.canRefer(entityClass, entityName)) {
                         addError(pipelinesWithErrors, new CaseInsensitiveString(entityName), format("%s '%s' does not have permission to refer to secrets using secret config '%s'.", entityNameOrErrorMessagePrefix, entityName, secretConfigId));
                     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/RulesServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/RulesServiceTest.java
@@ -96,7 +96,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(gitMaterial))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Pipeline 'up42' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessage("Pipeline 'up42' is referring to non-existent secret config 'secret_config_id'.");
         }
 
         @Test
@@ -147,8 +147,8 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(gitMaterial))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessageContaining("Pipeline 'up42' is referring to none-existent secret config 'secret_config_id'.")
-                    .hasMessageContaining("Pipeline 'up43' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessageContaining("Pipeline 'up42' is referring to non-existent secret config 'secret_config_id'.")
+                    .hasMessageContaining("Pipeline 'up43' is referring to non-existent secret config 'secret_config_id'.");
         }
 
         @Test
@@ -189,7 +189,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(gitMaterial))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Pipeline 'up42' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessage("Pipeline 'up42' is referring to non-existent secret config 'secret_config_id'.");
         }
 
         @Test
@@ -268,7 +268,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(material))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Pluggable SCM 'scm-name' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessage("Pluggable SCM 'scm-name' is referring to non-existent secret config 'secret_config_id'.");
         }
 
         @Test
@@ -298,7 +298,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(material))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Pluggable SCM 'scm-name' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessage("Pluggable SCM 'scm-name' is referring to non-existent secret config 'secret_config_id'.");
         }
 
         @Test
@@ -318,7 +318,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(material))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Pluggable SCM 'scm-name' is referring to none-existent secret config 'secret_config_id'.\nPluggable SCM 'scm-name' is referring to none-existent secret config 'unknown_id'.");
+                    .hasMessage("Pluggable SCM 'scm-name' is referring to non-existent secret config 'secret_config_id'.\nPluggable SCM 'scm-name' is referring to non-existent secret config 'unknown_id'.");
         }
     }
 
@@ -368,7 +368,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(scm))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Pluggable SCM 'scm-name' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessage("Pluggable SCM 'scm-name' is referring to non-existent secret config 'secret_config_id'.");
         }
 
         @Test
@@ -393,7 +393,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(scm))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Pluggable SCM 'scm-name' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessage("Pluggable SCM 'scm-name' is referring to non-existent secret config 'secret_config_id'.");
         }
 
         @Test
@@ -411,7 +411,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(scm))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Pluggable SCM 'scm-name' does not have permission to refer to secrets using secret config 'secret_config_id'.\nPluggable SCM 'scm-name' is referring to none-existent secret config 'unknown_id'.");
+                    .hasMessage("Pluggable SCM 'scm-name' does not have permission to refer to secrets using secret config 'secret_config_id'.\nPluggable SCM 'scm-name' is referring to non-existent secret config 'unknown_id'.");
         }
     }
 
@@ -455,7 +455,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(material))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Package Material 'repo-name' is referring to none-existent secret config 'unknown_id'.");
+                    .hasMessage("Package Material 'repo-name' is referring to non-existent secret config 'unknown_id'.");
         }
 
         @Test
@@ -475,7 +475,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(material))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Package Material 'repo-name' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessage("Package Material 'repo-name' is referring to non-existent secret config 'secret_config_id'.");
         }
 
         @Test
@@ -491,7 +491,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(material))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Package Material 'repo-name' does not have permission to refer to secrets using secret config 'secret_config_id'.\nPackage Material 'repo-name' is referring to none-existent secret config 'unknown_id'.");
+                    .hasMessage("Package Material 'repo-name' does not have permission to refer to secrets using secret config 'secret_config_id'.\nPackage Material 'repo-name' is referring to non-existent secret config 'unknown_id'.");
         }
     }
 
@@ -580,7 +580,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(buildAssigment))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Job: 'job1' in Pipeline: 'up42' and Pipeline Group: 'some_group' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessage("Job: 'job1' in Pipeline: 'up42' and Pipeline Group: 'some_group' is referring to non-existent secret config 'secret_config_id'.");
         }
 
         private BuildAssignment createAssignment(EnvironmentVariableContext environmentVariableContext, JobIdentifier identifier) {
@@ -642,7 +642,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(environmentConfig))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Environment 'dev' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessage("Environment 'dev' is referring to non-existent secret config 'secret_config_id'.");
         }
     }
 
@@ -689,7 +689,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(repository))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Package Repository 'repo-name' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessage("Package Repository 'repo-name' is referring to non-existent secret config 'secret_config_id'.");
         }
 
         @Test
@@ -712,7 +712,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(repository))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Package Repository 'repo-name' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessage("Package Repository 'repo-name' is referring to non-existent secret config 'secret_config_id'.");
         }
     }
 
@@ -765,7 +765,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(repository))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Package Repository 'repo-name' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessage("Package Repository 'repo-name' is referring to non-existent secret config 'secret_config_id'.");
         }
 
         @Test
@@ -826,7 +826,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(clusterProfile))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Cluster Profile 'cluster-id' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessage("Cluster Profile 'cluster-id' is referring to non-existent secret config 'secret_config_id'.");
         }
 
         @Test
@@ -885,7 +885,7 @@ class RulesServiceTest {
 
             assertThatCode(() -> rulesService.validateSecretConfigReferences(elasticProfile))
                     .isInstanceOf(RulesViolationException.class)
-                    .hasMessage("Cluster Profile 'cluster-profile-id' is referring to none-existent secret config 'secret_config_id'.");
+                    .hasMessage("Cluster Profile 'cluster-profile-id' is referring to non-existent secret config 'secret_config_id'.");
         }
 
         @Test


### PR DESCRIPTION
- fixes #12764 

It's not mandatory that plugins fail gracefully :-) If a plugin throws a RuntimeException, make sure we catch it and consider it total failure of secrets resolution for the flows which specifically handle SecretResolutionFailures.

This avoids work being stuck in the queue in a never-ending loop until the secrets are fixed. The downside of this is that transient errors from secrets plugins that need to talk to a server (e.g Hashicorp Vault) will not be retried automatically, however hopefully folks aren't relying upon this.

This seems better.