### PR TITLE
Increase UI responsiveness by decreasing default refresh interval to 5 seconds

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -182,7 +182,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     private static final GoSystemProperty<Integer> AGENT_STATUS_API_BIND_PORT = new GoIntSystemProperty("go.agent.status.api.bind.port", 8152);
 
     private static final GoSystemProperty<Integer> GO_SPA_TIMEOUT_IN_MILLIS = new GoIntSystemProperty("go.spa.timeout", (int) SECONDS.toMillis(60));
-    private static final GoSystemProperty<Integer> GO_SPA_REFRESH_INTERVAL_IN_MILLIS = new GoIntSystemProperty("go.spa.refresh.interval", (int) SECONDS.toMillis(10));
+    private static final GoSystemProperty<Integer> GO_SPA_REFRESH_INTERVAL_IN_MILLIS = new GoIntSystemProperty("go.spa.refresh.interval", (int) SECONDS.toMillis(5));
     private static final GoSystemProperty<Long> GO_PAC_CLONE_TIMEOUT_IN_MILLIS = new GoLongSystemProperty("go.pac.clone.timeout", SECONDS.toMillis(30));
 
     private static final GoSystemProperty<Boolean> ENABLE_ANALYTICS_ONLY_FOR_ADMINS = new GoBooleanSystemProperty("go.enable.analytics.only.for.admins", false);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/constants.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/constants.ts
@@ -17,5 +17,5 @@ const meta = document.querySelector("meta[name='gocd-params']");
 
 export const SERVER_TIMEZONE_UTC_OFFSET = parseInt(meta && meta.getAttribute("data-timezone") || "0", 10);
 export const SPA_REQUEST_TIMEOUT        = parseInt(meta && meta.getAttribute("data-page-timeout") || "5000", 10);
-export const SPA_REFRESH_INTERVAL       = parseInt(meta && meta.getAttribute("data-page-refresh-interval") || "10000", 10);
+export const SPA_REFRESH_INTERVAL       = parseInt(meta && meta.getAttribute("data-page-refresh-interval") || "5000", 10);
 export const AUTH_LOGIN_PATH            = "/go/auth/login";


### PR DESCRIPTION
This should be OK for most folks, although could potentially cause issues for some by doubling server requests.

The current 10 seconds is a really long time (especially when triggering UI actions like new builds), and since we seem not ready to move to websockets this seems the best option. 

If people have very slow servers (or it exposes performance issues with some APIs), folks can revert to the old behaviour with `-Dgo.spa.refresh.interval=10000` so let's give this a go.