### PR TITLE
Avoid warnings from wrapper due to duplicate encoding directives

### DIFF
--- a/installers/include/wrapper-license-linux-go-agent.conf
+++ b/installers/include/wrapper-license-linux-go-agent.conf
@@ -1,4 +1,3 @@
-@encoding=UTF-8
 # Tanuki license keys for GoCD Agent running on unix using absolute paths (uses the following license params):
 # wrapper.java.mainclass=org.tanukisoftware.wrapper.WrapperJarApp
 # wrapper.app.parameter.1=/usr/share/go-agent/lib/agent-bootstrapper.jar

--- a/installers/include/wrapper-license-linux-go-server.conf
+++ b/installers/include/wrapper-license-linux-go-server.conf
@@ -1,4 +1,3 @@
-@encoding=UTF-8
 # Tanuki license keys for GoCD Server running on unix using absolute paths (uses the following license params):
 # wrapper.java.mainclass=org.tanukisoftware.wrapper.WrapperJarApp
 # wrapper.app.parameter.1=/usr/share/go-server/lib/go.jar

--- a/installers/include/wrapper-license-relative-path-go-agent.conf
+++ b/installers/include/wrapper-license-relative-path-go-agent.conf
@@ -1,4 +1,3 @@
-@encoding=UTF-8
 # Tanuki license keys for GoCD Agent using relative paths (uses the following license params):
 # wrapper.java.mainclass=org.tanukisoftware.wrapper.WrapperJarApp
 # wrapper.app.parameter.1=lib/agent-bootstrapper.jar

--- a/installers/include/wrapper-license-relative-path-go-server.conf
+++ b/installers/include/wrapper-license-relative-path-go-server.conf
@@ -1,4 +1,3 @@
-@encoding=UTF-8
 # Tanuki license keys for GoCD Server using relative paths (uses the following license params):
 # wrapper.java.mainclass=org.tanukisoftware.wrapper.WrapperJarApp
 # wrapper.app.parameter.1=lib/go.jar

--- a/installers/include/wrapper-properties-go-server.conf
+++ b/installers/include/wrapper-properties-go-server.conf
@@ -1,2 +1,3 @@
 @encoding=UTF-8
 # Use this file to configure your GoCD server
+

--- a/installers/include/wrapper-properties.go-agent.conf.example
+++ b/installers/include/wrapper-properties.go-agent.conf.example
@@ -1,4 +1,3 @@
-@encoding=UTF-8
 # For a detailed description about setting various environment variables, see the page at
 # https://wrapper.tanukisoftware.com/doc/english/props-envvars.html
 

--- a/installers/include/wrapper-properties.go-server.conf.example
+++ b/installers/include/wrapper-properties.go-server.conf.example
@@ -1,4 +1,3 @@
-@encoding=UTF-8
 # For a detailed description about setting various environment variables, see the page at
 # https://wrapper.tanukisoftware.com/doc/english/props-envvars.html
 


### PR DESCRIPTION
Address annoying warnings such as

```
wrapper  | Encountered an invalid directive at line 263 of file '/go-agent/wrapper-config/wrapper.conf': @encoding=UTF-8
wrapper  | Encountered an invalid directive at line 9 of file '/go-agent/wrapper-config/wrapper-properties.conf': @encoding=UTF-8
```