### PR TITLE
feat: migrate Alpine-based agent images to pure musl libc

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/OperatingSystem.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/OperatingSystem.groovy
@@ -17,17 +17,19 @@
 package com.thoughtworks.go.build
 
 enum OperatingSystem {
-  windows("zip", "windows"),
-  linux("tar.gz", "linux"),
-  alpine_linux("tar.gz", "alpine-linux"),
-  mac("tar.gz", "mac")
+  windows("zip", "windows", "windows"),
+  linux("tar.gz", "linux", "linux"),
+  linux_alpine("tar.gz", "alpine-linux", "alpine"),
+  mac("tar.gz", "mac", "macosx")
 
   final String extension
   final String adoptiumAlias
+  final String tanukiWrapperAlias
 
-  OperatingSystem(String extension, String adoptiumAlias) {
+  OperatingSystem(String extension, String adoptiumAlias, String tanukiWrapperAlias) {
     this.extension = extension
     this.adoptiumAlias = adoptiumAlias
+    this.tanukiWrapperAlias = tanukiWrapperAlias
   }
 }
 

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -18,6 +18,7 @@ package com.thoughtworks.go.build.docker
 
 import com.thoughtworks.go.build.AdoptiumVersion
 import com.thoughtworks.go.build.Architecture
+import com.thoughtworks.go.build.OperatingSystem
 
 enum Distro implements DistroBehavior {
 
@@ -32,6 +33,11 @@ enum Distro implements DistroBehavior {
     @Override
     boolean isContinuousRelease() {
       true
+    }
+
+    @Override
+    OperatingSystem getOperatingSystemVariant() {
+      OperatingSystem.linux_alpine
     }
 
     @Override
@@ -54,46 +60,6 @@ enum Distro implements DistroBehavior {
         // procps is needed for tanuki wrapper shell script
         'apk add --no-cache tini-static git openssh-client bash curl procps',
       ]
-    }
-
-    @Override
-    String getMultiStageInputImage() {
-      "frolvlad/alpine-glibc:alpine-3"
-    }
-
-    @Override
-    String getMultiStageInputDirectory() {
-      "/usr/glibc-compat"
-    }
-
-    @Override
-    List<String> getInstallJavaCommands(AdoptiumVersion version) {
-      // Tanuki Wrapper currently requires glibc, which is not available in Alpine (which is a musl libc distro). See https://github.com/gocd/gocd/issues/11355
-      // for a discussion of this problem. To workaround this, use glibc built within https://hub.docker.com/r/frolvlad/alpine-glibc from source at
-      // https://github.com/Docker-Hub-frolvlad/docker-alpine-glibc since he original project at https://github.com/sgerrand/alpine-pkg-glibc is unmaintained.
-      //
-      // Logic needs to match
-      // - package contents from https://github.com/Docker-Hub-frolvlad/docker-alpine-glibc/blob/master/APKBUILD
-      // - pre-generated locales from pre-generated locales at https://github.com/Docker-Hub-frolvlad/docker-alpine-glibc/blob/master/Dockerfile
-      //
-      // Note that this means the JRE used also must be glibc-linked.
-      [
-        '# install glibc for the Tanuki Wrapper, and use by glibc-linked Adoptium JREs',
-        "  GLIBC_DIR=${getMultiStageInputDirectory()}",
-        '  GLIBC_LIB=$([ "$(arch)" = "aarch64" ] && echo ld-linux-aarch64.so.1 || echo ld-linux-x86-64.so.2)',
-        '  ln -s ${GLIBC_DIR}/lib/${GLIBC_LIB} /lib/${GLIBC_LIB}',
-        '  mkdir -p /lib64 && ln -s ${GLIBC_DIR}/lib/${GLIBC_LIB} /lib64/${GLIBC_LIB}',
-        '  ln -s ${GLIBC_DIR}/etc/ld.so.cache /etc/ld.so.cache',
-        '  echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh',
-        '  ${GLIBC_DIR}/sbin/ldconfig',
-        '# end installing glibc',
-      ] + super.getInstallJavaCommands(version)
-    }
-
-    @Override
-    Map<String, String> getEnvironmentVariables(DistroVersion v) {
-      // See pre-generated locales at https://github.com/Docker-Hub-frolvlad/docker-alpine-glibc/blob/master/Dockerfile
-      ['LANG': 'C.UTF-8'] + super.getEnvironmentVariables(v)
     }
   },
 
@@ -241,6 +207,11 @@ enum Distro implements DistroBehavior {
       [
         new DistroVersion(version: 'dind', releaseName: 'dind', eolDate: parseDate('2099-01-01'))
       ]
+    }
+
+    @Override
+    OperatingSystem getOperatingSystemVariant() {
+      OperatingSystem.linux_alpine
     }
 
     @Override

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/DistroBehavior.groovy
@@ -61,7 +61,7 @@ trait DistroBehavior {
   }
 
   List<String> getInstallJavaCommands(AdoptiumVersion version) {
-    def downloadUrl = version.toDownloadURLFor(OperatingSystem.linux, Architecture.dockerDynamic)
+    def downloadUrl = version.toDownloadURLFor(operatingSystemVariant, Architecture.dockerDynamic)
 
     return [
       "curl --fail --location --silent --show-error \"${downloadUrl}\" --output /tmp/jre.tar.gz",
@@ -69,6 +69,10 @@ trait DistroBehavior {
       'tar -xf /tmp/jre.tar.gz -C /gocd-jre --strip 1',
       'rm -rf /tmp/jre.tar.gz'
     ]
+  }
+
+  OperatingSystem getOperatingSystemVariant() {
+    OperatingSystem.linux
   }
 
   Set<Architecture> getSupportedArchitectures() {

--- a/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-agent/Dockerfile.agent.ftl
@@ -36,13 +36,10 @@ RUN curl --fail --location --silent --show-error "https://download.gocd.org/bina
     mv -v /go-agent-${goVersions.goVersion}/run /go-agent/run && \
     mv -v /go-agent-${goVersions.goVersion}/wrapper-config /go-agent/wrapper-config && \
     WRAPPERARCH=${dockerAliasToWrapperArchAsShell} && \
-    mv -v /go-agent-${goVersions.goVersion}/wrapper/wrapper-linux-$WRAPPERARCH* /go-agent/wrapper/ && \
-    mv -v /go-agent-${goVersions.goVersion}/wrapper/libwrapper-linux-$WRAPPERARCH* /go-agent/wrapper/ && \
+    mv -v /go-agent-${goVersions.goVersion}/wrapper/wrapper-${distro.operatingSystemVariant.tanukiWrapperAlias}-$WRAPPERARCH /go-agent/wrapper/wrapper && \
+    mv -v /go-agent-${goVersions.goVersion}/wrapper/libwrapper-${distro.operatingSystemVariant.tanukiWrapperAlias}-$WRAPPERARCH.so /go-agent/wrapper/libwrapper.so && \
     mv -v /go-agent-${goVersions.goVersion}/wrapper/wrapper.jar /go-agent/wrapper/ && \
     chown -R ${r"${UID}"}:0 /go-agent && chmod -R g=u /go-agent
-<#if distro.getMultiStageInputImage()?has_content >
-FROM ${distro.getMultiStageInputImage()} AS multistageinput
-</#if>
 FROM ${distro.getBaseImageLocation(distroVersion)}
 ARG TARGETARCH
 
@@ -61,9 +58,6 @@ ENV ${key}="${value}"
 
 ARG UID=1000
 ARG GID=1000
-<#if distro.getMultiStageInputImage()?has_content >
-COPY --from=multistageinput ${distro.getMultiStageInputDirectory()} ${distro.getMultiStageInputDirectory()}
-</#if>
 RUN \
 <#list distro.getBaseImageUpdateCommands(distroVersion) as command>
   ${command} && \

--- a/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
@@ -35,8 +35,8 @@ RUN curl --fail --location --silent --show-error "https://download.gocd.org/bina
     mv -v /go-server-${goVersions.goVersion}/run /go-server/run && \
     mv -v /go-server-${goVersions.goVersion}/wrapper-config /go-server/wrapper-config && \
     WRAPPERARCH=${dockerAliasToWrapperArchAsShell} && \
-    mv -v /go-server-${goVersions.goVersion}/wrapper/wrapper-linux-$WRAPPERARCH* /go-server/wrapper/ && \
-    mv -v /go-server-${goVersions.goVersion}/wrapper/libwrapper-linux-$WRAPPERARCH* /go-server/wrapper/ && \
+    mv -v /go-server-${goVersions.goVersion}/wrapper/wrapper-${distro.operatingSystemVariant.tanukiWrapperAlias}-$WRAPPERARCH /go-server/wrapper/wrapper && \
+    mv -v /go-server-${goVersions.goVersion}/wrapper/libwrapper-${distro.operatingSystemVariant.tanukiWrapperAlias}-$WRAPPERARCH.so /go-server/wrapper/libwrapper.so && \
     mv -v /go-server-${goVersions.goVersion}/wrapper/wrapper.jar /go-server/wrapper/ && \
     chown -R ${r"${UID}"}:0 /go-server && chmod -R g=u /go-server
 

--- a/installers/linux.gradle
+++ b/installers/linux.gradle
@@ -298,14 +298,14 @@ def configureLinuxPackage(Task packageTask, InstallerType installerType, Package
       injected.fileOps.copy {
         into "${buildRoot}/usr/share/${installerType.baseName}/wrapper"
         from("${extractDeltaPack.destinationDir}/bin") {
-          include 'wrapper-linux-x86-64*'
-          include 'wrapper-linux-arm-64*'
+          include "wrapper-${OperatingSystem.linux.tanukiWrapperAlias}-${Architecture.x64.tanukiWrapperAlias}*"
+          include "wrapper-${OperatingSystem.linux.tanukiWrapperAlias}-${Architecture.aarch64.tanukiWrapperAlias}*"
         }
 
         from("${extractDeltaPack.destinationDir}/lib") {
           include 'wrapper.jar'
-          include 'libwrapper-linux-x86-64*'
-          include 'libwrapper-linux-arm-64*'
+          include "libwrapper-${OperatingSystem.linux.tanukiWrapperAlias}-${Architecture.x64.tanukiWrapperAlias}*"
+          include "libwrapper-${OperatingSystem.linux.tanukiWrapperAlias}-${Architecture.aarch64.tanukiWrapperAlias}*"
         }
       }
     }

--- a/installers/osx.gradle
+++ b/installers/osx.gradle
@@ -58,11 +58,9 @@ def configureMacZip(Zip zipTask, InstallerType installerType, Zip genericZipTask
       exclude "${installerType.baseName}-${goVersions.goVersion}/bin/*.bat"
     }
 
-    def wrapperArch = arch == Architecture.aarch64 ? 'arm-64' : 'x86-64'
-
     from(genericZipTree) {
-      include "${installerType.baseName}-${goVersions.goVersion}/wrapper/wrapper-macosx-${wrapperArch}"
-      include "${installerType.baseName}-${goVersions.goVersion}/wrapper/libwrapper-macosx-${wrapperArch}*"
+      include "${installerType.baseName}-${goVersions.goVersion}/wrapper/wrapper-${OperatingSystem.mac.tanukiWrapperAlias}-${arch.tanukiWrapperAlias}"
+      include "${installerType.baseName}-${goVersions.goVersion}/wrapper/libwrapper-${OperatingSystem.mac.tanukiWrapperAlias}-${arch.tanukiWrapperAlias}*"
     }
 
     // include the wrapper.conf, but replace the java command


### PR DESCRIPTION
Tanuki Wrapper 3.7.0 brings Alpine Linux/musl libc builds of the wrapper, which allows us to finally remove use of glibc on Alpine, and switch back to using the Alpine-native Eclipse Temurin JDK builds, avoiding the issues described at https://github.com/gocd/gocd/issues/11355 .

One workaround is needed to ensure it can load the correct library - right now the Java-based JNI loader cannot locate `libwrapper-alpine-arm-64.so` as it's hardcoded to look for `linux` based on `os.name` and I'd rather not change the os.name, as it might affect other things. Workaround is to rename to the generic naming, which it also searches for on `java.library.path`.