### PR TITLE
Workaround Liquibase JDK 25 ServiceLoader issues

### DIFF
--- a/db-support/db-migration/build.gradle
+++ b/db-support/db-migration/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   implementation project.deps.commonsLang3
   implementation project.deps.gson
   implementation project.deps.jakartaAnnotation
+  compileOnly project.deps.jetBrainsAnnotations
 
   implementation(project.deps.liquibase) {
     // Not needed, according to https://github.com/liquibase/liquibase/issues/1866

--- a/db-support/db-migration/src/main/java/com/opencsv/exceptions/CsvMalformedLineException.java
+++ b/db-support/db-migration/src/main/java/com/opencsv/exceptions/CsvMalformedLineException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.opencsv.exceptions;
+
+/**
+ * Dummy class to workaround https://github.com/liquibase/liquibase/issues/7318 on JDK 25, by providing an
+ * implementation that does not depend on opencsv.
+ */
+@SuppressWarnings("unused")
+public class CsvMalformedLineException extends Exception {
+    public CsvMalformedLineException(String message) {
+        super(message);
+    }
+}

--- a/db-support/db-migration/src/main/java/com/thoughtworks/go/server/database/migration/DataMigrationRunner.java
+++ b/db-support/db-migration/src/main/java/com/thoughtworks/go/server/database/migration/DataMigrationRunner.java
@@ -15,28 +15,23 @@
  */
 package com.thoughtworks.go.server.database.migration;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
 
+@Slf4j
 public class DataMigrationRunner {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DataMigrationRunner.class);
-
-    private DataMigrationRunner() {
-    }
-
     public static void run(Connection cxn) throws SQLException {
-        LOGGER.info("Running data migrations...");
+        log.info("Running data migrations...");
 
         exec(cxn, M001.convertPipelineSelectionsToFilters());
         exec(cxn, M002.ensureFilterStateIsNotNull());
 
-        LOGGER.info("Data migrations completed.");
+        log.info("Data migrations completed.");
     }
 
     private static void exec(Connection cxn, Migration migration) throws SQLException {
@@ -46,9 +41,9 @@ public class DataMigrationRunner {
             Instant start = Instant.now();
             migration.run(cxn);
             cxn.commit();
-            LOGGER.info("Data migration took {} ms", Duration.between(start, Instant.now()).toMillis());
+            log.info("Data migration took {} ms", Duration.between(start, Instant.now()).toMillis());
         } catch (SQLException e) {
-            LOGGER.error("Data migration failed: {}", e.getMessage(), e);
+            log.error("Data migration failed: {}", e.getMessage(), e);
             cxn.rollback();
             throw e;
         }

--- a/db-support/db-migration/src/main/java/org/yaml/snakeyaml/LoaderOptions.java
+++ b/db-support/db-migration/src/main/java/org/yaml/snakeyaml/LoaderOptions.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.yaml.snakeyaml;
+
+/**
+ * Dummy class to workaround https://github.com/liquibase/liquibase/issues/7318 on JDK 25, by providing an
+ * implementation that does not depend on snakeyaml.
+ */
+public class LoaderOptions {
+}

--- a/db-support/db-migration/src/main/java/org/yaml/snakeyaml/constructor/BaseConstructor.java
+++ b/db-support/db-migration/src/main/java/org/yaml/snakeyaml/constructor/BaseConstructor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.yaml.snakeyaml.constructor;
+
+/**
+ * Dummy class to workaround https://github.com/liquibase/liquibase/issues/7318 on JDK 25, by providing an
+ * implementation that does not depend on snakeyaml.
+ */
+@SuppressWarnings("unused")
+public abstract class BaseConstructor {
+
+}

--- a/db-support/db-migration/src/main/java/org/yaml/snakeyaml/constructor/SafeConstructor.java
+++ b/db-support/db-migration/src/main/java/org/yaml/snakeyaml/constructor/SafeConstructor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.yaml.snakeyaml.constructor;
+
+import org.yaml.snakeyaml.LoaderOptions;
+
+/**
+ * Dummy class to workaround https://github.com/liquibase/liquibase/issues/7318 on JDK 25, by providing an
+ * implementation that does not depend on snakeyaml.
+ */
+@SuppressWarnings("unused")
+public class SafeConstructor extends BaseConstructor {
+
+    public SafeConstructor(LoaderOptions loaderOptions) {
+    }
+}

--- a/db-support/db-migration/src/test/java/com/thoughtworks/go/server/database/migration/DatabaseMigratorLiquibaseTest.java
+++ b/db-support/db-migration/src/test/java/com/thoughtworks/go/server/database/migration/DatabaseMigratorLiquibaseTest.java
@@ -16,12 +16,6 @@
 
 package com.thoughtworks.go.server.database.migration;
 
-import liquibase.Liquibase;
-import liquibase.UpdateSummaryOutputEnum;
-import liquibase.database.Database;
-import liquibase.database.DatabaseFactory;
-import liquibase.database.jvm.JdbcConnection;
-import liquibase.resource.ClassLoaderResourceAccessor;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +36,7 @@ import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LiquibaseMigrationTest {
+public class DatabaseMigratorLiquibaseTest {
     private BasicDataSource dataSource;
 
     @BeforeEach
@@ -99,12 +93,10 @@ public class LiquibaseMigrationTest {
         verifyTableDoesNotExists("USAGEDATAREPORTING");
     }
 
-    private void migrate(String migration) throws Exception {
-        Connection connection = dataSource.getConnection();
-        Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(connection));
-        Liquibase liquibase = new Liquibase("db-migration-scripts/" + migration, new ClassLoaderResourceAccessor(getClass().getClassLoader()), database);
-        liquibase.setShowSummaryOutput(UpdateSummaryOutputEnum.LOG);
-        liquibase.update();
+    private void migrate(String changeLogFile) throws Exception {
+        try (Connection connection = dataSource.getConnection()) {
+            new DatabaseMigrator().migrateSchema(changeLogFile, connection);
+        }
     }
 
     private List<String> tableList() throws SQLException {

--- a/db-support/db-migration/src/test/java/com/thoughtworks/go/server/database/migration/DatabaseMigratorTest.java
+++ b/db-support/db-migration/src/test/java/com/thoughtworks/go/server/database/migration/DatabaseMigratorTest.java
@@ -49,7 +49,7 @@ class DatabaseMigratorTest {
     void setUp() {
         this.migrator = new DatabaseMigrator() {
             @Override
-            Liquibase newLiquibaseFor(Database database) {
+            Liquibase newLiquibaseFor(String migration, Database database) {
                 return liquibase;
             }
         };


### PR DESCRIPTION
JDK 25.0.0 and 25.0.1 (maybe later) has an issue at https://bugs.openjdk.org/browse/JDK-8350481 where ServiceLoader doesn't handle missing classes the same way as previously. Provide stub implementations of these classes which certain optional Liquibase services reference to allow Liquibase to start-up correctly. This affects the LiquibaseAnalyticsListener and JsonChangeLogParser, YamlChangeLogParser.

Pending any resolution to https://github.com/liquibase/liquibase/issues/7318 (e.g via https://github.com/liquibase/liquibase/pull/7430 or via a JDK patch) this PR adds dummy versions of the relevant classes so the unused services can at least be loaded.