### PR TITLE
Revert "ui-dev: bump concurrent-ruby from 1.3.4 to 1.3.5 in /server/src/main/webapp/WEB-INF/rails"

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.4)
     crass (1.0.6)
     dartsass-sprockets (3.2.0)
       railties (>= 4.0.0)


### PR DESCRIPTION
Reverts gocd/gocd#13415