### PR TITLE
Add Debian 13 (Trixie) container images; remove Debian 11

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -186,8 +186,8 @@ enum Distro implements DistroBehavior {
     @Override
     List<DistroVersion> getSupportedVersions() {
       [ // See https://endoflife.date/debian
-        new DistroVersion(version: '11', releaseName: '11-slim', eolDate: parseDate('2026-08-31')),
-        new DistroVersion(version: '12', releaseName: '12-slim', eolDate: parseDate('2028-06-10')),
+        new DistroVersion(version: '12', releaseName: '12-slim', eolDate: parseDate('2026-06-10')),
+        new DistroVersion(version: '13', releaseName: '13-slim', eolDate: parseDate('2028-08-10')),
       ]
     }
   },


### PR DESCRIPTION
This change reverts Debian agent image support to upstream Debian security support (2 years); not the extended LTS updates from community. Debian agents are little used and tend to have high vulnerability counts.