### PR TITLE
Remove dead pipeline instance page link support

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/rails-shared/gocd-link-support.js
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/rails-shared/gocd-link-support.js
@@ -50,11 +50,6 @@
       openLinkInNewTab(jobDetailsPagePath);
     },
 
-    "pipeline_instance_page": function pipelineInstancePage(params) {
-      var pipelineInstancePath = '/go/internal/pipelines/' + pipelineName(params) + '/' + pipelineCounter(params);
-      openLinkInNewTab(pipelineInstancePath);
-    },
-
     "vsm_page": function vsmPage(params) {
       var vsmPath = '/go/pipelines/value_stream_map/' + pipelineName(params) + '/' + pipelineCounter(params);
       openLinkInNewTab(vsmPath);


### PR DESCRIPTION
The Pipeline Instance page links only seemed to work from old/legacy code which has long since been removed. These routes 404 now. Seems to only have been used by the analytics plugin, so seems low risk to remove.

Cleans up after https://github.com/gocd/gocd-analytics-plugin/issues/1308