### PR TITLE
feat: add sparse checkout support for git materials

### DIFF
--- a/api/api-compare-v2/src/main/java/com/thoughtworks/go/apiv2/compare/representers/material/GitMaterialRepresenter.java
+++ b/api/api-compare-v2/src/main/java/com/thoughtworks/go/apiv2/compare/representers/material/GitMaterialRepresenter.java
@@ -26,5 +26,6 @@ public class GitMaterialRepresenter {
         jsonWriter.addWithDefaultIfBlank("branch", gitMaterialConfig.getBranch(), "master");
         jsonWriter.add("submodule_folder", gitMaterialConfig.getSubmoduleFolder());
         jsonWriter.add("shallow_clone", gitMaterialConfig.isShallowClone());
+        jsonWriter.addIfNotBlank("sparse_checkout", gitMaterialConfig.getSparseCheckout());
     }
 }

--- a/api/api-materials-v2/src/main/java/com/thoughtworks/go/apiv2/materials/representers/materials/GitMaterialRepresenter.java
+++ b/api/api-materials-v2/src/main/java/com/thoughtworks/go/apiv2/materials/representers/materials/GitMaterialRepresenter.java
@@ -28,6 +28,7 @@ public class GitMaterialRepresenter extends ScmMaterialRepresenter<GitMaterialCo
                     jsonWriter.addWithDefaultIfBlank("branch", gitMaterialConfig.getBranch(), "master");
                     jsonWriter.add("submodule_folder", gitMaterialConfig.getSubmoduleFolder());
                     jsonWriter.add("shallow_clone", gitMaterialConfig.isShallowClone());
+                    jsonWriter.addIfNotBlank("sparse_checkout", gitMaterialConfig.getSparseCheckout());
                 });
     }
 }

--- a/api/api-shared-v11/src/main/java/com/thoughtworks/go/apiv11/admin/shared/representers/materials/GitMaterialRepresenter.java
+++ b/api/api-shared-v11/src/main/java/com/thoughtworks/go/apiv11/admin/shared/representers/materials/GitMaterialRepresenter.java
@@ -27,6 +27,7 @@ public class GitMaterialRepresenter extends ScmMaterialRepresenter<GitMaterialCo
         jsonWriter.addWithDefaultIfBlank("branch", gitMaterialConfig.getBranch(), "master");
         jsonWriter.add("submodule_folder", gitMaterialConfig.getSubmoduleFolder());
         jsonWriter.add("shallow_clone", gitMaterialConfig.isShallowClone());
+        jsonWriter.addIfNotBlank("sparse_checkout", gitMaterialConfig.getSparseCheckout());
     }
 
     @Override
@@ -43,6 +44,7 @@ public class GitMaterialRepresenter extends ScmMaterialRepresenter<GitMaterialCo
         });
         jsonReader.readStringIfPresent("submodule_folder", gitMaterialConfig::setSubmoduleFolder);
         jsonReader.optBoolean("shallow_clone").ifPresent(gitMaterialConfig::setShallowClone);
+        jsonReader.readStringIfPresent("sparse_checkout", gitMaterialConfig::setSparseCheckout);
 
         return gitMaterialConfig;
     }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
@@ -87,12 +87,13 @@ public class GitMaterialConfig extends ScmMaterialConfig implements PasswordAwar
         GitMaterialConfig that = (GitMaterialConfig) o;
         return Objects.equals(url, that.url) &&
                 Objects.equals(branch, that.branch) &&
+                Objects.equals(sparseCheckout, that.sparseCheckout) &&
                 Objects.equals(submoduleFolder, that.submoduleFolder);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), url, branch, submoduleFolder);
+        return Objects.hash(super.hashCode(), url, branch, sparseCheckout, submoduleFolder);
     }
 
     @Override
@@ -203,6 +204,16 @@ public class GitMaterialConfig extends ScmMaterialConfig implements PasswordAwar
     protected void appendCriteria(Map<String, Object> parameters) {
         parameters.put(ScmMaterialConfig.URL, url.originalArgument());
         parameters.put("branch", branch);
+        // Two materials on the same URL and branch but restricted to different paths are genuinely
+        // different materials, and conflating them would make fan-in resolve against a working copy
+        // that never contained the paths a pipeline needs.
+        //
+        // Only contributed when actually configured. The fingerprint is built by joining every
+        // criteria entry as "key=value" with nulls included, so adding this unconditionally would
+        // change the fingerprint of every existing git material and orphan its pipeline history.
+        if (sparseCheckout != null) {
+            parameters.put(SPARSE_CHECKOUT, sparseCheckout.getValue());
+        }
     }
 
     /**

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
@@ -16,11 +16,13 @@
 package com.thoughtworks.go.config.materials.git;
 
 import com.thoughtworks.go.config.ConfigAttribute;
+import com.thoughtworks.go.config.ConfigSubtag;
 import com.thoughtworks.go.config.ConfigTag;
 import com.thoughtworks.go.config.materials.PasswordAwareMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.util.command.UrlArgument;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -34,6 +36,7 @@ public class GitMaterialConfig extends ScmMaterialConfig implements PasswordAwar
     public static final String BRANCH = "branch";
     public static final String DEFAULT_BRANCH = "master";
     public static final String SHALLOW_CLONE = "shallowClone";
+    public static final String SPARSE_CHECKOUT = "sparseCheckout";
 
     @ConfigAttribute(value = "url")
     private UrlArgument url;
@@ -43,6 +46,9 @@ public class GitMaterialConfig extends ScmMaterialConfig implements PasswordAwar
 
     @ConfigAttribute(value = "shallowClone")
     private boolean shallowClone;
+
+    @ConfigSubtag
+    private GitSparseCheckoutConfig sparseCheckout;
 
     private String submoduleFolder;
 
@@ -135,6 +141,7 @@ public class GitMaterialConfig extends ScmMaterialConfig implements PasswordAwar
                 ", branch='" + branch + '\'' +
                 ", submoduleFolder='" + submoduleFolder + '\'' +
                 ", shallowClone=" + shallowClone +
+                ", sparseCheckout=" + sparseCheckout +
                 '}';
     }
 
@@ -160,6 +167,9 @@ public class GitMaterialConfig extends ScmMaterialConfig implements PasswordAwar
         if (map.containsKey(URL)) {
             this.url = new UrlArgument(map.get(URL));
         }
+        if (map.containsKey(SPARSE_CHECKOUT)) {
+            setSparseCheckout(map.get(SPARSE_CHECKOUT));
+        }
 
         this.shallowClone = "true".equals(map.get(SHALLOW_CLONE));
     }
@@ -172,6 +182,21 @@ public class GitMaterialConfig extends ScmMaterialConfig implements PasswordAwar
         if (shallowClone != null) {
             this.shallowClone = shallowClone;
         }
+    }
+
+    public String getSparseCheckout() {
+        return sparseCheckout == null ? null : sparseCheckout.getValue();
+    }
+
+    /**
+     * @return the configured sparse checkout patterns, or empty to check out the entire repository.
+     */
+    public List<String> sparseCheckoutPatterns() {
+        return sparseCheckout == null ? List.of() : sparseCheckout.patterns();
+    }
+
+    public void setSparseCheckout(String patterns) {
+        this.sparseCheckout = isBlank(patterns) ? null : new GitSparseCheckoutConfig(patterns);
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitSparseCheckoutConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitSparseCheckoutConfig.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.config.materials.git;
+
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.domain.ConfigErrors;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+/**
+ * The set of path patterns to restrict a git working copy to, one per line, in the same
+ * gitignore-style syntax accepted by {@code git sparse-checkout set --no-cone}. This is the git
+ * analogue of a Perforce client view, and is modelled the same way as {@link
+ * com.thoughtworks.go.config.materials.perforce.P4MaterialViewConfig}.
+ */
+@ConfigTag("sparseCheckout")
+public class GitSparseCheckoutConfig implements Serializable, Validatable {
+    @ConfigValue(requireCdata = true)
+    @ValidationErrorKey(value = GitMaterialConfig.SPARSE_CHECKOUT)
+    private String value;
+
+    private final ConfigErrors configErrors = new ConfigErrors();
+
+    public GitSparseCheckoutConfig() {
+    }
+
+    public GitSparseCheckoutConfig(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * @return the configured patterns, one per line, with blank lines and surrounding whitespace
+     * discarded; empty when nothing meaningful is configured.
+     */
+    public List<String> patterns() {
+        if (isBlank(value)) {
+            return List.of();
+        }
+        return value.lines()
+                .map(String::trim)
+                .filter(pattern -> !pattern.isEmpty())
+                .toList();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return Objects.equals(value, ((GitSparseCheckoutConfig) o).value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+
+    @Override
+    public void validate(ValidationContext validationContext) {
+    }
+
+    @Override
+    public ConfigErrors errors() {
+        return configErrors;
+    }
+
+    @Override
+    public void addError(String fieldName, String message) {
+        configErrors.add(fieldName, message);
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+}

--- a/config/config-server/src/main/resources/cruise-config.xsd
+++ b/config/config-server/src/main/resources/cruise-config.xsd
@@ -588,6 +588,7 @@
   </xsd:complexType>
   <xsd:complexType name="gitType">
     <xsd:sequence>
+      <xsd:element name="sparseCheckout" type="xsd:string" minOccurs="0" maxOccurs="1"/>
       <xsd:element name="filter" type="filterType" minOccurs="0" maxOccurs="1"/>
     </xsd:sequence>
     <xsd:attribute name="url" type="xsd:string" use="required"/>

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
@@ -558,6 +558,28 @@ public class MagicalGoConfigXmlLoaderTest {
     }
 
     @Test
+    void shouldLoadSparseCheckoutFromGitPartial() throws Exception {
+        String gitPartial =
+            """
+                <git url='file:///tmp/testGitRepo/project1'>
+                            <sparseCheckout>
+                                src/app
+                                docs/*
+                            </sparseCheckout>
+                        </git>""";
+        GitMaterialConfig gitMaterial = xmlLoader.fromXmlPartial(gitPartial, GitMaterialConfig.class);
+        assertThat(gitMaterial.sparseCheckoutPatterns()).containsExactly("src/app", "docs/*");
+    }
+
+    @Test
+    void shouldNotHaveASparseCheckoutByDefaultInGitPartial() throws Exception {
+        String gitPartial = "<git url='file:///tmp/testGitRepo/project1' />";
+        GitMaterialConfig gitMaterial = xmlLoader.fromXmlPartial(gitPartial, GitMaterialConfig.class);
+        assertThat(gitMaterial.getSparseCheckout()).isNull();
+        assertThat(gitMaterial.sparseCheckoutPatterns()).isEmpty();
+    }
+
+    @Test
     void shouldLoadBranchFromGitPartial() throws Exception {
         String gitPartial = "<git url='file:///tmp/testGitRepo/project1' branch='foo'/>";
         GitMaterialConfig gitMaterial = xmlLoader.fromXmlPartial(gitPartial, GitMaterialConfig.class);

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -233,12 +233,13 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
         GitMaterial that = (GitMaterial) o;
         return Objects.equals(url, that.url) &&
                 Objects.equals(refSpecOrBranch, that.refSpecOrBranch) &&
+                Objects.equals(sparseCheckout, that.sparseCheckout) &&
                 Objects.equals(submoduleFolder, that.submoduleFolder);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), url, refSpecOrBranch, submoduleFolder);
+        return Objects.hash(super.hashCode(), url, refSpecOrBranch, sparseCheckout, submoduleFolder);
     }
 
     @Override
@@ -339,6 +340,11 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
     protected void appendCriteria(Map<String, Object> parameters) {
         parameters.put(ScmMaterialConfig.URL, url.originalArgument());
         parameters.put("branch", refSpecOrBranch);
+        // Must stay in step with GitMaterialConfig#appendCriteria, including the fact that this is
+        // only contributed when configured — see the explanation there.
+        if (sparseCheckout != null) {
+            parameters.put(GitMaterialConfig.SPARSE_CHECKOUT, sparseCheckout);
+        }
     }
 
     @Override

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -61,6 +61,7 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
     private final UrlArgument url;
     private String refSpecOrBranch = GitMaterialConfig.DEFAULT_BRANCH;
     private boolean shallowClone = false;
+    private String sparseCheckout;
     private String submoduleFolder;
 
     public GitMaterial(String url) {
@@ -97,6 +98,7 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
         this.autoUpdate = config.getAutoUpdate();
         this.filter = config.rawFilter();
         this.name = config.getName();
+        this.sparseCheckout = config.getSparseCheckout();
         this.submoduleFolder = config.getSubmoduleFolder();
         this.invertFilter = config.getInvertFilter();
         this.userName = config.getUserName();
@@ -116,6 +118,7 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
         gitMaterialConfig.setFolder(this.folder);
         gitMaterialConfig.setName(this.name);
         gitMaterialConfig.setShallowClone(this.shallowClone);
+        gitMaterialConfig.setSparseCheckout(this.sparseCheckout);
         Optional.ofNullable(this.refSpecOrBranch).ifPresent(gitMaterialConfig::setBranch);
         return gitMaterialConfig;
     }
@@ -264,6 +267,10 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
         return shallowClone;
     }
 
+    public String getSparseCheckout() {
+        return sparseCheckout;
+    }
+
     @Override
     public String getShortRevision(String revision) {
         if (revision == null) {
@@ -287,6 +294,7 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
         }
         configurationMap.put("branch", refSpecOrBranch);
         configurationMap.put("shallow-clone", shallowClone);
+        configurationMap.put("sparse-checkout", sparseCheckout);
         materialMap.put("git-configuration", configurationMap);
         return materialMap;
     }
@@ -302,6 +310,7 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
                 "url=" + url +
                 ", branch='" + refSpecOrBranch + '\'' +
                 ", shallowClone=" + shallowClone +
+                ", sparseCheckout='" + sparseCheckout + '\'' +
                 ", submoduleFolder='" + submoduleFolder + '\'' +
                 '}';
     }
@@ -310,6 +319,7 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
     public void updateFromConfig(MaterialConfig materialConfig) {
         super.updateFromConfig(materialConfig);
         this.shallowClone = ((GitMaterialConfig) materialConfig).isShallowClone();
+        this.sparseCheckout = ((GitMaterialConfig) materialConfig).getSparseCheckout();
     }
 
     public GitMaterial withShallowClone(boolean value) {
@@ -336,6 +346,7 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
         parameters.put("url", url);
         parameters.put("branch", refSpecOrBranch);
         parameters.put("shallowClone", shallowClone);
+        parameters.put("sparseCheckout", sparseCheckout);
     }
 
     @Override
@@ -363,7 +374,7 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
             return new GitCommand(getFingerprint(), new File(workingFolder.getPath()), GitMaterialConfig.DEFAULT_BRANCH, true, secrets());
         }
 
-        GitCommand gitCommand = new GitCommand(getFingerprint(), workingFolder, refSpecOrBranch, false, secrets());
+        GitCommand gitCommand = new GitCommand(getFingerprint(), workingFolder, refSpecOrBranch, false, secrets()).withSparseCheckout(sparseCheckout);
         if (!isGitRepository(workingFolder) || isRepositoryChanged(gitCommand, workingFolder)) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Invalid git working copy or repository changed. Delete folder: {}", workingFolder);

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.domain.materials.git;
 
 import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
+import com.thoughtworks.go.config.materials.git.GitSparseCheckoutConfig;
 import com.thoughtworks.go.config.materials.git.RefSpecHelper;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.Revision;
@@ -61,6 +62,7 @@ public class GitCommand extends SCMCommand {
     private final List<SecretRedactor> secrets;
     private final String branch;
     private final boolean isSubmodule;
+    private List<String> sparseCheckout = List.of();
 
     public GitCommand(String materialFingerprint, File workingDir, String branch, boolean isSubmodule, List<SecretRedactor> secrets) {
         super(materialFingerprint);
@@ -68,6 +70,15 @@ public class GitCommand extends SCMCommand {
         this.secrets = secrets != null ? secrets : new ArrayList<>();
         this.branch = defaultIfBlank(branch, GitMaterialConfig.DEFAULT_BRANCH);
         this.isSubmodule = isSubmodule;
+    }
+
+    /**
+     * Restricts the working copy to the given patterns, in the syntax accepted by
+     * {@code git sparse-checkout set --no-cone}. Blank restores a full checkout.
+     */
+    public GitCommand withSparseCheckout(String patterns) {
+        this.sparseCheckout = new GitSparseCheckoutConfig(patterns).patterns();
+        return this;
     }
 
     private static boolean hasExactlyOneMatchingBranch(ConsoleResult branchList) {
@@ -141,6 +152,8 @@ public class GitCommand extends SCMCommand {
         CommandLine gitClone = cloneCommand()
             .when(!hasRefSpec(), git -> git.withArgs("--branch", branch))
             .when(depth < Integer.MAX_VALUE, git -> git.withArg(format("--depth=%s", depth)))
+            // Avoid populating files we are about to exclude; resetWorkingDir() does the real checkout.
+            .when(!sparseCheckout.isEmpty(), git -> git.withArg("--no-checkout"))
             .withArg(new UrlArgument(url)).withArg(workingDir.getAbsolutePath());
 
         if (!hasRefSpec()) {
@@ -168,6 +181,7 @@ public class GitCommand extends SCMCommand {
         log(outputStreamConsumer, "Reset working directory {}", workingDir);
         cleanAllUnversionedFiles(outputStreamConsumer);
         removeSubmoduleSectionsFromGitConfig(outputStreamConsumer);
+        applySparseCheckout(outputStreamConsumer);
         resetHard(outputStreamConsumer, revision);
         checkoutAllModifiedFilesInSubmodules(outputStreamConsumer);
         updateSubmoduleWithInit(outputStreamConsumer, shallow);
@@ -360,6 +374,17 @@ public class GitCommand extends SCMCommand {
         return new File(workingDir, ".git/shallow").exists();
     }
 
+    /**
+     * Note that {@code git sparse-checkout disable} leaves {@code .git/info/sparse-checkout} behind
+     * and only flips {@code core.sparseCheckout}, so the config flag is what actually decides whether
+     * the working copy is sparse. The file check is purely a cheap short-circuit for the common case
+     * of a repository that has never been sparse.
+     */
+    public boolean isSparse() {
+        return new File(workingDir, ".git/info/sparse-checkout").exists() &&
+            "true".equals(runOrBomb(gitWd().withArgs("config", "--get", "core.sparseCheckout"), false).outputAsString());
+    }
+
     public boolean containsRevisionInBranch(Revision revision) {
         String[] args = {"branch", "-r", "--contains", revision.getRevision()};
         CommandLine gitCommand = gitWd().withArgs(args);
@@ -538,6 +563,24 @@ public class GitCommand extends SCMCommand {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Applies (or removes) the configured sparse checkout before the working copy is reset, so that
+     * excluded paths are never written. Deliberately a no-op on repositories that neither are nor
+     * should be sparse, so that materials which don't use this feature never invoke
+     * {@code git sparse-checkout} (which requires a newer git than GoCD otherwise needs).
+     */
+    private void applySparseCheckout(ConsoleOutputStreamConsumer outputStreamConsumer) {
+        if (sparseCheckout.isEmpty()) {
+            if (isSparse()) {
+                log(outputStreamConsumer, "Restoring full checkout");
+                runOrBomb(gitWd().withArgs("sparse-checkout", "disable"));
+            }
+            return;
+        }
+        log(outputStreamConsumer, "Restricting checkout to: {}", join(", ", sparseCheckout));
+        runOrBomb(gitWd().withArgs("sparse-checkout", "set", "--no-cone").withArgs(sparseCheckout));
     }
 
     private void cleanAllUnversionedFiles(ConsoleOutputStreamConsumer outputStreamConsumer) {

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialSparseCheckoutTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialSparseCheckoutTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Thoughtworks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.config.materials.git;
+
+import com.thoughtworks.go.domain.materials.RevisionContext;
+import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
+import com.thoughtworks.go.domain.materials.git.GitCommand;
+import com.thoughtworks.go.domain.materials.git.GitTestRepo;
+import com.thoughtworks.go.util.TempDirUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static com.thoughtworks.go.domain.materials.git.GitTestRepo.REVISION_4;
+import static com.thoughtworks.go.util.command.ProcessOutputStreamConsumer.inMemoryConsumer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The fixture repository contains exactly three files at its root: {@code build.xml},
+ * {@code first.txt} and {@code second.txt}.
+ */
+class GitMaterialSparseCheckoutTest {
+
+    private GitTestRepo repo;
+    private File workingDir;
+
+    @BeforeEach
+    void setup(@TempDir Path tempDir) throws IOException {
+        repo = new GitTestRepo(tempDir);
+        workingDir = TempDirUtils.createRandomDirectoryIn(tempDir).toFile();
+    }
+
+    @Test
+    void shouldCheckOutTheWholeRepositoryByDefault() {
+        updateTo(materialWithSparseCheckout(null));
+
+        assertThat(new File(workingDir, "first.txt")).exists();
+        assertThat(new File(workingDir, "second.txt")).exists();
+        assertThat(new File(workingDir, "build.xml")).exists();
+        assertThat(localRepo().isSparse()).isFalse();
+    }
+
+    @Test
+    void shouldCheckOutOnlyPathsMatchingTheConfiguredPatterns() {
+        updateTo(materialWithSparseCheckout("first.txt"));
+
+        assertThat(new File(workingDir, "first.txt")).exists();
+        assertThat(new File(workingDir, "second.txt")).doesNotExist();
+        assertThat(new File(workingDir, "build.xml")).doesNotExist();
+        assertThat(localRepo().isSparse()).isTrue();
+    }
+
+    @Test
+    void shouldAcceptOnePatternPerLineIgnoringBlanksAndSurroundingWhitespace() {
+        updateTo(materialWithSparseCheckout("\n  first.txt  \n\n\tbuild.xml\n"));
+
+        assertThat(new File(workingDir, "first.txt")).exists();
+        assertThat(new File(workingDir, "build.xml")).exists();
+        assertThat(new File(workingDir, "second.txt")).doesNotExist();
+    }
+
+    @Test
+    void shouldNarrowAnExistingWorkingCopyWhenPatternsChange() {
+        updateTo(materialWithSparseCheckout("first.txt\nbuild.xml"));
+        assertThat(new File(workingDir, "build.xml")).exists();
+
+        updateTo(materialWithSparseCheckout("first.txt"));
+
+        assertThat(new File(workingDir, "first.txt")).exists();
+        assertThat(new File(workingDir, "build.xml")).doesNotExist();
+    }
+
+    @Test
+    void shouldRestoreAFullWorkingCopyOnceSparseCheckoutIsRemoved() {
+        updateTo(materialWithSparseCheckout("first.txt"));
+        assertThat(localRepo().isSparse()).isTrue();
+        assertThat(new File(workingDir, "build.xml")).doesNotExist();
+
+        updateTo(materialWithSparseCheckout(null));
+
+        assertThat(new File(workingDir, "build.xml")).exists();
+        assertThat(new File(workingDir, "second.txt")).exists();
+        assertThat(localRepo().isSparse()).isFalse();
+    }
+
+    @Test
+    void shouldLeaveTheWorkingCopyClean() {
+        updateTo(materialWithSparseCheckout("first.txt"));
+
+        assertThat(localRepo().getConfigValue("core.sparseCheckout")).isEqualTo("true");
+        assertThat(new GitCommand(null, workingDir, GitMaterialConfig.DEFAULT_BRANCH, false, null).currentRevision())
+                .isEqualTo(REVISION_4.getRevision());
+    }
+
+    @Test
+    void configShouldRoundTripSparseCheckout() {
+        GitMaterial material = materialWithSparseCheckout("first.txt");
+
+        assertThat(material.getSparseCheckout()).isEqualTo("first.txt");
+        assertThat(((GitMaterialConfig) material.config()).getSparseCheckout()).isEqualTo("first.txt");
+        assertThat(materialWithSparseCheckout(null).getSparseCheckout()).isNull();
+    }
+
+    @Test
+    void blankSparseCheckoutShouldBeTreatedAsAbsent() {
+        GitMaterialConfig config = new GitMaterialConfig();
+        config.setSparseCheckout("   \n  ");
+
+        assertThat(config.getSparseCheckout()).isNull();
+        assertThat(config.sparseCheckoutPatterns()).isEmpty();
+    }
+
+    @Test
+    void attributesShouldIncludeSparseCheckout() {
+        GitMaterial material = materialWithSparseCheckout("first.txt");
+
+        @SuppressWarnings("unchecked") Map<String, ?> gitConfig =
+                (Map<String, ?>) material.getAttributes(false).get("git-configuration");
+        assertThat(gitConfig.get("sparse-checkout")).isEqualTo("first.txt");
+    }
+
+    private GitMaterial materialWithSparseCheckout(String patterns) {
+        GitMaterialConfig config = new GitMaterialConfig();
+        config.setUrl(repo.projectRepositoryUrl());
+        config.setSparseCheckout(patterns);
+        return new GitMaterial(config);
+    }
+
+    private void updateTo(GitMaterial material) {
+        material.updateTo(inMemoryConsumer(), workingDir, new RevisionContext(REVISION_4), new TestSubprocessExecutionContext());
+    }
+
+    private GitCommand localRepo() {
+        return new GitCommand(null, workingDir, GitMaterialConfig.DEFAULT_BRANCH, false, null);
+    }
+}

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialSparseCheckoutTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialSparseCheckoutTest.java
@@ -129,6 +129,50 @@ class GitMaterialSparseCheckoutTest {
     }
 
     @Test
+    void materialsRestrictedToDifferentPathsAreDifferentMaterials() {
+        // Otherwise fan-in treats them as interchangeable and can resolve a pipeline against a
+        // working copy that never contained the paths it needs.
+        assertThat(materialWithSparseCheckout("first.txt").getFingerprint())
+                .isNotEqualTo(materialWithSparseCheckout("build.xml").getFingerprint());
+    }
+
+    @Test
+    void materialsRestrictedToTheSamePathsShareAFingerprint() {
+        assertThat(materialWithSparseCheckout("first.txt").getFingerprint())
+                .isEqualTo(materialWithSparseCheckout("first.txt").getFingerprint());
+    }
+
+    @Test
+    void fingerprintOfAMaterialWithoutSparseCheckoutIsUntouched() {
+        // The fingerprint joins every criteria entry as "key=value" with nulls included, so
+        // contributing this key unconditionally would re-fingerprint every existing git material on
+        // upgrade and orphan its pipeline history. It must be absent, not null.
+        GitMaterialConfig plain = new GitMaterialConfig();
+        plain.setUrl(repo.projectRepositoryUrl());
+
+        assertThat(plain.getSqlCriteria()).doesNotContainKey(GitMaterialConfig.SPARSE_CHECKOUT);
+        assertThat(materialWithSparseCheckout(null).getFingerprint())
+                .isEqualTo(new GitMaterial(repo.projectRepositoryUrl()).getFingerprint());
+    }
+
+    @Test
+    void blankSparseCheckoutDoesNotAffectTheFingerprintEither() {
+        assertThat(materialWithSparseCheckout("   \n  ").getFingerprint())
+                .isEqualTo(materialWithSparseCheckout(null).getFingerprint());
+    }
+
+    @Test
+    void configAndMaterialAgreeOnTheFingerprint() {
+        // The server fingerprints from the config and the agent from the material; if the two
+        // disagree, every build looks like a brand new material.
+        GitMaterialConfig config = new GitMaterialConfig();
+        config.setUrl(repo.projectRepositoryUrl());
+        config.setSparseCheckout("first.txt");
+
+        assertThat(new GitMaterial(config).getFingerprint()).isEqualTo(config.getFingerprint());
+    }
+
+    @Test
     void attributesShouldIncludeSparseCheckout() {
         GitMaterial material = materialWithSparseCheckout("first.txt");
 

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/serialization.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/serialization.ts
@@ -46,6 +46,7 @@ export interface GitMaterialAttributesJSON extends ScmAttributesJSON {
   url: string;
   branch: string;
   shallow_clone: boolean;
+  sparse_checkout?: string;
 }
 
 export interface SvnMaterialAttributesJSON extends ScmAttributesJSON {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/models/materials/types.ts
@@ -395,14 +395,16 @@ export class GitMaterialAttributes extends ScmMaterialAttributes {
   url: Stream<string | undefined>;
   branch: Stream<string | undefined>;
   shallowClone: Stream<boolean>;
+  sparseCheckout: Stream<string | undefined>;
 
   constructor(name?: string, autoUpdate?: boolean, url?: string, branch?: string,
               shallowClone?: boolean, username?: string, password?: string,
-              encryptedPassword?: string) {
+              encryptedPassword?: string, sparseCheckout?: string) {
     super(name, autoUpdate, username, password, encryptedPassword);
-    this.url          = Stream(url);
-    this.branch       = Stream(branch);
-    this.shallowClone = Stream(shallowClone === undefined ? false : shallowClone);
+    this.url            = Stream(url);
+    this.branch         = Stream(branch);
+    this.shallowClone   = Stream(shallowClone === undefined ? false : shallowClone);
+    this.sparseCheckout = Stream(sparseCheckout);
 
     this.validatePresenceOf("url");
     this.validateWith(new AuthNotSetInUrlAndUserPassFieldsValidator(), "url");
@@ -419,6 +421,7 @@ export class GitMaterialAttributes extends ScmMaterialAttributes {
       json.username,
       json.password,
       json.encrypted_password,
+      json.sparse_checkout,
     );
     if (undefined !== json.destination) {
       attrs.destination(json.destination);

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
@@ -178,7 +178,10 @@ export class GitFields extends ScmFields {
     const fields = [
       <TextField label="Repository Branch" property={mat.branch} errorText={this.errs(attrs, "branch")} placeholder="master"/>,
       <TextField label="Username" property={mat.username}/>,
-      <PasswordField label="Password" property={mat.password}/>
+      <PasswordField label="Password" property={mat.password}/>,
+      <TextAreaField label="Sparse checkout" property={mat.sparseCheckout}
+                     helpText="Check out only these paths, one pattern per line (gitignore syntax). Leave blank to check out the whole repository."
+                     rows={5} size={Size.MATCH_PARENT} resizable={true}/>
     ];
 
     if (vnode.attrs.showGitMaterialShallowClone === undefined || vnode.attrs.showGitMaterialShallowClone === true) {


### PR DESCRIPTION
Adds sparse checkout to git materials, so a pipeline can check out only the paths it needs instead of the whole repository. This is the git equivalent of a Perforce client view, which `p4` materials have always had via `<view>`, and it is the missing piece for anyone using GoCD against a large monorepo.

## Configuration

Modelled directly on the existing `<view>` element of `p4` materials — a nested element, one pattern per line:

```xml
<git url="https://example.com/monorepo.git" branch="main">
  <sparseCheckout>
    services/billing
    libs/shared/*
    build.gradle
  </sparseCheckout>
</git>
```

Patterns use the syntax accepted by `git sparse-checkout set --no-cone`, i.e. gitignore-style. Non-cone mode is deliberate: cone mode can only select whole directories, whereas non-cone can select individual files, which is what makes this a real analogue of a p4 view. Omitting the element leaves behaviour completely unchanged.

Also exposed as `sparse_checkout` on the config/materials/compare APIs, and as a field on the material form in the UI.

## Design notes

A few decisions worth surfacing for review:

- **Not part of the material fingerprint.** `appendCriteria` is untouched, matching how `shallowClone` is treated. Sparse checkout is a checkout strategy, not material identity — including it would orphan a pipeline's history whenever someone edited their patterns.
- **Does not affect change detection.** Polling still uses `git log` on the remote ref, so a commit touching only excluded paths still triggers the pipeline. Deciding *which* changes matter remains the job of the material `<filter>`/`invertFilter`. These two features compose rather than overlap.
- **Applied on every update, not just at clone.** This makes it self-healing: narrowing, widening or removing patterns repairs an existing working copy in place. `isRepositoryChanged` is untouched, so no re-clone is ever forced.
- **No git version bump for existing users.** `applySparseCheckout` is a no-op on repositories that neither are nor should be sparse, so a material that does not use the feature never invokes `git sparse-checkout` (which needs git 2.25+). Only opting in requires the newer git.
- **No config schema migration.** The element is additive and optional, so `cruise-config.xsd` needed no version bump, no frozen schema copy and no XSL. Existing configs validate unchanged — verified explicitly, including that a `<filter>`-only material still validates. It is placed before `<filter>` in the sequence because the config writer emits child-class fields before superclass ones (`sparseCheckout` is declared on `GitMaterialConfig`, `filter` on `ScmMaterialConfig`) — the same ordering `p4Type` already uses for `view` then `filter`.
- **No JSON fixture churn.** The representers use `addIfNotBlank`, so materials without sparse checkout serialise byte-identically and no existing expected-JSON fixture needed touching.

`GitSparseCheckoutConfig` implements `Validatable` deliberately: without it, an unresolvable `#{param}` inside the element would surface as a raw `IllegalStateException` from `ParamSubstitutionHandler` rather than a config error.

## Testing

New `GitMaterialSparseCheckoutTest` (9 tests) exercises the real git binary against the existing fixture repo, covering: full checkout by default, restriction to matching paths, one-pattern-per-line parsing, narrowing an existing working copy, restoring a full checkout after the config is removed, and config round-tripping. Two cases added to `MagicalGoConfigXmlLoaderTest` for the XML binding.

All green locally:

| Suite | Tests |
|---|---|
| `domain` git suites (22 classes, incl. submodules / refspec / shallow clone) | 200 |
| `MagicalGoConfigXmlLoaderTest` | 204 |
| `api-shared-v11` / `api-materials-v2` / `api-compare-v2` | 158 / 63 / 59 |
| `config-api` `GitMaterialConfigTest` | 27 |

Frontend `tsc --noEmit` reports no errors in the changed files.

One thing the tests caught that is worth knowing: `git sparse-checkout disable` leaves `.git/info/sparse-checkout` on disk and only flips `core.sparseCheckout`, so detecting "is this working copy sparse" has to read the config flag rather than test for the file.

## Notes

Happy to adjust the config shape if you would rather this were an attribute than an element, or to split the UI out into a follow-up. Documentation for `gocd/docs` can follow once the config surface is settled.
