### PR TITLE
Use Chainguard images from Docker Hub

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -111,7 +111,7 @@ enum Distro implements DistroBehavior {
 
     @Override
     String getBaseImageLocation(DistroVersion distroVersion) {
-      "cgr.dev/chainguard/wolfi-base"
+      "docker.io/chainguard/wolfi-base"
     }
 
     @Override

--- a/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
@@ -17,7 +17,7 @@
 # Please file any issues or PRs at https://github.com/gocd/gocd
 ###############################################################################################
 
-FROM cgr.dev/chainguard/bash:latest AS gocd-agent-unzip
+FROM chainguard/bash:latest AS gocd-agent-unzip
 ARG TARGETARCH
 ARG UID=1000
 <#if useFromArtifact >

--- a/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
@@ -17,7 +17,7 @@
 # Please file any issues or PRs at https://github.com/gocd/gocd
 ###############################################################################################
 
-FROM cgr.dev/chainguard/bash:latest AS gocd-server-unzip
+FROM chainguard/bash:latest AS gocd-server-unzip
 ARG TARGETARCH
 ARG UID=1000
 <#if useFromArtifact >


### PR DESCRIPTION
Images are now available here, and this improves ability to use Docker Hub cache/proxy within CI