### PR TITLE
Add support for Almalinux 10 (based off Kitten preview for now)

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -141,6 +141,7 @@ enum Distro implements DistroBehavior {
         "echo 'fastestmirror=1' >> /etc/dnf/dnf.conf",
         "echo 'install_weak_deps=False' >> /etc/dnf/dnf.conf",
         "microdnf upgrade -y",
+        "microdnf install -y shadow-utils",
       ]
     }
 
@@ -156,6 +157,7 @@ enum Distro implements DistroBehavior {
     List<DistroVersion> getSupportedVersions() {
       return [ // See https://endoflife.date/almalinux
         new DistroVersion(version: '9', releaseName: '9-minimal', eolDate: parseDate('2032-05-31')),
+        new DistroVersion(version: '10', releaseName: '10-kitten-minimal', eolDate: parseDate('2035-05-31')),
       ]
     }
   },


### PR DESCRIPTION
Adds support for building an AlmaLinux 10 image (RHEL 10 clone).

Currently blocked on 
- [ ] support among virtualization platforms to make local dev possible https://github.com/lima-vm/lima/issues/3063