### PR TITLE
chore: Add -XX:+UseCompactObjectHeaders by default to reduce mem usage on JDK 25+

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeAgent.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeAgent.groovy
@@ -64,14 +64,18 @@ class InstallerTypeAgent implements InstallerType {
     [
       '--enable-native-access=ALL-UNNAMED',    // JDK 25+: Needed by JNA used by OSHI library at least
       '--sun-misc-unsafe-memory-access=allow', // JDK 25+: sun.misc.Unsafe needed by Felix SecureAction and probably others
-      '-XX:+IgnoreUnrecognizedVMOptions',      // JDK <25: Allow use of --sun-misc-unsafe-memory-access on older JVMs without errors
+      '-XX:+UseCompactObjectHeaders',          // JDK 25+: Reduce memory usage where possible
+      '-XX:+IgnoreUnrecognizedVMOptions',      // JDK <25: Allow use of --sun-misc-unsafe-memory-access and CompactObjectHeaders on older JVMs without errors
     ]
   }
 
   // Note that these apply to the bootstrapper/launcher, but not necessarily the agent itself (see AGENT_STARTUP_ARGS for that)
   @Override
   List<String> getJvmArgs() {
-    []
+    [
+      '-XX:+UseCompactObjectHeaders',     // JDK 25+: Reduce memory usage where possible
+      '-XX:+IgnoreUnrecognizedVMOptions', // JDK <25: Allow use of CompactObjectHeaders on older JVMs without errors
+    ]
   }
 
   // Note that these apply to both the launcher/bootstrapper and the agent itself

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeServer.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/InstallerTypeServer.groovy
@@ -56,7 +56,8 @@ class InstallerTypeServer implements InstallerType {
       '--add-opens=java.base/java.util=ALL-UNNAMED', // Required at least for cloning GoConfig subclasses of java.util classes :(
       '--enable-native-access=ALL-UNNAMED',          // JDK 25+: Needed by com.kenai.jffi.internal.StubLoader at least
       '--sun-misc-unsafe-memory-access=allow',       // JDK 25+: sun.misc.Unsafe needed by Felix SecureAction, object cloning and probably others
-      '-XX:+IgnoreUnrecognizedVMOptions',            // JDK <25: Allow use of --sun-misc-unsafe-memory-access on older JVMs without errors
+      '-XX:+UseCompactObjectHeaders',                // JDK 25+: Reduce memory usage where possible
+      '-XX:+IgnoreUnrecognizedVMOptions',            // JDK <25: Allow use of --sun-misc-unsafe-memory-access and CompactObjectHeaders on older JVMs without errors
     ]
   }
 

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/JRuby.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/JRuby.groovy
@@ -25,8 +25,8 @@ abstract class JRuby extends JavaExec {
     '--add-opens=java.base/java.io=ALL-UNNAMED',     // JDK 17+: Enable native sub-process control by default
     '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',  //          Often needed by bundler and such to fork processes
     '--enable-native-access=ALL-UNNAMED',            // JDK 25+: Needed by com.kenai.jffi.internal.StubLoader at least
-    '--sun-misc-unsafe-memory-access=allow',         // JDK 25+: sun.misc.Unsafe needed by org.jruby.util.StringSupport at least
-    '-XX:+IgnoreUnrecognizedVMOptions',              // JDK <25: Allow use of --sun-misc-unsafe-memory-access on older JVMs without errors
+    '--sun-misc-unsafe-memory-access=allow',         // JDK 25+: sun.misc.Unsafe needed by Jruby 9.4 org.jruby.util.StringSupport at least
+    '-XX:+UseCompactObjectHeaders',                  // JDK 25+: Reduce memory usage where possible
   ]
 
   static jrubySystemProperties = [

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.java.installations.auto-download=false
 # These override Gradle defaults which are not applied if we add custom args as noted in https://github.com/gradle/gradle/issues/19750.
 # The defaults were taken from
 # https://github.com/gradle/gradle/blob/68744f918ea82142a63c2904d346473799814be6/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java#L44
-org.gradle.jvmargs=-Xmx700m -Xms128m -XX:MaxMetaspaceSize=300m
+org.gradle.jvmargs=-Xmx700m -Xms128m -XX:MaxMetaspaceSize=300m -XX:+UseCompactObjectHeaders
 
 # Allows the locally published, repackaged TFS SDK (see tfs-impl-14) to resolve on CI, where dependencies are forced through Nexus
 allowMavenLocalForGroups=com.microsoft.tfs


### PR DESCRIPTION
It will likely be on by default by JDK 29, but for now we can opt-in. Build is always run on JDK 25+ so can add it there by default.