### PR TITLE
chore: clean up minor code smells in JobInstances

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/domain/JobInstances.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/JobInstances.java
@@ -123,7 +123,7 @@ public class JobInstances extends BaseCollection<JobInstance> {
     }
 
     public long latestTransitionId() {
-        long latest = JobStateTransition.NOT_PERSISTED;
+        long latest = PersistentObject.NOT_PERSISTED;
         for (JobInstance jobInstance : this) {
             long id = jobInstance.latestTransitionId();
             if (id > latest) {

--- a/domain/src/main/java/com/thoughtworks/go/domain/JobInstances.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/JobInstances.java
@@ -51,7 +51,7 @@ public class JobInstances extends BaseCollection<JobInstance> {
         AtomicReference<JobInstance> removed = new AtomicReference<>();
         if (!removeFirstIf(jobInstance -> jobInstance.getName().equals(name) && removed.getAndSet(jobInstance) == null)) {
             throw bomb("Does not contain plan with name " + name);
-        };
+        }
         return removed.get();
     }
 


### PR DESCRIPTION
Two small, non-functional Sonar cleanups in JobInstances.java:

- style: remove redundant empty statement in `removeByName` (Sonar S1116)
- refactor: access `NOT_PERSISTED` via declaring class `PersistentObject` instead of subclass `JobStateTransition` (Sonar S3252)

No functional changes. `JobInstancesTest` passes and a clean Gradle build succeeds.