### PR TITLE
feat: show commit author and hash on pipeline activity instance cards

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/pipeline_run_info_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/pipeline_run_info_widget.tsx
@@ -87,6 +87,15 @@ export class PipelineRunWidget extends MithrilViewComponent<PipelineRunAttrs> {
           </span>
         </div>
         <div class={styles.revision}>Revision: {pipelineRunInfo.revision()}</div>
+        {pipelineRunInfo.materialRevisions().length > 0 && (() => {
+          const firstRev = pipelineRunInfo.materialRevisions()[0];
+          const shortHash = firstRev.revision().substring(0, 8);
+          return <div class={styles.revision} data-test-id={"commit-info"}>
+            <span data-test-id={"commit-author"} title={firstRev.user()}>{firstRev.user()}</span>
+            {" — "}
+            <span data-test-id={"commit-hash"} title={firstRev.revision()}>{shortHash}</span>
+          </div>;
+        })()}
         <div class={styles.scheduleInfo}
              data-test-id={"time"}
              title={PipelineRunWidget.getTimeServer(pipelineRunInfo.scheduledTimestamp())}>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/pipeline_run_info_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/pipeline_run_info_widget.tsx
@@ -74,9 +74,12 @@ export class PipelineRunWidget extends MithrilViewComponent<PipelineRunAttrs> {
 
   view(vnode: m.Vnode<PipelineRunAttrs>): m.Children | void | null {
     const pipelineRunInfo = vnode.attrs.pipelineRunInfo;
+    const revisions = pipelineRunInfo.materialRevisions();
+    const firstRev = revisions.length > 0 ? revisions[0] : undefined;
+    const shortHash = firstRev ? firstRev.revision().substring(0, 8) : undefined;
 
     return <tr class={styles.groupContent}
-               data-test-id={this.dataTestId("pipeline-instance", pipelineRunInfo.label())}>
+           data-test-id={this.dataTestId("pipeline-instance", pipelineRunInfo.label())}>
       <td class={styles.left} data-test-id={"meta"}>
         <div class={classnames(styles.run, styles.header)}>
           <span class={styles.label} data-test-id={"counter"}>
@@ -87,15 +90,13 @@ export class PipelineRunWidget extends MithrilViewComponent<PipelineRunAttrs> {
           </span>
         </div>
         <div class={styles.revision}>Revision: {pipelineRunInfo.revision()}</div>
-        {pipelineRunInfo.materialRevisions().length > 0 && (() => {
-          const firstRev = pipelineRunInfo.materialRevisions()[0];
-          const shortHash = firstRev.revision().substring(0, 8);
-          return <div class={styles.revision} data-test-id={"commit-info"}>
+        {firstRev && (
+          <div class={styles.revision} data-test-id={"commit-info"}>
             <span data-test-id={"commit-author"} title={firstRev.user()}>{firstRev.user()}</span>
             {" — "}
             <span data-test-id={"commit-hash"} title={firstRev.revision()}>{shortHash}</span>
-          </div>;
-        })()}
+          </div>
+        )}
         <div class={styles.scheduleInfo}
              data-test-id={"time"}
              title={PipelineRunWidget.getTimeServer(pipelineRunInfo.scheduledTimestamp())}>

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/spec/pipeline_run_info_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipeline_activity/spec/pipeline_run_info_widget_spec.tsx
@@ -92,6 +92,58 @@ describe("PipelineRunInfoWidget", () => {
       expect(helper.byTestId("time", pipelineRunContainer))
         .toHaveAttr("title", timeFormatter.formatInServerTime(pipelineRunInfo.scheduledTimestamp()));
     });
+
+    it("should not render commit info when there are no material revisions", () => {
+      pipelineRunInfo = PipelineRunInfo.fromJSON(PipelineActivityData.underConstruction().groups[0].history[0]);
+      mount(pipelineRunInfo);
+
+      const pipelineRunContainer = helper.byTestId(`pipeline-instance-${pipelineRunInfo.label()}`);
+      expect(helper.byTestId("commit-info", pipelineRunContainer)).not.toBeInDOM();
+    });
+  });
+
+  describe("Commit info", () => {
+    it("should render commit author from the first material revision", () => {
+      const pipelineRunInfo = PipelineRunInfo.fromJSON(PipelineActivityData.pipelineRunInfo(passed("Test")));
+      mount(pipelineRunInfo);
+
+      const pipelineRunContainer = helper.byTestId(`pipeline-instance-${pipelineRunInfo.label()}`);
+      expect(helper.byTestId("commit-info", pipelineRunContainer)).toBeInDOM();
+      expect(helper.byTestId("commit-author", pipelineRunContainer)).toBeInDOM();
+      expect(helper.byTestId("commit-author", pipelineRunContainer))
+        .toHaveText(pipelineRunInfo.materialRevisions()[0].user());
+    });
+
+    it("should render shortened commit hash (first 8 chars) from the first material revision", () => {
+      const pipelineRunInfo = PipelineRunInfo.fromJSON(PipelineActivityData.pipelineRunInfo(passed("Test")));
+      mount(pipelineRunInfo);
+
+      const pipelineRunContainer = helper.byTestId(`pipeline-instance-${pipelineRunInfo.label()}`);
+      const fullRevision         = pipelineRunInfo.materialRevisions()[0].revision();
+      expect(helper.byTestId("commit-hash", pipelineRunContainer)).toBeInDOM();
+      expect(helper.byTestId("commit-hash", pipelineRunContainer))
+        .toHaveText(fullRevision.substring(0, 8));
+    });
+
+    it("should show full commit hash as tooltip on commit hash element", () => {
+      const pipelineRunInfo = PipelineRunInfo.fromJSON(PipelineActivityData.pipelineRunInfo(passed("Test")));
+      mount(pipelineRunInfo);
+
+      const pipelineRunContainer = helper.byTestId(`pipeline-instance-${pipelineRunInfo.label()}`);
+      const fullRevision         = pipelineRunInfo.materialRevisions()[0].revision();
+      expect(helper.byTestId("commit-hash", pipelineRunContainer))
+        .toHaveAttr("title", fullRevision);
+    });
+
+    it("should show full author name as tooltip on commit author element", () => {
+      const pipelineRunInfo = PipelineRunInfo.fromJSON(PipelineActivityData.pipelineRunInfo(passed("Test")));
+      mount(pipelineRunInfo);
+
+      const pipelineRunContainer = helper.byTestId(`pipeline-instance-${pipelineRunInfo.label()}`);
+      const author               = pipelineRunInfo.materialRevisions()[0].user();
+      expect(helper.byTestId("commit-author", pipelineRunContainer))
+        .toHaveAttr("title", author);
+    });
   });
 
   describe("Stage status", () => {


### PR DESCRIPTION
The pipeline activity page shows a top-level pipeline revision but doesn't surface the developer name or per-material commit hash from `buildCause.materialRevisions`. This change adds both to each instance card using data already returned by the existing API, making it easier to identify who triggered a pipeline run and from which commit at a glance.

Note: branch name is not yet available in the pipeline activity JSON response (omitted from `ScmMaterial.toJson()`) — a follow-up backend change could expose it. Fyi @chadlwilson 