### PR TITLE
Remove duplicate element of AGENT_STARTUP_ARGS filled into subprocess command line

### DIFF
--- a/agent-process-launcher/src/main/java/com/thoughtworks/go/agent/AgentProcessParentImpl.java
+++ b/agent-process-launcher/src/main/java/com/thoughtworks/go/agent/AgentProcessParentImpl.java
@@ -121,7 +121,7 @@ public class AgentProcessParentImpl implements AgentProcessParent {
             String[] startupArgs = startupArgsString.split(" ");
             for (String startupArg : startupArgs) {
                 String decodedStartupArg = startupArg.trim().replace("%20", " ");
-                if (!isEmpty(decodedStartupArg)) {
+                if (!isEmpty(decodedStartupArg) && !commandSnippets.contains(decodedStartupArg)) {
                     commandSnippets.add(decodedStartupArg);
                 }
             }


### PR DESCRIPTION
gocd agent’s subprocess can set JVM OPTS by setting GOCD_AGENT_JVM_OPTS environment variable. but when i run into kubernetes gocd-agent by using docker image, the GOCD_AGENT_JVM_OPTS inject duplicate.
```
go@gocd-default-agent-0:~$ ps aux | grep java
go           103  0.2  0.0  16128  4224 ?        Sl   08:07   1:16 /go-agent/bin/../wrapper/wrapper-linux-x86-64 /go-agent/bin/../wrapper-config/wrapper.conf wrapper.syslog.ident=go-agent wrapper.pidfile=/go-agent/run/go-agent.pid wrapper.name=go-agent wrapper.displayname=go-agent wrapper.statusfile=/go-agent/run/go-agent.status wrapper.java.statusfile=/go-agent/run/go-agent.java.status wrapper.script.version=3.5.54 --
go           130  0.1  0.0 8116764 245508 ?      Sl   08:07   0:35 /gocd-jre/bin/java -Dgo.console.stdout=true -Djava.library.path=wrapper -classpath wrapper/wrapper.jar:lib/agent-bootstrapper.jar -Dwrapper.key=esebB_6UvMbnpJGRBIRUdUM3kB2mLl26 -Dwrapper.port=32000 -Dwrapper.jvm.port.min=31000 -Dwrapper.jvm.port.max=31999 -Dwrapper.disable_console_input=TRUE -Dwrapper.pid=103 -Dwrapper.version=3.5.54-st -Dwrapper.native_library=wrapper -Dwrapper.arch=x86 -Dwrapper.cpu.timeout=10 -Dwrapper.jvmid=1 -Dwrapper.lang.domain=wrapper -Dwrapper.lang.folder=../lang org.tanukisoftware.wrapper.WrapperJarApp lib/agent-bootstrapper.jar -serverUrl http://gocd-server.gocd.svc.cluster.local:8153/go
go           205  0.2  0.1 11026768 440536 ?     Sl   08:07   1:05 /gocd-jre/bin/java -Xms128m -Xmx256m -Dgo.console.stdout=true -Dagent.get.work.interval=1000 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps -Xmx4096m -Dgo.console.stdout=true -Dagent.get.work.interval=1000 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps -Xmx4096m -Dagent.plugins.md5=1b83f68c4c42d67560cb4079cd3def6c -Dagent.binary.md5=4364afbd6e0b75a65bbf2d4ca875f331 -Dagent.launcher.md5=f350255126a2861ee420b5b09a166a3a -Dagent.tfs.md5=27517594e97566cb09e5f8dd13b54c20 -Dagent.bootstrapper.version=23.5.0-18179 -jar agent.jar -serverUrl http://gocd-server.gocd.svc.cluster.local:8153/go -sslVerificationMode FULL
go          2011  0.0  0.0   6480  2328 pts/0    S+   16:04   0:00 grep java
go@gocd-default-agent-0:~$ echo $GOCD_AGENT_JVM_OPTS
-Dagent.get.work.interval=1000 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps -Xmx4096m
```
the above stdout is printed when i execute `ps aux | grep java` and `echo $GOCD_AGENT_JVM_OPTS`
and when the `AgentProcessParentImpl.run(..)` log under the text
```
2025-05-18 16:15:19,929 INFO  [WrapperJarAppMain] ServerBinaryDownloader:126 - Got server response
2025-05-18 16:15:19,960 INFO  [WrapperJarAppMain] ServerBinaryDownloader:134 - Piped the stream to admin/tfs-impl.jar
2025-05-18 16:15:19,961 INFO  [WrapperJarAppMain] PerfTimer:53 - Performance: Downloading new admin/tfs-impl.jar with md5 signature: 27517594e97566cb09e5f8dd13b54c20 took 36ms
2025-05-18 16:15:19,963 INFO  [WrapperJarAppMain] AgentProcessParentImpl:66 - Launching Agent with command: /gocd-jre/bin/java -Xms128m -Xmx256m -Dgo.console.stdout=true -Dagent.get.work.interval=1000 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps -Xmx4096m -Dgo.console.stdout=true -Dagent.get.work.interval=1000 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps -Xmx4096m -Dagent.plugins.md5=1b83f68c4c42d67560cb4079cd3def6c -Dagent.binary.md5=4364afbd6e0b75a65bbf2d4ca875f331 -Dagent.launcher.md5=f350255126a2861ee420b5b09a166a3a -Dagent.tfs.md5=27517594e97566cb09e5f8dd13b54c20 -Dagent.bootstrapper.version=23.5.0-18179 -jar agent.jar -serverUrl http://gocd-server.gocd.svc.cluster.local:8153/go -sslVerificationMode FULL
```

look at the Launching Agent with command log section
```
Launching Agent with command: /gocd-jre/bin/java -Xms128m -Xmx256m
 -Dgo.console.stdout=true -Dagent.get.work.interval=1000 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps -Xmx4096m
 -Dgo.console.stdout=true -Dagent.get.work.interval=1000 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps -Xmx4096m
```

it is applied duplicate GOCD_AGENT_JVM_OPTS. i want to fix this problem by adding specific condition that check existed args