### PR TITLE
ui: keep locked pipeline icon background neutral when user lacks unlock permission

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/src/main/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -345,6 +345,13 @@ body {
   &.disabled {
     color: #999;
     cursor: not-allowed;
+    background: none;
+
+    &:hover,
+    &:focus {
+      color: #999;
+      background: none;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #13296.

### What's the problem?

On the dashboard, when a pipeline is locked and the current user does **not** have operate permission to unlock it, the locked-pipeline icon is rendered with a purple background instead of the muted "no permission" look used by the other action icons in the same row (e.g. the *Edit Configuration* gear).

### Why does this happen?

The disabled lock icon is rendered via `f.button`, which adds Foundation's `.button` class on top of `.pipeline_locked.disabled`. Foundation contributes a `.button.disabled` rule with the primary colour as its background. Since that rule has the same specificity as `.pipeline_locked.disabled` and is declared earlier in the cascade, the purple background wins.

The enabled lock case (`.pipeline_locked` only) already has `background: none` and is fine. The disabled state was missing the corresponding override.

### The fix

Set `background: none` on `.pipeline_locked.disabled`, and lock the colour/background for the hover and focus pseudo-classes so the icon stays neutral when a no-permission user mouses over it. Result: the disabled lock icon looks consistent with the other disabled action icons on the dashboard.

The change is CSS-only and limited to the disabled state of `.pipeline_locked`.