### PR TITLE
Sleep at least 1 second before checking dockerd status to workaround cgroupsv2 challenges

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-agent/run-docker-daemon.sh
+++ b/buildSrc/src/main/resources/gocd-docker-agent/run-docker-daemon.sh
@@ -16,7 +16,11 @@
 # shellcheck disable=SC2086
 $(which dind) dockerd --host=unix:///var/run/docker.sock ${DOCKERD_ADDITIONAL_ARGS:-'--host=tcp://localhost:2375'} > /var/log/dockerd.log 2>&1 &
 
-waited=0
+# Wait a short amount of time to avoid race conditions with the dind script on cgroupsv2, which seems to be due to
+# script code at https://github.com/moby/moby/blob/b249c5ebd214e2977d0fdb1e07d82366f5849cf9/hack/dind#L59-L69
+waited=${DOCKERD_INITIAL_WAIT_SECS:-1}
+sleep ${waited}
+
 until [ $waited -ge ${DOCKERD_MAX_WAIT_SECS:-30} ] || docker stats --no-stream; do
   sleep 1
   ((waited++))


### PR DESCRIPTION

The `dind` hack script on cgroupsv2 needs to move processes to different groups which does not work reliably when there are other scripts (such as this one) creating new processes in the entrypoint creating forked processes at the same time due to race conditions.

This adds an initial wait to give the `dind` hack script time to do its thing before passing off to dockerd.
- See https://github.com/moby/moby/blob/master/hack/dind
- See https://github.com/docker-library/docker/blob/master/dockerd-entrypoint.sh for what this script replaces.