### PR TITLE
Switch from curl image to Chainguard bash images as utility image

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
@@ -17,8 +17,7 @@
 # Please file any issues or PRs at https://github.com/gocd/gocd
 ###############################################################################################
 
-FROM curlimages/curl:latest AS gocd-agent-unzip
-USER root
+FROM cgr.dev/chainguard/bash:latest AS gocd-agent-unzip
 ARG TARGETARCH
 ARG UID=1000
 <#if useFromArtifact >

--- a/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
@@ -17,8 +17,7 @@
 # Please file any issues or PRs at https://github.com/gocd/gocd
 ###############################################################################################
 
-FROM curlimages/curl:latest AS gocd-server-unzip
-USER root
+FROM cgr.dev/chainguard/bash:latest AS gocd-server-unzip
 ARG TARGETARCH
 ARG UID=1000
 <#if useFromArtifact >

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -34,7 +34,7 @@ tasks.register('initializeBuildx') {
         commandLine = ['docker', 'buildx', 'rm', '--force', '--keep-state', builderName]
         ignoreExitValue = true
       }
-      project.exec { commandLine = ['docker', 'buildx', 'create', '--use', '--name', builderName, '--driver-opt', 'image=moby/buildkit:v0.16.0-rootless'] }
+      project.exec { commandLine = ['docker', 'buildx', 'create', '--use', '--name', builderName, '--driver-opt', 'image=moby/buildkit:buildx-stable-1-rootless'] }
       project.exec { commandLine = ['docker', 'buildx', 'inspect', '--bootstrap', builderName] }
     }
   }


### PR DESCRIPTION
The curl image currently has issues on latest buildkit due to being built with an old Buildah version which includes xattrs in tar layers which Docker 25, and especially rootless DIND/fuse-overlayfs (which we use for builds) do not like. Switching to one of the Chainguard images is probably better. Images are similarish size and rebuilt more regularly.

In any case, switches for now due to https://github.com/moby/buildkit/issues/5478 and https://github.com/curl/curl-container/issues/55