### PR TITLE
Correct minor omission in server logging for hung jobs

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/ConsoleActivityMonitor.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ConsoleActivityMonitor.java
@@ -107,9 +107,9 @@ public class ConsoleActivityMonitor {
                 consoleService.appendToConsoleLogSafe(jobIdentifier, messages.consoleMessage(jobTerminationThreshold(jobIdentifier)));
                 jobActivityMap.remove(jobIdentifier);
                 removeHungJobWarning(jobIdentifier);
-                LOGGER.info("Cancelled hung job '{}' as it was hung for more than '{}' minutes", jobIdentifier.toFullString(), difference);
+                LOGGER.info("Cancelled hung job '{}' as it was hung for more than '{}' minutes", jobIdentifier.toFullString(), difference.toMinutes());
             } else if (difference.compareTo(warningThreshold) > 0) {
-                LOGGER.info("Job '{}' hung for more than '{}' minutes", jobIdentifier.toFullString(), difference);
+                LOGGER.info("Job '{}' hung for more than '{}' minutes", jobIdentifier.toFullString(), difference.toMinutes());
                 removeHungJobWarning(jobIdentifier);
                 addJobHungWarning(jobIdentifier, difference, messages);
             }


### PR DESCRIPTION
As noted in #14124. Console logging is fine, just the server log.