### PR TITLE
Correct the Freemarker logger selection to use SLF4J

### DIFF
--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/FreemarkerTemplateEngineFactory.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/FreemarkerTemplateEngineFactory.java
@@ -17,6 +17,7 @@ package com.thoughtworks.go.spark.spa.spring;
 
 import com.thoughtworks.go.spark.SparkController;
 import freemarker.core.XHTMLOutputFormat;
+import freemarker.log.Logger;
 import freemarker.template.Configuration;
 import freemarker.template.TemplateExceptionHandler;
 import org.springframework.beans.factory.InitializingBean;
@@ -57,6 +58,7 @@ public class FreemarkerTemplateEngineFactory implements ServletContextAware, Ini
 
     @Override
     public void afterPropertiesSet() {
+        System.setProperty(Logger.SYSTEM_PROPERTY_NAME_LOGGER_LIBRARY, "SLF4J");
         Configuration configuration = new Configuration(Configuration.VERSION_2_3_34);
         configuration.setDefaultEncoding("utf-8");
         configuration.setLogTemplateExceptions(true);


### PR DESCRIPTION
Is it auto-selecting `java.util.logging` somehow (not sure if SLF4J is in the auto-selection for v2.3), which in itself is not being redirected to SLF4J. Can lead to logging being in the wrong file during Freemarker startup issues makings things difficult to debug.