### PR TITLE
Align UI poll intervals for delayed refresh pages with default intervals, in millis

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/ajax_poller.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/ajax_poller.ts
@@ -19,16 +19,16 @@ import m from "mithril";
 import Stream from "mithril/stream";
 
 export interface Options<T> {
-  intervalSeconds: number;
-  initialIntervalSeconds: number;
+  intervalMillis: number;
+  initialIntervalMillis: number;
   visibilityBackoffFactor: number;
 
   repeaterFn(currentPromise: (value: T) => any): Promise<T>;
 }
 
-const defaultOptions = {
-  intervalSeconds: CONSTANTS.SPA_REFRESH_INTERVAL / 1000,
-  initialIntervalSeconds: 0,
+export const defaultPollerOptions = {
+  intervalMillis: CONSTANTS.SPA_REFRESH_INTERVAL_MILLIS,
+  initialIntervalMillis: 0,
   visibilityBackoffFactor: 3
 };
 
@@ -51,15 +51,15 @@ export class AjaxPoller<T> {
 
   constructor(options: (() => Promise<T>) | Partial<Options<T>>) {
     // @ts-ignore
-    this.options = _.assign({}, defaultOptions, "function" === typeof options ? {repeaterFn: options} : options);
+    this.options = _.assign({}, defaultPollerOptions, "function" === typeof options ? {repeaterFn: options} : options);
     if (doesBrowserSupportPageVisibilityAPI) {
       document.addEventListener("visibilitychange", this.handleVisibilityChange.bind(this), false);
     }
   }
 
-  start(initialInterval = Math.max(this.options.initialIntervalSeconds, 0)) {
+  start(initialIntervalMillis = Math.max(this.options.initialIntervalMillis, 0)) {
     this.abort   = false;
-    this.timeout = window.setTimeout(this.fire.bind(this), initialInterval * 1000);
+    this.timeout = window.setTimeout(this.fire.bind(this), initialIntervalMillis);
   }
 
   stop() {
@@ -118,9 +118,9 @@ export class AjaxPoller<T> {
 
   private currentPollInterval() {
     if (!windowIsInForeground() || this.isPageHidden()) {
-      return this.options.intervalSeconds * this.options.visibilityBackoffFactor * 1000;
+      return this.options.intervalMillis * this.options.visibilityBackoffFactor;
     } else {
-      return this.options.intervalSeconds * 1000;
+      return this.options.intervalMillis;
     }
   }
 }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/constants.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/constants.ts
@@ -15,7 +15,7 @@
  */
 const meta = document.querySelector("meta[name='gocd-params']");
 
-export const SERVER_TIMEZONE_UTC_OFFSET = parseInt(meta && meta.getAttribute("data-timezone") || "0", 10);
-export const SPA_REQUEST_TIMEOUT        = parseInt(meta && meta.getAttribute("data-page-timeout") || "5000", 10);
-export const SPA_REFRESH_INTERVAL       = parseInt(meta && meta.getAttribute("data-page-refresh-interval") || "5000", 10);
-export const AUTH_LOGIN_PATH            = "/go/auth/login";
+export const SERVER_TIMEZONE_UTC_OFFSET_MINS   = parseInt(meta && meta.getAttribute("data-timezone") || "0", 10) / 60000;
+export const SPA_REQUEST_TIMEOUT_MILLIS        = parseInt(meta && meta.getAttribute("data-page-timeout") || "5000", 10);
+export const SPA_REFRESH_INTERVAL_MILLIS       = parseInt(meta && meta.getAttribute("data-page-refresh-interval") || "5000", 10);
+export const AUTH_LOGIN_PATH                   = "/go/auth/login";

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/mrequest.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/mrequest.ts
@@ -29,7 +29,7 @@ const setHeaders = (xhr: JQuery.jqXHR, version: string) => {
 };
 
 export const mrequest = {
-  timeout: CONSTANTS.SPA_REQUEST_TIMEOUT,
+  timeout: CONSTANTS.SPA_REQUEST_TIMEOUT_MILLIS,
   globalAjaxErrorHandler: () => {
     $(document).ajaxError((_event, jqXHR) => {
       if (jqXHR.status === 401) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/helpers/time_formatter.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/helpers/time_formatter.ts
@@ -19,7 +19,7 @@ import {LRUCache} from "lru-cache";
 import moment from "moment";
 import "moment-duration-format";
 
-const utcOffsetInMinutes = CONSTANTS.SERVER_TIMEZONE_UTC_OFFSET / 60000;
+const utcOffsetInMinutes = CONSTANTS.SERVER_TIMEZONE_UTC_OFFSET_MINS;
 const CACHE_SIZE         = 10000;
 const DATE_FORMAT        = "DD MMM YYYY";
 const LOCAL_TIME_FORMAT  = "DD MMM, YYYY [at] HH:mm:ss [Local Time]";

--- a/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/stage_overview_shim_for_vsm.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/single_page_apps/stage_overview_shim_for_vsm.tsx
@@ -41,12 +41,12 @@ $(() => {
   window.getStageOverviewFor = (pipelineName: string, pipelineCounter: string | number, stageName: string, stageCounter: string | number, status: string, currentStageIndex: string, totalNumberOfStages: string, canEdit: boolean, templateName: string) => {
     window.event?.stopPropagation();
     closeStageOverview();
-    const repeatInterval = 9999999;
+    const refreshEnabled = false;
 
     // @ts-ignore
     window.stageOverviewStateForVSM.show(pipelineName, pipelineCounter, stageName, stageCounter);
     // @ts-ignore
-    StageOverviewViewModel.initialize(pipelineName, pipelineCounter, stageName, stageCounter, status, repeatInterval).then((result) => window.stageOverviewStateForVSM.model(result));
+    StageOverviewViewModel.initialize(pipelineName, pipelineCounter, stageName, stageCounter, status, refreshEnabled).then((result) => window.stageOverviewStateForVSM.model(result));
 
     // Has to match div ID in Graph_Renderer.renderPipelineInstance
     const stageOverviewContainer = document.getElementById(`stage-overview-container-for-pipeline-${pipelineName}-${pipelineCounter}-stage-${stageName}-${stageCounter}`)!;
@@ -75,7 +75,7 @@ $(() => {
                               stageCounter={stageCounter}
                               stages={[]}
                               templateName={templateNameFromString}
-                              pollingInterval={repeatInterval}
+                              refreshEnabled={refreshEnabled}
                               isDisplayedOnVSMPage={true}
                               leftPositionForVSMStageOverview={leftPosition}
                               stageInstanceFromDashboard={stageInstanceFromDashboard}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/index.tsx
@@ -41,7 +41,7 @@ export interface Attrs {
   stageStatus: StageState | string;
   stages: any[];
   templateName: string | undefined | null;
-  pollingInterval?: number;
+  refreshEnabled: boolean;
   canAdminister: boolean;
   stageInstanceFromDashboard: any;
   isDisplayedOnPipelineActivityPage?: boolean;
@@ -184,7 +184,7 @@ export class StageOverview extends MithrilComponent<Attrs, State> {
                          pipelineName={vnode.attrs.pipelineName}
                          pipelineCounter={vnode.attrs.pipelineCounter}
                          templateName={vnode.attrs.templateName}
-                         pollingInterval={vnode.attrs.pollingInterval}
+                         refreshEnabled={vnode.attrs.refreshEnabled}
                          status={vnode.state.status}
                          shouldSelectLatestStageCounterOnUpdate={vnode.state.shouldSelectLatestStageCounterOnUpdate}
                          latestStageCounter={vnode.state.latestStageCounter}

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/job_count_and_rerun_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/job_count_and_rerun_widget.tsx
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+import {ErrorResponse} from "helpers/api_request_builder";
+import {MithrilComponent} from "jsx/mithril-component";
 import m from "mithril";
 import Stream from "mithril/stream";
-import {ErrorResponse} from "../../../helpers/api_request_builder";
-import {MithrilComponent} from "../../../jsx/mithril-component";
-import {ButtonGroup, Secondary} from "../../components/buttons";
-import {FlashMessageModelWithTimeout, MessageType} from "../../components/flash_message";
+import {ButtonGroup, Secondary} from "views/components/buttons";
+import {FlashMessageModelWithTimeout, MessageType} from "views/components/flash_message";
 import * as styles from "./index.scss";
 import {JobsViewModel} from "./models/jobs_view_model";
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/models/jobs_view_model.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/models/jobs_view_model.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import Stream from 'mithril/stream';
-import {ApiRequestBuilder, ApiVersion} from "../../../../helpers/api_request_builder";
-import {SparkRoutes} from "../../../../helpers/spark_routes";
-import {Agents} from "../../../../models/agents/agents";
+import {ApiRequestBuilder, ApiVersion} from "helpers/api_request_builder";
+import {SparkRoutes} from "helpers/spark_routes";
+import Stream from "mithril/stream";
+import {Agents} from "models/agents/agents";
 import {JobDurationStrategyHelper} from "./job_duration_stratergy_helper";
 import {JobJSON, Result} from "./types";
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/models/stage_instance.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/models/stage_instance.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import {ApiRequestBuilder, ApiVersion} from "helpers/api_request_builder";
+import * as CONSTANTS from "helpers/constants";
+import {SparkRoutes} from "helpers/spark_routes";
 import moment from "moment";
-import {ApiRequestBuilder, ApiVersion} from "../../../../helpers/api_request_builder";
-import * as CONSTANTS from "../../../../helpers/constants";
-import {SparkRoutes} from "../../../../helpers/spark_routes";
 import {JobDurationStrategyHelper} from "./job_duration_stratergy_helper";
 import {JobJSON, Result, StageInstanceJSON} from "./types";
 
@@ -47,7 +47,7 @@ export class StageInstance {
 
   triggeredOnServerTime(): string {
     const SERVER_TIME_FORMAT = "DD MMM, YYYY [at] HH:mm:ss Z [Server Time]";
-    const utcOffsetInMinutes = CONSTANTS.SERVER_TIMEZONE_UTC_OFFSET / 60000;
+    const utcOffsetInMinutes = CONSTANTS.SERVER_TIMEZONE_UTC_OFFSET_MINS;
     return moment.unix(this.stageScheduledAtInSecs()).utcOffset(utcOffsetInMinutes).format(SERVER_TIME_FORMAT);
   }
 
@@ -98,7 +98,7 @@ export class StageInstance {
     }
 
     const SERVER_TIME_FORMAT = "DD MMM, YYYY [at] HH:mm:ss Z [Server Time]";
-    const utcOffsetInMinutes = CONSTANTS.SERVER_TIMEZONE_UTC_OFFSET / 60000;
+    const utcOffsetInMinutes = CONSTANTS.SERVER_TIMEZONE_UTC_OFFSET_MINS;
     const completedTime = this.json.jobs[0].job_state_transitions.find(t => t.state === "Completed")!.state_change_time;
 
     return moment.unix(+completedTime / 1000).utcOffset(utcOffsetInMinutes).format(SERVER_TIME_FORMAT);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/stage_overview_header.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/stage_overview/stage_overview_header.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
+import {ErrorResponse} from "helpers/api_request_builder";
+import {MithrilComponent} from "jsx/mithril-component";
 import m from "mithril";
 import Stream from "mithril/stream";
+import {FlashMessage, FlashMessageModelWithTimeout, MessageType} from "views/components/flash_message";
+import {SelectField, SelectFieldOptions} from "views/components/forms/input_fields";
 import * as Icons from "views/components/icons";
-import {ErrorResponse} from "../../../helpers/api_request_builder";
-import {MithrilComponent} from "../../../jsx/mithril-component";
-import {FlashMessage, FlashMessageModelWithTimeout, MessageType} from "../../components/flash_message";
-import {SelectField, SelectFieldOptions} from "../../components/forms/input_fields";
-import {Link} from "../../components/link";
+import {Link} from "views/components/link";
 import * as styles from "./index.scss";
 import {StageInstance} from "./models/stage_instance";
 import {StageOverviewViewModel} from "./models/stage_overview_view_model";
@@ -35,7 +35,7 @@ interface StageHeaderAttrs {
   stageInstanceFromDashboard: any;
   canAdminister: boolean;
   templateName: string | undefined | null;
-  pollingInterval?: number;
+  refreshEnabled: boolean;
   status: Stream<string>;
   flashMessage: FlashMessageModelWithTimeout;
   stageInstance: Stream<StageInstance>;
@@ -60,7 +60,7 @@ export class StageHeaderWidget extends MithrilComponent<StageHeaderAttrs, StageH
       vnode.attrs.isLoading(true);
 
       // pass in the stage state as passed/failed, this value is just to denote whether the current stage instance has completed.
-      StageOverviewViewModel.initialize(vnode.attrs.pipelineName, vnode.attrs.pipelineCounter, vnode.attrs.stageName, vnode.attrs.userSelectedStageCounter(), StageState.Passed, vnode.attrs.pollingInterval)
+      StageOverviewViewModel.initialize(vnode.attrs.pipelineName, vnode.attrs.pipelineCounter, vnode.attrs.stageName, vnode.attrs.userSelectedStageCounter(), StageState.Passed, vnode.attrs.refreshEnabled)
         .then((result) => {
           let stageResult = result.stageInstance().result();
           if (stageResult === "Unknown") {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/agents.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/agents.tsx
@@ -88,7 +88,6 @@ export class AgentsPage extends Page<null, State> {
 
     new AjaxPoller({
                      repeaterFn:      this.fetchData.bind(this, vnode),
-                     intervalSeconds: 10
                    }).start();
   }
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/config_repos.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AjaxPoller} from "helpers/ajax_poller";
+import {AjaxPoller, defaultPollerOptions} from "helpers/ajax_poller";
 import {ApiResult} from "helpers/api_request_builder";
 import {pipeline} from "helpers/utils";
 import _ from "lodash";
@@ -138,7 +138,7 @@ export class ConfigReposPage extends Page<null, State> {
     vnode.state.webhookUrlFor = (_, __) => "server url provider not initialized.";
     vnode.state.siteUrlsConfigured = () => this.siteUrls().isConfigured();
 
-    new AjaxPoller({repeaterFn: this.refreshConfigRepos.bind(this, vnode), initialIntervalSeconds: 10}).start();
+    new AjaxPoller({repeaterFn: this.refreshConfigRepos.bind(this, vnode), initialIntervalMillis: defaultPollerOptions.intervalMillis}).start();
   }
 
   oncreate(vnode: m.Vnode<null, State>) {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {AjaxPoller} from "helpers/ajax_poller";
+import {AjaxPoller, defaultPollerOptions} from "helpers/ajax_poller";
 import {ApiRequestBuilder, ApiResult, ApiVersion, ErrorResponse, SuccessResponse} from "helpers/api_request_builder";
 import {SparkRoutes} from "helpers/spark_routes";
 import m from "mithril";
@@ -25,7 +25,7 @@ import {ToggleConfirmModal} from "views/pages/maintenance_mode/confirm_modal";
 import {MaintenanceModeWidget} from "views/pages/maintenance_mode/maintenance_mode_widget";
 import {Page} from "views/pages/page";
 
-const CLEAR_MESSAGE_AFTER_INTERVAL_IN_SECONDS = 10;
+const CLEAR_MESSAGE_AFTER_INTERVAL_MILLIS = 10000;
 
 interface SaveOperation<T> {
   onSave: (obj: T, e: Event) => void;
@@ -50,7 +50,7 @@ export class Message {
     setTimeout(() => {
       this.message = null;
       m.redraw();
-    }, CLEAR_MESSAGE_AFTER_INTERVAL_IN_SECONDS * 1000);
+    }, CLEAR_MESSAGE_AFTER_INTERVAL_MILLIS);
   }
 }
 
@@ -103,7 +103,7 @@ export class MaintenanceModePage extends Page<null, State> {
 
     const options = {
       repeaterFn: () => this.fetchData(vnode),
-      intervalSeconds: 10
+      intervalMillis: defaultPollerOptions.intervalMillis * 2
     };
 
     new AjaxPoller(options).start();

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/materials.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AjaxPoller} from "helpers/ajax_poller";
+import {AjaxPoller, defaultPollerOptions} from "helpers/ajax_poller";
 import {ApiResult, ErrorResponse} from "helpers/api_request_builder";
 import {SparkRoutes} from "helpers/spark_routes";
 import _ from "lodash";
@@ -104,7 +104,7 @@ export class MaterialsPage extends Page<null, State> {
       new ShowModificationsModal(material).render();
     };
 
-    new AjaxPoller({repeaterFn: this.refreshMaterials.bind(this, vnode), initialIntervalSeconds: 10}).start();
+    new AjaxPoller({repeaterFn: this.refreshMaterials.bind(this, vnode), initialIntervalMillis: defaultPollerOptions.intervalMillis}).start();
   }
 
   componentToDisplay(vnode: m.Vnode<null, State>): m.Children {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity.tsx
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+// @ts-ignore
 import {docsUrl} from "gen/gocd_version";
-import {AjaxPoller} from "helpers/ajax_poller";
+import {AjaxPoller, defaultPollerOptions} from "helpers/ajax_poller";
 import {ApiResult} from "helpers/api_request_builder";
 import m from "mithril";
 import Stream from "mithril/stream";
@@ -68,7 +69,7 @@ export class PipelineActivityPage extends Page<null, State> implements ResultAwa
     super();
     this.poller = new AjaxPoller({
                                    repeaterFn: this.fetchPipelineHistory.bind(this),
-                                   initialIntervalSeconds: 10
+                                   initialIntervalMillis: defaultPollerOptions.intervalMillis
                                  });
   }
 


### PR DESCRIPTION
Reduces the initial poll delay on agents/config_repos/materials/pipeline_activity pages to 5s, same as the default refresh rate after the first poll.

This makes the UI more responsive, while also hopefully making functional/integration tests faster and more predictable with standard timeouts.