### PR TITLE
test: add regression tests for XXE handling in XML parsing

### DIFF
--- a/config/config-api/src/test/java/com/thoughtworks/go/util/XpathUtilsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/util/XpathUtilsTest.java
@@ -96,6 +96,24 @@ public class XpathUtilsTest {
     }
 
     @Test
+    void shouldRejectXmlContainingDocTypeDeclarationToPreventXXE() throws Exception {
+        String maliciousXml = """
+            <?xml version="1.0"?>
+            <!DOCTYPE root [
+              <!ENTITY xxe SYSTEM "file:///etc/passwd">
+            ]>
+            <root>
+            <son>
+            <grandson name="&xxe;"/>
+            </son>
+            </root>""";
+
+        File file = getTestFile(maliciousXml);
+
+        assertThrows(XPathExpressionException.class, () -> XpathUtils.evaluate(file, "/root/son/grandson/@name"));
+    }
+
+    @Test
     public void shouldReturnEmptyStringWhenMatchedNodeIsNotTextNode() throws Exception {
         String xpath = "/root/son";
         String value = XpathUtils.evaluate(getTestFile(), xpath);

--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/plugininfo/GoPluginDescriptorParserTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/plugininfo/GoPluginDescriptorParserTest.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.plugin.infra.plugininfo;
 
 import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.ValidationException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -71,6 +72,34 @@ class GoPluginDescriptorParserTest {
                 "GoCD Team", "https://gocd.org", List.of("Linux", "Windows"));
 
             assertTrue(pluginDescriptor.extensionClasses().isEmpty());
+        }
+
+        @Test
+        void shouldRejectPluginXmlContainingDoctypeDeclarationToPreventXXE() throws IOException {
+            String maliciousXml = """
+            <?xml version="1.0"?>
+            <!DOCTYPE go-plugin [
+              <!ENTITY xxe SYSTEM "file:///etc/passwd">
+            ]>
+            <go-plugin id="com.thoughtworks.gocd.analytics" version="1">
+              <about>
+                <name>GoCD Analytics Plugin</name>
+                <version>3.1.1-1113</version>
+                <target-go-version>20.9.0</target-go-version>
+                <description>&xxe; attempt</description>
+                <vendor>
+                  <name>NoThoughtWorks, Inc.</name>
+                  <url>https://github.com/gocd/fake-gocd-analytics-plugin</url>
+                </vendor>
+                <target-os>
+                  <value>Linux</value>
+                </target-os>
+              </about>
+            </go-plugin>""";
+
+            try (InputStream pluginXml = new ByteArrayInputStream(maliciousXml.getBytes(UTF_8))) {
+                assertThrows(ValidationException.class, () -> parseXml(pluginXml, "/tmp/", new File("/tmp/"), true));
+            }
         }
 
         @SuppressWarnings("SameParameterValue")


### PR DESCRIPTION
This is a clean resubmission of https://github.com/gocd/gocd/pull/14508.

As discussed there, this PR only keeps the two regression tests. Since `FEATURE_SECURE_PROCESSING` is sufficient on Java 21+, no source changes are required.