### PR TITLE
Reduce some api dependencies and clarify where JCL redirects are needed due to libraries

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -17,17 +17,23 @@
 description = 'GoCD Base'
 
 dependencies {
+  // Make BouncyCastle essentially an optional dependency. If you use GoAgentServerClientBuilder, you'll need it.
   compileOnly project.deps.bouncyCastle
   compileOnly project.deps.bouncyCastlePkix
 
-  api project.deps.commonsIO
-  api project.deps.commonsLang3
+  api project.deps.slf4jApi
+  api project.deps.jodaTime
+
+  implementation project.deps.commonsIO
+  implementation project.deps.commonsLang3
+
   api(project.deps.apacheHttpComponents) {
     exclude(module: 'commons-codec')
-    exclude(module: 'commons-logging')
   }
-  api project.deps.jodaTime
-  api project.deps.slf4jJcl
+  if (project.deps.apacheHttpComponents) {
+    implementation project.deps.slf4jJcl // Allow commons-logging replacement
+  }
+
   compileOnly project.deps.logback
   testImplementation project.deps.logback
 

--- a/config/config-api/build.gradle
+++ b/config/config-api/build.gradle
@@ -33,6 +33,9 @@ dependencies {
   }
   api project.deps.cloning
   api project.deps.springWeb
+  if (project.deps.springWeb) {
+    implementation project.deps.slf4jJcl // Allow commons-logging replacement
+  }
   implementation project.deps.slf4jApi
   implementation project.deps.felix
   implementation project.deps.jodaTime

--- a/db-support/db-migration/build.gradle
+++ b/db-support/db-migration/build.gradle
@@ -26,6 +26,9 @@ dependencies {
   implementation project.deps.commonsLang3
   implementation project.deps.gson
   implementation project.deps.springContext
+  if (project.deps.commonsDbcp || project.deps.springContext) {
+    implementation project.deps.slf4jJcl // Allow commons-logging replacement
+  }
   implementation project.deps.jakartaAnnotation
 
   implementation(project.deps.liquibase) {

--- a/db-support/db-support-base/build.gradle
+++ b/db-support/db-support-base/build.gradle
@@ -16,6 +16,9 @@
 
 dependencies {
   implementation project.deps.commonsDbcp
+  if (project.deps.commonsDbcp) {
+    implementation project.deps.slf4jJcl // Allow commons-logging replacement
+  }
   api project.deps.commonsLang3
   api project.deps.ztExec
   api(project.deps.apacheAnt) {

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -32,6 +32,9 @@ dependencies {
   implementation project.deps.cloning
   implementation project.deps.jodaTime
   implementation project.deps.springTx
+  if (project.deps.springTx) {
+    implementation project.deps.slf4jJcl // Allow commons-logging replacement
+  }
   api project.deps.semanticVersion
   compileOnly project.deps.jetBrainsAnnotations
   testImplementation project(path: ':config:config-api', configuration: 'testOutput')

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -257,13 +257,13 @@ dependencies {
   api project.deps.springWeb
   api project.deps.springWebmvc
   api project.deps.springContextSupport
-  api(project.deps.springSecurityWeb) {
-    exclude(group: 'org.springframework')
-  }
+  api project.deps.springSecurityWeb
   implementation(project.deps.springSecurity)
   if (project.deps.springWeb) {
-    // used by CommonsMultipartResolver
-    implementation project.deps.commonsFileUpload
+    implementation project.deps.commonsFileUpload // used by CommonsMultipartResolver
+  }
+  if (project.deps.commonsDbcp || project.deps.oscache || project.deps.springWeb) {
+    implementation project.deps.slf4jJcl // Allow commons-logging replacement
   }
   implementation project.deps.aspectj
   implementation project.deps.urlrewrite

--- a/spark/spark-base/build.gradle
+++ b/spark/spark-base/build.gradle
@@ -27,6 +27,9 @@ dependencies {
   implementation project.deps.jacksonCore
   implementation project.deps.jacksonDatabind
   implementation project.deps.springWeb
+  if (project.deps.springWeb) {
+    implementation project.deps.slf4jJcl // Allow commons-logging replacement
+  }
 
   api(project.deps.spark) {
     transitive = false

--- a/test/http-mocks/build.gradle
+++ b/test/http-mocks/build.gradle
@@ -21,6 +21,10 @@ dependencies {
   implementation project.deps.gson
   implementation project.deps.spring
   implementation project.deps.springTest
+  if (project.deps.apacheHttpComponents || project.deps.spring) {
+    implementation project.deps.slf4jJcl // Allow commons-logging replacement
+  }
+
   implementation project.deps.assertJ
   implementation project.deps.jsonUnit
 }

--- a/test/test-utils/build.gradle
+++ b/test/test-utils/build.gradle
@@ -26,6 +26,10 @@ dependencies {
   implementation project(path: ':base', configuration: 'runtimeElements')
   api project(path: ':util', configuration: 'runtimeElements')
   api project.deps.springTest
+  if (project.deps.springTest) {
+    implementation project.deps.slf4jJcl // Allow commons-logging replacement
+  }
+
   api project.deps.logback
   implementation project.deps.jetty
   implementation project.deps.jettyJmx

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -19,6 +19,9 @@ description = 'GoCD Utils'
 dependencies {
   implementation project(path: ':base', configuration: 'runtimeElements')
   api project.deps.springContext
+  if (project.deps.springContext) {
+    implementation project.deps.slf4jJcl // Allow commons-logging replacement
+  }
   api project.deps.gson
   implementation project.deps.cloning
   api project.deps.jdom


### PR DESCRIPTION
Try and make it more explicit the places that need a commons-logging replacement, rather than relying on inheriting from `base`.

Prepares for factoring out the ApacheHttpComponents bits.