### PR TITLE
Make maintenance mode SPA more responsive

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode.tsx
@@ -103,8 +103,7 @@ export class MaintenanceModePage extends Page<null, State> {
 
     const options = {
       repeaterFn: () => this.fetchData(vnode),
-      intervalSeconds: 30,
-      initialIntervalSeconds: 30
+      intervalSeconds: 10
     };
 
     new AjaxPoller(options).start();


### PR DESCRIPTION
Default UI poll is now 5 seconds. Changing this back to 10 seconds, similar to how it was prior to #5627. Checking job status every 10 seconds should not be an issue in 2025.