### PR TITLE
Avoid multiple stage overviews being displayed on VSM when server is slow to return model

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/stage_overview_shim_for_vsm.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/stage_overview_shim_for_vsm.tsx
@@ -30,17 +30,16 @@ $(() => {
     // @ts-ignore
     const state = window.stageOverviewStateForVSM;
 
-    if (state.model()) {
-      const stageOverviewContainer = document.getElementById(`stage-overview-container-for-pipeline-${state.getPipelineName()}-${state.getPipelineCounter()}-stage-${state.getStageName()}-${state.getStageCounter()}`)!;
-      m.mount(stageOverviewContainer, null);
-      state.hide();
-    }
+    const stageOverviewContainer = document.getElementById(`stage-overview-container-for-pipeline-${state.getPipelineName()}-${state.getPipelineCounter()}-stage-${state.getStageName()}-${state.getStageCounter()}`)!;
+    m.mount(stageOverviewContainer, null);
+    state.hide();
   }
 
   document.getElementById("vsm-container")!.onclick = closeStageOverview;
 
   // @ts-ignore
   window.getStageOverviewFor = (pipelineName: string, pipelineCounter: string | number, stageName: string, stageCounter: string | number, status: string, currentStageIndex: string, totalNumberOfStages: string, canEdit: boolean, templateName: string) => {
+    window.event?.stopPropagation();
     closeStageOverview();
     const repeatInterval = 9999999;
 
@@ -49,6 +48,7 @@ $(() => {
     // @ts-ignore
     StageOverviewViewModel.initialize(pipelineName, pipelineCounter, stageName, stageCounter, status, repeatInterval).then((result) => window.stageOverviewStateForVSM.model(result));
 
+    // Has to match div ID in Graph_Renderer.renderPipelineInstance
     const stageOverviewContainer = document.getElementById(`stage-overview-container-for-pipeline-${pipelineName}-${pipelineCounter}-stage-${stageName}-${stageCounter}`)!;
     const stageInstanceFromDashboard = {
       status

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/models/stage_overview_state.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/models/stage_overview_state.js
@@ -37,7 +37,7 @@ const StageOverviewState = {
   },
 
   hide: () => {
-    if(StageOverviewState.model()) {
+    if (StageOverviewState.model()) {
       StageOverviewState.model().stopRepeater();
       StageOverviewState.model(undefined);
     }


### PR DESCRIPTION
If the server is slow to return it's possible to lose track of modals that need closing and the UI will get stuck with multiple rendered. This is due to the state.model() check which only succeeds when the server has returned, even if the user has changed their mind and clicked a different stage.

This check was being used as a workaround to avoid the `onclick` handler for clicking outside a modal firing afterwards and then immediately closing the same modal, which can be handled better by preventing propagation for clicks inside a stage bar. Sadly due to the legacy onclick handlers here this is being prevented with a deprecated browser property as not sure of a better way :-/