### PR TITLE
Revert "ui-dev: bump tzinfo-data from 1.2024.2 to 1.2025.1 in /server/src/main/webapp/WEB-INF/rails"

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
+++ b/server/src/main/webapp/WEB-INF/rails/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.4)
     crass (1.0.6)
     dartsass-sprockets (3.2.0)
       railties (>= 4.0.0)
@@ -211,7 +211,7 @@ GEM
       railties (>= 4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2025.1)
+    tzinfo-data (1.2024.2)
       tzinfo (>= 1.0.0)
     websocket-driver (0.7.7)
       base64


### PR DESCRIPTION
Reverts gocd/gocd#13422