### PR TITLE
Fix re-display of stage overview models on VSM pages

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/stage_overview_shim_for_vsm.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/stage_overview_shim_for_vsm.tsx
@@ -31,9 +31,8 @@ $(() => {
     const state = window.stageOverviewStateForVSM;
 
     if (state.model()) {
-      const ele = document.getElementById(`stage-overview-container-for-pipeline-${state.getPipelineName()}-${state.getPipelineCounter()}-stage-${state.getStageName()}-${state.getStageCounter()}`)!;
-      ele.innerHTML = "";
-
+      const stageOverviewContainer = document.getElementById(`stage-overview-container-for-pipeline-${state.getPipelineName()}-${state.getPipelineCounter()}-stage-${state.getStageName()}-${state.getStageCounter()}`)!;
+      m.mount(stageOverviewContainer, null);
       state.hide();
     }
   }


### PR DESCRIPTION
Previously the Mithril views were not properly unmounted - instead innerHTML was directly cleared, leading to the virtual dom node sticking around and mithril being confused about how it needs to clean-up the DOM when displaying again. This would fail when removing nodes.

It seems equivalent (and more correct) to unmount the view by mounting a null component at the overview DOM.

This was raised at https://groups.google.com/g/go-cd/c/dXsUxF4XTIA