### PR TITLE
fix: prevent XXE in XML parsing (Sonar S2755)

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/util/XpathUtils.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/util/XpathUtils.java
@@ -98,6 +98,7 @@ public class XpathUtils {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             return factory;
         } catch (ParserConfigurationException e) {
             throw new RuntimeException(e);

--- a/config/config-api/src/test/java/com/thoughtworks/go/util/XpathUtilsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/util/XpathUtilsTest.java
@@ -96,6 +96,24 @@ public class XpathUtilsTest {
     }
 
     @Test
+    void shouldRejectXmlContainingDocTypeDeclarationToPreventXXE() throws Exception {
+        String maliciousXml = """
+            <?xml version="1.0"?>
+            <!DOCTYPE root [
+              <!ENTITY xxe SYSTEM "file:///etc/passwd">
+            ]>
+            <root>
+            <son>
+            <grandson name="&xxe;"/>
+            </son>
+            </root>""";
+
+        File file = getTestFile(maliciousXml);
+
+        assertThrows(XPathExpressionException.class, () -> XpathUtils.evaluate(file, "/root/son/grandson/@name"));
+    }
+
+    @Test
     public void shouldReturnEmptyStringWhenMatchedNodeIsNotTextNode() throws Exception {
         String xpath = "/root/son";
         String value = XpathUtils.evaluate(getTestFile(), xpath);

--- a/domain/src/test/java/com/thoughtworks/go/domain/JobInstancesTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/JobInstancesTest.java
@@ -25,9 +25,9 @@ import static com.thoughtworks.go.domain.StageState.*;
 import static com.thoughtworks.go.helper.JobInstanceMother.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class JobInstancesTest {
+class JobInstancesTest {
     @Test
-    public void shouldFilterByStatus() {
+    void shouldFilterByStatus() {
         final JobInstance instance1 = new JobInstance("test");
         final JobInstance instance2 = new JobInstance("test2");
         instance2.setState(JobState.Assigned);
@@ -38,28 +38,28 @@ public class JobInstancesTest {
     }
 
     @Test
-    public void shouldGetMostRecentCompletedBuild() {
+    void shouldGetMostRecentCompletedBuild() {
         JobInstances jobInstances = mixedBuilds();
         JobInstance mostRecentCompleted = jobInstances.mostRecentCompleted();
         assertThat(mostRecentCompleted).isEqualTo(jobInstances.get(2));
     }
 
     @Test
-    public void shouldGetMostRecentPassedBuild() {
+    void shouldGetMostRecentPassedBuild() {
         JobInstances jobInstances = mixedBuilds();
         JobInstance mostRecent = jobInstances.mostRecentPassed();
         assertThat(mostRecent).isEqualTo(jobInstances.get(1));
     }
 
     @Test
-    public void shouldGetMostRecentPassedWhenBuilding() {
+    void shouldGetMostRecentPassedWhenBuilding() {
         JobInstances jobInstances = new JobInstances(passed("passed"), building("unit"));
         JobInstance mostRecent = jobInstances.mostRecentPassed();
         assertThat(mostRecent.getName()).isEqualTo("passed");
     }
 
     @Test
-    public void shouldGetMostRecentPassedBuildIfThereAreFailedBuilds() {
+    void shouldGetMostRecentPassedBuildIfThereAreFailedBuilds() {
         JobInstances jobInstances = new JobInstances(failed("foo"), passed("foo"));
         JobInstance mostRecent = jobInstances.mostRecentPassed();
         assertThat(mostRecent).isEqualTo(jobInstances.get(1));
@@ -82,13 +82,13 @@ public class JobInstancesTest {
     }
 
     @Test
-    public void shouldReturnNullObjectWhenNoMostRecentPassedInstance() {
+    void shouldReturnNullObjectWhenNoMostRecentPassedInstance() {
         JobInstance actual = new JobInstances().mostRecentPassed();
         assertThat(actual.isNull()).isTrue();
     }
 
     @Test
-    public void shouldReturnStatusBuildingWhenAnyBuildsAreBuilding() {
+    void shouldReturnStatusBuildingWhenAnyBuildsAreBuilding() {
         JobInstances builds = new JobInstances();
         builds.add(completed("passports", JobResult.Passed));
         builds.add(completed("visas", JobResult.Cancelled));
@@ -97,7 +97,7 @@ public class JobInstancesTest {
     }
 
     @Test
-    public void jobShouldBeCancelledWhenNoActiveBuildAndHaveAtLeastOneCancelledJob() {
+    void jobShouldBeCancelledWhenNoActiveBuildAndHaveAtLeastOneCancelledJob() {
         JobInstances builds = new JobInstances();
         builds.add(completed("passports", JobResult.Passed));
         builds.add(completed("passports-failed", JobResult.Failed));
@@ -107,7 +107,7 @@ public class JobInstancesTest {
     }
 
     @Test
-    public void shouldReturnStatusFailingWhenAnyPlansHaveFailedAndNotAllAreCompleted() {
+    void shouldReturnStatusFailingWhenAnyPlansHaveFailedAndNotAllAreCompleted() {
         JobInstances builds = new JobInstances();
         builds.add(completed("passports", JobResult.Failed));
         builds.add(completed("visas", JobResult.Passed));
@@ -116,7 +116,7 @@ public class JobInstancesTest {
     }
 
     @Test
-    public void shouldReturnLatestTransitionDate() {
+    void shouldReturnLatestTransitionDate() {
         Date expectedLatest = date(3908, 10, 12);
         Date actualLatest = new JobInstances(
             completed(completed("job1"), JobResult.Failed, expectedLatest),

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/plugininfo/GoPluginDescriptorParser.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/plugininfo/GoPluginDescriptorParser.java
@@ -185,6 +185,9 @@ public final class GoPluginDescriptorParser {
         SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
         try {
             schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            schemaFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
             return schemaFactory.newSchema(klass.getResource(schemaResourcePath));
         } catch (SAXException e) {
             throw new RuntimeException(e);

--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/plugininfo/GoPluginDescriptorParserTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/plugininfo/GoPluginDescriptorParserTest.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.plugin.infra.plugininfo;
 
 import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.ValidationException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -71,6 +72,34 @@ class GoPluginDescriptorParserTest {
                 "GoCD Team", "https://gocd.org", List.of("Linux", "Windows"));
 
             assertTrue(pluginDescriptor.extensionClasses().isEmpty());
+        }
+
+        @Test
+        void shouldRejectPluginXmlContainingDoctypeDeclarationToPreventXXE() throws IOException {
+            String maliciousXml = """
+            <?xml version="1.0"?>
+            <!DOCTYPE go-plugin [
+              <!ENTITY xxe SYSTEM "file:///etc/passwd">
+            ]>
+            <go-plugin id="com.thoughtworks.gocd.analytics" version="1">
+              <about>
+                <name>GoCD Analytics Plugin</name>
+                <version>3.1.1-1113</version>
+                <target-go-version>20.9.0</target-go-version>
+                <description>&xxe; attempt</description>
+                <vendor>
+                  <name>NoThoughtWorks, Inc.</name>
+                  <url>https://github.com/gocd/fake-gocd-analytics-plugin</url>
+                </vendor>
+                <target-os>
+                  <value>Linux</value>
+                </target-os>
+              </about>
+            </go-plugin>""";
+
+            try (InputStream pluginXml = new ByteArrayInputStream(maliciousXml.getBytes(UTF_8))) {
+                assertThrows(ValidationException.class, () -> parseXml(pluginXml, "/tmp/", new File("/tmp/"), true));
+            }
         }
 
         @SuppressWarnings("SameParameterValue")


### PR DESCRIPTION
XpathUtils only had FEATURE_SECURE_PROCESSING set, which isn't enough on its own - explicitly disallow DOCTYPE now. Same gap in GoPluginDescriptorParser's SchemaFactory, so blocked external DTD/schema access there too.

Added tests for both that check a DOCTYPE-declared external entity gets rejected instead of resolved.