### PR TITLE
Improve error messages returned during certain config repo parsing failures

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigFileList.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigFileList.java
@@ -17,7 +17,6 @@ package com.thoughtworks.go.plugin.access.configrepo;
 
 import com.thoughtworks.go.plugin.configrepo.contract.ErrorCollection;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class ConfigFileList {
@@ -37,18 +36,11 @@ public class ConfigFileList {
         this.files = files;
     }
 
-    public static ConfigFileList withError(String location, String err) {
-        ErrorCollection errs = new ErrorCollection();
-        errs.addError(location, err);
-        return new ConfigFileList(new ArrayList<>(), errs);
-    }
-
     public static ConfigFileList from(List<String> files) {
         ErrorCollection errs = new ErrorCollection();
        if (files == null) {
            errs.addError("Plugin response message",
                    "The plugin returned a response that indicates that it doesn't correctly implement this endpoint");
-
        }
       return new ConfigFileList(files, errs);
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v3/JsonMessageHandler3_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v3/JsonMessageHandler3_0.java
@@ -143,8 +143,7 @@ public class JsonMessageHandler3_0 implements JsonMessageHandler {
             StringBuilder builder = new StringBuilder();
             builder.append("Unexpected error when handling plugin response").append('\n');
             builder.append(ex);
-            // "location" of error is runtime. This is what user will see in config repo errors list.
-            errors.addError("runtime", builder.toString());
+            errors.addError("Plugin response message", builder.toString());
             LOGGER.error(builder.toString(), ex);
             return new CRParseResult(errors);
         }

--- a/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/codec/ArtifactTypeAdapter.java
+++ b/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/codec/ArtifactTypeAdapter.java
@@ -27,7 +27,7 @@ public class ArtifactTypeAdapter extends TypeAdapter implements JsonDeserializer
 
     @Override
     public CRArtifact deserialize(JsonElement json, Type type, JsonDeserializationContext context) throws JsonParseException {
-        return determineJsonElementForDistinguishingImplementers(json, context, TYPE, TypeAdapter.ARTIFACT_ORIGIN);
+        return determineJsonElementForDistinguishingImplementers(json, context, TYPE);
     }
 
     @Override

--- a/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/codec/MaterialTypeAdapter.java
+++ b/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/codec/MaterialTypeAdapter.java
@@ -21,37 +21,28 @@ import com.thoughtworks.go.plugin.configrepo.contract.material.*;
 import java.lang.reflect.Type;
 
 public class MaterialTypeAdapter extends TypeAdapter implements JsonDeserializer<CRMaterial>, JsonSerializer<CRMaterial>  {
-
     private static final String TYPE = "type";
 
     @Override
     public CRMaterial deserialize(JsonElement json, Type type, JsonDeserializationContext context) throws JsonParseException {
-        return determineJsonElementForDistinguishingImplementers(json, context, TYPE, ARTIFACT_ORIGIN);
+        return determineJsonElementForDistinguishingImplementers(json, context, TYPE);
     }
 
     @Override
     protected Class<?> classForName(String typeName, String origin) {
-        if(typeName.equals(CRDependencyMaterial.TYPE_NAME))
-            return CRDependencyMaterial.class;
-        if(typeName.equals(CRPackageMaterial.TYPE_NAME))
-            return CRPackageMaterial.class;
-        if(typeName.equals(CRPluggableScmMaterial.TYPE_NAME))
-            return CRPluggableScmMaterial.class;
-        if(typeName.equals(CRGitMaterial.TYPE_NAME))
-            return CRGitMaterial.class;
-        if(typeName.equals(CRHgMaterial.TYPE_NAME))
-            return CRHgMaterial.class;
-        if(typeName.equals(CRSvnMaterial.TYPE_NAME))
-            return CRSvnMaterial.class;
-        if(typeName.equals(CRP4Material.TYPE_NAME))
-            return CRP4Material.class;
-        if(typeName.equals(CRTfsMaterial.TYPE_NAME))
-            return CRTfsMaterial.class;
-        if(typeName.equals(CRConfigMaterial.TYPE_NAME))
-            return CRConfigMaterial.class;
-        else
-            throw new JsonParseException(
-                    String.format("Invalid or unknown material type '%s'",typeName));
+        return switch (typeName) {
+            case CRDependencyMaterial.TYPE_NAME -> CRDependencyMaterial.class;
+            case CRPackageMaterial.TYPE_NAME -> CRPackageMaterial.class;
+            case CRPluggableScmMaterial.TYPE_NAME -> CRPluggableScmMaterial.class;
+            case CRGitMaterial.TYPE_NAME -> CRGitMaterial.class;
+            case CRHgMaterial.TYPE_NAME -> CRHgMaterial.class;
+            case CRSvnMaterial.TYPE_NAME -> CRSvnMaterial.class;
+            case CRP4Material.TYPE_NAME -> CRP4Material.class;
+            case CRTfsMaterial.TYPE_NAME -> CRTfsMaterial.class;
+            case CRConfigMaterial.TYPE_NAME -> CRConfigMaterial.class;
+            default -> throw new JsonParseException(
+                String.format("Invalid or unknown material type '%s'", typeName));
+        };
     }
 
     @Override

--- a/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/codec/TaskTypeAdapter.java
+++ b/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/codec/TaskTypeAdapter.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.plugin.configrepo.contract.tasks.*;
 import java.lang.reflect.Type;
 
 public class TaskTypeAdapter extends TypeAdapter implements JsonDeserializer<CRTask>, JsonSerializer<CRTask> {
+    static final String ARTIFACT_ORIGIN = "artifact_origin";
     private static final String TYPE = "type";
 
     @Override
@@ -32,16 +33,21 @@ public class TaskTypeAdapter extends TypeAdapter implements JsonDeserializer<CRT
 
     @Override
     protected Class<?> classForName(String typeName, String origin) {
-        if (typeName.equals(CRExecTask.TYPE_NAME))
+        if (typeName.equals(CRExecTask.TYPE_NAME)) {
             return CRExecTask.class;
-        if (typeName.equals(CRBuildFramework.rake.toString()))
+        }
+        if (typeName.equals(CRBuildFramework.rake.toString())) {
             return CRBuildTask.class;
-        if (typeName.equals(CRBuildFramework.ant.toString()))
+        }
+        if (typeName.equals(CRBuildFramework.ant.toString())) {
             return CRBuildTask.class;
-        if (typeName.equals(CRBuildFramework.nant.toString()))
+        }
+        if (typeName.equals(CRBuildFramework.nant.toString())) {
             return CRNantTask.class;
-        if (typeName.equals(CRPluggableTask.TYPE_NAME))
+        }
+        if (typeName.equals(CRPluggableTask.TYPE_NAME)) {
             return CRPluggableTask.class;
+        }
 
         if (typeName.equals(CRAbstractFetchTask.TYPE_NAME)) {
             return CRAbstractFetchTask.ArtifactOrigin.getArtifactOrigin(origin).getArtifactTaskClass();

--- a/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/contract/ErrorCollection.java
+++ b/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/contract/ErrorCollection.java
@@ -69,13 +69,12 @@ public class ErrorCollection {
     public String getErrorsAsText() {
         StringBuilder errorsBuilder = new StringBuilder();
         for (Map.Entry<String, List<String>> entry : this.errors.entrySet()) {
-            errorsBuilder.append('\n');
             errorsBuilder.append(entry.getKey()).append(';');
 
             for (int i = 1; i <= entry.getValue().size(); i++) {
                 errorsBuilder.append('\n').append(i).append(". ").append(entry.getValue().get(i - 1));
             }
-            errorsBuilder.append("\n");
+            errorsBuilder.append('\n');
         }
         return errorsBuilder.toString();
     }

--- a/plugin-infra/go-plugin-config-repo/src/test/java/com/thoughtworks/go/plugin/configrepo/codec/TaskTypeAdapterTest.java
+++ b/plugin-infra/go-plugin-config-repo/src/test/java/com/thoughtworks/go/plugin/configrepo/codec/TaskTypeAdapterTest.java
@@ -86,7 +86,7 @@ public class TaskTypeAdapterTest {
     public void shouldInstantiateATaskForTypeFetch() {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("type", "fetch");
-        jsonObject.addProperty(TypeAdapter.ARTIFACT_ORIGIN, "gocd");
+        jsonObject.addProperty(TaskTypeAdapter.ARTIFACT_ORIGIN, "gocd");
         taskTypeAdapter.deserialize(jsonObject, type, jsonDeserializationContext);
 
         verify(jsonDeserializationContext).deserialize(jsonObject, CRFetchArtifactTask.class);
@@ -96,7 +96,7 @@ public class TaskTypeAdapterTest {
     public void shouldInstantiateATaskForTypeFetchPluggableArtifact() {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("type", "fetch");
-        jsonObject.addProperty(TypeAdapter.ARTIFACT_ORIGIN, "external");
+        jsonObject.addProperty(TaskTypeAdapter.ARTIFACT_ORIGIN, "external");
         taskTypeAdapter.deserialize(jsonObject, type, jsonDeserializationContext);
 
         verify(jsonDeserializationContext).deserialize(jsonObject, CRFetchPluggableArtifactTask.class);
@@ -106,7 +106,7 @@ public class TaskTypeAdapterTest {
     public void shouldThrowExceptionForFetchIfOriginIsInvalid() {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("type", "fetch");
-        jsonObject.addProperty(TypeAdapter.ARTIFACT_ORIGIN, "fsg");
+        jsonObject.addProperty(TaskTypeAdapter.ARTIFACT_ORIGIN, "fsg");
 
         assertThatThrownBy(() -> taskTypeAdapter.deserialize(jsonObject, type, jsonDeserializationContext))
                 .isInstanceOf(JsonParseException.class)

--- a/plugin-infra/go-plugin-config-repo/src/test/java/com/thoughtworks/go/plugin/configrepo/codec/TypeAdapterTest.java
+++ b/plugin-infra/go-plugin-config-repo/src/test/java/com/thoughtworks/go/plugin/configrepo/codec/TypeAdapterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.configrepo.codec;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TypeAdapterTest {
+
+    @Mock
+    private JsonDeserializationContext jsonDeserializationContext;
+
+    @Test
+    public void shouldThrowIfTypeElementCannotBeFound() {
+        JsonObject jsonObject = new JsonObject();
+
+        assertThatThrownBy(() -> new DummyTypeAdapter().determineJsonElementForDistinguishingImplementers(jsonObject, jsonDeserializationContext, "typeField"))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("JSON element from plugin did not contain [typeField] property for determining its type. Check your syntax, or the plugin logic.");
+    }
+
+    @Test
+    public void shouldReturnDefaultOriginIfNotSuppliedThrowIfTypeElementCannotBeFound() {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("typeField", "someType");
+
+        DummyTypeAdapter adapter = spy(new DummyTypeAdapter());
+
+        adapter.determineJsonElementForDistinguishingImplementers(jsonObject, jsonDeserializationContext, "typeField");
+
+        verify(adapter).classForName("someType", "gocd");
+    }
+
+    private static class DummyTypeAdapter extends TypeAdapter {
+        @Override
+        protected Class<?> classForName(String typeName, String origin) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
The error messages are unhelpful when a plugin does not return a type for something like a material, and does not failure itself. This changes to return a decent error message and test for it.