### PR TITLE
fix: ensure jgit gpg settings don't have unsupported key format in configuration

### DIFF
--- a/config/config-server/src/main/java/com/thoughtworks/go/service/ConfigRepository.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/service/ConfigRepository.java
@@ -88,6 +88,7 @@ public class ConfigRepository {
     private void updateWithDefaults(StoredConfig config) {
         config.setInt(ConfigConstants.CONFIG_GC_SECTION, null, ConfigConstants.CONFIG_KEY_AUTO, 0);
         config.setBoolean(ConfigConstants.CONFIG_COMMIT_SECTION, null, ConfigConstants.CONFIG_KEY_GPGSIGN, false);
+        config.setString(ConfigConstants.CONFIG_GPG_SECTION, null, ConfigConstants.CONFIG_KEY_FORMAT, GpgConfig.GpgFormat.OPENPGP.toConfigValue());
     }
 
     public Repository getGitRepo() {

--- a/config/config-server/src/test/java/com/thoughtworks/go/service/ConfigRepositoryTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/service/ConfigRepositoryTest.java
@@ -88,6 +88,17 @@ public class ConfigRepositoryTest {
         }
     }
 
+    @Test @SuppressWarnings("try")
+    public void shouldBeAbleToCheckInWithPossiblyUnsupportedGlobalGpgSettings() throws Exception {
+        try (UndoableUserGitConfig ignored = new UndoableUserGitConfig(c -> c.setString(ConfigConstants.CONFIG_GPG_SECTION, null, ConfigConstants.CONFIG_KEY_FORMAT, "ssh"))) {
+            configRepo = new ConfigRepository(systemEnvironment);
+            configRepo.initialize();
+            configRepo.checkin(new GoConfigRevision("v1", "md5-v1", "user-name", "100.3.9", new TimeProvider()));
+            assertThat(configRepo.getRevision("md5-v1").getContent()).isEqualTo("v1");
+            assertThat(configRepo.getCurrentRevCommit().getRawGpgSignature()).isNull();
+        }
+    }
+
     private static class UndoableUserGitConfig implements AutoCloseable {
         private final String originalConfig;
 


### PR DESCRIPTION
- fixes #14357 

Possibly would be better to just disable this system/user git configuration reading entirely, but I am unsure of the implications and whether it is needed by some folks.