### PR TITLE
Configure authenticated docker registry mirror correctly

### DIFF
--- a/db-support/db-support-mysql/build.gradle
+++ b/db-support/db-support-mysql/build.gradle
@@ -38,3 +38,5 @@ dependencies {
     exclude group: 'junit' // Test containers depends on legacy junit, see https://github.com/testcontainers/testcontainers-java/issues/970
   }
 }
+
+test.dependsOn ':docker:configureDockerRegistryMirror'

--- a/db-support/db-support-postgresql/build.gradle
+++ b/db-support/db-support-postgresql/build.gradle
@@ -37,3 +37,5 @@ dependencies {
   testImplementation project.deps.junit5Api
   testRuntimeOnly project.deps.junit5Engine
 }
+
+test.dependsOn ':docker:configureDockerRegistryMirror'

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -1,3 +1,5 @@
+import groovy.json.JsonOutput
+
 /*
  * Copyright Thoughtworks, Inc.
  *
@@ -22,7 +24,29 @@ subprojects {
   apply plugin: 'base'
 }
 
+def configureDockerRegistryMirror = tasks.register('configureDockerRegistryMirror') {
+  doFirst {
+    if (!project.hasProperty('skipDockerBuild') && System.env.DOCKERHUB_MIRROR_USERNAME && System.env.DOCKERHUB_MIRROR_PASSWORD) {
+      logger.lifecycle("Configuring dockerhub mirror credentials, assuming docker.gocd.io is configured...")
+      def dockerConfig = file("${System.properties['user.home']}/.docker/config.json")
+      dockerConfig.mkdirs()
+
+      // See https://github.com/moby/moby/issues/30880#issuecomment-798807332 for why normal docker login to docker.gocd.io as registry mirror doesn't work
+      // Docker uses the wrong credentials when trying to use a registry mirror, so we set the docker.gocd.io creds for Docker Hub
+      dockerConfig.text = JsonOutput.toJson([
+        auths: [
+          "https://index.docker.io/v1/": [
+            auth: "${System.env.DOCKERHUB_MIRROR_USERNAME}:${System.env.DOCKERHUB_MIRROR_PASSWORD}".bytes.encodeBase64().toString()
+          ]
+        ]
+      ])
+    }
+  }
+}
+
 tasks.register('initializeBuildx') {
+  dependsOn configureDockerRegistryMirror
+
   def injected = project.objects.newInstance(InjectedExecOps)
   doFirst {
     if (!project.hasProperty('skipDockerBuild')) {
@@ -30,12 +54,19 @@ tasks.register('initializeBuildx') {
       def builderName = 'gocd-builder'
       logger.lifecycle("Initializing docker buildx builder [$builderName]...")
 
+      def buildkitConfig = file("${rootProject.layout.buildDirectory.get()}/buildkitd.toml")
+      buildkitConfig.text = System.env.DOCKERHUB_MIRROR_USERNAME && System.env.DOCKERHUB_MIRROR_PASSWORD
+        ? """\
+          [registry."docker.io"]
+            mirrors = ["docker.gocd.io"]""".stripIndent()
+        : ""
+
       injected.execOps.exec { commandLine = ['docker', 'buildx', 'version'] }
       injected.execOps.exec {
         commandLine = ['docker', 'buildx', 'rm', '--force', '--keep-state', builderName]
         ignoreExitValue = true
       }
-      injected.execOps.exec { commandLine = ['docker', 'buildx', 'create', '--use', '--name', builderName, '--driver-opt', 'image=moby/buildkit:buildx-stable-1-rootless'] }
+      injected.execOps.exec { commandLine = ['docker', 'buildx', 'create', '--use', '--name', builderName, '--config', buildkitConfig.path, '--driver-opt', 'image=moby/buildkit:buildx-stable-1-rootless'] }
       injected.execOps.exec { commandLine = ['docker', 'buildx', 'inspect', '--bootstrap', builderName] }
     }
   }


### PR DESCRIPTION
If we have credentials for a registry mirror, assume that we are configured with one that needs authentication and use a workaround to authenticate with it correctly.

Also, configures buildkit for use of the same registry mirror (hopefully)