### PR TITLE
Fix spurious NullPointerException during AgentAssignment job status processing for jobs cancelled prior to assignment

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/domain/JobState.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/JobState.java
@@ -52,6 +52,10 @@ public enum JobState {
         return this == Assigned || isBuilding();
     }
 
+    public boolean isInactiveOnAgent() {
+        return this == Rescheduled || this == Completed;
+    }
+
     public boolean isCompleted() {
         return this == Completed;
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/ConsoleActivityMonitor.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ConsoleActivityMonitor.java
@@ -191,7 +191,7 @@ public class ConsoleActivityMonitor {
             JobIdentifier identifier = job.getIdentifier();
             if (job.getState().isBuilding()) {
                 jobLastActivityMap.putIfAbsent(identifier, timeProvider.currentTimeMillis());
-            } else if (job.isCompleted() || job.isRescheduled()) {
+            } else if (job.getState().isInactiveOnAgent()) {
                 jobLastActivityMap.remove(identifier);
                 removeHungJobWarning(identifier);
             }

--- a/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
@@ -659,12 +659,12 @@ public class ScheduleService {
                 transactionTemplate.execute(new TransactionCallbackWithoutResult() {
                     @Override
                     protected void doInTransactionWithoutResult(TransactionStatus status) {
-                        LOGGER.warn("[Job Reschedule] Rescheduling and marking old job as ignored: {}", toBeRescheduled);
                         //Reloading it because we want to see the latest committed state after acquiring the mutex.
                         JobInstance oldJob = jobInstanceService.buildById(toBeRescheduled.getId());
-                        if (oldJob.isCompleted() || oldJob.isRescheduled()) {
+                        if (oldJob.getState().isInactiveOnAgent()) {
                             return;
                         }
+                        LOGGER.warn("[Job Reschedule] Rescheduling and marking old job as ignored: {}", toBeRescheduled);
                         JobInstance newJob = oldJob.clone();
                         oldJob.changeState(JobState.Rescheduled);
                         jobInstanceService.updateStateAndResult(oldJob);

--- a/server/src/test-integration/java/com/thoughtworks/go/domain/activity/AgentAssignmentTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/domain/activity/AgentAssignmentTest.java
@@ -70,14 +70,14 @@ public class AgentAssignmentTest {
         agentAssignment.jobStatusChanged(assigned);
 
         assertThat(agentAssignment.latestActiveJobOnAgent("uuid")).isEqualTo(assigned);
+        assertThat(agentAssignment.size()).isEqualTo(1);
     }
 
     @Test
     public void shouldIgnoreScheduledJob() {
         JobInstance scheduled = JobInstanceMother.scheduled("dev");
         agentAssignment.jobStatusChanged(scheduled);
-
-        assertThat(agentAssignment.latestActiveJobOnAgent("uuid")).isNull();
+        assertThat(agentAssignment.size()).isZero();
     }
 
     @Test
@@ -86,6 +86,14 @@ public class AgentAssignmentTest {
         JobInstance expected = pipeline.getFirstStage().getJobInstances().getFirst();
 
         assertThat(agentAssignment.latestActiveJobOnAgent("uuid").getId()).isEqualTo(expected.getId());
+        assertThat(agentAssignment.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldIgnoreJobNotAssignedToAgent() {
+        JobInstance created = new JobInstance();
+        agentAssignment.jobStatusChanged(created);
+        assertThat(agentAssignment.size()).isZero();
     }
 
     @Test
@@ -95,14 +103,19 @@ public class AgentAssignmentTest {
         agentAssignment.jobStatusChanged(completed);
 
         assertThat(agentAssignment.latestActiveJobOnAgent("uuid")).isNull();
+        assertThat(agentAssignment.size()).isZero();
     }
 
     @Test
     public void shouldReturnNullAfterJobIsRescheduled() {
+        JobInstance assigned = JobInstanceMother.assignedWithAgentId("dev", "uuid");
+        agentAssignment.jobStatusChanged(assigned);
+
         JobInstance rescheduled = JobInstanceMother.rescheduled("dev", "uuid");
         agentAssignment.jobStatusChanged(rescheduled);
 
         assertThat(agentAssignment.latestActiveJobOnAgent("uuid")).isNull();
+        assertThat(agentAssignment.size()).isZero();
     }
 }
 


### PR DESCRIPTION
25.4.0 changed AgentAssignment to manage using a ConcurrentHashMap which does not support null keys like the previous Map.

As a result it's possible to now get errors like the below logged in edge cases such as a job being cancelled prior to agent assignment. Shouldnt be causing a functional issue; just `ERROR` noise in the logs.

```
2026-01-12 16:22:10,004 ERROR [qtp284184548-69] JobInstanceService:143 - error notifying listener for job JobInstance{stageId=1, name='defaultJob', state=Completed, result=Cancelled, agentUuid='null', stateTransitions=[com.thoughtworks.go.domain.JobStateTransition@6502812a[currentState=Scheduled,jobId=1,stageId=1,stateChangeTime=Mon Jan 12 16:22:05 GMT+08:00 2026,id=1], com.thoughtworks.go.domain.JobStateTransition@10fbd2a1[currentState=Completed,jobId=1,stageId=1,stateChangeTime=Mon Jan 12 16:22:09 GMT+08:00 2026,id=2]], scheduledDate=Mon Jan 12 16:22:05 GMT+08:00 2026, timeProvider=com.thoughtworks.go.util.TimeProvider@c427708, ignored=false, identifier=JobIdentifier[pipeline1e28b42ac, 1, 1, first, 1, defaultJob, 1], plan=null, runOnAllAgents=false, runMultipleInstance=false}
java.lang.NullPointerException: Cannot invoke "Object.hashCode()" because "key" is null
	at java.base/java.util.concurrent.ConcurrentHashMap.replaceNode(ConcurrentHashMap.java:1125)
	at java.base/java.util.concurrent.ConcurrentHashMap.remove(ConcurrentHashMap.java:1116)
	at com.thoughtworks.go.domain.activity.AgentAssignment.jobStatusChanged(AgentAssignment.java:46)
	at com.thoughtworks.go.server.service.JobInstanceService$2.afterCommit(JobInstanceService.java:141)
``` 