### PR TITLE
Fix deprecated uses of Gradle's project.exec/javaexec

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -678,13 +678,14 @@ dependencyCheck {
 }
 
 dependencyCheckAggregate {
+  def injected = project.objects.newInstance(InjectedExecOps)
   doFirst {
-    project.exec {
+    injected.execOps.exec {
       commandLine = [ "gem", "install", "bundler-audit", "--no-document" ]
       standardOutput = System.out
       errorOutput = System.err
     }
-    project.exec {
+    injected.execOps.exec {
       commandLine = [ "bundle", "audit", "update" ]
       standardOutput = System.out
       errorOutput = System.err
@@ -728,8 +729,9 @@ if (System.getenv().containsKey("GO_SERVER_URL")) {
     archiveFileName = "dependency-check-data-updated.zip"
     destinationDirectory = layout.buildDirectory
 
+    def injected = project.objects.newInstance(InjectedExecOps)
     doLast {
-      project.exec {
+      injected.execOps.exec {
         workingDir = projectDir
         commandLine = [
           "curl",
@@ -777,7 +779,7 @@ task newSPA {
       * limitations under the License.
       """.stripIndent().trim()
 
-    String javaOrJavaScriptLicencseHeader = "/*\n${licenseHeader.split('\n').collect { eachLine -> " ${eachLine}" }.join("\n")}\n */\n\n"
+    String javaOrJavaScriptLicenseHeader = "/*\n${licenseHeader.split('\n').collect { eachLine -> " ${eachLine}" }.join("\n")}\n */\n\n"
 
 
     file("${mountPoint}/${spaName}.tsx").withWriter { out ->
@@ -795,7 +797,7 @@ task newSPA {
           //tslint:disable-next-line
           new ${entityName}SPA();
         """
-      out.println(javaOrJavaScriptLicencseHeader + contents.stripIndent().trim() + "\n")
+      out.println(javaOrJavaScriptLicenseHeader + contents.stripIndent().trim() + "\n")
     }
 
     file("${pagesBase}/${spaName}.tsx").withWriter { out ->
@@ -825,7 +827,7 @@ task newSPA {
             }
           }
         """
-      out.println(javaOrJavaScriptLicencseHeader + contents.stripIndent().trim() + "\n")
+      out.println(javaOrJavaScriptLicenseHeader + contents.stripIndent().trim() + "\n")
     }
 
     file("${widgetBase}/${spaName}_widget.tsx").withWriter { out ->
@@ -845,7 +847,7 @@ task newSPA {
             }
           }
         """
-      out.println(javaOrJavaScriptLicencseHeader + contents.stripIndent().trim() + "\n")
+      out.println(javaOrJavaScriptLicenseHeader + contents.stripIndent().trim() + "\n")
     }
 
     file("${modelsBase}/${spaName}.ts").withWriter { out ->
@@ -867,7 +869,7 @@ task newSPA {
             }
           }
         """
-      out.println(javaOrJavaScriptLicencseHeader + contents.stripIndent().trim() + "\n")
+      out.println(javaOrJavaScriptLicenseHeader + contents.stripIndent().trim() + "\n")
     }
 
     file("spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/${entityName}Controller.java").withWriter { out ->
@@ -914,7 +916,7 @@ task newSPA {
             }
           }
         """
-      out.println(javaOrJavaScriptLicencseHeader + contents.stripIndent().trim() + "\n")
+      out.println(javaOrJavaScriptLicenseHeader + contents.stripIndent().trim() + "\n")
     }
 
     addUrlRewriteRule("${spaName} UI")
@@ -933,6 +935,7 @@ task newSPA {
 
 task removeApi {
   description = "Helper to create a delete an api module. Pass `-PapiName=roles-config -PapiVersion=v1`"
+  def injected = project.objects.newInstance(InjectedExecOps)
 
   doFirst {
     String apiName = project.apiName
@@ -972,11 +975,11 @@ task removeApi {
       out.println(newContents)
     }
 
-    project.exec {
+    injected.execOps.exec {
       commandLine = ['git', 'add', '-u']
     }
 
-    project.exec {
+    injected.execOps.exec {
       commandLine = ['git', 'commit', '-m', "Removed ${apiName} version ${project.apiVersion}"]
     }
   }

--- a/buildSrc/src/main/groovy/InjectedExecOps.groovy
+++ b/buildSrc/src/main/groovy/InjectedExecOps.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+interface InjectedExecOps {
+  @Inject
+  ExecOperations getExecOps()
+}

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/YarnInstallTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/YarnInstallTask.groovy
@@ -21,13 +21,20 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
 
 class YarnInstallTask extends DefaultTask {
+
+  private ExecOperations execOperations
 
   private File workingDir
   private File nodeModules
 
-  YarnInstallTask() {
+  @Inject
+  YarnInstallTask(ExecOperations execOperations) {
+    this.execOperations = execOperations
     inputs.property('os', OperatingSystem.current().toString())
     project.afterEvaluate({
       inputs.file(project.file("${getWorkingDir()}/package.json"))
@@ -55,7 +62,7 @@ class YarnInstallTask extends DefaultTask {
 
   @TaskAction
   def install() {
-    project.exec { execTask ->
+    execOperations.exec { execTask ->
       execTask.environment("FORCE_COLOR", "true")
       execTask.standardOutput = System.out
       execTask.errorOutput = System.err

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -23,19 +23,20 @@ subprojects {
 }
 
 tasks.register('initializeBuildx') {
+  def injected = project.objects.newInstance(InjectedExecOps)
   doFirst {
     if (!project.hasProperty('skipDockerBuild')) {
       // Need to do once before everything (not in parallel) see https://github.com/docker/buildx/issues/344
       def builderName = 'gocd-builder'
       logger.lifecycle("Initializing docker buildx builder [$builderName]...")
 
-      project.exec { commandLine = ['docker', 'buildx', 'version'] }
-      project.exec {
+      injected.execOps.exec { commandLine = ['docker', 'buildx', 'version'] }
+      injected.execOps.exec {
         commandLine = ['docker', 'buildx', 'rm', '--force', '--keep-state', builderName]
         ignoreExitValue = true
       }
-      project.exec { commandLine = ['docker', 'buildx', 'create', '--use', '--name', builderName, '--driver-opt', 'image=moby/buildkit:buildx-stable-1-rootless'] }
-      project.exec { commandLine = ['docker', 'buildx', 'inspect', '--bootstrap', builderName] }
+      injected.execOps.exec { commandLine = ['docker', 'buildx', 'create', '--use', '--name', builderName, '--driver-opt', 'image=moby/buildkit:buildx-stable-1-rootless'] }
+      injected.execOps.exec { commandLine = ['docker', 'buildx', 'inspect', '--bootstrap', builderName] }
     }
   }
 }

--- a/docker/gocd-agent/build.gradle
+++ b/docker/gocd-agent/build.gradle
@@ -108,7 +108,7 @@ subprojects {
     // test image
     task.verifyHelper = {
       def cleanContainer = { OutputStream errorStream = System.err ->
-        project.exec {
+        execOperations.exec {
           workingDir = project.rootProject.projectDir
           commandLine = ["docker", "rm", "--force", docker.dockerImageName]
           standardOutput = System.out
@@ -119,7 +119,7 @@ subprojects {
       cleanContainer.call(OutputStream.nullOutputStream()) // Clean-up after any previous aborted runs
 
       // daemonize the container
-      project.exec {
+      execOperations.exec {
         def additionalFlags = distro == Distro.docker ? ["--privileged"] : []
         workingDir = project.rootProject.projectDir
         commandLine = ["docker", "run", "-e", "GO_SERVER_URL=http://localhost:8153/go", "-d", "--name", docker.dockerImageName] + additionalFlags + [docker.imageNameWithTag] as List<String>
@@ -139,7 +139,7 @@ subprojects {
         }
 
         distro.additionalVerifyCommands.each { command ->
-          project.exec {
+          execOperations.exec {
             workingDir = project.rootProject.projectDir
             commandLine = ["docker", "exec", docker.dockerImageName] + command
             standardOutput = System.out

--- a/docker/gocd-server/build.gradle
+++ b/docker/gocd-server/build.gradle
@@ -99,7 +99,7 @@ subprojects {
     // test image
     task.verifyHelper = {
       def cleanContainer = { OutputStream errorStream = System.err ->
-        project.exec {
+        execOperations.exec {
           workingDir = project.rootProject.projectDir
           commandLine = ["docker", "rm", "--force", docker.dockerImageName]
           standardOutput = System.out
@@ -110,7 +110,7 @@ subprojects {
       cleanContainer.call(OutputStream.nullOutputStream()) // Clean-up after any previous aborted runs
 
       // daemonize the container
-      project.exec {
+      execOperations.exec {
         workingDir = project.rootProject.projectDir
         commandLine = ["docker", "run", "-d", "--name", docker.dockerImageName, docker.imageNameWithTag]
         standardOutput = System.out
@@ -129,7 +129,7 @@ subprojects {
         }
 
         distro.additionalVerifyCommands.each { command ->
-          project.exec {
+          execOperations.exec {
             workingDir = project.rootProject.projectDir
             commandLine = ["docker", "exec", docker.dockerImageName] + command
             standardOutput = System.out

--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -127,7 +127,7 @@ enum PackageType {
 }
 
 private File destFile(String url) {
-  new File(gradle.gradleUserHomeDir, "download-cache/${DigestUtils.md5Hex(url)}/${new File(new URL(url).path).name}")
+  new File(gradle.gradleUserHomeDir, "download-cache/${DigestUtils.md5Hex(url)}/${new File(URI.create(url).toURL().path).name}")
 }
 
 def configureLinuxPackage(DefaultTask packageTask, InstallerType installerType, PackageType packageType, File buildRoot, Configuration configuration, File destDir) {
@@ -135,6 +135,8 @@ def configureLinuxPackage(DefaultTask packageTask, InstallerType installerType, 
     dependsOn configuration
     dependsOn extractDeltaPack
     outputs.dir(destDir)
+
+    def injected = project.objects.newInstance(InjectedExecOps)
 
     doFirst {
       project.delete(buildRoot)
@@ -299,7 +301,7 @@ def configureLinuxPackage(DefaultTask packageTask, InstallerType installerType, 
     }
 
     doLast {
-      project.exec {
+      injected.execOps.exec {
         List<String> cmd = []
         cmd += ['fpm']
 

--- a/installers/windows.gradle
+++ b/installers/windows.gradle
@@ -104,7 +104,7 @@ def configureWindowsFilesystem(Task windowsInstallerTask, InstallerType installe
   }
 }
 
-def executeNSIS(InstallerType installerType, File buildRoot, File destDir) {
+def executeNSIS(ExecOperations execOperations, InstallerType installerType, File buildRoot, File destDir) {
 
   project.mkdir(destDir)
 
@@ -141,7 +141,7 @@ def executeNSIS(InstallerType installerType, File buildRoot, File destDir) {
 
   cmdArgs += ["-V4"] // verbose
 
-  project.exec { ExecSpec execSpec ->
+  execOperations.exec { ExecSpec execSpec ->
     commandLine = (["makensis"] + cmdArgs + [project.file("windows/${installerType.baseName}.nsi").path])
 
     standardOutput = System.out
@@ -159,9 +159,10 @@ task agentWindows64bitExe { DefaultTask thisTask ->
 
   configureWindowsFilesystem(thisTask, installerType, agentGenericZip, buildRoot)
 
+  def injected = project.objects.newInstance(InjectedExecOps)
   doLast {
     project.copy { from('go-agent/win/ServerURL.ini') into(buildRoot) }
-    executeNSIS(installerType, buildRoot, destDir)
+    executeNSIS(injected.execOps, installerType, buildRoot, destDir)
   }
 
   finalizedBy(project.tasks.create("${thisTask.name}Metadata", InstallerMetadataTask.class) {
@@ -180,8 +181,9 @@ task serverWindows64bitExe { DefaultTask thisTask ->
 
   configureWindowsFilesystem(thisTask, installerType, serverGenericZip, buildRoot)
 
+  def injected = project.objects.newInstance(InjectedExecOps)
   doLast {
-    executeNSIS(installerType, buildRoot, destDir)
+    executeNSIS(injected.execOps, installerType, buildRoot, destDir)
   }
 
   finalizedBy(project.tasks.create("${thisTask.name}Metadata", InstallerMetadataTask.class) {

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -23,16 +23,18 @@ task updateBuildMap {
   String password = System.getenv('BUILD_MAP_PASSWORD')
 
   onlyIf { username && password }
+
+  def injected = project.objects.newInstance(InjectedExecOps)
   doFirst {
     project.delete(checkoutDir)
 
-    exec {
+    injected.execOps.exec {
       commandLine = ['git', 'clone', '--quiet', "https://github.com/gocd/build_map", checkoutDir]
       standardOutput = System.out
       errorOutput = System.err
     }
 
-    exec {
+   injected.execOps.exec {
       commandLine = ['./build_go_cd_commit_to_package.rb']
       workingDir = checkoutDir
       standardOutput = System.out

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -169,9 +169,9 @@ project.ext.railsSystemProperties = [
   'jdk.net.URLClassPath.disableClassPathURLCheck': true
 ]
 
-project.ext.jrubyexec = { Closure<JavaExecSpec> cl ->
+project.ext.jrubyexec = { ExecOperations execOperations, Closure<JavaExecSpec> cl ->
   try {
-    project.javaexec { JavaExecSpec javaExecSpec ->
+    execOperations.javaexec { JavaExecSpec javaExecSpec ->
       cl.delegate = javaExecSpec
 
       LinkedHashMap<String, Object> originalEnv = new LinkedHashMap<String, Object>(javaExecSpec.environment)
@@ -448,8 +448,9 @@ task findGemsToNotPack {
   outputs.file(outputFile)
   outputs.cacheIf { true }
 
+  def injected = project.objects.newInstance(InjectedExecOps)
   doFirst {
-    project.jrubyexec {
+    project.jrubyexec(injected.execOps) {
       environment += [
         'OUTPUT_FILE'   : outputFile,
         'BUNDLE_GEMFILE': file("${project.railsRoot}/Gemfile")
@@ -469,8 +470,9 @@ task generateRubygemsLicenseReport {
   outputs.file(licenseReportFile)
   outputs.cacheIf { true }
 
+  def injected = project.objects.newInstance(InjectedExecOps)
   doFirst {
-    project.jrubyexec {
+    project.jrubyexec(injected.execOps) {
       environment += [
         'OUTPUT_FILE'   : licenseReportFile,
         'BUNDLE_GEMFILE': file("${project.railsRoot}/Gemfile")

--- a/server/rails.gradle
+++ b/server/rails.gradle
@@ -118,8 +118,9 @@ task initializeRailsGems {
 
   outputs.dir(project.bundledGemDir)
 
+  def injected = project.objects.newInstance(InjectedExecOps)
   doFirst {
-    project.jrubyexec {
+    project.jrubyexec(injected.execOps) {
       workingDir = project.railsRoot
       args = ['-S', 'bundle', 'install']
       maxHeapSize = '1g'


### PR DESCRIPTION
Fixes most remaining deprecations other than configuration-related ones from license resolution.