### PR TITLE
Only show scroll bars when necessary for material commit searches

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -902,7 +902,7 @@ $commits-width: 635px;
   right: 10px;
   z-index: 100;
   background: #fff;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .commit_info {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials/index.scss
@@ -184,7 +184,7 @@ $button-color: #2d6ca2;
 .comment {
   white-space: pre-wrap;
   max-height: 160px;
-  overflow-y: scroll;
+  overflow-y: auto;
   width: 100%;
 }
 


### PR DESCRIPTION
Removes the weird non-interactive scroll bars on
- dashboard > pipeline trigger > material revision search
- materials admin > show modifications > commits more|less cell