### PR TITLE
chore: bump packaged JDK to 25.0.4+7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,9 @@ def goVersions = new GoVersions(
   packagedJavaVersion: new AdoptiumVersion(
     feature: 25,
     interim: 0,    // set to `null` for the first release of a new featureVersion
-    update:  3,    // set to `null` for the first release of a new featureVersion
+    update:  4,    // set to `null` for the first release of a new featureVersion
     patch:   null, // set to `null` for most releases. Patch releases are "exceptional".
-    build:   9
+    build:   7
   ),
 )
 ext.goVersions = goVersions


### PR DESCRIPTION
See https://www.oracle.com/java/technologies/javase/25-0-4-relnotes.html and https://github.com/adoptium/temurin/issues/275