### PR TITLE
Revert "ui-dev: bump bigdecimal from 3.1.8 to 3.1.9 in /server/src/main/webapp/WEB-INF/rails"

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -62,7 +62,8 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    bigdecimal (3.1.9)
+    bigdecimal (3.1.8)
+    bigdecimal (3.1.8-java)
     builder (3.3.0)
     capybara (3.40.0)
       addressable


### PR DESCRIPTION
Reverts gocd/gocd#13362