### PR TITLE
fix: validate template/pipeline names exist when creating via the API

### DIFF
--- a/api/api-pipeline-config-v11/src/main/java/com/thoughtworks/go/apiv11/admin/pipelineconfig/PipelineConfigControllerV11.java
+++ b/api/api-pipeline-config-v11/src/main/java/com/thoughtworks/go/apiv11/admin/pipelineconfig/PipelineConfigControllerV11.java
@@ -44,6 +44,7 @@ import spark.Request;
 import spark.Response;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import static com.thoughtworks.go.api.util.HaltApiResponses.*;
@@ -236,10 +237,13 @@ public class PipelineConfigControllerV11 extends ApiController implements SparkS
 
 
     private void haltIfEntityBySameNameInRequestExists(PipelineConfig pipelineConfig) {
-        if (pipelineConfigService.getPipelineConfig(pipelineConfig.name().toString()) == null) {
+        CaseInsensitiveString name = Optional.ofNullable(pipelineConfig.name())
+            .orElseThrow(() -> haltBecauseOfReason("Pipeline name must be specified for creating a pipeline."));
+
+        if (pipelineConfigService.getPipelineConfig(name.toString()) == null) {
             return;
         }
-        pipelineConfig.addError("name", EntityType.Pipeline.alreadyExists(pipelineConfig.name()));
-        throw haltBecauseEntityAlreadyExists(jsonWriter(pipelineConfig), "pipeline", pipelineConfig.getName());
+        pipelineConfig.addError("name", EntityType.Pipeline.alreadyExists(name));
+        throw haltBecauseEntityAlreadyExists(jsonWriter(pipelineConfig), "pipeline", name);
     }
 }

--- a/api/api-pipeline-config-v11/src/test/groovy/com/thoughtworks/go/apiv11/pipelineconfig/PipelineConfigControllerV11Test.groovy
+++ b/api/api-pipeline-config-v11/src/test/groovy/com/thoughtworks/go/apiv11/pipelineconfig/PipelineConfigControllerV11Test.groovy
@@ -381,6 +381,17 @@ class PipelineConfigControllerV11Test implements SecurityServiceTrait, Controlle
       }
 
       @Test
+      void 'should fail if name is blank'() {
+        def pipeline = pipeline()
+        pipeline.remove("name")
+        postWithApiHeader(controller.controllerPath(), [group: "new_grp", pipeline: pipeline])
+
+        assertThatResponse()
+          .isUnprocessableEntity()
+          .hasJsonMessage("Pipeline name must be specified for creating a pipeline.")
+      }
+
+      @Test
       void "should fail if group is blank"() {
         postWithApiHeader(controller.controllerPath(), [group: '', pipeline: pipeline()])
 
@@ -713,7 +724,7 @@ class PipelineConfigControllerV11Test implements SecurityServiceTrait, Controlle
         doAnswer({ InvocationOnMock invocation ->
           HttpLocalizedOperationResult result = invocation.arguments.last()
           result.setMessage("The pipeline 'pipeline1' was deleted successfully.")
-        }).when(pipelineConfigService).deletePipelineConfig(any(), eq(this.pipeline), any())
+        }).when(pipelineConfigService).deletePipelineConfig(any(), eq(pipeline), any())
 
 
         deleteWithApiHeader(controller.controllerPath("/pipeline1"))

--- a/api/api-template-config-v7/src/main/java/com/thoughtworks/go/apiv7/admin/templateconfig/TemplateConfigControllerV7.java
+++ b/api/api-template-config-v7/src/main/java/com/thoughtworks/go/apiv7/admin/templateconfig/TemplateConfigControllerV7.java
@@ -26,6 +26,7 @@ import com.thoughtworks.go.api.util.GsonTransformer;
 import com.thoughtworks.go.apiv7.admin.templateconfig.representers.ParametersRepresenter;
 import com.thoughtworks.go.apiv7.admin.templateconfig.representers.TemplateConfigRepresenter;
 import com.thoughtworks.go.apiv7.admin.templateconfig.representers.TemplatesConfigRepresenter;
+import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.ParamsConfig;
 import com.thoughtworks.go.config.PipelineTemplateConfig;
 import com.thoughtworks.go.config.TemplateToPipelines;
@@ -46,6 +47,7 @@ import spark.route.HttpMethod;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import static com.thoughtworks.go.api.util.HaltApiResponses.*;
@@ -194,10 +196,13 @@ public class TemplateConfigControllerV7 extends ApiController implements SparkSp
 
 
     private void haltIfEntityBySameNameInRequestExists(PipelineTemplateConfig templateConfig, HttpLocalizedOperationResult result) {
-        if (templateConfigService.loadForView(templateConfig.name().toString(), result) == null) {
+        CaseInsensitiveString name = Optional.ofNullable(templateConfig.name())
+            .orElseThrow(() -> haltBecauseOfReason("Template name must be specified for creating a template."));
+
+        if (templateConfigService.loadForView(name.toString(), result) == null) {
             return;
         }
-        templateConfig.addError("name", EntityType.Template.alreadyExists(templateConfig.name()));
-        throw haltBecauseEntityAlreadyExists(jsonWriter(templateConfig), "template", templateConfig.name());
+        templateConfig.addError("name", EntityType.Template.alreadyExists(name));
+        throw haltBecauseEntityAlreadyExists(jsonWriter(templateConfig), "template", name);
     }
 }

--- a/api/api-template-config-v7/src/test/groovy/com/thoughtworks/go/apiv7/admin/templateconfig/TemplateConfigControllerV7Test.groovy
+++ b/api/api-template-config-v7/src/test/groovy/com/thoughtworks/go/apiv7/admin/templateconfig/TemplateConfigControllerV7Test.groovy
@@ -297,6 +297,15 @@ class TemplateConfigControllerV7Test implements SecurityServiceTrait, Controller
         .isUnprocessableEntity()
         .hasJsonMessage("Save failed.")
       }
+
+      @Test
+      void 'should fail if name is blank'() {
+        postWithApiHeader(controller.controllerPath(), [stages: []])
+
+        assertThatResponse()
+          .isUnprocessableEntity()
+          .hasJsonMessage("Template name must be specified for creating a template.")
+      }
     }
   }
 


### PR DESCRIPTION
Currently if you don't supply `name` you get a `500` error due to the earlier duplicate lookup, which is not intended.

e.g
```
$ curl -u view:badger -X post http://localhost:8153/go/api/admin/templates \
-H 'Accept: application/vnd.go.cd+json' \
-H 'Content-Type: application/json' \
-d '{"pipeline":"[Any Pipeline]","stage":"something","event":"All","match_commits":false,"template_name":"something"}'
{
  "message" : "Cannot invoke \"com.thoughtworks.go.config.CaseInsensitiveString.toString()\" because the return value of \"com.thoughtworks.go.config.PipelineTemplateConfig.name()\" is null"
}%
```