### PR TITLE
Lock lodash types at previous version

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -61,7 +61,7 @@
     "@types/jasmine-ajax": "^3.3.5",
     "@types/jquery": "^3.5.32",
     "@types/license-checker": "^25.0.6",
-    "@types/lodash": "^4.17.20",
+    "@types/lodash": "4.17.19",
     "@types/mini-css-extract-plugin": "^1.4.3",
     "@types/mithril": "2.2.7",
     "@types/node": "^22.17.2",

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -1876,10 +1876,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:^4.17.20":
-  version: 4.17.20
-  resolution: "@types/lodash@npm:4.17.20"
-  checksum: 10/8cd8ad3bd78d2e06a93ae8d6c9907981d5673655fec7cb274a4d9a59549aab5bb5b3017361280773b8990ddfccf363e14d1b37c97af8a9fe363de677f9a61524
+"@types/lodash@npm:4.17.19":
+  version: 4.17.19
+  resolution: "@types/lodash@npm:4.17.19"
+  checksum: 10/555e53da60dd9904ef4b6f4e663abb965cf45582079f2ea231a18b0b48df4808b60f36c978548fcf5e307bf12ccd563bd4551963039028ea120b1695c7146f7c
   languageName: node
   linkType: hard
 
@@ -5689,7 +5689,7 @@ __metadata:
     "@types/jasmine-ajax": "npm:^3.3.5"
     "@types/jquery": "npm:^3.5.32"
     "@types/license-checker": "npm:^25.0.6"
-    "@types/lodash": "npm:^4.17.20"
+    "@types/lodash": "npm:4.17.19"
     "@types/mini-css-extract-plugin": "npm:^1.4.3"
     "@types/mithril": "npm:2.2.7"
     "@types/node": "npm:^22.17.2"


### PR DESCRIPTION
As usual, types have been broken in a non backwards compatible way by someone on the internet for no apparent reason.