### PR TITLE
Bump liquibase from 4.29.2 to 4.33.0

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -77,7 +77,7 @@ final Map<String, String> libraries = [
   jsonUnit            : 'net.javacrumbs.json-unit:json-unit-assertj:4.1.1',
   jsoup               : 'org.jsoup:jsoup:1.21.1',
   junit5Bom           : 'org.junit:junit-bom:5.13.3',
-  liquibase           : 'org.liquibase:liquibase-core:4.29.2',
+  liquibase           : 'org.liquibase:liquibase-core:4.33.0',
   liquibaseSlf4j      : 'com.mattbertolini:liquibase-slf4j:5.1.0',
   logback             : 'ch.qos.logback:logback-classic:1.5.18',
   lombok              : 'org.projectlombok:lombok:1.18.38',


### PR DESCRIPTION
https://github.com/liquibase/liquibase/releases/tag/v4.33.0

Earlier releases had issues either due to unnecessary SnakeYaml dependency being introduced, and later https://github.com/liquibase/liquibase/issues/7011