### PR TITLE
Allow secrets references within config repos that dont share a material with any pipeline

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/RulesService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/RulesService.java
@@ -78,7 +78,7 @@ public class RulesService {
         if (!pipelinesWithErrors.isEmpty()) {
             LOGGER.debug("[Material Update] Failure: {}", errorString(pipelinesWithErrors));
         }
-        if (pipelines.size() == pipelinesWithErrors.size()) {
+        if (!pipelines.isEmpty() && pipelines.size() == pipelinesWithErrors.size()) {
             throw new RulesViolationException(errorString(pipelinesWithErrors));
         }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdaterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdaterTest.java
@@ -91,7 +91,7 @@ public class MaterialDatabaseUpdaterTest {
     public void shouldFailWithAReasonableMessageWhenExceptionMessageIsNull() {
         Material material = new GitMaterial("url", "branch");
         Exception exceptionWithNullMessage = new RuntimeException(null, new RuntimeException("Inner exception has non-null message"));
-        String message = "Modification check failed for material: " + material.getLongDescription() + "\nNo pipelines are affected by this material, perhaps this material is unused.";
+        String message = "Modification check failed for material: " + material.getLongDescription() + "\nNo pipelines affected, may only affect configuration repositories.";
         when(goConfigService.pipelinesWithMaterial(material.config().getFingerprint())).thenReturn(Collections.emptyList());
 
         when(materialRepository.findMaterialInstance(material)).thenThrow(exceptionWithNullMessage);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/RulesServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/RulesServiceTest.java
@@ -208,6 +208,14 @@ class RulesServiceTest {
 
             assertThat(rulesService.validateSecretConfigReferences(gitMaterial)).isEqualTo(true);
         }
+
+        @Test
+        void shouldNotErrorOutOnScmMaterialUsedOnlyForConfigRepo() {
+            GitMaterial gitMaterial = new GitMaterial("http://example.com");
+            gitMaterial.setPassword("{{SECRET:[secret_config_id][password]}}");
+
+            assertThat(rulesService.validateSecretConfigReferences(gitMaterial)).isEqualTo(true);
+        }
     }
 
     @Nested

--- a/server/src/test-integration/java/com/thoughtworks/go/server/materials/MaterialDatabaseDependencyUpdaterTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/materials/MaterialDatabaseDependencyUpdaterTest.java
@@ -123,7 +123,7 @@ public class MaterialDatabaseDependencyUpdaterTest {
         }
 
         HealthStateType scope = HealthStateType.general(HealthStateScope.forMaterial(dependencyMaterial));
-        ServerHealthState state = ServerHealthState.errorWithHtml("Modification check failed for material: pipeline-name [ stage-name ]\nNo pipelines are affected by this material, perhaps this material is unused.", "Description of error", scope);
+        ServerHealthState state = ServerHealthState.errorWithHtml("Modification check failed for material: pipeline-name [ stage-name ]\nNo pipelines affected, may only affect configuration repositories.", "Description of error", scope);
         verify(healthService).update(state);
     }
 


### PR DESCRIPTION
Per the discussion at https://groups.google.com/g/go-cd/c/JlzHTa-Vy_0/m/EvpRpsofBwAJ secrets resolution fails within the `password` of a config repo material which it is not used by any pipelines.

If you add a single pipeline that uses the material it works, so this change makes things consistent, and improves the error messages somewhat.

There is a separate question about whether config repos should be able to refer to arbitrary secrets, however it is still an admin function to manage such repos so this should be relatively safe.

Separately, its noted that "test connection" for pipeline materials resolves secrets but does not attempt to validate whether a Pipeline should be allowed to use that secret, as should happen at runtime - however that is not addressed here.