### PR TITLE
Correct sources and javadoc generation for plugin api and config repo jars

### DIFF
--- a/plugin-infra/go-plugin-api/build.gradle
+++ b/plugin-infra/go-plugin-api/build.gradle
@@ -55,6 +55,8 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
   from javadoc.destinationDir
 }
 
+assemble.dependsOn sourcesJar, javadocJar
+
 publishing {
   publications {
     mavenJava(MavenPublication) {

--- a/plugin-infra/go-plugin-config-repo/build.gradle
+++ b/plugin-infra/go-plugin-config-repo/build.gradle
@@ -49,3 +49,5 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
   archiveClassifier = 'javadoc'
   from javadoc.destinationDir
 }
+
+assemble.dependsOn sourcesJar, javadocJar


### PR DESCRIPTION
Somehow this got broken with 24.5.0; possibly due to Gradle task refactoring, although can't find the root cause. This adds back the generation of jars which will fix Maven Central publishing for the next release.