### PR TITLE
Remove remaining .go.cd links

### DIFF
--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/DashboardGroupRepresenterTest.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/DashboardGroupRepresenterTest.groovy
@@ -44,7 +44,7 @@ class DashboardGroupRepresenterTest {
   class PipelineGroups {
     private Map<String, LinkedHashMap<String, String>> expectedLinks = [
       doc : [
-        href: 'https://api.go.cd/current/#pipeline-groups'
+        href: 'https://api.gocd.org/current/#pipeline-groups'
       ],
       self: [
         href: 'http://test.host/go/api/config/pipeline_groups'

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/DashboardRepresenterTest.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/DashboardRepresenterTest.groovy
@@ -59,7 +59,7 @@ class DashboardRepresenterTest {
 
     assertThatJson(actualJson._links).isEqualTo([
       self: [href: "http://test.host/go/api/dashboard"],
-      doc : [href: "https://api.go.cd/current/#dashboard"]
+      doc : [href: "https://api.gocd.org/current/#dashboard"]
     ])
 
     assertThatJson(actualJson._embedded.pipeline_groups).isEqualTo([

--- a/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenterTest.groovy
+++ b/api/api-dashboard-v4/src/test/groovy/com/thoughtworks/go/apiv4/dashboard/representers/PipelineRepresenterTest.groovy
@@ -60,7 +60,7 @@ class PipelineRepresenterTest {
     assertThatJson(json).isEqualTo([
       _links                : [
         self: [href: 'http://test.host/go/api/pipelines/pipeline_name/history'],
-        doc : [href: 'https://api.go.cd/current/#pipelines']
+        doc : [href: 'https://api.gocd.org/current/#pipelines']
       ],
       _embedded             : [
         instances: [

--- a/api/api-environments-v3/src/test/groovy/com/thoughtworks/go/apiv3/environments/EnvironmentsControllerV3Test.groovy
+++ b/api/api-environments-v3/src/test/groovy/com/thoughtworks/go/apiv3/environments/EnvironmentsControllerV3Test.groovy
@@ -161,7 +161,7 @@ class EnvironmentsControllerV3Test implements SecurityServiceTrait, ControllerTr
           ],
           "_links"   : [
             "doc" : [
-              "href": "https://api.go.cd/current/#environment-config"
+              "href": "https://api.gocd.org/current/#environment-config"
             ],
             "self": [
               "href": "http://test.host/go/api/admin/environments"

--- a/api/api-environments-v3/src/test/groovy/com/thoughtworks/go/apiv3/environments/representers/EnvironmentRepresenterTest.groovy
+++ b/api/api-environments-v3/src/test/groovy/com/thoughtworks/go/apiv3/environments/representers/EnvironmentRepresenterTest.groovy
@@ -33,7 +33,7 @@ class EnvironmentRepresenterTest {
     def environmentConfig = [
       "_links"               : [
         "doc" : [
-          "href": "https://api.go.cd/current/#environment-config"
+          "href": "https://api.gocd.org/current/#environment-config"
         ],
         "find": [
           "href": "http://test.host/go/api/admin/environments/:name"
@@ -84,7 +84,7 @@ class EnvironmentRepresenterTest {
         [
           "_links": [
             "doc" : [
-              "href": "https://api.go.cd/current/#pipelines"
+              "href": "https://api.gocd.org/current/#pipelines"
             ],
             "find": [
               "href": "/api/admin/pipelines/:pipeline_name"
@@ -98,7 +98,7 @@ class EnvironmentRepresenterTest {
         [
           "_links": [
             "doc" : [
-              "href": "https://api.go.cd/current/#pipelines"
+              "href": "https://api.gocd.org/current/#pipelines"
             ],
             "find": [
               "href": "/api/admin/pipelines/:pipeline_name"
@@ -137,7 +137,7 @@ class EnvironmentRepresenterTest {
     def response = [
       "_links"               : [
         "doc" : [
-          "href": "https://api.go.cd/current/#environment-config"
+          "href": "https://api.gocd.org/current/#environment-config"
         ],
         "find": [
           "href": "http://test.host/go/api/admin/environments/:name"
@@ -158,7 +158,7 @@ class EnvironmentRepresenterTest {
         [
           "_links": [
             "doc" : [
-              "href": "https://api.go.cd/current/#pipelines"
+              "href": "https://api.gocd.org/current/#pipelines"
             ],
             "find": [
               "href": "/api/admin/pipelines/:pipeline_name"
@@ -172,7 +172,7 @@ class EnvironmentRepresenterTest {
         [
           "_links": [
             "doc" : [
-              "href": "https://api.go.cd/current/#pipelines"
+              "href": "https://api.gocd.org/current/#pipelines"
             ],
             "find": [
               "href": "/api/admin/pipelines/:pipeline_name"

--- a/api/api-environments-v3/src/test/groovy/com/thoughtworks/go/apiv3/environments/representers/EnvironmentsRepresenterTest.groovy
+++ b/api/api-environments-v3/src/test/groovy/com/thoughtworks/go/apiv3/environments/representers/EnvironmentsRepresenterTest.groovy
@@ -48,7 +48,7 @@ class EnvironmentsRepresenterTest {
           [
             "_links"               : [
               "doc" : [
-                "href": "https://api.go.cd/current/#environment-config"
+                "href": "https://api.gocd.org/current/#environment-config"
               ],
               "find": [
                 "href": "http://test.host/go/api/admin/environments/:name"
@@ -69,7 +69,7 @@ class EnvironmentsRepresenterTest {
               [
                 "_links": [
                   "doc" : [
-                    "href": "https://api.go.cd/current/#pipelines"
+                    "href": "https://api.gocd.org/current/#pipelines"
                   ],
                   "find": [
                     "href": "/api/admin/pipelines/:pipeline_name"
@@ -83,7 +83,7 @@ class EnvironmentsRepresenterTest {
               [
                 "_links": [
                   "doc" : [
-                    "href": "https://api.go.cd/current/#pipelines"
+                    "href": "https://api.gocd.org/current/#pipelines"
                   ],
                   "find": [
                     "href": "/api/admin/pipelines/:pipeline_name"
@@ -99,7 +99,7 @@ class EnvironmentsRepresenterTest {
           [
             "_links"               : [
               "doc" : [
-                "href": "https://api.go.cd/current/#environment-config"
+                "href": "https://api.gocd.org/current/#environment-config"
               ],
               "find": [
                 "href": "http://test.host/go/api/admin/environments/:name"
@@ -120,7 +120,7 @@ class EnvironmentsRepresenterTest {
               [
                 "_links": [
                   "doc" : [
-                    "href": "https://api.go.cd/current/#pipelines"
+                    "href": "https://api.gocd.org/current/#pipelines"
                   ],
                   "find": [
                     "href": "/api/admin/pipelines/:pipeline_name"
@@ -137,7 +137,7 @@ class EnvironmentsRepresenterTest {
       ],
       "_links"   : [
         "doc" : [
-          "href": "https://api.go.cd/current/#environment-config"
+          "href": "https://api.gocd.org/current/#environment-config"
         ],
         "self": [
           "href": "http://test.host/go/api/admin/environments"
@@ -156,7 +156,7 @@ class EnvironmentsRepresenterTest {
       ],
       "_links"   : [
         "doc" : [
-          "href": "https://api.go.cd/current/#environment-config"
+          "href": "https://api.gocd.org/current/#environment-config"
         ],
         "self": [
           "href": "http://test.host/go/api/admin/environments"

--- a/api/api-environments-v3/src/test/groovy/com/thoughtworks/go/apiv3/environments/representers/PipelineRepresenterTest.groovy
+++ b/api/api-environments-v3/src/test/groovy/com/thoughtworks/go/apiv3/environments/representers/PipelineRepresenterTest.groovy
@@ -35,7 +35,7 @@ class PipelineRepresenterTest {
     assertThatJson(json).isEqualTo([
       "_links": [
         "doc" : [
-          "href": "https://api.go.cd/current/#pipelines"
+          "href": "https://api.gocd.org/current/#pipelines"
         ],
         "find": [
           "href": "/api/admin/pipelines/:pipeline_name"

--- a/api/api-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/pipelinegroups/representers/PipelineGroupRepresenterTest.groovy
+++ b/api/api-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/pipelinegroups/representers/PipelineGroupRepresenterTest.groovy
@@ -82,7 +82,7 @@ class PipelineGroupRepresenterTest {
           href: 'http://test.host/go/api/admin/pipeline_groups/group'
         ],
         doc: [
-          href: 'https://api.go.cd/current/#pipeline-group-config'
+          href: 'https://api.gocd.org/current/#pipeline-group-config'
         ],
         find: [
           href: 'http://test.host/go/api/admin/pipeline_groups/:group_name'

--- a/api/api-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/pipelinegroups/representers/PipelineGroupsRepresenterTest.groovy
+++ b/api/api-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/pipelinegroups/representers/PipelineGroupsRepresenterTest.groovy
@@ -63,7 +63,7 @@ class PipelineGroupsRepresenterTest {
           href: 'http://test.host/go/api/admin/pipeline_groups'
         ],
         doc: [
-          href: 'https://api.go.cd/current/#pipeline-group-config'
+          href: 'https://api.gocd.org/current/#pipeline-group-config'
         ],
         find: [
           href: 'http://test.host/go/api/admin/pipeline_groups/:group_name'

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/TriggerWithOptionsViewRepresenterTest.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/representers/TriggerWithOptionsViewRepresenterTest.groovy
@@ -105,7 +105,7 @@ class TriggerWithOptionsViewRepresenterTest {
   }
 
   private def linksJSON = [
-    "doc"     : ["href": "https://api.go.cd/current/#pipeline-trigger-options"],
+    "doc"     : ["href": "https://api.gocd.org/current/#pipeline-trigger-options"],
     "self"    : ["href": "http://test.host/go/api/pipelines/my-pipeline/trigger_options"],
     "schedule": ["href": "http://test.host/go/api/pipelines/my-pipeline/schedule"]
   ]

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/dashboard_groups_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/dashboard_groups_spec.js
@@ -99,7 +99,7 @@ describe("DashboardGroups", () => {
           "href": "http://localhost:8153/go/api/config/pipeline_groups/first"
         },
         "doc":  {
-          "href": "https://api.go.cd/current/#pipeline-groups"
+          "href": "https://api.gocd.org/current/#pipeline-groups"
         }
       },
       "name":           "first",
@@ -115,7 +115,7 @@ describe("DashboardGroups", () => {
           "href": "http://localhost:8153/go/api/config/environments/first/show"
         },
         "doc":  {
-          "href": "https://api.go.cd/current/#environments"
+          "href": "https://api.gocd.org/current/#environments"
         }
       },
       "name":           "first",

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/dashboard_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/dashboard_spec.js
@@ -99,7 +99,7 @@ describe("Dashboard", () => {
                 "href": "http://localhost:8153/go/api/config/pipeline_groups/first"
               },
               "doc":  {
-                "href": "https://api.go.cd/current/#pipeline-groups"
+                "href": "https://api.gocd.org/current/#pipeline-groups"
               }
             },
             "name":      "first",
@@ -113,7 +113,7 @@ describe("Dashboard", () => {
                 "href": "http://localhost:8153/go/api/pipelines/up42/history"
               },
               "doc":  {
-                "href": "https://api.go.cd/current/#pipelines"
+                "href": "https://api.gocd.org/current/#pipelines"
               }
             },
             "name":                   "up42",
@@ -136,7 +136,7 @@ describe("Dashboard", () => {
                       "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
                     },
                     "doc":  {
-                      "href": "https://api.go.cd/current/#get-pipeline-instance"
+                      "href": "https://api.gocd.org/current/#get-pipeline-instance"
                     }
                   },
                   "label":        "1",
@@ -151,7 +151,7 @@ describe("Dashboard", () => {
                             "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage/1"
                           },
                           "doc":  {
-                            "href": "https://api.go.cd/current/#get-stage-instance"
+                            "href": "https://api.gocd.org/current/#get-stage-instance"
                           }
                         },
                         "name":         "up42_stage",

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipeline_instance_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipeline_instance_spec.js
@@ -108,7 +108,7 @@ describe("Dashboard", () => {
           "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
         },
         "doc":             {
-          "href": "https://api.go.cd/current/#get-pipeline-instance"
+          "href": "https://api.gocd.org/current/#get-pipeline-instance"
         }
       },
       "label":        "1",
@@ -123,7 +123,7 @@ describe("Dashboard", () => {
                 "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage/1"
               },
               "doc":  {
-                "href": "https://api.go.cd/current/#get-stage-instance"
+                "href": "https://api.gocd.org/current/#get-stage-instance"
               }
             },
             "name":         "up42_stage",
@@ -141,7 +141,7 @@ describe("Dashboard", () => {
                 "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage/1"
               },
               "doc":  {
-                "href": "https://api.go.cd/current/#get-stage-instance"
+                "href": "https://api.gocd.org/current/#get-stage-instance"
               }
             },
             "name":         "up42_stage",

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipeline_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipeline_spec.js
@@ -290,7 +290,7 @@ describe("Dashboard", () => {
           "href": "http://localhost:8153/go/api/pipelines/up42/history"
         },
         "doc":  {
-          "href": "https://api.go.cd/current/#pipelines"
+          "href": "https://api.gocd.org/current/#pipelines"
         }
       },
       "name":                     "up42",
@@ -320,7 +320,7 @@ describe("Dashboard", () => {
                 "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
               },
               "doc":  {
-                "href": "https://api.go.cd/current/#get-pipeline-instance"
+                "href": "https://api.gocd.org/current/#get-pipeline-instance"
               }
             },
             "label":        "1",
@@ -335,7 +335,7 @@ describe("Dashboard", () => {
                       "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage/1"
                     },
                     "doc":  {
-                      "href": "https://api.go.cd/current/#get-stage-instance"
+                      "href": "https://api.gocd.org/current/#get-stage-instance"
                     }
                   },
                   "name":         "up42_stage",

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipelines_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipelines_spec.js
@@ -42,7 +42,7 @@ describe("Dashboard", () => {
             "href": "http://localhost:8153/go/api/pipelines/up42/history"
           },
           "doc":                  {
-            "href": "https://api.go.cd/current/#pipelines"
+            "href": "https://api.gocd.org/current/#pipelines"
           }
         },
         "name":                   "up42",
@@ -65,7 +65,7 @@ describe("Dashboard", () => {
                   "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
                 },
                 "doc":             {
-                  "href": "https://api.go.cd/current/#get-pipeline-instance"
+                  "href": "https://api.gocd.org/current/#get-pipeline-instance"
                 }
               },
               "label":        "1",
@@ -80,7 +80,7 @@ describe("Dashboard", () => {
                         "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage/1"
                       },
                       "doc":  {
-                        "href": "https://api.go.cd/current/#get-stage-instance"
+                        "href": "https://api.gocd.org/current/#get-stage-instance"
                       }
                     },
                     "name":         "up42_stage",

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/dashboard_widget_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/dashboard_widget_spec.js
@@ -353,7 +353,7 @@ describe("Dashboard Widget", () => {
                 "href": "http://localhost:8153/go/api/config/pipeline_groups/first"
               },
               "doc":  {
-                "href": "https://api.go.cd/current/#pipeline-groups"
+                "href": "https://api.gocd.org/current/#pipeline-groups"
               }
             },
             "name":           "first",
@@ -383,7 +383,7 @@ describe("Dashboard Widget", () => {
                 "href": "http://localhost:8153/go/api/pipelines/up42/history"
               },
               "doc":  {
-                "href": "https://api.go.cd/current/#pipelines"
+                "href": "https://api.gocd.org/current/#pipelines"
               }
             },
             "name":                   "up42",
@@ -407,7 +407,7 @@ describe("Dashboard Widget", () => {
                       "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
                     },
                     "doc":  {
-                      "href": "https://api.go.cd/current/#get-pipeline-instance"
+                      "href": "https://api.gocd.org/current/#get-pipeline-instance"
                     }
                   },
                   "label":        "1",
@@ -422,7 +422,7 @@ describe("Dashboard Widget", () => {
                             "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage/1"
                           },
                           "doc":  {
-                            "href": "https://api.go.cd/current/#get-stage-instance"
+                            "href": "https://api.gocd.org/current/#get-stage-instance"
                           }
                         },
                         "name":         "up42_stage",
@@ -443,7 +443,7 @@ describe("Dashboard Widget", () => {
                 "href": "http://localhost:8153/go/api/pipelines/up43/history"
               },
               "doc":  {
-                "href": "https://api.go.cd/current/#pipelines"
+                "href": "https://api.gocd.org/current/#pipelines"
               }
             },
             "name":                   "up43",
@@ -468,7 +468,7 @@ describe("Dashboard Widget", () => {
                       "href": "http://localhost:8153/go/api/pipelines/up43/instance/1"
                     },
                     "doc":  {
-                      "href": "https://api.go.cd/current/#get-pipeline-instance"
+                      "href": "https://api.gocd.org/current/#get-pipeline-instance"
                     }
                   },
                   "label":        "1",
@@ -483,7 +483,7 @@ describe("Dashboard Widget", () => {
                             "href": "http://localhost:8153/go/api/stages/up43/1/up43_stage/1"
                           },
                           "doc":  {
-                            "href": "https://api.go.cd/current/#get-stage-instance"
+                            "href": "https://api.gocd.org/current/#get-stage-instance"
                           }
                         },
                         "name":         "up43_stage",

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/model/dashboard_view_model_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/model/dashboard_view_model_spec.js
@@ -201,7 +201,7 @@ describe("Dashboard View Model", () => {
                 "href": "http://localhost:8153/go/api/config/pipeline_groups/first"
               },
               "doc":  {
-                "href": "https://api.go.cd/current/#pipeline-groups"
+                "href": "https://api.gocd.org/current/#pipeline-groups"
               }
             },
             "name":           "first",
@@ -224,7 +224,7 @@ describe("Dashboard View Model", () => {
           "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
         },
         "doc":             {
-          "href": "https://api.go.cd/current/#get-pipeline-instance"
+          "href": "https://api.gocd.org/current/#get-pipeline-instance"
         }
       },
       "label":        counter,
@@ -239,7 +239,7 @@ describe("Dashboard View Model", () => {
                 "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage/1"
               },
               "doc":  {
-                "href": "https://api.go.cd/current/#get-stage-instance"
+                "href": "https://api.gocd.org/current/#get-stage-instance"
               }
             },
             "name":         "up42_stage",
@@ -263,7 +263,7 @@ describe("Dashboard View Model", () => {
             "href": "http://localhost:8153/go/api/pipelines/up42/history"
           },
           "doc":                  {
-            "href": "https://api.go.cd/current/#pipelines"
+            "href": "https://api.gocd.org/current/#pipelines"
           }
         },
         "name":                   pipelineName,

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
@@ -33,7 +33,7 @@ describe("Dashboard Pipeline Instance Widget", () => {
         "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
       },
       "doc":  {
-        "href": "https://api.go.cd/current/#get-pipeline-instance"
+        "href": "https://api.gocd.org/current/#get-pipeline-instance"
       }
     },
     "label":        "1",
@@ -48,7 +48,7 @@ describe("Dashboard Pipeline Instance Widget", () => {
               "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage/1"
             },
             "doc":  {
-              "href": "https://api.go.cd/current/#get-stage-instance"
+              "href": "https://api.gocd.org/current/#get-stage-instance"
             }
           },
           "name":         "up42_stage",
@@ -178,7 +178,7 @@ describe("Dashboard Pipeline Instance Widget", () => {
                 "href": "http://localhost:8153/go/api/config/pipeline_groups/first"
               },
               "doc":  {
-                "href": "https://api.go.cd/current/#pipeline-groups"
+                "href": "https://api.gocd.org/current/#pipeline-groups"
               }
             },
             "name":           "first",
@@ -200,7 +200,7 @@ describe("Dashboard Pipeline Instance Widget", () => {
             "href": "http://localhost:8153/go/api/pipelines/up42/history"
           },
           "doc":  {
-            "href": "https://api.go.cd/current/#pipelines"
+            "href": "https://api.gocd.org/current/#pipelines"
           }
         },
         "name":                   pipelineName,

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -44,7 +44,7 @@ describe("Dashboard Pipeline Widget", () => {
           "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
         },
         "doc":  {
-          "href": "https://api.go.cd/current/#get-pipeline-instance"
+          "href": "https://api.gocd.org/current/#get-pipeline-instance"
         }
       },
       "label":        "1",
@@ -59,7 +59,7 @@ describe("Dashboard Pipeline Widget", () => {
                 "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage/1"
               },
               "doc":  {
-                "href": "https://api.go.cd/current/#get-stage-instance"
+                "href": "https://api.gocd.org/current/#get-stage-instance"
               }
             },
             "name":         "up42_stage",
@@ -900,7 +900,7 @@ describe("Dashboard Pipeline Widget", () => {
           "href": "http://localhost:8153/go/api/pipelines/up42/history"
         },
         "doc":  {
-          "href": "https://api.go.cd/current/#pipelines"
+          "href": "https://api.gocd.org/current/#pipelines"
         }
       },
       "name":                   pipelineName,
@@ -930,7 +930,7 @@ describe("Dashboard Pipeline Widget", () => {
                 "href": "http://localhost:8153/go/api/config/pipeline_groups/first"
               },
               "doc":  {
-                "href": "https://api.go.cd/current/#pipeline-groups"
+                "href": "https://api.gocd.org/current/#pipeline-groups"
               }
             },
             "name":           "first",

--- a/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/stages_instance_widget_spec.js
+++ b/server/src/main/webapp/WEB-INF/rails/spec/webpack/views/dashboard/stages_instance_widget_spec.js
@@ -31,7 +31,7 @@ describe("Dashboard Stages Instance Widget", () => {
         "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
       },
       "doc":  {
-        "href": "https://api.go.cd/current/#get-pipeline-instance"
+        "href": "https://api.gocd.org/current/#get-pipeline-instance"
       }
     },
     "label":        "1",
@@ -46,7 +46,7 @@ describe("Dashboard Stages Instance Widget", () => {
               "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage/1"
             },
             "doc":  {
-              "href": "https://api.go.cd/current/#get-stage-instance"
+              "href": "https://api.gocd.org/current/#get-stage-instance"
             }
           },
           "name":         "up42_stage",
@@ -63,7 +63,7 @@ describe("Dashboard Stages Instance Widget", () => {
               "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage2/1"
             },
             "doc":  {
-              "href": "https://api.go.cd/current/#get-stage-instance"
+              "href": "https://api.gocd.org/current/#get-stage-instance"
             }
           },
           "name":         "up42_stage2",
@@ -81,7 +81,7 @@ describe("Dashboard Stages Instance Widget", () => {
               "href": "http://localhost:8153/go/api/stages/up42/1/cancelled_stage/1"
             },
             "doc":  {
-              "href": "https://api.go.cd/current/#get-stage-instance"
+              "href": "https://api.gocd.org/current/#get-stage-instance"
             }
           },
           "name":         "cancelled_stage",

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/spec/analytics_frame_spec.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/shared/spec/analytics_frame_spec.ts
@@ -28,7 +28,7 @@ describe("AnalyticsFrame", () => {
 
   describe("load", () => {
     it("should call before and after function", () => {
-      const TEST_URL = "http://test.go.cd/foo",
+      const TEST_URL = "http://test.gocd.org/foo",
             frame    = new Frame("some-uid");
       jasmine.Ajax.stubRequest(TEST_URL).andReturn({});
 
@@ -62,7 +62,7 @@ describe("AnalyticsFrame", () => {
     });
 
     it("should set data and view on successful load", () => {
-      const TEST_URL        = "http://test.go.cd/foo",
+      const TEST_URL        = "http://test.gocd.org/foo",
             frame           = new Frame("some-uid"),
             beforeFn        = jasmine.createSpy("beforeFn"),
             afterFn         = jasmine.createSpy("afterFn"),
@@ -81,7 +81,7 @@ describe("AnalyticsFrame", () => {
       expect(frame.errors()).toBeNull();
     });
     it("should set errors on failure", () => {
-      const TEST_URL = "http://test.go.cd/foo",
+      const TEST_URL = "http://test.gocd.org/foo",
             frame    = new Frame("some-uid"),
             beforeFn = jasmine.createSpy("beforeFn"),
             afterFn  = jasmine.createSpy("afterFn");
@@ -102,7 +102,7 @@ describe("AnalyticsFrame", () => {
 
   describe("fetch", () => {
     it("should call handler with data on success", () => {
-      const TEST_URL        = "http://test.go.cd/foo",
+      const TEST_URL        = "http://test.gocd.org/foo",
             frame           = new Frame("some-uid"),
             handlerFn       = jasmine.createSpy("handler"),
             successResponse = {data: {key: "data-from-server"}, view_path: "/go/some-path-to-analytics-plugin"};
@@ -118,7 +118,7 @@ describe("AnalyticsFrame", () => {
       expect(handlerFn).toHaveBeenCalledWith({key: "data-from-server"}, null);
     });
     it("should call handler with error on failure", () => {
-      const TEST_URL  = "http://test.go.cd/foo",
+      const TEST_URL  = "http://test.gocd.org/foo",
             frame     = new Frame("some-uid"),
             handlerFn = jasmine.createSpy("handler");
       jasmine.Ajax.stubRequest(TEST_URL, undefined, "GET").andReturn({
@@ -136,35 +136,35 @@ describe("AnalyticsFrame", () => {
 
   describe("withParam", () => {
     it("should return url with param when param name and value are not null", () => {
-      const TEST_URL = "http://test.go.cd/foo";
+      const TEST_URL = "http://test.gocd.org/foo";
       const frame    = new Frame("some-uid");
 
       expect(frame.withParam(TEST_URL, "test", "bar")).toBe(`${TEST_URL}?test=bar`);
     });
 
     it("should return url as it is when param name is empty string", () => {
-      const TEST_URL = "http://test.go.cd/foo";
+      const TEST_URL = "http://test.gocd.org/foo";
       const frame    = new Frame("some-uid");
 
       expect(frame.withParam(TEST_URL, "", "bar")).toBe(TEST_URL);
     });
 
     it("should return url as it is when param name and value are empty string", () => {
-      const TEST_URL = "http://test.go.cd/foo";
+      const TEST_URL = "http://test.gocd.org/foo";
       const frame    = new Frame("some-uid");
 
       expect(frame.withParam(TEST_URL, "", "")).toBe(TEST_URL);
     });
 
     it("should return url with param name when param value is empty string", () => {
-      const TEST_URL = "http://test.go.cd/foo";
+      const TEST_URL = "http://test.gocd.org/foo";
       const frame    = new Frame("some-uid");
 
       expect(frame.withParam(TEST_URL, "some-param", "")).toBe(`${TEST_URL}?some-param`);
     });
 
     it("should append params if one already exist", () => {
-      const TEST_URL = "http://test.go.cd/foo?foo=bar";
+      const TEST_URL = "http://test.gocd.org/foo?foo=bar";
       const frame    = new Frame("some-uid");
 
       expect(frame.withParam(TEST_URL, "test", "foo")).toBe(`${TEST_URL}&test=foo`);

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -143,7 +143,7 @@ public class Routes {
 
     public static class Dashboard {
         public static final String SELF = "/api/dashboard";
-        public static final String DOC = "https://api.go.cd/current/#dashboard";
+        public static final String DOC = "https://api.gocd.org/current/#dashboard";
     }
 
     public static class MaterialConfig {
@@ -182,12 +182,12 @@ public class Routes {
     }
 
     public static class PipelineGroup {
-        public static final String DOC = "https://api.go.cd/current/#pipeline-groups";
+        public static final String DOC = "https://api.gocd.org/current/#pipeline-groups";
         public static final String SELF = "/api/config/pipeline_groups";
     }
 
     public static class PipelineGroupsAdmin {
-        public static final String DOC = "https://api.go.cd/current/#pipeline-group-config";
+        public static final String DOC = "https://api.gocd.org/current/#pipeline-group-config";
         public static final String BASE = "/api/admin/pipeline_groups";
 
         public static final String NAME_PATH = "/:group_name";
@@ -231,7 +231,7 @@ public class Routes {
     }
 
     public static class Environments {
-        public static final String DOC = "https://api.go.cd/current/#environment-config";
+        public static final String DOC = "https://api.gocd.org/current/#environment-config";
         public static final String BASE = "/api/admin/environments";
         public static final String NAME = "/:name";
 
@@ -246,8 +246,8 @@ public class Routes {
 
     public static class Pipeline {
         public static final String BASE = "/api/pipelines";
-        public static final String DOC = "https://api.go.cd/current/#pipelines";
-        public static final String DOC_TRIGGER_OPTIONS = "https://api.go.cd/current/#pipeline-trigger-options";
+        public static final String DOC = "https://api.gocd.org/current/#pipelines";
+        public static final String DOC_TRIGGER_OPTIONS = "https://api.gocd.org/current/#pipeline-trigger-options";
 
         public static final String PAUSE_PATH = "/:pipeline_name/pause";
         public static final String UNPAUSE_PATH = "/:pipeline_name/unpause";


### PR DESCRIPTION
Most are just in test data, but there are some that seem to be in doc links for APIs.