### PR TITLE
Refresh Tanuki Wrapper licenses valid for new releases through to 2026-06-03

### DIFF
--- a/installers/include/wrapper-license-linux-go-agent.conf
+++ b/installers/include/wrapper-license-linux-go-agent.conf
@@ -6,13 +6,13 @@
 # wrapper.app.parameter.1=/usr/share/go-agent/lib/agent-bootstrapper.jar
 
 wrapper.license.type=DEV
-wrapper.license.id=202403190000005
+wrapper.license.id=202504080000004
 wrapper.license.licensee=ThoughtWorks
 wrapper.license.group=Go
 wrapper.license.dev_application=GoCD Agent On Linux
 wrapper.license.features=64bit
-wrapper.license.key.0=4844-0af0-683d-bc70
-wrapper.license.key.1=dab6-33bf-d978-d9ec
-wrapper.license.key.2=032f-d28a-bf15-d17c
-wrapper.license.key.3=ebae-ad54-86c9-6d25
-wrapper.license.key.4=cc3d-6bb6-63a1-4fef
+wrapper.license.key.0=4844-0af0-6a1e-eff0
+wrapper.license.key.1=aa0b-76a8-9941-0601
+wrapper.license.key.2=a432-6a56-8da0-b595
+wrapper.license.key.3=1d52-c279-192b-3a62
+wrapper.license.key.4=c932-fc50-eb80-49c4

--- a/installers/include/wrapper-license-linux-go-server.conf
+++ b/installers/include/wrapper-license-linux-go-server.conf
@@ -6,13 +6,13 @@
 # wrapper.app.parameter.1=/usr/share/go-server/lib/go.jar
 
 wrapper.license.type=DEV
-wrapper.license.id=202403190000004
+wrapper.license.id=202504080000005
 wrapper.license.licensee=ThoughtWorks
 wrapper.license.group=Go
 wrapper.license.dev_application=GoCD Server On Linux
 wrapper.license.features=64bit
-wrapper.license.key.0=4844-0af0-683d-bc70
-wrapper.license.key.1=18f4-fc2b-904b-fb84
-wrapper.license.key.2=4cac-3361-2945-85e1
-wrapper.license.key.3=6241-ecdf-8362-5ebb
-wrapper.license.key.4=47f0-88ec-a131-4309
+wrapper.license.key.0=4844-0af0-6a1e-eff0
+wrapper.license.key.1=28cd-bb8b-3eba-c77b
+wrapper.license.key.2=143e-03d9-be7f-31de
+wrapper.license.key.3=e061-9c1d-0df3-ee9a
+wrapper.license.key.4=1d88-ebff-d011-8d4d

--- a/installers/include/wrapper-license-relative-path-go-agent.conf
+++ b/installers/include/wrapper-license-relative-path-go-agent.conf
@@ -6,13 +6,13 @@
 # wrapper.app.parameter.1=lib/agent-bootstrapper.jar
 
 wrapper.license.type=DEV
-wrapper.license.id=202403190000006
+wrapper.license.id=202504080000003
 wrapper.license.licensee=ThoughtWorks
 wrapper.license.group=Go
 wrapper.license.dev_application=GoCD Agent
 wrapper.license.features=64bit
-wrapper.license.key.0=4844-0af0-683d-bc70
-wrapper.license.key.1=aa8d-c303-f788-235d
-wrapper.license.key.2=5058-96a6-539c-fe30
-wrapper.license.key.3=3c3c-ceef-dd84-8e7b
-wrapper.license.key.4=e1b1-139c-6945-baf1
+wrapper.license.key.0=4844-0af0-6a1e-eff0
+wrapper.license.key.1=8427-6128-0a90-f302
+wrapper.license.key.2=6f6f-380a-f21b-aede
+wrapper.license.key.3=6be4-a612-f498-3586
+wrapper.license.key.4=4dc8-e6cb-8efa-51cf

--- a/installers/include/wrapper-license-relative-path-go-server.conf
+++ b/installers/include/wrapper-license-relative-path-go-server.conf
@@ -6,13 +6,13 @@
 # wrapper.app.parameter.1=lib/go.jar
 
 wrapper.license.type=DEV
-wrapper.license.id=202403190000007
+wrapper.license.id=202504080000002
 wrapper.license.licensee=ThoughtWorks
 wrapper.license.group=Go
 wrapper.license.dev_application=GoCD Server
 wrapper.license.features=64bit
-wrapper.license.key.0=4844-0af0-683d-bc70
-wrapper.license.key.1=c66a-c135-7a03-2727
-wrapper.license.key.2=580a-d7a3-3374-80b5
-wrapper.license.key.3=f17e-6e51-b286-3612
-wrapper.license.key.4=4f4c-f586-1c7d-37f6
+wrapper.license.key.0=4844-0af0-6a1e-eff0
+wrapper.license.key.1=d379-9738-3af4-fabb
+wrapper.license.key.2=f9b9-ca91-1702-d588
+wrapper.license.key.3=962d-80d7-61c7-72f2
+wrapper.license.key.4=32d3-3616-65bc-3c37


### PR DESCRIPTION
Kindly provided to us via the folks at https://wrapper.tanukisoftware.com ❤️