### PR TITLE
Don't change hover cursor for unclickable icons

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
@@ -45,7 +45,7 @@ class Icon extends MithrilViewComponent<Attrs> {
         <i title={title}
            data-test-id={vnode.attrs["data-test-id"] ? vnode.attrs["data-test-id"] : `${this.title}-icon`}
            data-test-disabled-element={vnode.attrs.disabled}
-           class={classnames({[styles.enabled]: !vnode.attrs.disabled}, this.name, {[styles.disabled]: vnode.attrs.disabled})}
+           class={classnames({[styles.enabled]: vnode.attrs.onclick && !vnode.attrs.disabled}, this.name, {[styles.disabled]: vnode.attrs.onclick && vnode.attrs.disabled})}
            aria-describedby={vnode.attrs.describedBy}
            {...vnode.attrs}
            onclick={vnode.attrs.disabled ? undefined : vnode.attrs.onclick}/>


### PR DESCRIPTION
Icons can be used as buttons, but when not explicitly disabled they are treated as clickable with a hover cursor change, even without an onclick handler which is misleading. This change only adds enabled/disabled handling for icons that have onclick handlers.