### PR TITLE
Improve cache lifecycle to clear cache on destroy

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/cache/GoCache.java
+++ b/server/src/main/java/com/thoughtworks/go/server/cache/GoCache.java
@@ -67,6 +67,7 @@ public class GoCache {
 
     @PreDestroy
     public void destroy() {
+        clear();
         Optional.ofNullable(ehCache.getCacheManager())
             .ifPresent(cm -> cm.removeCache(ehCache.getName()));
     }

--- a/server/src/main/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDao.java
@@ -47,6 +47,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 
+import javax.annotation.PreDestroy;
 import java.util.*;
 
 import static com.thoughtworks.go.util.IBatisUtil.arguments;
@@ -654,5 +655,11 @@ public class JobInstanceSqlMapDao extends SqlMapClientDaoSupport implements JobI
 
     String cacheKeyForFindDetailedJobHistoryViaCursor(String pipelineName, String stageName, String jobConfigName, String suffix, long cursor, Integer pageSize) {
         return cacheKeyGenerator.generate("findDetailedJobHistoryViaCursor", pipelineName.toLowerCase(), stageName.toLowerCase(), jobConfigName.toLowerCase(), suffix, cursor, pageSize);
+    }
+
+    @PreDestroy
+    public void destroy() {
+        cache.flushAll(new Date());
+        latestCompletedCache.destroy();
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/cache/LazyCacheTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/cache/LazyCacheTest.java
@@ -30,27 +30,27 @@ public class LazyCacheTest {
     public void shouldGetValueFromCacheIfPresent() {
         Object valueInCache = new Object();
 
-        Ehcache ehcache = mock(Ehcache.class);
-        when(ehcache.get("foo")).thenReturn(new Element("foo", valueInCache));
+        Ehcache ehCache = mock(Ehcache.class);
+        when(ehCache.get("foo")).thenReturn(new Element("foo", valueInCache));
 
         Supplier<?> supplier = mock(Supplier.class);
-        assertThat(new LazyCache(ehcache, null).get("foo", supplier)).isSameAs(valueInCache);
+        assertThat(new LazyCache(ehCache, null).get("foo", supplier)).isSameAs(valueInCache);
         verifyNoInteractions(supplier);
     }
 
     @Test
     public void shouldComputeValueFromSupplierIfNotPresentInCache() {
-        Ehcache ehcache = mock(Ehcache.class);
-        when(ehcache.get("foo")).thenReturn(null);
+        Ehcache ehCache = mock(Ehcache.class);
+        when(ehCache.get("foo")).thenReturn(null);
 
         Object lazilyComputedValue = new Object();
 
         @SuppressWarnings("unchecked") Supplier<Object> supplier = mock(Supplier.class);
         when(supplier.get()).thenReturn(lazilyComputedValue);
-        assertThat(new LazyCache(ehcache, null).get("foo", supplier)).isSameAs(lazilyComputedValue);
+        assertThat(new LazyCache(ehCache, null).get("foo", supplier)).isSameAs(lazilyComputedValue);
         verify(supplier, times(1)).get();
 
-        verify(ehcache, times(2)).get("foo");
-        verify(ehcache, times(1)).put(new Element("foo", lazilyComputedValue));
+        verify(ehCache, times(2)).get("foo");
+        verify(ehCache, times(1)).put(new Element("foo", lazilyComputedValue));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoCachingTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoCachingTest.java
@@ -71,7 +71,6 @@ class PipelineSqlMapDaoCachingTest {
     void setup() {
         transactionSynchronizationManager = mock(TransactionSynchronizationManager.class);
         goCache = new StubGoCache(new TestTransactionSynchronizationManager());
-        goCache.clear();
         mockTemplate = mock(SqlMapClientTemplate.class);
         repository = mock(MaterialRepository.class);
         environmentVariableDao = mock(EnvironmentVariableDao.class);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dao/PipelineStateDaoCachingTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dao/PipelineStateDaoCachingTest.java
@@ -59,7 +59,6 @@ public class PipelineStateDaoCachingTest {
     public void setup() {
         transactionSynchronizationManager = mock(TransactionSynchronizationManager.class);
         goCache = new StubGoCache(new TestTransactionSynchronizationManager());
-        goCache.clear();
         mockTemplate = mock(SqlMapClientTemplate.class);
         SessionFactory mockSessionFactory = mock(SessionFactory.class);
         transactionTemplate = mock(TransactionTemplate.class);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dao/PipelineStateDaoTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dao/PipelineStateDaoTest.java
@@ -49,7 +49,6 @@ class PipelineStateDaoTest {
     @BeforeEach
     void setup() {
         goCache = new StubGoCache(new TestTransactionSynchronizationManager());
-        goCache.clear();
         mockSessionFactory = mock(SessionFactory.class);
         transactionTemplate = mock(TransactionTemplate.class);
         pipelineStateDao = new PipelineStateDao(goCache, transactionTemplate, null,


### PR DESCRIPTION
Makes no practical difference during a safe shutdown, but makes Spring lifecycle tests safer since destroy should be called between tests, even if the object is re-used. Could theoretically remove all of the manual clears around the codebase, but will leave them for now.