### PR TITLE
Revert "ui: bump lru-cache from 11.2.7 to 11.3.5 in /server/src/main/webapp/WEB-INF/rails"

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -45,7 +45,7 @@
     "jquery": "^3.7.1",
     "lodash": "^4.18.1",
     "lodash-inflection": "^1.5.0",
-    "lru-cache": "~11.3.5",
+    "lru-cache": "~11.2.7",
     "mithril": "^2.3.8",
     "moment": "^2.30.1",
     "moment-duration-format": "^2.3.2",

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -4893,7 +4893,7 @@ __metadata:
     license-checker: "npm:^25.0.1"
     lodash: "npm:^4.18.1"
     lodash-inflection: "npm:^1.5.0"
-    lru-cache: "npm:~11.3.5"
+    lru-cache: "npm:~11.2.7"
     mini-css-extract-plugin: "npm:^2.10.2"
     mithril: "npm:^2.3.8"
     mockdate: "npm:^3.0.5"
@@ -6269,10 +6269,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:~11.3.5":
-  version: 11.3.5
-  resolution: "lru-cache@npm:11.3.5"
-  checksum: 10c0/5b54ef7b88afb4bd25b7a778f1b2b1cde32d9770913e530da34ab203cf0442413bcaa6e372800cbab9562557a4480e4d8bf32e3a368bb5a91b12218eca085c66
+"lru-cache@npm:~11.2.7":
+  version: 11.2.7
+  resolution: "lru-cache@npm:11.2.7"
+  checksum: 10c0/549cdb59488baa617135fc12159cafb1a97f91079f35093bb3bcad72e849fc64ace636d244212c181dfdf1a99bbfa90757ff303f98561958ee4d0f885d9bd5f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts gocd/gocd#14309