### PR TITLE
fix: enable pipeline move action when filter narrows the rendered groups

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines.tsx
@@ -243,6 +243,7 @@ export class AdminPipelinesPage extends Page<null, State> {
       sm,
       shouldOpenEditView: this.operation === "edit"
     };
+    const canMovePipeline                              = vnode.state.pipelineGroups().length > 1;
     const filteredPipelineGrps: Stream<PipelineGroups> = Stream();
     if (vnode.state.searchText()) {
       const results = _.filter(vnode.state.pipelineGroups(), (grp: PipelineGroup) => grp.matches(vnode.state.searchText()));
@@ -259,7 +260,10 @@ export class AdminPipelinesPage extends Page<null, State> {
     return (
       <div>
         <FlashMessage type={this.flashMessage.type} message={this.flashMessage.message}/>
-        <PipelineGroupsWidget {...vnode.state} pipelineGroups={filteredPipelineGrps} scrollOptions={scrollOptions}/>
+        <PipelineGroupsWidget {...vnode.state}
+                              pipelineGroups={filteredPipelineGrps}
+                              canMovePipeline={canMovePipeline}
+                              scrollOptions={scrollOptions}/>
       </div>
     );
   }

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/admin_pipelines_widget.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/admin_pipelines_widget.tsx
@@ -54,6 +54,7 @@ export interface PipelinesScrollOptions {
 
 export interface Attrs extends Operations {
   pipelineGroups: Stream<PipelineGroups>;
+  canMovePipeline: boolean;
   createPipelineGroup: () => void;
   scrollOptions: PipelinesScrollOptions;
 }
@@ -246,11 +247,10 @@ export class PipelineGroupsWidget extends MithrilViewComponent<Attrs> {
         </div>
       ];
     }
-    const canMovePipeline = vnode.attrs.pipelineGroups().length > 1;
     return (
       <div data-test-id="pipeline-groups">
         {vnode.attrs.pipelineGroups().map((group) => {
-          return <PipelineGroupWidget canMovePipeline={canMovePipeline} group={group} {...vnode.attrs} />;
+          return <PipelineGroupWidget {...vnode.attrs} group={group} />;
         })}
       </div>
     );

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/admin_pipelines_widget_spec.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/admin_pipelines/admin_pipelines_widget_spec.tsx
@@ -46,6 +46,7 @@ describe("PipelineGroupsWidget", () => {
       doExtractPipeline: jasmine.createSpy("doExtractPipeline"),
       doMovePipeline: jasmine.createSpy("doMovePipeline"),
       pipelineGroups: Stream(new PipelineGroups()),
+      canMovePipeline: false,
       onError: jasmine.createSpy("onError"),
       onSuccessfulSave: jasmine.createSpy("onSuccessfulSave"),
       scrollOptions: {sm: stubAllMethods(["hasTarget", "shouldScroll"]), shouldOpenEditView: false}
@@ -287,6 +288,20 @@ describe("PipelineGroupsWidget", () => {
     it("should be able to move a pipeline", () => {
       attrs.pipelineGroups().push(new PipelineGroup("foo", new Pipelines(PipelineWithOrigin.fromJSON(pipelineJSON))));
       attrs.pipelineGroups().push(new PipelineGroup("bar", new Pipelines()));
+      attrs.canMovePipeline = true;
+      helper.mount(() => {
+        return <PipelineGroupsWidget {...attrs}/>;
+      });
+
+      const movePipelineElement = helper.byTestId(`move-pipeline-${pipelineJSON.name}`);
+
+      expect(movePipelineElement).not.toBeDisabled();
+      expect(movePipelineElement).toHaveAttr("title", "Move pipeline 'some-pipeline'");
+    });
+
+    it("should allow moving a pipeline when only one group is rendered but more groups exist (e.g. when filtering)", () => {
+      attrs.pipelineGroups().push(new PipelineGroup("foo", new Pipelines(PipelineWithOrigin.fromJSON(pipelineJSON))));
+      attrs.canMovePipeline = true;
       helper.mount(() => {
         return <PipelineGroupsWidget {...attrs}/>;
       });


### PR DESCRIPTION
Fixes #12427.

### What's the problem?

On **Admin > Pipelines**, when the *Search for a pipeline name* filter narrows the rendered list of pipeline groups down to one, the **Move pipeline** action for any pipeline in that view becomes disabled with the tooltip *"Cannot move pipeline '<name>' as there are no other group(s)"*, even when other pipeline groups exist and are valid move targets.

The behaviour can be reproduced by:

1. Going to **Admin > Pipelines** with at least two pipeline groups defined.
2. Typing a search term in the filter box that only matches pipelines from a single group.
3. Trying to move the matched pipeline. The move icon is greyed out.

### Why does this happen?

`PipelineGroupsWidget` in `admin_pipelines_widget.tsx` was deriving `canMovePipeline` from `vnode.attrs.pipelineGroups().length > 1`. The `admin_pipelines.tsx` page hands that widget the *filtered* groups stream, so the calculation reflects whatever the filter is currently showing rather than what actually exists on the server. The move modal itself already pulls its target list from the unfiltered page state, so the only broken thing is the up-front availability check.

### The fix

Compute `canMovePipeline` once in `admin_pipelines.tsx` using the full unfiltered `vnode.state.pipelineGroups()` and pass it down as an explicit attr on `PipelineGroupsWidget`. The widget no longer infers move availability from whatever subset of groups it happens to render.

### Tests

- Existing tests retained, with `canMovePipeline` now set explicitly per scenario (the previous setup just happened to match the inferred value).
- New regression test "should allow moving a pipeline when only one group is rendered but more groups exist (e.g. when filtering)" covers the issue: a single group is rendered, but `canMovePipeline` is true and the action should remain enabled.