### PR TITLE
Fix display of stage overview models for VSM nodes which have periods in their IDs

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/stage_overview_shim_for_vsm.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/stage_overview_shim_for_vsm.tsx
@@ -54,8 +54,11 @@ $(() => {
       status
     };
 
+    // Needs to match logic within Graph_Renderer.sanitizeVsmNodeId which creates the elements being searched for
+    const sanitizeVsmNodeId = (id: string) => id.replace(/\./g, '_id-');
+
     // @ts-ignore
-    const totalWidth = new Array(...document.querySelector(`#${CSS.escape(pipelineName)}`).classList).indexOf("current") !== -1 ? 237 : 192;
+    const totalWidth = new Array(...document.getElementById(sanitizeVsmNodeId(pipelineName)).classList).indexOf("current") !== -1 ? 237 : 192;
     const spaceBetweenStages = 4;
     const initialLeftPosition = -36;
 


### PR DESCRIPTION
Fixes #13397 

There is some historical weird escaping of node IDs for the VSM view which needs to be matched by login in the shim to display modals, or the node cannot be located correctly.

It's difficult to reuse code between the legacy JS and the typescript SPAs here, so duplicating the logic for now.

The old `CSS.escape` should not be needed (especially changing to lookup by ID), and looking back I cannot understand why I added it.