### PR TITLE
Only install Java 21+ for Linux packages

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/GoVersions.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/GoVersions.groovy
@@ -37,7 +37,7 @@ class GoVersions implements Serializable {
   AdoptiumVersion packagedJavaVersion
 
   List<String> preferredJavaVersions() {
-    [VERSION_11, VERSION_17, VERSION_21, VERSION_25, VERSION_29] // LTS versions
+    [VERSION_21, VERSION_25, VERSION_29] // LTS versions
       .findAll { v -> v.ordinal() >= toVersion(targetJavaVersion).ordinal() && v.ordinal() <= toVersion(buildJavaVersion).ordinal() }
       .sort()
       .reverse()


### PR DESCRIPTION
We hope to make Java 21 the minimum soon; this will helps us ensure that the installs/upgrades work fine before we change the actual code minimum Java version.