### PR TITLE
Workaround issue with duplicate agent startup command line args

### DIFF
--- a/buildSrc/src/main/resources/gocd-docker-agent/docker-entrypoint.sh
+++ b/buildSrc/src/main/resources/gocd-docker-agent/docker-entrypoint.sh
@@ -165,7 +165,9 @@ if [ "$1" = "${AGENT_WORK_DIR}/bin/go-agent" ]; then
 
   # Allow configuration of the forked agent process when started by the bootstrapper
   echo "set.default.GOCD_AGENT_JVM_OPTS=" >> /go-agent/wrapper-config/wrapper-properties.conf
-  echo "set.AGENT_STARTUP_ARGS=%AGENT_STARTUP_ARGS% -Dgo.console.stdout=true %GOCD_AGENT_JVM_OPTS%" >> /go-agent/wrapper-config/wrapper-properties.conf
+  echo "# Workaround for circular reference issue noted at https://wrapper.tanukisoftware.com/doc/english/props-envvars.html#definition" >> /go-agent/wrapper-config/wrapper-properties.conf
+  echo "set.default.AGENT_STARTUP_ARGS_INTERNAL=%AGENT_STARTUP_ARGS% -Dgo.console.stdout=true %GOCD_AGENT_JVM_OPTS%" >> /go-agent/wrapper-config/wrapper-properties.conf
+  echo "set.AGENT_STARTUP_ARGS=%AGENT_STARTUP_ARGS_INTERNAL%" >> /go-agent/wrapper-config/wrapper-properties.conf
 fi
 
 try exec /usr/local/sbin/tini -g -- "$@"

--- a/installers/linux/shared/partials/_go-agent-config-migration.sh.erb
+++ b/installers/linux/shared/partials/_go-agent-config-migration.sh.erb
@@ -66,7 +66,9 @@
         fi
 
         if [ ! -z "${MIGRATED_AGENT_STARTUP_ARGS}" ]; then
-          /bin/echo -E "set.AGENT_STARTUP_ARGS=%AGENT_STARTUP_ARGS% ${MIGRATED_AGENT_STARTUP_ARGS}" >> ${MIGRATION_FILE}
+          /bin/echo -E "# Workaround for circular reference issue noted at https://wrapper.tanukisoftware.com/doc/english/props-envvars.html#definition" >> ${MIGRATION_FILE}
+          /bin/echo -E "set.default.AGENT_STARTUP_ARGS_INTERNAL=%AGENT_STARTUP_ARGS% ${MIGRATED_AGENT_STARTUP_ARGS}" >> ${MIGRATION_FILE}
+          /bin/echo -E "set.AGENT_STARTUP_ARGS=%AGENT_STARTUP_ARGS_INTERNAL%" >> ${MIGRATION_FILE}
         fi
 
         index=100


### PR DESCRIPTION
Tanuki Wrapper seems to cause duplication of args in commands during config reloads according to its own documentation at https://wrapper.tanukisoftware.com/doc/english/props-envvars.html#definition

This is their suggested workaround, which seems to work OK. See #13664 which raises the issue and resolves it in a different way.