### PR TITLE
Build alpine images for arm64/aarch64; upgrading x64 images to glibc 2.41

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -25,82 +25,84 @@ enum Distro implements DistroBehavior {
   alpine {
     @Override
     List<DistroVersion> getSupportedVersions() {
-      return [ // See https://endoflife.date/alpine
+      [ // See https://endoflife.date/alpine
         new DistroVersion(version: '3', releaseName: '3', eolDate: parseDate('2099-01-01')),
       ]
     }
 
     @Override
     boolean isContinuousRelease() {
-      return true
+      true
     }
 
     @Override
     List<String> getBaseImageUpdateCommands(DistroVersion v) {
-      return ['apk --no-cache upgrade']
+      ['apk --no-cache upgrade']
     }
 
     @Override
     List<String> getCreateUserAndGroupCommands() {
-      return [
+      [
         'adduser -D -u ${UID} -s /bin/bash -G root go'
       ]
     }
 
     @Override
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
-      return [
+      [
         // procps is needed for tanuki wrapper shell script
         'apk add --no-cache git openssh-client bash curl procps'
       ]
     }
 
     @Override
+    String getMultiStageInputImage() {
+      "frolvlad/alpine-glibc:alpine-3"
+    }
+
+    @Override
+    String getMultiStageInputCopyToTmp() {
+      "/usr/glibc-compat"
+    }
+
+    @Override
     List<String> getInstallJavaCommands(Project project) {
-      // Originally copied verbatim from https://github.com/AdoptOpenJDK/openjdk-docker/blob/436253bad9e494ea0043da22fca197e6055a538a/15/jdk/alpine/Dockerfile.hotspot.releases.slim#L24-L55
-      // Subsequent to this, Adoptium have moved to use of native Alpine/musl libc builds for JDK 16/17 onwards.
-      // More detail at https://github.com/adoptium/temurin-build/issues/2688 and https://github.com/adoptium/containers/issues/1
-      // Unfortunately, these do not work for GoCD due to the Tanuki Wrapper which does not currently work with musl libc,
-      // nor alternate compatibility layers such as libc6-compat or gcompat.
-      return [
+      // Tanuki Wrapper current currently requires glibc, which is not available in Alpine (which is a musl libc distro).
+      // See https://github.com/gocd/gocd/issues/11355 for a discussion of this problem.
+      // To workaround this, use glibc built within https://hub.docker.com/r/frolvlad/alpine-glibc from source at
+      // https://github.com/Docker-Hub-frolvlad/docker-alpine-glibc since he original project at https://github.com/sgerrand/alpine-pkg-glibc
+      // is unmaintained.
+      //
+      // Note that this means the JRE used also must be glibc-linked.
+      [
         '# install glibc for the Tanuki Wrapper, and use by glibc-linked Adoptium JREs',
-        '  apk add --no-cache tzdata --virtual .build-deps curl',
-        '  GLIBC_VER="2.34-r0"',
-        '  ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download"',
-        '  curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub',
-        '  SGERRAND_RSA_SHA256="823b54589c93b02497f1ba4dc622eaef9c813e6b0f0ebbb2f771e32adf9f4ef2"',
-        '  echo "${SGERRAND_RSA_SHA256} */etc/apk/keys/sgerrand.rsa.pub" | sha256sum -c -',
-        '  curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk > /tmp/glibc-${GLIBC_VER}.apk',
-        '  apk add --no-cache --force-overwrite /tmp/glibc-${GLIBC_VER}.apk',
-        '  curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk > /tmp/glibc-bin-${GLIBC_VER}.apk',
-        '  apk add --no-cache /tmp/glibc-bin-${GLIBC_VER}.apk',
-        '  curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk > /tmp/glibc-i18n-${GLIBC_VER}.apk',
-        '  apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk',
-        '  /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true',
-        '  echo "export LANG=$LANG" > /etc/profile.d/locale.sh',
-        '  apk del --purge .build-deps glibc-i18n',
-        '  rm -rf /tmp/*.apk /var/cache/apk/*',
+        '  mkdir -p /lib64',
+        '  ln -s /usr/glibc-compat/etc/ld.so.cache /etc/ld.so.cache',
+        '  ln -s /usr/glibc-compat/lib/ld-linux-$(arch).so.1 /lib/ld-linux-$(arch).so.1',
+        '  ln -s /usr/glibc-compat/lib64/ld-linux-$(arch).so.1 /lib64/ld-linux-$(arch).so.1',
+        '  echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh', // See pre-generated locales at https://github.com/Docker-Hub-frolvlad/docker-alpine-glibc/blob/master/Dockerfile
         '# end installing glibc',
       ] + super.getInstallJavaCommands(project)
+    }
+
+    @Override
+    Map<String, String> getEnvironmentVariables(DistroVersion v) {
+      // See pre-generated locales at https://github.com/Docker-Hub-frolvlad/docker-alpine-glibc/blob/master/Dockerfile
+      ['LANG': 'C.UTF-8'] + super.getEnvironmentVariables(v)
     }
   },
 
   wolfi {
     @Override
-    Set<Architecture> getSupportedArchitectures() {
-      [Architecture.x64, Architecture.aarch64]
-    }
-
-    @Override
     List<DistroVersion> getSupportedVersions() {
-      return [
+      [
          new DistroVersion(version: 'latest', releaseName: 'latest', eolDate: parseDate('2099-01-01'))
       ]
     }
 
     @Override
     boolean isContinuousRelease() {
-      return true
+      true
     }
 
     @Override
@@ -110,19 +112,19 @@ enum Distro implements DistroBehavior {
 
     @Override
     List<String> getBaseImageUpdateCommands(DistroVersion v) {
-      return ['apk --no-cache upgrade']
+      ['apk --no-cache upgrade']
     }
 
     @Override
     List<String> getCreateUserAndGroupCommands() {
-      return [
+      [
         'adduser -D -u ${UID} -s /bin/bash -G root go'
       ]
     }
 
     @Override
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
-      return [
+      [
         // procps is needed for tanuki wrapper shell script
         'apk add --no-cache git openssh-client bash curl procps glibc-locale-en'
       ]
@@ -131,13 +133,8 @@ enum Distro implements DistroBehavior {
 
   almalinux {
     @Override
-    Set<Architecture> getSupportedArchitectures() {
-      [Architecture.x64, Architecture.aarch64]
-    }
-
-    @Override
     List<String> getBaseImageUpdateCommands(DistroVersion v) {
-      return [
+      [
         "echo 'fastestmirror=1' >> /etc/dnf/dnf.conf",
         "echo 'install_weak_deps=False' >> /etc/dnf/dnf.conf",
         "microdnf upgrade -y",
@@ -146,7 +143,7 @@ enum Distro implements DistroBehavior {
 
     @Override
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
-      return [
+      [
         "microdnf install -y git-core openssh-clients bash unzip curl-minimal procps-ng coreutils-single glibc-langpack-en tar",
         "microdnf clean all",
         "rm -rf var/cache/dnf",
@@ -154,7 +151,7 @@ enum Distro implements DistroBehavior {
     }
     @Override
     List<DistroVersion> getSupportedVersions() {
-      return [ // See https://endoflife.date/almalinux
+      [ // See https://endoflife.date/almalinux
         new DistroVersion(version: '9', releaseName: '9-minimal', eolDate: parseDate('2032-05-31')),
       ]
     }
@@ -162,13 +159,8 @@ enum Distro implements DistroBehavior {
 
   debian {
     @Override
-    Set<Architecture> getSupportedArchitectures() {
-      [Architecture.x64, Architecture.aarch64]
-    }
-
-    @Override
     List<String> getBaseImageUpdateCommands(DistroVersion v) {
-      return [
+      [
         'DEBIAN_FRONTEND=noninteractive apt-get update',
         'DEBIAN_FRONTEND=noninteractive apt-get upgrade -y',
       ]
@@ -176,7 +168,7 @@ enum Distro implements DistroBehavior {
 
     @Override
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
-      return [
+      [
         'DEBIAN_FRONTEND=noninteractive apt-get install -y git-core openssh-client bash unzip curl ca-certificates locales procps coreutils',
         'DEBIAN_FRONTEND=noninteractive apt-get clean all',
         'rm -rf /var/lib/apt/lists/*',
@@ -186,7 +178,7 @@ enum Distro implements DistroBehavior {
 
     @Override
     List<DistroVersion> getSupportedVersions() {
-      return [ // See https://endoflife.date/debian
+      [ // See https://endoflife.date/debian
         new DistroVersion(version: '11', releaseName: '11-slim', eolDate: parseDate('2026-08-31')),
         new DistroVersion(version: '12', releaseName: '12-slim', eolDate: parseDate('2028-06-10')),
       ]
@@ -201,23 +193,23 @@ enum Distro implements DistroBehavior {
 
     @Override
     List<String> getBaseImageUpdateCommands(DistroVersion v) {
-      return debian.getBaseImageUpdateCommands(v)
+      debian.getBaseImageUpdateCommands(v)
     }
 
     @Override
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
-      return debian.getInstallPrerequisitesCommands(v)
+      debian.getInstallPrerequisitesCommands(v)
     }
 
     List<String> getCreateUserAndGroupCommands() {
-      return [
+      [
         '(userdel --remove --force ubuntu || true)',
       ] + super.getCreateUserAndGroupCommands()
     }
 
     @Override
     List<DistroVersion> getSupportedVersions() {
-      return [ // See https://endoflife.date/ubuntu "Maintenance & Security Support"
+      [ // See https://endoflife.date/ubuntu "Maintenance & Security Support"
         new DistroVersion(version: '20.04', releaseName: '20.04', eolDate: parseDate('2025-05-31')),
         new DistroVersion(version: '22.04', releaseName: '22.04', eolDate: parseDate('2027-04-01')),
         new DistroVersion(version: '24.04', releaseName: '24.04', eolDate: parseDate('2029-04-25')),
@@ -228,29 +220,29 @@ enum Distro implements DistroBehavior {
   docker {
     @Override
     OperatingSystem getOperatingSystem() {
-      return alpine.getOperatingSystem()
+      alpine.getOperatingSystem()
     }
 
     @Override
     boolean isPrivilegedModeSupport() {
-      return true
+      true
     }
 
     @Override
     List<DistroVersion> getSupportedVersions() {
-      return [
+      [
         new DistroVersion(version: 'dind', releaseName: 'dind', eolDate: parseDate('2099-01-01'))
       ]
     }
 
     @Override
     List<String> getBaseImageUpdateCommands(DistroVersion v) {
-      return alpine.getBaseImageUpdateCommands(v)
+      alpine.getBaseImageUpdateCommands(v)
     }
 
     @Override
     List<String> getCreateUserAndGroupCommands() {
-      return alpine.getCreateUserAndGroupCommands() +
+      alpine.getCreateUserAndGroupCommands() +
         [
           'adduser go docker' // Add user to the docker group used to control access to the Docker daemon unix socket
         ]
@@ -258,35 +250,45 @@ enum Distro implements DistroBehavior {
 
     @Override
     List<String> getInstallPrerequisitesCommands(DistroVersion v) {
-      return alpine.getInstallPrerequisitesCommands(v) +
+      alpine.getInstallPrerequisitesCommands(v) +
         [
           'apk add --no-cache sudo',
         ]
     }
 
     @Override
+    String getMultiStageInputImage() {
+      alpine.getMultiStageInputImage()
+    }
+
+    @Override
+    String getMultiStageInputCopyToTmp() {
+      alpine.getMultiStageInputCopyToTmp()
+    }
+
+    @Override
     List<String> getInstallJavaCommands(Project project) {
-      return alpine.getInstallJavaCommands(project)
+      alpine.getInstallJavaCommands(project)
     }
 
     @Override
     Map<String, String> getEnvironmentVariables(DistroVersion v) {
-      return alpine.getEnvironmentVariables(v)
+      alpine.getEnvironmentVariables(v)
     }
 
     @Override
     List<List<String>> getAdditionalVerifyCommands() {
-      return [
+      [
         ['docker', 'run', 'hello-world']
       ]
     }
   }
 
   static Date parseDate(String date) {
-    return Date.parse("yyyy-MM-dd", date)
+    Date.parse("yyyy-MM-dd", date)
   }
 
   GString projectName(DistroVersion v) {
-    return "${name()}-${v.version}"
+    "${name()}-${v.version}"
   }
 }

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
@@ -54,6 +54,14 @@ trait DistroBehavior {
     ]
   }
 
+  String getMultiStageInputImage() {
+    null
+  }
+
+  String getMultiStageInputCopyToTmp() {
+    null
+  }
+
   List<String> getInstallPrerequisitesCommands(DistroVersion v) {
     throw new RuntimeException("Subclasses must implement!")
   }
@@ -74,7 +82,7 @@ trait DistroBehavior {
   }
 
   Set<Architecture> getSupportedArchitectures() {
-    [Architecture.x64]
+    [Architecture.x64, Architecture.aarch64]
   }
 
   Architecture getDockerVerifyArchitecture() {

--- a/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
@@ -40,7 +40,9 @@ RUN curl --fail --location --silent --show-error "https://download.gocd.org/bina
     mv -v /go-agent-${goVersion}/wrapper/libwrapper-linux-$WRAPPERARCH* /go-agent/wrapper/ && \
     mv -v /go-agent-${goVersion}/wrapper/wrapper.jar /go-agent/wrapper/ && \
     chown -R ${r"${UID}"}:0 /go-agent && chmod -R g=u /go-agent
-
+<#if distro.getMultiStageInputImage()?has_content >
+FROM ${distro.getMultiStageInputImage()} AS multistageinput
+</#if>
 FROM ${distro.getBaseImageLocation(distroVersion)}
 ARG TARGETARCH
 
@@ -63,7 +65,9 @@ ENV ${key}="${value}"
 
 ARG UID=1000
 ARG GID=1000
-
+<#if distro.getMultiStageInputImage()?has_content >
+COPY --from=multistageinput ${distro.getMultiStageInputCopyToTmp()} ${distro.getMultiStageInputCopyToTmp()}
+</#if>
 RUN \
 <#if additionalFiles?size != 0>
 # add mode and permissions for files we added above


### PR DESCRIPTION
Resolves #11355

Replaces the old, unsupported alpine glibc package with frolvlad's builds for Alpine 3.x, in lieu of native musl libc builds of the Tanuki wrapper, which would allow complete removal of glibc from the Alpine-based images.