### PR TITLE
Re-generate ldconfig with glibc installed

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -84,6 +84,7 @@ enum Distro implements DistroBehavior {
         '  mkdir -p /lib64 && ln -s ${GLIBC_DIR}/lib/${GLIBC_LIB} /lib64/${GLIBC_LIB}',
         '  ln -s ${GLIBC_DIR}/etc/ld.so.cache /etc/ld.so.cache',
         '  echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh',
+        '  ${GLIBC_DIR}/sbin/ldconfig',
         '# end installing glibc',
       ] + super.getInstallJavaCommands(project)
     }


### PR DESCRIPTION
Normally an APK install of glibc does this in a post-install trigger, so should probably do the same.